### PR TITLE
(maint) Fix setting of facterng flag

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -77,7 +77,8 @@ module Puppet
           the "facter-ng" gem). This is not necessary if Facter 3.x or later is installed.
           This setting is still experimental.',
         :hook    => proc do |value|
-          if value
+          value = munge(value)
+          if value && Puppet::Util::Package.versioncmp(Facter.value('facterversion'), '4.0.0') < 0
             begin
               original_facter = Object.const_get(:Facter)
               Object.send(:remove_const, :Facter)

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -189,6 +189,7 @@ describe "Defaults" do
 
     it "raises an exception if facter-ng could not be loaded" do
       allow_any_instance_of(Puppet::Settings::BooleanSetting).to receive(:require).with('facter-ng').and_raise(LoadError)
+      allow(Facter).to receive(:value).with('facterversion').and_return('3.11.4')
 
       expect{ Puppet.settings[:facterng] = true }.to raise_exception ArgumentError, 'facter-ng could not be loaded'
     end
@@ -200,6 +201,7 @@ describe "Defaults" do
         Object.send(:remove_const, :Facter)
         Object.const_set(:Facter, Module.new)
 
+        allow(Facter).to receive(:value).with('facterversion').and_return('3.11.4')
         allow_any_instance_of(Puppet::Settings::BooleanSetting).to receive(:require).with('facter-ng').and_return(true)
         allow(Facter).to receive(:respond_to?).and_return(false)
       end


### PR DESCRIPTION
The settings hook is called twice in one run when trying to set/unset the `facterng` flag which makes `Facter` module to not be present and puppet to raise an error.