### PR TITLE
(Pup-10778)  Allow whitespace in regex for AIX user password parsing

### DIFF
--- a/lib/puppet/provider/user/aix.rb
+++ b/lib/puppet/provider/user/aix.rb
@@ -178,7 +178,7 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
       # does not have a password.
       break if line =~ /^\S+:$/
 
-      match_obj = /password = (\S+)/.match(line)
+      match_obj = /password\s+=\s+(\S+)/.match(line)
     end
     return :absent unless match_obj
 
@@ -211,7 +211,7 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
       tempfile = Tempfile.new("puppet_#{user}_pw", :encoding => Encoding::ASCII)
       tempfile << "#{user}:#{value}\n"
       tempfile.close()
-  
+
       # Options '-e', '-c', use encrypted password and clear flags
       # Must receive "user:enc_password" as input
       # command, arguments = {:failonfail => true, :combine => true}

--- a/spec/fixtures/unit/provider/user/aix/aix_passwd_file.out
+++ b/spec/fixtures/unit/provider/user/aix/aix_passwd_file.out
@@ -6,6 +6,10 @@ test_aix_user:
 no_password_user:
         lastupdate = another_last_update
 
+tab_password_user:
+        password  =  some_password
+        lastupdate = another_last_update
+
 daemon:
         password = *
 

--- a/spec/unit/provider/user/aix_spec.rb
+++ b/spec/unit/provider/user/aix_spec.rb
@@ -143,6 +143,11 @@ describe 'Puppet::Type::User::Provider::Aix' do
     it "returns the user's password" do
       expect(call_parse_password).to eql('some_password')
     end
+
+    it "returns the user's password with tabs" do
+      resource[:name] = 'tab_password_user'
+      expect(call_parse_password).to eql('some_password')
+    end
   end
 
   # TODO: If we move from using Mocha to rspec's mocks,


### PR DESCRIPTION
Prior to this commit, the aix user resource only allowed for a static
pattern when parsing the passwd file for passwords. This would cause the
resource to be continually applied if the password line had spacing that
did not align with the pattern. This commit changes the parsing to allow
for abitrary spacing in the password line.