### PR TITLE
(PUP-10712) Json terminus for node and report fix

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1874,7 +1874,11 @@ EOT
       :default  => "$statedir/last_run_report.yaml",
       :type     => :file,
       :mode     => "0640",
-      :desc     => "Where puppet agent stores the last run report in yaml format."
+      :desc     => "Where Puppet Agent stores the last run report, by default, in yaml format.
+        The format of the report can be changed by setting the `cache` key of the `report` terminus
+        in the [routes.yaml](https://puppet.com/docs/puppet/latest/config_file_routes.html) file.
+        To avoid mismatches between content and file extension, this setting needs to be
+        manually updated to reflect the terminus changes."
     },
     :graph => {
       :default  => false,

--- a/lib/puppet/indirector/report/json.rb
+++ b/lib/puppet/indirector/report/json.rb
@@ -24,7 +24,7 @@ class Puppet::Transaction::Report::Json < Puppet::Indirector::JSON
     FileUtils.mkdir_p(File.dirname(filename))
 
     begin
-      Puppet::Util.replace_file(filename, mode) do |fh|
+      Puppet::FileSystem.replace_file(filename, mode) do |fh|
         fh.print JSON.dump(request.instance)
       end
     rescue TypeError => detail

--- a/lib/puppet/indirector/report/yaml.rb
+++ b/lib/puppet/indirector/report/yaml.rb
@@ -24,7 +24,7 @@ class Puppet::Transaction::Report::Yaml < Puppet::Indirector::Yaml
     FileUtils.mkdir_p(File.dirname(filename))
 
     begin
-      Puppet::Util.replace_file(filename, mode) do |fh|
+      Puppet::FileSystem.replace_file(filename, mode) do |fh|
         fh.print YAML.dump(request.instance)
       end
     rescue TypeError => detail

--- a/spec/unit/indirector/report/json_spec.rb
+++ b/spec/unit/indirector/report/json_spec.rb
@@ -4,6 +4,7 @@ require 'puppet/transaction/report'
 require 'puppet/indirector/report/json'
 
 describe Puppet::Transaction::Report::Json do
+  include PuppetSpec::Files
   describe '#save' do
     subject(:indirection) { described_class.indirection }
 

--- a/spec/unit/indirector/report/json_spec.rb
+++ b/spec/unit/indirector/report/json_spec.rb
@@ -35,8 +35,7 @@ describe Puppet::Transaction::Report::Json do
       indirection.save(report)
 
       if Puppet::Util::Platform.windows?
-        require 'puppet/util/windows/security'
-        mode = Puppet::Util::Windows::Security.get_mode(file)
+        mode = File.stat(file).mode
       else
         mode = Puppet::FileSystem.stat(file).mode
       end
@@ -63,15 +62,9 @@ describe Puppet::Transaction::Report::Json do
     context 'when report cannot be saved' do
       it 'raises Error' do
         FileUtils.mkdir_p(file)
-        if Puppet::Util::Platform.windows?
-          expect {
-            indirection.save(report)
-           }.to raise_error(Puppet::Util::Windows::Error, /Access is denied./)
-        else
-          expect {
-            indirection.save(report)
-           }.to raise_error(Errno::EISDIR, /last_run_report.json/)
-        end
+        expect {
+          indirection.save(report)
+         }.to raise_error(Errno::EISDIR, /last_run_report.json/)
       end
     end
   end

--- a/spec/unit/indirector/report/yaml_spec.rb
+++ b/spec/unit/indirector/report/yaml_spec.rb
@@ -46,8 +46,7 @@ describe Puppet::Transaction::Report::Yaml do
       indirection.save(report)
 
       if Puppet::Util::Platform.windows?
-        require 'puppet/util/windows/security'
-        mode = Puppet::Util::Windows::Security.get_mode(file)
+        mode = File.stat(file).mode
       else
         mode = Puppet::FileSystem.stat(file).mode
       end
@@ -83,15 +82,9 @@ describe Puppet::Transaction::Report::Yaml do
     context 'when report cannot be saved' do
       it 'raises Error' do
         FileUtils.mkdir_p(file)
-        if Puppet::Util::Platform.windows?
-          expect {
-            indirection.save(report)
-           }.to raise_error(Puppet::Util::Windows::Error, /Access is denied./)
-        else
-          expect {
-            indirection.save(report)
-           }.to raise_error(Errno::EISDIR, /last_run_report.yaml/)
-        end
+        expect {
+          indirection.save(report)
+        }.to raise_error(Errno::EISDIR, /last_run_report.yaml/)
       end
     end
   end


### PR DESCRIPTION
The implementation in https://github.com/puppetlabs/puppet/pull/8398
used Puppet::Util.replace_file which is an old implementation to the new
Puppet::FileSystem.replace_file

Replaced Puppet::Util.replace_file with Puppet::FileSystem.replace_file
and updated the specs.