### PR TITLE
(PUP-10730) Convert puppet http responses to net/http responses

### DIFF
--- a/lib/puppet/http.rb
+++ b/lib/puppet/http.rb
@@ -24,6 +24,7 @@ module Puppet
     require 'puppet/http/pool'
     require 'puppet/http/dns'
     require 'puppet/http/response'
+    require 'puppet/http/response_net_http'
     require 'puppet/http/service'
     require 'puppet/http/service/ca'
     require 'puppet/http/service/compiler'

--- a/lib/puppet/http.rb
+++ b/lib/puppet/http.rb
@@ -24,6 +24,7 @@ module Puppet
     require 'puppet/http/pool'
     require 'puppet/http/dns'
     require 'puppet/http/response'
+    require 'puppet/http/response_converter'
     require 'puppet/http/response_net_http'
     require 'puppet/http/service'
     require 'puppet/http/service/ca'

--- a/lib/puppet/http.rb
+++ b/lib/puppet/http.rb
@@ -1,10 +1,4 @@
 module Puppet
-  module Network
-    module HTTP
-      require 'puppet/network/http_pool'
-    end
-  end
-
   # Contains an HTTP client for making network requests to puppet and other
   # HTTP servers.
   #
@@ -41,5 +35,12 @@ module Puppet
     require 'puppet/http/redirector'
     require 'puppet/http/retry_after_handler'
     require 'puppet/http/external_client'
+  end
+
+  # Legacy HTTP API
+  module Network
+    module HTTP
+      require 'puppet/network/http_pool'
+    end
   end
 end

--- a/lib/puppet/http/client.rb
+++ b/lib/puppet/http/client.rb
@@ -350,7 +350,7 @@ class Puppet::HTTP::Client
 
         # don't call return within the `request` block
         http.request(request) do |nethttp|
-          response = Puppet::HTTP::Response.new(nethttp, request.uri)
+          response = Puppet::HTTP::ResponseNetHTTP.new(request.uri, nethttp)
           begin
             Puppet.debug("HTTP #{request.method.upcase} #{request.uri} returned #{response.code} #{response.reason}")
 

--- a/lib/puppet/http/external_client.rb
+++ b/lib/puppet/http/external_client.rb
@@ -22,7 +22,7 @@ class Puppet::HTTP::ExternalClient < Puppet::HTTP::Client
     options[:use_ssl] = url.scheme == 'https'
 
     client = @http_client_class.new(url.host, url.port, options)
-    response = Puppet::HTTP::Response.new(client.get(url.request_uri, headers, options), url)
+    response = Puppet::HTTP::ResponseNetHTTP.new(url, client.get(url.request_uri, headers, options))
 
     if block_given?
       yield response
@@ -44,7 +44,7 @@ class Puppet::HTTP::ExternalClient < Puppet::HTTP::Client
     options[:use_ssl] = url.scheme == 'https'
 
     client = @http_client_class.new(url.host, url.port, options)
-    response = Puppet::HTTP::Response.new(client.post(url.request_uri, body, headers, options), url)
+    response = Puppet::HTTP::ResponseNetHTTP.new(url, client.post(url.request_uri, body, headers, options))
 
     if block_given?
       yield response

--- a/lib/puppet/http/response.rb
+++ b/lib/puppet/http/response.rb
@@ -3,10 +3,6 @@
 # @api abstract
 # @api public
 class Puppet::HTTP::Response
-  # @api private
-  # @return [Net::HTTP] the Net::HTTP response
-  attr_reader :nethttp
-
   # @return [URI] the response url
   attr_reader :url
 

--- a/lib/puppet/http/response.rb
+++ b/lib/puppet/http/response.rb
@@ -1,39 +1,42 @@
 # Represents the response returned from the server from an HTTP request.
 #
+# @api abstract
 # @api public
 class Puppet::HTTP::Response
   # @api private
   # @return [Net::HTTP] the Net::HTTP response
   attr_reader :nethttp
 
-  # @return [URI] the response uri
+  # @return [URI] the response url
   attr_reader :url
 
-  # Object to represent the response returned from an HTTP request.
+  # Create a response associated with the URL.
   #
-  # @param [Net::HTTP] nethttp the request response
   # @param [URI] url
-  def initialize(nethttp, url)
-    @nethttp = nethttp
+  # @param [Integer] HTTP status
+  # @param [String] HTTP reason
+  def initialize(url, code, reason)
     @url = url
+    @code = code
+    @reason = reason
   end
 
-  # Extract the response code.
+  # Return the response code.
   #
   # @return [Integer] Response code for the request
   #
   # @api public
   def code
-    @nethttp.code.to_i
+    @code
   end
 
-  # Extract the response message.
+  # Return the response message.
   #
   # @return [String] Response message for the request
   #
   # @api public
   def reason
-    @nethttp.message
+    @reason
   end
 
   # Returns the entire response body. Can be used instead of
@@ -44,7 +47,7 @@ class Puppet::HTTP::Response
   #
   # @api public
   def body
-    @nethttp.body
+    raise NotImplementedError
   end
 
   # Streams the response body to the caller in chunks. Can be used instead of
@@ -57,9 +60,7 @@ class Puppet::HTTP::Response
   #
   # @api public
   def read_body(&block)
-    raise ArgumentError, "A block is required" unless block_given?
-
-    @nethttp.read_body(&block)
+    raise NotImplementedError
   end
 
   # Check if the request received a response of success (HTTP 2xx).
@@ -68,7 +69,7 @@ class Puppet::HTTP::Response
   #
   # @api public
   def success?
-    @nethttp.is_a?(Net::HTTPSuccess)
+    200 <= @code && @code < 300
   end
 
   # Get a header case-insensitively.
@@ -78,7 +79,7 @@ class Puppet::HTTP::Response
   #
   # @api public
   def [](name)
-    @nethttp[name]
+    raise NotImplementedError
   end
 
   # Yield each header name and value. Returns an enumerator if no block is given.
@@ -88,7 +89,7 @@ class Puppet::HTTP::Response
   #
   # @api public
   def each_header(&block)
-    @nethttp.each_header(&block)
+    raise NotImplementedError
   end
 
   # Ensure the response body is fully read so that the server is not blocked

--- a/lib/puppet/http/response_converter.rb
+++ b/lib/puppet/http/response_converter.rb
@@ -1,0 +1,24 @@
+module Puppet::HTTP::ResponseConverter
+  module_function
+
+  # Borrowed from puppetserver, see https://github.com/puppetlabs/puppetserver/commit/a1ebeaaa5af590003ccd23c89f808ba4f0c89609
+  def to_ruby_response(response)
+    str_code = response.code.to_s
+
+    # Copied from Net::HTTPResponse because it is private there.
+    clazz = Net::HTTPResponse::CODE_TO_OBJ[str_code] or
+      Net::HTTPResponse::CODE_CLASS_TO_OBJ[str_code[0,1]] or
+      Net::HTTPUnknownResponse
+    result = clazz.new(nil, str_code, nil)
+    result.body = response.body
+    # This is nasty, nasty.  But apparently there is no way to create
+    # an instance of Net::HttpResponse from outside of the library and have
+    # the body be readable, unless you do stupid things like this.
+    result.instance_variable_set(:@read, true)
+    response.each_header do |k,v|
+      result[k] = v
+    end
+    result
+  end
+end
+

--- a/lib/puppet/http/response_net_http.rb
+++ b/lib/puppet/http/response_net_http.rb
@@ -1,0 +1,42 @@
+# Adapts Net::HTTPResponse to Puppet::HTTP::Response
+#
+# @api public
+class Puppet::HTTP::ResponseNetHTTP < Puppet::HTTP::Response
+
+  # Create a response associated with the URL.
+  #
+  # @param [URI] url
+  # @param [Net::HTTPResponse] nethttp The response
+  def initialize(url, nethttp)
+    super(url, nethttp.code.to_i, nethttp.message)
+
+    @nethttp = nethttp
+  end
+
+  # (see Puppet::HTTP::Response#body)
+  def body
+    @nethttp.body
+  end
+
+  # (see Puppet::HTTP::Response#read_body)
+  def read_body(&block)
+    raise ArgumentError, "A block is required" unless block_given?
+
+    @nethttp.read_body(&block)
+  end
+
+  # (see Puppet::HTTP::Response#success?)
+  def success?
+    @nethttp.is_a?(Net::HTTPSuccess)
+  end
+
+  # (see Puppet::HTTP::Response#[])
+  def [](name)
+    @nethttp[name]
+  end
+
+  # (see Puppet::HTTP::Response#each_header)
+  def each_header(&block)
+    @nethttp.each_header(&block)
+  end
+end

--- a/lib/puppet/indirector/catalog/rest.rb
+++ b/lib/puppet/indirector/catalog/rest.rb
@@ -28,11 +28,11 @@ class Puppet::Resource::Catalog::Rest < Puppet::Indirector::REST
     if e.response.code == 404
       return nil unless request.options[:fail_on_404]
 
-      _, body = parse_response(e.response.nethttp)
+      _, body = parse_response(e.response)
       msg = _("Find %{uri} resulted in 404 with the message: %{body}") % { uri: elide(e.response.url.path, 100), body: body }
       raise Puppet::Error, msg
     else
-      raise convert_to_http_error(e.response.nethttp)
+      raise convert_to_http_error(e.response)
     end
   end
 end

--- a/lib/puppet/indirector/facts/rest.rb
+++ b/lib/puppet/indirector/facts/rest.rb
@@ -16,11 +16,11 @@ class Puppet::Node::Facts::Rest < Puppet::Indirector::REST
     if e.response.code == 404
       return nil unless request.options[:fail_on_404]
 
-      _, body = parse_response(e.response.nethttp)
+      _, body = parse_response(e.response)
       msg = _("Find %{uri} resulted in 404 with the message: %{body}") % { uri: elide(e.response.url.path, 100), body: body }
       raise Puppet::Error, msg
     else
-      raise convert_to_http_error(e.response.nethttp)
+      raise convert_to_http_error(e.response)
     end
   end
 
@@ -39,7 +39,6 @@ class Puppet::Node::Facts::Rest < Puppet::Indirector::REST
     nil
   rescue Puppet::HTTP::ResponseError => e
     # always raise even if fail_on_404 is false
-    raise convert_to_http_error(e.response.nethttp)
-
+    raise convert_to_http_error(e.response)
   end
 end

--- a/lib/puppet/indirector/file_bucket_file/rest.rb
+++ b/lib/puppet/indirector/file_bucket_file/rest.rb
@@ -15,7 +15,7 @@ module Puppet::FileBucketFile
       )
     rescue Puppet::HTTP::ResponseError => e
       return nil if e.response.code == 404
-      raise convert_to_http_error(e.response.nethttp)
+      raise convert_to_http_error(e.response)
     end
 
     def find(request)
@@ -32,7 +32,7 @@ module Puppet::FileBucketFile
       )
       filebucket_file
     rescue Puppet::HTTP::ResponseError => e
-      raise convert_to_http_error(e.response.nethttp)
+      raise convert_to_http_error(e.response)
     end
 
     def save(request)
@@ -44,7 +44,7 @@ module Puppet::FileBucketFile
         environment: request.environment.to_s,
       )
     rescue Puppet::HTTP::ResponseError => e
-      raise convert_to_http_error(e.response.nethttp)
+      raise convert_to_http_error(e.response)
     end
   end
 end

--- a/lib/puppet/indirector/file_content/rest.rb
+++ b/lib/puppet/indirector/file_content/rest.rb
@@ -25,11 +25,11 @@ class Puppet::Indirector::FileContent::Rest < Puppet::Indirector::REST
     if e.response.code == 404
       return nil unless request.options[:fail_on_404]
 
-      _, body = parse_response(e.response.nethttp)
+      _, body = parse_response(e.response)
       msg = _("Find %{uri} resulted in 404 with the message: %{body}") % { uri: elide(e.response.url.path, 100), body: body }
       raise Puppet::Error, msg
     else
-      raise convert_to_http_error(e.response.nethttp)
+      raise convert_to_http_error(e.response)
     end
   end
 end

--- a/lib/puppet/indirector/file_metadata/rest.rb
+++ b/lib/puppet/indirector/file_metadata/rest.rb
@@ -22,11 +22,11 @@ class Puppet::Indirector::FileMetadata::Rest < Puppet::Indirector::REST
     if e.response.code == 404
       return nil unless request.options[:fail_on_404]
 
-      _, body = parse_response(e.response.nethttp)
+      _, body = parse_response(e.response)
       msg = _("Find %{uri} resulted in 404 with the message: %{body}") % { uri: elide(e.response.url.path, 100), body: body }
       raise Puppet::Error, msg
     else
-      raise convert_to_http_error(e.response.nethttp)
+      raise convert_to_http_error(e.response)
     end
   end
 
@@ -50,6 +50,6 @@ class Puppet::Indirector::FileMetadata::Rest < Puppet::Indirector::REST
     # since it's search, return empty array instead of nil
     return [] if e.response.code == 404
 
-    raise convert_to_http_error(e.response.nethttp)
+    raise convert_to_http_error(e.response)
   end
 end

--- a/lib/puppet/indirector/node/rest.rb
+++ b/lib/puppet/indirector/node/rest.rb
@@ -19,11 +19,11 @@ class Puppet::Node::Rest < Puppet::Indirector::REST
     if e.response.code == 404
       return nil unless request.options[:fail_on_404]
 
-      _, body = parse_response(e.response.nethttp)
+      _, body = parse_response(e.response)
       msg = _("Find %{uri} resulted in 404 with the message: %{body}") % { uri: elide(e.response.url.path, 100), body: body }
       raise Puppet::Error, msg
     else
-      raise convert_to_http_error(e.response.nethttp)
+      raise convert_to_http_error(e.response)
     end
   end
 end

--- a/lib/puppet/indirector/report/rest.rb
+++ b/lib/puppet/indirector/report/rest.rb
@@ -17,13 +17,13 @@ class Puppet::Transaction::Report::Rest < Puppet::Indirector::REST
   rescue Puppet::HTTP::ResponseError => e
     return nil if e.response.code == 404
 
-    raise convert_to_http_error(e.response.nethttp)
+    raise convert_to_http_error(e.response)
   end
 
   # This is called by the superclass when not using our httpclient.
   def handle_response(request, response)
-    if !response.is_a?(Net::HTTPSuccess)
-      server_version = response[Puppet::HTTP::HEADER_PUPPET_VERSION]
+    if !response.success?
+      server_version = response[Puppet::Network::HEADER_PUPPET_VERSION]
       if server_version &&
          SemanticPuppet::Version.parse(server_version).major < Puppet::Indirector::REST::MAJOR_VERSION_JSON_DEFAULT &&
          Puppet[:preferred_serialization_format] != 'pson'

--- a/lib/puppet/indirector/report/rest.rb
+++ b/lib/puppet/indirector/report/rest.rb
@@ -23,7 +23,7 @@ class Puppet::Transaction::Report::Rest < Puppet::Indirector::REST
   # This is called by the superclass when not using our httpclient.
   def handle_response(request, response)
     if !response.is_a?(Net::HTTPSuccess)
-      server_version = response[Puppet::Network::HTTP::HEADER_PUPPET_VERSION]
+      server_version = response[Puppet::HTTP::HEADER_PUPPET_VERSION]
       if server_version &&
          SemanticPuppet::Version.parse(server_version).major < Puppet::Indirector::REST::MAJOR_VERSION_JSON_DEFAULT &&
          Puppet[:preferred_serialization_format] != 'pson'

--- a/lib/puppet/indirector/rest.rb
+++ b/lib/puppet/indirector/rest.rb
@@ -27,8 +27,8 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
   private
 
   def convert_to_http_error(response)
-    if response.body.to_s.empty? && response.respond_to?(:message)
-      returned_message = response.message
+    if response.body.to_s.empty? && response.reason
+      returned_message = response.reason
     elsif response['content-type'].is_a?(String)
       content_type, body = parse_response(response)
       if content_type =~ /[pj]son/
@@ -41,7 +41,7 @@ class Puppet::Indirector::REST < Puppet::Indirector::Terminus
     end
 
     message = _("Error %{code} on SERVER: %{returned_message}") % { code: response.code, returned_message: returned_message }
-    Net::HTTPError.new(message, response)
+    Net::HTTPError.new(message, Puppet::HTTP::ResponseConverter.to_ruby_response(response))
   end
 
   # Returns the content_type, stripping any appended charset, and the

--- a/lib/puppet/type/file/source.rb
+++ b/lib/puppet/type/file/source.rb
@@ -340,7 +340,7 @@ module Puppet
 
     def handle_response_error(response)
       message = "Error #{response.code} on SERVER: #{response.body.empty? ? response.reason : response.body}"
-      raise Net::HTTPError.new(message, response.nethttp)
+      raise Net::HTTPError.new(message, Puppet::HTTP::ResponseConverter.to_ruby_response(response))
     end
   end
 

--- a/spec/unit/http/client_spec.rb
+++ b/spec/unit/http/client_spec.rb
@@ -154,7 +154,7 @@ describe Puppet::HTTP::Client do
       stub_request(:get, uri)
 
       response = client.get(uri)
-      expect(response).to be_an_instance_of(Puppet::HTTP::Response)
+      expect(response).to be_a(Puppet::HTTP::Response)
       expect(response).to be_success
       expect(response.code).to eq(200)
     end
@@ -224,7 +224,7 @@ describe Puppet::HTTP::Client do
       stub_request(:head, uri)
 
       response = client.head(uri)
-      expect(response).to be_an_instance_of(Puppet::HTTP::Response)
+      expect(response).to be_a(Puppet::HTTP::Response)
       expect(response).to be_success
       expect(response.code).to eq(200)
     end
@@ -284,7 +284,7 @@ describe Puppet::HTTP::Client do
       stub_request(:put, uri)
 
       response = client.put(uri, "", headers: {'Content-Type' => 'text/plain'})
-      expect(response).to be_an_instance_of(Puppet::HTTP::Response)
+      expect(response).to be_a(Puppet::HTTP::Response)
       expect(response).to be_success
       expect(response.code).to eq(200)
     end
@@ -353,7 +353,7 @@ describe Puppet::HTTP::Client do
       stub_request(:post, uri)
 
       response = client.post(uri, "", headers: {'Content-Type' => 'text/plain'})
-      expect(response).to be_an_instance_of(Puppet::HTTP::Response)
+      expect(response).to be_a(Puppet::HTTP::Response)
       expect(response).to be_success
       expect(response.code).to eq(200)
     end
@@ -435,7 +435,7 @@ describe Puppet::HTTP::Client do
       stub_request(:delete, uri)
 
       response = client.delete(uri)
-      expect(response).to be_an_instance_of(Puppet::HTTP::Response)
+      expect(response).to be_a(Puppet::HTTP::Response)
       expect(response).to be_success
       expect(response.code).to eq(200)
     end

--- a/spec/unit/http/external_client_spec.rb
+++ b/spec/unit/http/external_client_spec.rb
@@ -61,7 +61,7 @@ describe Puppet::HTTP::ExternalClient do
       stub_request(:get, uri)
 
       response = client.get(uri)
-      expect(response).to be_an_instance_of(Puppet::HTTP::Response)
+      expect(response).to be_a(Puppet::HTTP::Response)
       expect(response).to be_success
       expect(response.code).to eq(200)
     end
@@ -113,7 +113,7 @@ describe Puppet::HTTP::ExternalClient do
       stub_request(:post, uri)
 
       response = client.post(uri, "", headers: {'Content-Type' => 'text/plain'})
-      expect(response).to be_an_instance_of(Puppet::HTTP::Response)
+      expect(response).to be_a(Puppet::HTTP::Response)
       expect(response).to be_success
       expect(response.code).to eq(200)
     end

--- a/spec/unit/http/session_spec.rb
+++ b/spec/unit/http/session_spec.rb
@@ -222,6 +222,8 @@ describe Puppet::HTTP::Session do
   end
 
   context 'when retrieving capabilities' do
+    let(:response) { Puppet::HTTP::Response.new(uri, 200, 'OK') }
+
     let(:session) do
       resolver = DummyResolver.new(good_service)
       described_class.new(client, [resolver])
@@ -242,7 +244,7 @@ describe Puppet::HTTP::Session do
       end
 
       it "supports locales if the cached service's version is 5.3.4 or greater" do
-        response = Puppet::HTTP::Response.new({'X-Puppet-Version' => '5.3.4'}, uri)
+        allow(response).to receive(:[]).with('X-Puppet-Version').and_return('5.3.4')
 
         session.route_to(:puppet)
         session.process_response(response)
@@ -251,7 +253,7 @@ describe Puppet::HTTP::Session do
       end
 
       it "does not support locales if the cached service's version is 5.3.3" do
-        response = Puppet::HTTP::Response.new({'X-Puppet-Version' => '5.3.3'}, uri)
+        allow(response).to receive(:[]).with('X-Puppet-Version').and_return('5.3.3')
 
         session.route_to(:puppet)
         session.process_response(response)
@@ -260,7 +262,7 @@ describe Puppet::HTTP::Session do
       end
 
       it "does not support locales if the cached service's version is missing" do
-        response = Puppet::HTTP::Response.new({}, uri)
+        allow(response).to receive(:[]).with('X-Puppet-Version').and_return(nil)
 
         session.route_to(:puppet)
         session.process_response(response)
@@ -277,7 +279,7 @@ describe Puppet::HTTP::Session do
       end
 
       it "supports json if the cached service's version is 5 or greater" do
-        response = Puppet::HTTP::Response.new({'X-Puppet-Version' => '5.5.12'}, uri)
+        allow(response).to receive(:[]).with('X-Puppet-Version').and_return('5.5.12')
 
         session.route_to(:puppet)
         session.process_response(response)
@@ -286,7 +288,7 @@ describe Puppet::HTTP::Session do
       end
 
       it "does not support json if the cached service's version is less than 5.0" do
-        response = Puppet::HTTP::Response.new({'X-Puppet-Version' => '4.10.1'}, uri)
+        allow(response).to receive(:[]).with('X-Puppet-Version').and_return('4.10.1')
 
         session.route_to(:puppet)
         session.process_response(response)
@@ -295,7 +297,7 @@ describe Puppet::HTTP::Session do
       end
 
       it "supports json if the cached service's version is missing" do
-        response = Puppet::HTTP::Response.new({}, uri)
+        allow(response).to receive(:[]).with('X-Puppet-Version').and_return(nil)
 
         session.route_to(:puppet)
         session.process_response(response)

--- a/spec/unit/indirector/report/rest_spec.rb
+++ b/spec/unit/indirector/report/rest_spec.rb
@@ -62,7 +62,7 @@ describe Puppet::Transaction::Report::Rest do
 
       stub_request(:put, uri)
         .to_return(status: 500,
-                   headers: { 'Content-Type' => 'text/pson', Puppet::Network::HTTP::HEADER_PUPPET_VERSION => '4.10.1' })
+                   headers: { 'Content-Type' => 'text/pson', Puppet::HTTP::HEADER_PUPPET_VERSION => '4.10.1' })
 
       expect {
         described_class.indirection.save(report)
@@ -74,7 +74,7 @@ describe Puppet::Transaction::Report::Rest do
 
       stub_request(:put, uri)
         .to_return(status: 500,
-                   headers: { 'Content-Type' => 'text/pson', Puppet::Network::HTTP::HEADER_PUPPET_VERSION => '4.10.1' })
+                   headers: { 'Content-Type' => 'text/pson', Puppet::HTTP::HEADER_PUPPET_VERSION => '4.10.1' })
 
       expect {
         described_class.indirection.save(report)

--- a/spec/unit/indirector/rest_spec.rb
+++ b/spec/unit/indirector/rest_spec.rb
@@ -24,11 +24,11 @@ class Puppet::FailingTestModel::Rest < Puppet::Indirector::REST
     if response.code == 404
       return nil unless request.options[:fail_on_404]
 
-      _, body = parse_response(response.nethttp)
+      _, body = parse_response(response)
       msg = _("Find %{uri} resulted in 404 with the message: %{body}") % { uri: elide(response.url.path, 100), body: body }
       raise Puppet::Error, msg
     else
-      raise convert_to_http_error(response.nethttp)
+      raise convert_to_http_error(response)
     end
   end
 end


### PR DESCRIPTION
Previously puppet's legacy connection adapter assumed the http client implementation returned instances of `Puppet::HTTP::Response` that wrapped `Net::HTTPResponse`. But that isn't true when running in puppetserver.

Now the legacy connection adapter converts `Puppet::HTTP::Response` instances (returned by the new http client implementation) to `Net::HTTPResponse`. This makes it possible for report processors, rest termini and server functions that call the legacy http API to continue working in puppetserver 7.