### PR TITLE
(PUP-10713) Ensure environment cache is consistent when entries are cleared

### DIFF
--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -424,7 +424,6 @@ module Puppet::Environments
       @cache.each_pair do |name, entry|
         evict_if_expired(name, entry, t)
       end
-      @next_expiration = @expirations.first || END_OF_TIME
     end
 
     # This implementation evicts the cache, and always gets the current
@@ -473,6 +472,7 @@ module Puppet::Environments
         @cache_expiration_service.evicted(name.to_sym)
         clear(name)
         @expirations.delete(entry.expires)
+        @next_expiration = @expirations.first || END_OF_TIME
         Puppet.settings.clear_environment_settings(name)
       end
     end

--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -420,7 +420,7 @@ module Puppet::Environments
     def clear_all_expired()
       t = Time.now
       return if t < @next_expiration && ! @cache.any? {|name, _| @cache_expiration_service.expired?(name.to_sym) }
-      to_expire = @cache.select { |name, entry| entry.expires < t || @cache_expiration_service.expired?(name.to_sym) }
+      to_expire = @cache.select { |name, entry| entry.expired?(t) || @cache_expiration_service.expired?(name.to_sym) }
       to_expire.each do |name, entry|
         Puppet.debug {"Evicting cache entry for environment '#{name}'"}
         @cache_expiration_service.evicted(name.to_sym)
@@ -470,7 +470,8 @@ module Puppet::Environments
     # Evicts the entry if it has expired
     # Also clears caches in Settings that may prevent the entry from being updated
     def evict_if_expired(name)
-      if (result = @cache[name]) && (result.expired? || @cache_expiration_service.expired?(name.to_sym))
+      t = Time.now
+      if (entry = @cache[name]) && (entry.expired?(t) || @cache_expiration_service.expired?(name.to_sym))
         Puppet.debug {"Evicting cache entry for environment '#{name}'"}
         @cache_expiration_service.evicted(name.to_sym)
         clear(name)
@@ -489,7 +490,7 @@ module Puppet::Environments
       def touch
       end
 
-      def expired?
+      def expired?(now)
         false
       end
 
@@ -504,7 +505,7 @@ module Puppet::Environments
 
     # Always evicting entry
     class NotCachedEntry < Entry
-      def expired?
+      def expired?(now)
         true
       end
 
@@ -525,8 +526,8 @@ module Puppet::Environments
         @ttl_seconds = ttl_seconds
       end
 
-      def expired?
-        Time.now > @ttl
+      def expired?(now)
+        now > @ttl
       end
 
       def label

--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -475,6 +475,7 @@ module Puppet::Environments
         Puppet.debug {"Evicting cache entry for environment '#{name}'"}
         @cache_expiration_service.evicted(name.to_sym)
         clear(name)
+        @expirations.delete(entry.expires)
         Puppet.settings.clear_environment_settings(name)
       end
     end

--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -420,13 +420,9 @@ module Puppet::Environments
     def clear_all_expired()
       t = Time.now
       return if t < @next_expiration && ! @cache.any? {|name, _| @cache_expiration_service.expired?(name.to_sym) }
-      to_expire = @cache.select { |name, entry| entry.expired?(t) || @cache_expiration_service.expired?(name.to_sym) }
-      to_expire.each do |name, entry|
-        Puppet.debug {"Evicting cache entry for environment '#{name}'"}
-        @cache_expiration_service.evicted(name.to_sym)
-        clear(name)
-        @expirations.delete(entry.expires)
-        Puppet.settings.clear_environment_settings(name)
+
+      @cache.each_pair do |name, entry|
+        evict_if_expired(name, entry, t)
       end
       @next_expiration = @expirations.first || END_OF_TIME
     end
@@ -440,7 +436,7 @@ module Puppet::Environments
     #
     # @!macro loader_get_conf
     def get_conf(name)
-      evict_if_expired(name)
+      evict_if_expired(name, @cache[name])
       @loader.get_conf(name)
     end
 
@@ -469,9 +465,10 @@ module Puppet::Environments
 
     # Evicts the entry if it has expired
     # Also clears caches in Settings that may prevent the entry from being updated
-    def evict_if_expired(name)
-      t = Time.now
-      if (entry = @cache[name]) && (entry.expired?(t) || @cache_expiration_service.expired?(name.to_sym))
+    def evict_if_expired(name, entry, t = Time.now)
+      return unless entry
+
+      if entry.expired?(t) || @cache_expiration_service.expired?(name.to_sym)
         Puppet.debug {"Evicting cache entry for environment '#{name}'"}
         @cache_expiration_service.evicted(name.to_sym)
         clear(name)

--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -379,7 +379,6 @@ module Puppet::Environments
       elsif (result = @loader.get(name))
         # environment loaded, cache it
         cache_entry = entry(result)
-        @cache_expiration_service.created(result)
         add_entry(name, cache_entry)
         result
       end
@@ -389,6 +388,7 @@ module Puppet::Environments
     def add_entry(name, cache_entry)
       Puppet.debug {"Caching environment '#{name}' #{cache_entry.label}"}
       @cache[name] = cache_entry
+      @cache_expiration_service.created(cache_entry.value)
       expires = cache_entry.expires
       @expirations.add(expires)
       if @next_expiration > expires

--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -438,9 +438,21 @@ module Puppet::Environments
       return if t < @next_expiration && ! @cache.any? {|name, _| @cache_expiration_service.expired?(name.to_sym) }
 
       @cache.each_pair do |name, entry|
-        evict_if_expired(name, entry, t)
+        clear_if_expired(name, entry, t)
       end
     end
+
+    # Clear an environment if it is expired, either by exceeding its time to live, or
+    # through an explicit eviction determined by the cache expiration service.
+    #
+    def clear_if_expired(name, entry, t = Time.now)
+      return unless entry
+
+      if entry.expired?(t) || @cache_expiration_service.expired?(name.to_sym)
+        clear_entry(name, entry)
+      end
+    end
+    private :clear_if_expired
 
     # This implementation evicts the cache, and always gets the current
     # configuration of the environment
@@ -451,7 +463,7 @@ module Puppet::Environments
     #
     # @!macro loader_get_conf
     def get_conf(name)
-      evict_if_expired(name, @cache[name])
+      clear_if_expired(name, @cache[name])
       @loader.get_conf(name)
     end
 
@@ -475,16 +487,6 @@ module Puppet::Environments
         else
           TTLEntry.new(env, ttl)    # Entry that expires in ttl from when it was created
         end
-      end
-    end
-
-    # Evicts the entry if it has expired
-    # Also clears caches in Settings that may prevent the entry from being updated
-    def evict_if_expired(name, entry, t = Time.now)
-      return unless entry
-
-      if entry.expired?(t) || @cache_expiration_service.expired?(name.to_sym)
-        clear_entry(name, entry)
       end
     end
 

--- a/spec/unit/environments_spec.rb
+++ b/spec/unit/environments_spec.rb
@@ -648,6 +648,14 @@ config_version=$vardir/random/scripts
         expect(service.created_envs).to eq([:an_environment])
       end
 
+      it "evicts an environment" do
+        with_environment_loaded(service) do |cached|
+          cached.clear(:an_environment)
+        end
+
+        expect(service.evicted_envs).to eq([:an_environment])
+      end
+
       it "does not evict an unexpired environment" do
         Puppet[:environment_timeout] = 'unlimited'
 

--- a/spec/unit/environments_spec.rb
+++ b/spec/unit/environments_spec.rb
@@ -656,6 +656,15 @@ config_version=$vardir/random/scripts
         expect(service.evicted_envs).to eq([:an_environment])
       end
 
+      it "clears all environments" do
+        with_environment_loaded(service) do |cached|
+          cached.get!(:another_environment)
+          cached.clear_all
+        end
+
+        expect(service.evicted_envs).to eq([:an_environment, :another_environment])
+      end
+
       it "does not evict an unexpired environment" do
         Puppet[:environment_timeout] = 'unlimited'
 

--- a/spec/unit/environments_spec.rb
+++ b/spec/unit/environments_spec.rb
@@ -679,10 +679,7 @@ config_version=$vardir/random/scripts
       it "evicts an expired environment" do
         service = ReplayExpirationService.new
 
-        # The `Cached#clear_all_expired` method tries to optimize the case where
-        # no entries are expired. But if `Time.now < @next_expiration` and there is
-        # an expired entry, then the `service#expired?` method is called twice.
-        expect(service).to receive(:expired?).twice.and_return(true)
+        expect(service).to receive(:expired?).and_return(true)
 
         with_environment_loaded(service) do |cached|
           cached.get!(:an_environment)
@@ -726,8 +723,7 @@ config_version=$vardir/random/scripts
         Puppet[:environment_timeout] = 60
         Puppet[:environment_timeout_mode] = :from_last_used
 
-        # see note above about "twice"
-        expect(service).to receive(:expired?).twice.and_return(true)
+        expect(service).to receive(:expired?).and_return(true)
 
         with_environment_loaded(service) do |cached|
           # even though the environment was recently touched, it's been expired


### PR DESCRIPTION
The environment cache has two methods to clear a cached environment (`clear_all` and `clear(name)`) and two methods to clear expired environment(s) (`clear_all_expired` and `clear_if_expired(name)`). An environment can become expired if the environment timeout is exceeded or if it is marked as expired through the puppetserver [environment-cache REST endpoint](https://puppet.com/docs/puppetserver/5.3/admin-api/v1/environment-cache.html#delete-puppet-admin-apiv1environment-cache).

When an environment is cleared, we need to delete the environment from memory (which contains the AST for parsed puppet code), notify the cache expiration service, delete the environment-specific text domain and environment-specific settings. Prior to this PR, we didn't clear environment consistently. To remedy that, this PR:

* Creates a `clear_entry` method to handle all cache removals. It mirrors the `add_entry` method.
* All `clear*` methods call `clear_entry`.

Each cache entry defined an `expires` and `expired?` method which basically did the same thing. The former returns the time when the entry expires and the latter returns true if the entry is currently expired. This PR removes the `expires` logic.

The `clear_all_expired` method tried to short-circuit if the `next expiration` time was in the future, see 299f5d597b0d1c32bf3c49adf125ba5d547351c4. Specifically:

> To avoid a worst case where there are many cached environments expiring
> a long time in the future, the algorithm keeps a sorted set of times
> where an expiration will take place. It uses this, and advice from the
> external cache service to determine if environments should be evicted or
> not. As environments are frequntly requested, this ensures that the list
> of cached environments is not traversed and checked when there is a
> guarnatee that there are no expirations.

However, the `next_expiration` time was not updated when `get_conf` or `clear` removed an expired environment. And even if that time was updated correctly, we can't get around the fact that an environment may be expired via the REST endpoint at any time. So we still need to ask the cache expiration service if an environment that hasn't reached its timeout was expired through the REST endpoint.