### PR TITLE
(PUP-10772) Only accept msgpack if gem is installed

### DIFF
--- a/lib/puppet/network/formats.rb
+++ b/lib/puppet/network/formats.rb
@@ -255,7 +255,8 @@ Puppet::Network::FormatHandler.create_serialized_formats(:rich_data_msgpack, mim
   end
 
   def supported?(klass)
-    klass == Puppet::Resource::Catalog &&
+    suitable? &&
+      klass == Puppet::Resource::Catalog &&
       Puppet.lookup(:current_environment).rich_data?
   end
 end

--- a/spec/unit/http/service_spec.rb
+++ b/spec/unit/http/service_spec.rb
@@ -137,7 +137,7 @@ describe Puppet::HTTP::Service do
     catalog_mimes = if Puppet.features.msgpack?
                       %w[application/vnd.puppet.rich+json application/json application/vnd.puppet.rich+msgpack application/x-msgpack text/pson]
                     else
-                      %w[application/vnd.puppet.rich+json application/json application/vnd.puppet.rich+msgpack text/pson]
+                      %w[application/vnd.puppet.rich+json application/json text/pson]
                     end
     expect(service.mime_types(Puppet::Resource::Catalog)).to eq(catalog_mimes)
   end


### PR DESCRIPTION
Previously the agent always advertised that it accepted the rich data msgpack
format (application/vnd.puppet.rich+msgpack) even if the agent didn't have the
msgpack gem installed locally. If the msgpack gem was installed on the server,
and the server selected the rich data msgpack format, then the agent would fail
to deserialize the catalog.

Now we call the `suitable?` method in the superclass so the msgpack feature
constrain is taken into account. Calling the super `supported?` method triggers
a bunch of other logic around whether or not the format implements required
methods, so avoid that.

Note the "raw" msgpack format didn't have this issue because it didn't override
the "supported?" method.