### PR TITLE
(PUP-10779) Raise not implemented error if TemplateWrapper#tags is called

### DIFF
--- a/lib/puppet/parser/templatewrapper.rb
+++ b/lib/puppet/parser/templatewrapper.rb
@@ -50,7 +50,7 @@ class Puppet::Parser::TemplateWrapper
   # @return [Array<String>] The tags defined in the current scope
   # @api public
   def tags
-    scope.tags
+    raise NotImplementedError, "Call 'all_tags' instead."
   end
 
   # @return [Array<String>] All the defined tags

--- a/spec/unit/parser/templatewrapper_spec.rb
+++ b/spec/unit/parser/templatewrapper_spec.rb
@@ -57,9 +57,10 @@ describe Puppet::Parser::TemplateWrapper do
     expect(tw.all_tags).to eq(["tag1","tag2"])
   end
 
-  it "provides the tags defined in the current scope with #tags" do
-    expect(scope).to receive(:tags).and_return(["tag1", "tag2"])
-    expect(tw.tags).to eq(["tag1","tag2"])
+  it "raises not implemented error" do
+    expect {
+      tw.tags
+    }.to raise_error(NotImplementedError, /Call 'all_tags' instead/)
   end
 
   it "raises error on access to removed in-scope variables via method calls" do


### PR DESCRIPTION
The Scope#tags method was removed in 02576c98fa5, but the test didn't catch it
because we don't verify partial doubles. Since it's public API, keep the method
but raise an exception so it's clear what the issue is.