### PR TITLE
(maint) Verify partial doubles in 6.x

### DIFF
--- a/lib/puppet/provider/package/apt.rb
+++ b/lib/puppet/provider/package/apt.rb
@@ -51,6 +51,10 @@ Puppet::Type.type(:package).provide :apt, :parent => :dpkg, :source => :dpkg do
     @property_flush = {}
   end
 
+  def mark
+    @property_flush[:mark]
+  end
+
   def mark=(value)
     @property_flush[:mark] = value
   end

--- a/lib/puppet/util/posix.rb
+++ b/lib/puppet/util/posix.rb
@@ -23,7 +23,7 @@ module Puppet::Util::POSIX
           groups << group.name if group.mem.include?(user)
         end
       end
-  
+
       uniq_groups = groups.uniq
       if uniq_groups != groups
         Puppet.debug(_('Removing any duplicate group entries'))

--- a/spec/integration/resource/type_collection_spec.rb
+++ b/spec/integration/resource/type_collection_spec.rb
@@ -11,12 +11,8 @@ describe Puppet::Resource::TypeCollection do
       @dir = tmpfile("autoload_testing")
       FileUtils.mkdir_p @dir
 
-      loader = Object.new
-      allow(loader).to receive(:load).and_return(nil)
-      allow(loader).to receive(:set_entry)
-
-      loaders = Object.new
-      expect(loaders).to receive(:runtime3_type_loader).at_most(:once).and_return(loader)
+      loader = double('loader', load: nil, set_entry: nil)
+      loaders = double('loaders', runtime3_type_loader: loader)
       expect(Puppet::Pops::Loaders).to receive(:loaders).at_most(:once).and_return(loaders)
 
       environment = Puppet::Node::Environment.create(:env, [@dir])

--- a/spec/integration/transaction_spec.rb
+++ b/spec/integration/transaction_spec.rb
@@ -61,7 +61,7 @@ describe Puppet::Transaction do
 
     transaction = Puppet::Transaction.new(catalog, nil, Puppet::Graph::SequentialPrioritizer.new)
 
-    expect(resource).not_to receive(:evaluate)
+    expect(resource).not_to receive(:retrieve)
 
     transaction.evaluate
   end
@@ -86,7 +86,7 @@ describe Puppet::Transaction do
 
     transaction = Puppet::Transaction.new(catalog, nil, Puppet::Graph::SequentialPrioritizer.new)
 
-    expect(resource).not_to receive(:evaluate)
+    expect(resource).not_to receive(:retrieve)
 
     transaction.evaluate
   end
@@ -315,14 +315,12 @@ describe Puppet::Transaction do
         file1 = tmpfile("file1")
         file2 = tmpfile("file2")
 
+        expect(Puppet::FileSystem).to_not be_exist(file2)
+
         exec1 = Puppet::Type.type(:exec).new(
           :name        => "exec1",
           :path        => ENV["PATH"],
           :command     => touch(file1),
-        )
-
-        allow(exec1).to receive(:eval_generate).and_return(
-          [ Puppet::Type.type(:notify).new(:name => "eval1_notify") ]
         )
 
         exec2 = Puppet::Type.type(:exec).new(
@@ -331,9 +329,6 @@ describe Puppet::Transaction do
           :command     => touch(file2),
           :refreshonly => true,
           :subscribe   => exec1,
-        )
-        allow(exec2).to receive(:eval_generate).and_return(
-          [ Puppet::Type.type(:notify).new(:name => "eval2_notify") ]
         )
 
         Puppet[:tags] = "exec"

--- a/spec/integration/util/windows/adsi_spec.rb
+++ b/spec/integration/util/windows/adsi_spec.rb
@@ -157,7 +157,9 @@ describe Puppet::Util::Windows::ADSI::Group,
 
       # touch the native_object member to have it lazily loaded, so COM objects can be stubbed
       admins.native_object
-      allow(admins.native_object).to receive(:Members).and_return(members)
+      without_partial_double_verification do
+        allow(admins.native_object).to receive(:Members).and_return(members)
+      end
 
       # well-known NULL SID
       expect(admins.members[0].sid).to eq('S-1-0-0')

--- a/spec/integration/util/windows/registry_spec.rb
+++ b/spec/integration/util/windows/registry_spec.rb
@@ -146,16 +146,6 @@ describe Puppet::Util::Windows::Registry do
         utf_8_bytes = ENDASH_UTF_8 + TM_UTF_8
         utf_8_str = utf_8_bytes.pack('c*').force_encoding(Encoding::UTF_8)
 
-        # this problematic Ruby codepath triggers a conversion of UTF-16LE to
-        # a local codepage which can totally break when that codepage has no
-        # conversion from the given UTF-16LE characters to local codepage
-        # a prime example is that IBM437 has no conversion from a Unicode en-dash
-        expect(Win32::Registry).not_to receive(:export_string)
-
-        # also, expect that we're using our variants of keys / values, not Rubys
-        expect(Win32::Registry).not_to receive(:each_key)
-        expect(Win32::Registry).not_to receive(:each_value)
-
         hklm.create("#{puppet_key}\\#{subkey_name}", Win32::Registry::KEY_ALL_ACCESS | regsam) do |reg|
           reg.write("#{guid}", Win32::Registry::REG_SZ, utf_16_str)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -84,10 +84,7 @@ RSpec.configure do |config|
   config.filter_run_when_matching :focus
 
   config.mock_with :rspec do |mocks|
-    # We really should have this on, but it breaks a _lot_ of tests. We'll
-    # need to go through and fix those tests first before it can be enabled
-    # for real.
-    mocks.verify_partial_doubles = false
+    mocks.verify_partial_doubles = true
   end
 
   tmpdir = Puppet::FileSystem.expand_path(Dir.mktmpdir("rspecrun"))

--- a/spec/unit/agent_spec.rb
+++ b/spec/unit/agent_spec.rb
@@ -3,9 +3,13 @@ require 'puppet/agent'
 require 'puppet/configurer'
 
 class AgentTestClient
-  def run
+  def initialize(transaction_uuid = nil, job_id = nil)
+  end
+
+  def run(client_args)
     # no-op
   end
+
   def stop
     # no-op
   end
@@ -51,11 +55,10 @@ describe Puppet::Agent do
 
   it "should create an instance of its client class and run it when asked to run" do
     client = double('client')
-    expect(AgentTestClient).to receive(:new).and_return(client)
-
-    expect(client).to receive(:run)
+    allow(AgentTestClient).to receive(:new).with(nil, nil).and_return(client)
 
     allow(@agent).to receive(:disabled?).and_return(false)
+    expect(client).to receive(:run)
     @agent.run
   end
 
@@ -92,7 +95,6 @@ describe Puppet::Agent do
 
   describe "when being run" do
     before do
-      allow(AgentTestClient).to receive(:lockfile_path).and_return("/my/lock")
       allow(@agent).to receive(:disabled?).and_return(false)
     end
 
@@ -188,7 +190,7 @@ describe Puppet::Agent do
         allow(lockfile).to receive(:lock).and_return(false)
       end
 
-      it "should notify that a run is already in progres" do
+      it "should notify that a run is already in progress" do
         client = AgentTestClient.new
         expect(AgentTestClient).to receive(:new).and_return(client)
         expect(Puppet).to receive(:notice).with(/Run of .* already in progress; skipping .* exists/)

--- a/spec/unit/application/agent_spec.rb
+++ b/spec/unit/application/agent_spec.rb
@@ -202,7 +202,6 @@ describe Puppet::Application::Agent do
       allow(Puppet::Resource::Catalog.indirection).to receive(:terminus_class=)
       allow(Puppet::Resource::Catalog.indirection).to receive(:cache_class=)
       allow(Puppet::Node::Facts.indirection).to receive(:terminus_class=)
-      allow(Puppet).to receive(:settraps)
     end
 
     it "should not run with extra arguments" do

--- a/spec/unit/application/filebucket_spec.rb
+++ b/spec/unit/application/filebucket_spec.rb
@@ -42,7 +42,6 @@ describe Puppet::Application::Filebucket do
   describe "during setup" do
     before :each do
       allow(Puppet::Log).to receive(:newdestination)
-      allow(Puppet).to receive(:settraps)
       allow(Puppet::FileBucket::Dipper).to receive(:new)
       allow(@filebucket.options).to receive(:[])
     end
@@ -157,7 +156,6 @@ describe Puppet::Application::Filebucket do
   describe "when running" do
     before :each do
       allow(Puppet::Log).to receive(:newdestination)
-      allow(Puppet).to receive(:settraps)
       allow(Puppet::FileBucket::Dipper).to receive(:new)
       allow(@filebucket.options).to receive(:[])
 

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -594,13 +594,6 @@ describe Puppet::Application do
     end
 
     it "should raise an error if dispatch returns no command" do
-      allow(@app).to receive(:get_command).and_return(nil)
-      expect(Puppet).to receive(:send_log).with(:err, "Could not run: No valid command or main")
-      expect { @app.run }.to exit_with 1
-    end
-
-    it "should raise an error if dispatch returns an invalid command" do
-      allow(@app).to receive(:get_command).and_return(:this_function_doesnt_exist)
       expect(Puppet).to receive(:send_log).with(:err, "Could not run: No valid command or main")
       expect { @app.run }.to exit_with 1
     end

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -7,8 +7,10 @@ require 'timeout'
 
 describe Puppet::Application do
   before(:each) do
-    @app = Class.new(Puppet::Application).new
-    @appclass = @app.class
+    @appclass = Class.new(Puppet::Application) do
+      def handle_unknown(opt, arg); end
+    end
+    @app = @appclass.new
 
     allow(@app).to receive(:name).and_return("test_app")
   end

--- a/spec/unit/confine/feature_spec.rb
+++ b/spec/unit/confine/feature_spec.rb
@@ -22,7 +22,7 @@ describe Puppet::Confine::Feature do
     end
 
     it "should use the Puppet features instance to test validity" do
-      expect(Puppet.features).to receive(:myfeature?)
+      Puppet.features.add(:myfeature) do true end
       @confine.valid?
     end
 

--- a/spec/unit/confine_spec.rb
+++ b/spec/unit/confine_spec.rb
@@ -2,6 +2,12 @@ require 'spec_helper'
 
 require 'puppet/confine'
 
+class Puppet::TestConfine < Puppet::Confine
+  def pass?(value)
+    false
+  end
+end
+
 describe Puppet::Confine do
   it "should require a value" do
     expect { Puppet::Confine.new }.to raise_error(ArgumentError)
@@ -33,7 +39,7 @@ describe Puppet::Confine do
 
   describe "when testing all values" do
     before do
-      @confine = Puppet::Confine.new(%w{a b c})
+      @confine = Puppet::TestConfine.new(%w{a b c})
       @confine.label = "foo"
     end
 
@@ -64,7 +70,7 @@ describe Puppet::Confine do
   end
 
   describe "when testing the result of the values" do
-    before { @confine = Puppet::Confine.new(%w{a b c d}) }
+    before { @confine = Puppet::TestConfine.new(%w{a b c d}) }
 
     it "should return an array with the result of the test for each value" do
       allow(@confine).to receive(:pass?).and_return(true)

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -199,9 +199,10 @@ describe "Defaults" do
         @original_facter = Object.const_get(:Facter)
 
         Object.send(:remove_const, :Facter)
-        Object.const_set(:Facter, Module.new)
+        facter = double('facter')
+        allow(facter).to receive(:value).with('facterversion').and_return('3.11.4')
+        Object.const_set(:Facter, facter)
 
-        allow(Facter).to receive(:value).with('facterversion').and_return('3.11.4')
         allow_any_instance_of(Puppet::Settings::BooleanSetting).to receive(:require).with('facter-ng').and_return(true)
         allow(Facter).to receive(:respond_to?).and_return(false)
       end

--- a/spec/unit/face/node_spec.rb
+++ b/spec/unit/face/node_spec.rb
@@ -15,13 +15,6 @@ describe Puppet::Face[:node, '0.0.1'] do
   end
 
   describe 'when running #clean' do
-    before :each do
-      allow(Puppet::Node::Facts.indirection).to receive(:terminus_class=)
-      allow(Puppet::Node::Facts.indirection).to receive(:cache_class=)
-      allow(Puppet::Node).to receive(:terminus_class=)
-      allow(Puppet::Node).to receive(:cache_class=)
-    end
-
     it 'should invoke #cleanup' do
       expect(subject).to receive(:cleanup).with('hostname')
       subject.clean('hostname')
@@ -30,10 +23,6 @@ describe Puppet::Face[:node, '0.0.1'] do
 
   describe "clean action" do
     before :each do
-      allow(Puppet::Node::Facts.indirection).to receive(:terminus_class=)
-      allow(Puppet::Node::Facts.indirection).to receive(:cache_class=)
-      allow(Puppet::Node).to receive(:terminus_class=)
-      allow(Puppet::Node).to receive(:cache_class=)
       allow(subject).to receive(:cleanup)
     end
 

--- a/spec/unit/file_serving/configuration/parser_spec.rb
+++ b/spec/unit/file_serving/configuration/parser_spec.rb
@@ -87,7 +87,6 @@ describe Puppet::FileServing::Configuration::Parser do
     before do
       @mount = double('testmount', :name => "one", :validate => true)
       expect(Puppet::FileServing::Mount::File).to receive(:new).with("one").and_return(@mount)
-      allow(@parser).to receive(:add_modules_mount)
     end
 
     it "should set the mount path to the path attribute from that section" do

--- a/spec/unit/file_serving/metadata_spec.rb
+++ b/spec/unit/file_serving/metadata_spec.rb
@@ -266,9 +266,9 @@ describe Puppet::FileServing::Metadata, :uses_checksums => true do
       path = tmpfile('bar')
       FileUtils.touch(path)
 
-      allow(Puppet::Util::Windows::Security).to receive(:get_owner).with(path, :use).and_raise(invalid_error)
-      allow(Puppet::Util::Windows::Security).to receive(:get_group).with(path, :use).and_raise(invalid_error)
-      allow(Puppet::Util::Windows::Security).to receive(:get_mode).with(path, :use).and_raise(invalid_error)
+      allow(Puppet::Util::Windows::Security).to receive(:get_owner).with(path).and_raise(invalid_error)
+      allow(Puppet::Util::Windows::Security).to receive(:get_group).with(path).and_raise(invalid_error)
+      allow(Puppet::Util::Windows::Security).to receive(:get_mode).with(path).and_raise(invalid_error)
 
       stat = Puppet::FileSystem.stat(path)
 

--- a/spec/unit/file_serving/terminus_helper_spec.rb
+++ b/spec/unit/file_serving/terminus_helper_spec.rb
@@ -2,13 +2,20 @@ require 'spec_helper'
 
 require 'puppet/file_serving/terminus_helper'
 
+class Puppet::FileServing::TestHelper
+  include Puppet::FileServing::TerminusHelper
+
+  attr_reader :model
+
+  def initialize(model)
+    @model = model
+  end
+end
+
 describe Puppet::FileServing::TerminusHelper do
   before do
-    @helper = Object.new
-    @helper.extend(Puppet::FileServing::TerminusHelper)
-
     @model = double('model')
-    allow(@helper).to receive(:model).and_return(@model)
+    @helper = Puppet::FileServing::TestHelper.new(@model)
 
     @request = double('request', :key => "url", :options => {})
 

--- a/spec/unit/forge/module_release_spec.rb
+++ b/spec/unit/forge/module_release_spec.rb
@@ -22,13 +22,8 @@ describe Puppet::Forge::ModuleRelease do
   let(:uri) { " "}
   let(:release) { Puppet::Forge::ModuleRelease.new(ssl_repository, JSON.parse(release_json)) }
 
-  let(:mock_file) {
-    mock_io = StringIO.new
-    allow(mock_io).to receive(:path).and_return('/dev/null')
-    mock_io
-  }
-
-  let(:mock_dir) { '/tmp' }
+  let(:mock_file) { double('file', path: '/dev/null') }
+  let(:mock_dir) { tmpdir('dir') }
 
   let(:destination) { tmpfile('forge_module_release') }
 

--- a/spec/unit/indirector/face_spec.rb
+++ b/spec/unit/indirector/face_spec.rb
@@ -33,7 +33,6 @@ describe Puppet::Indirector::Face do
   describe "as an instance" do
     it "should be able to determine its indirection" do
       # Loading actions here can get, um, complicated
-      allow(Puppet::Face).to receive(:load_actions)
       expect(Puppet::Indirector::Face.new(:catalog, '0.0.1').indirection).to equal(Puppet::Resource::Catalog.indirection)
     end
   end

--- a/spec/unit/indirector/facts/facter_spec.rb
+++ b/spec/unit/indirector/facts/facter_spec.rb
@@ -22,7 +22,6 @@ describe Puppet::Node::Facts::Facter do
   end
 
   before :each do
-    allow(Puppet::Node::Facts::Facter).to receive(:reload_facter)
     @facter = Puppet::Node::Facts::Facter.new
     allow(Facter).to receive(:to_hash).and_return({})
     @name = "me"

--- a/spec/unit/indirector/file_bucket_file/selector_spec.rb
+++ b/spec/unit/indirector/file_bucket_file/selector_spec.rb
@@ -5,22 +5,40 @@ require 'puppet/indirector/file_bucket_file/file'
 require 'puppet/indirector/file_bucket_file/rest'
 
 describe Puppet::FileBucketFile::Selector do
+  let(:model) { Puppet::FileBucket::File.new('') }
+  let(:indirection) { Puppet::FileBucket::File.indirection }
+  let(:terminus) { indirection.terminus(:selector) }
+
   %w[head find save search destroy].each do |method|
     describe "##{method}" do
       it "should proxy to rest terminus for https requests" do
-        request = double('request', :protocol => 'https')
+        key = "https://example.com/path/to/file"
 
-        expect_any_instance_of(Puppet::FileBucketFile::Rest).to receive(method).with(request)
+        expect(indirection.terminus(:rest)).to receive(method)
 
-        subject.send(method, request)
+        if method == 'save'
+          terminus.send(method, indirection.request(method, key, model))
+        else
+          terminus.send(method, indirection.request(method, key, nil))
+        end
       end
 
       it "should proxy to file terminus for other requests" do
-        request = double('request', :protocol => 'file')
+        key = "file:///path/to/file"
 
-        expect_any_instance_of(Puppet::FileBucketFile::File).to receive(method).with(request)
-
-        subject.send(method, request)
+        case method
+        when 'save'
+          expect(indirection.terminus(:file)).to receive(method)
+          terminus.send(method, indirection.request(method, key, model))
+        when 'find', 'head'
+          expect(indirection.terminus(:file)).to receive(method)
+          terminus.send(method, indirection.request(method, key, nil))
+        else
+          # file terminus doesn't implement search or destroy
+          expect {
+            terminus.send(method, indirection.request(method, key, nil))
+          }.to raise_error(NoMethodError)
+        end
       end
     end
   end

--- a/spec/unit/indirector/indirection_spec.rb
+++ b/spec/unit/indirector/indirection_spec.rb
@@ -178,29 +178,25 @@ describe Puppet::Indirector::Indirection do
 
     describe "creates a request" do
       it "should create it with its name as the request's indirection name" do
-        expect(Puppet::Indirector::Request).to receive(:new).with(@indirection.name, anything, anything)
-        @indirection.request(:funtest, "yayness")
+        expect(@indirection.request(:funtest, "yayness", nil).indirection_name).to eq(@indirection.name)
       end
 
       it "should require a method and key" do
-        expect(Puppet::Indirector::Request).to receive(:new).with(anything, :funtest, "yayness")
-        @indirection.request(:funtest, "yayness")
+        request = @indirection.request(:funtest, "yayness", nil)
+        expect(request.method).to eq(:funtest)
+        expect(request.key).to eq("yayness")
       end
 
       it "should support optional arguments" do
-        expect(Puppet::Indirector::Request).to receive(:new).with(anything, anything, anything, {:one => :two})
-        @indirection.request(:funtest, "yayness", :one => :two)
+        expect(@indirection.request(:funtest, "yayness", nil, :one => :two).options).to eq(:one => :two)
       end
 
       it "should not pass options if none are supplied" do
-        expect(Puppet::Indirector::Request).to receive(:new).with(anything, anything, anything)
-        @indirection.request(:funtest, "yayness")
+        expect(@indirection.request(:funtest, "yayness", nil).options).to eq({})
       end
 
       it "should return the request" do
-        request = double('request')
-        expect(Puppet::Indirector::Request).to receive(:new).and_return(request)
-        expect(@indirection.request(:funtest, "yayness")).to equal(request)
+        expect(@indirection.request(:funtest, "yayness", nil)).to be_a(Puppet::Indirector::Request)
       end
     end
 
@@ -833,7 +829,7 @@ describe Puppet::Indirector::Indirection do
     end
 
     it "should not create a terminus instance until one is actually needed" do
-      expect(Puppet::Indirector).not_to receive(:terminus)
+      expect(@indirection).not_to receive(:terminus)
       Puppet::Indirector::Indirection.new(double('model'), :lazytest)
     end
 

--- a/spec/unit/indirector/key/file_spec.rb
+++ b/spec/unit/indirector/key/file_spec.rb
@@ -19,7 +19,6 @@ describe Puppet::SSL::Key::File do
       allow(Puppet.settings).to receive(:use)
 
       @searcher = Puppet::SSL::Key::File.new
-      allow(@searcher).to receive(:ca?).and_return(false)
       expect(@searcher.public_key_path("whatever")).to eq(File.expand_path("/public/key/dir/whatever.pem"))
     end
   end

--- a/spec/unit/indirector_spec.rb
+++ b/spec/unit/indirector_spec.rb
@@ -112,8 +112,8 @@ describe Puppet::Indirector, "when registering an indirection" do
   end
 
   it "should pass any provided options to the indirection during initialization" do
-    expect(Puppet::Indirector::Indirection).to receive(:new).with(@thingie, :first, {:some => :options, :indirected_class => 'Thingie'})
-    @indirection = @thingie.indirects :first, :some => :options
+    expect(Puppet::Indirector::Indirection).to receive(:new).with(@thingie, :first, {:doc => 'some docs', :indirected_class => 'Thingie'})
+    @indirection = @thingie.indirects :first, :doc => 'some docs'
   end
 
   it "should extend the class to handle serialization" do

--- a/spec/unit/network/authconfig_spec.rb
+++ b/spec/unit/network/authconfig_spec.rb
@@ -6,9 +6,6 @@ describe Puppet::Network::DefaultAuthProvider do
   before :each do
     allow(Puppet::FileSystem).to receive(:stat).and_return(double('stat', :ctime => :now))
     allow(Time).to receive(:now).and_return(Time.now)
-
-    allow_any_instance_of(Puppet::Network::DefaultAuthProvider).to receive(:exists?).and_return(true)
-    # FIXME @authprovider = Puppet::Network::DefaultAuthProvider.new("dummy")
   end
 
   describe "when initializing" do

--- a/spec/unit/network/http/api/indirected_routes_spec.rb
+++ b/spec/unit/network/http/api/indirected_routes_spec.rb
@@ -17,17 +17,12 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
   before do
     Puppet::IndirectorTesting.indirection.terminus_class = :memory
     Puppet::IndirectorTesting.indirection.terminus.clear
-    allow(handler).to receive(:warn_if_near_expiration)
   end
 
   describe "when converting a URI into a request" do
     let(:environment) { Puppet::Node::Environment.create(:env, []) }
     let(:env_loaders) { Puppet::Environments::Static.new(environment) }
     let(:params) { { :environment => "env" } }
-
-    before do
-      allow(handler).to receive(:handler).and_return("foo")
-    end
 
     around do |example|
       Puppet.override(:environments => env_loaders) do
@@ -179,10 +174,6 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
   describe "when converting a request into a URI" do
     let(:environment) { Puppet::Node::Environment.create(:myenv, []) }
     let(:request) { Puppet::Indirector::Request.new(:foo, :find, "with spaces", nil, :foo => :bar, :environment => environment) }
-
-    before do
-      allow(handler).to receive(:handler).and_return("foo")
-    end
 
     it "should include the environment in the query string of the URI" do
       expect(handler.class.request_to_uri(request)).to eq("#{master_url_prefix}/foo/with%20spaces?environment=myenv&foo=bar")

--- a/spec/unit/network/http/handler_spec.rb
+++ b/spec/unit/network/http/handler_spec.rb
@@ -102,11 +102,6 @@ describe Puppet::Network::HTTP::Handler do
       { :status => 200 }
     end
 
-    before do
-      allow(handler).to receive(:check_authorization)
-      allow(handler).to receive(:warn_if_near_expiration)
-    end
-
     it "should setup a profiler when the puppet-profiling header exists" do
       request = a_request
       request[:headers][Puppet::Network::HTTP::HEADER_ENABLE_PROFILING.downcase] = "true"

--- a/spec/unit/property_spec.rb
+++ b/spec/unit/property_spec.rb
@@ -5,6 +5,7 @@ Puppet::Type.newtype(:property_test) do
   newparam(:name, isnamevar: true)
 end
 Puppet::Type.type(:property_test).provide(:property_test) do
+  attr_accessor :foo
 end
 
 describe Puppet::Property do

--- a/spec/unit/provider/nameservice_spec.rb
+++ b/spec/unit/provider/nameservice_spec.rb
@@ -3,11 +3,28 @@ require 'puppet/provider/nameservice'
 require 'puppet/etc'
 require 'puppet_spec/character_encoding'
 
+Puppet::Type.newtype(:nameservice_dummytype) do
+  newparam(:name)
+  ensurable
+  newproperty(:foo)
+  newproperty(:bar)
+end
+
+Puppet::Type.type(:nameservice_dummytype).provide(:nameservice_dummyprovider, parent: Puppet::Provider::NameService) do
+  def posixmethod(param)
+    param
+  end
+
+  def modifycmd(param, value)
+    []
+  end
+end
+
 describe Puppet::Provider::NameService do
 
   before :each do
-    described_class.initvars
-    described_class.resource_type = faketype
+    provider.class.initvars
+    provider.class.resource_type = faketype
   end
 
   # These are values getpwent might give you
@@ -41,16 +58,12 @@ describe Puppet::Provider::NameService do
   # The provider sometimes relies on @resource for valid properties so let's
   # create a fake type with properties that match our fake struct.
   let :faketype do
-    Puppet::Type.newtype(:nameservice_dummytype) do
-      newparam(:name)
-      ensurable
-      newproperty(:foo)
-      newproperty(:bar)
-    end
+    Puppet::Type.type(:nameservice_dummytype)
   end
 
   let :provider do
-    described_class.new(:name => 'bob', :foo => 'fooval', :bar => 'barval')
+    Puppet::Type.type(:nameservice_dummytype).provider(:nameservice_dummyprovider)
+      .new(:name => 'bob', :foo => 'fooval', :bar => 'barval')
   end
 
   let :resource do
@@ -91,61 +104,61 @@ describe Puppet::Provider::NameService do
 
   describe "#options" do
     it "should add options for a valid property" do
-      described_class.options :foo, :key1 => 'val1', :key2 => 'val2'
-      described_class.options :bar, :key3 => 'val3'
-      expect(described_class.option(:foo, :key1)).to eq('val1')
-      expect(described_class.option(:foo, :key2)).to eq('val2')
-      expect(described_class.option(:bar, :key3)).to eq('val3')
+      provider.class.options :foo, :key1 => 'val1', :key2 => 'val2'
+      provider.class.options :bar, :key3 => 'val3'
+      expect(provider.class.option(:foo, :key1)).to eq('val1')
+      expect(provider.class.option(:foo, :key2)).to eq('val2')
+      expect(provider.class.option(:bar, :key3)).to eq('val3')
     end
 
     it "should raise an error for an invalid property" do
-      expect { described_class.options :baz, :key1 => 'val1' }.to raise_error(
+      expect { provider.class.options :baz, :key1 => 'val1' }.to raise_error(
         Puppet::Error, 'baz is not a valid attribute for nameservice_dummytype')
     end
   end
 
   describe "#option" do
     it "should return the correct value" do
-      described_class.options :foo, :key1 => 'val1', :key2 => 'val2'
-      expect(described_class.option(:foo, :key2)).to eq('val2')
+      provider.class.options :foo, :key1 => 'val1', :key2 => 'val2'
+      expect(provider.class.option(:foo, :key2)).to eq('val2')
     end
 
     it "should symbolize the name first" do
-      described_class.options :foo, :key1 => 'val1', :key2 => 'val2'
-      expect(described_class.option('foo', :key2)).to eq('val2')
+      provider.class.options :foo, :key1 => 'val1', :key2 => 'val2'
+      expect(provider.class.option('foo', :key2)).to eq('val2')
     end
 
     it "should return nil if no option has been specified earlier" do
-      expect(described_class.option(:foo, :key2)).to be_nil
+      expect(provider.class.option(:foo, :key2)).to be_nil
     end
 
     it "should return nil if no option for that property has been specified earlier" do
-      described_class.options :bar, :key2 => 'val2'
-      expect(described_class.option(:foo, :key2)).to be_nil
+      provider.class.options :bar, :key2 => 'val2'
+      expect(provider.class.option(:foo, :key2)).to be_nil
     end
 
     it "should return nil if no matching key can be found for that property" do
-      described_class.options :foo, :key3 => 'val2'
-      expect(described_class.option(:foo, :key2)).to be_nil
+      provider.class.options :foo, :key3 => 'val2'
+      expect(provider.class.option(:foo, :key2)).to be_nil
     end
   end
 
   describe "#section" do
     it "should raise an error if resource_type has not been set" do
-      expect(described_class).to receive(:resource_type).and_return(nil)
-      expect { described_class.section }.to raise_error Puppet::Error, 'Cannot determine Etc section without a resource type'
+      expect(provider.class).to receive(:resource_type).and_return(nil)
+      expect { provider.class.section }.to raise_error Puppet::Error, 'Cannot determine Etc section without a resource type'
     end
 
     # the return values are hard coded so I am using types that actually make
     # use of the nameservice provider
     it "should return pw for users" do
-      described_class.resource_type = Puppet::Type.type(:user)
-      expect(described_class.section).to eq('pw')
+      provider.class.resource_type = Puppet::Type.type(:user)
+      expect(provider.class.section).to eq('pw')
     end
 
     it "should return gr for groups" do
-      described_class.resource_type = Puppet::Type.type(:group)
-      expect(described_class.section).to eq('gr')
+      provider.class.resource_type = Puppet::Type.type(:group)
+      expect(provider.class.section).to eq('gr')
     end
   end
 
@@ -213,7 +226,7 @@ describe Puppet::Provider::NameService do
       # encoding
       allow(Etc).to receive(:getpwent).and_return(*utf_8_mixed_users)
       result = PuppetSpec::CharacterEncoding.with_external_encoding(Encoding::UTF_8) do
-        described_class.instances
+        provider.class.instances
       end
       expect(result.map(&:name)).to eq(
         [
@@ -228,7 +241,7 @@ describe Puppet::Provider::NameService do
     it "should have object names in their original encoding/bytes if they would not be valid UTF-8" do
       allow(Etc).to receive(:getpwent).and_return(*latin_1_mixed_users)
       result = PuppetSpec::CharacterEncoding.with_external_encoding(Encoding::ISO_8859_1) do
-        described_class.instances
+        provider.class.instances
       end
       expect(result.map(&:name)).to eq(
         [
@@ -243,40 +256,40 @@ describe Puppet::Provider::NameService do
     it "should pass the Puppet::Etc :canonical_name Struct member to the constructor" do
       users = [ Struct::Passwd.new(invalid_utf_8_jose, invalid_utf_8_jose, 1002, 2000), nil ]
       allow(Etc).to receive(:getpwent).and_return(*users)
-      expect(described_class).to receive(:new).with(:name => escaped_utf_8_jose, :canonical_name => invalid_utf_8_jose, :ensure => :present)
-      described_class.instances
+      expect(provider.class).to receive(:new).with(:name => escaped_utf_8_jose, :canonical_name => invalid_utf_8_jose, :ensure => :present)
+      provider.class.instances
     end
   end
 
   describe "validate" do
     it "should pass if no check is registered at all" do
-      expect { described_class.validate(:foo, 300) }.to_not raise_error
-      expect { described_class.validate('foo', 300) }.to_not raise_error
+      expect { provider.class.validate(:foo, 300) }.to_not raise_error
+      expect { provider.class.validate('foo', 300) }.to_not raise_error
     end
 
     it "should pass if no check for that property is registered" do
-      described_class.verify(:bar, 'Must be 100') { |val| val == 100 }
-      expect { described_class.validate(:foo, 300) }.to_not raise_error
-      expect { described_class.validate('foo', 300) }.to_not raise_error
+      provider.class.verify(:bar, 'Must be 100') { |val| val == 100 }
+      expect { provider.class.validate(:foo, 300) }.to_not raise_error
+      expect { provider.class.validate('foo', 300) }.to_not raise_error
     end
 
     it "should pass if the value is valid" do
-      described_class.verify(:foo, 'Must be 100') { |val| val == 100 }
-      expect { described_class.validate(:foo, 100) }.to_not raise_error
-      expect { described_class.validate('foo', 100) }.to_not raise_error
+      provider.class.verify(:foo, 'Must be 100') { |val| val == 100 }
+      expect { provider.class.validate(:foo, 100) }.to_not raise_error
+      expect { provider.class.validate('foo', 100) }.to_not raise_error
     end
 
     it "should raise an error if the value is invalid" do
-      described_class.verify(:foo, 'Must be 100') { |val| val == 100 }
-      expect { described_class.validate(:foo, 200) }.to raise_error(ArgumentError, 'Invalid value 200: Must be 100')
-      expect { described_class.validate('foo', 200) }.to raise_error(ArgumentError, 'Invalid value 200: Must be 100')
+      provider.class.verify(:foo, 'Must be 100') { |val| val == 100 }
+      expect { provider.class.validate(:foo, 200) }.to raise_error(ArgumentError, 'Invalid value 200: Must be 100')
+      expect { provider.class.validate('foo', 200) }.to raise_error(ArgumentError, 'Invalid value 200: Must be 100')
     end
   end
 
   describe "getinfo" do
     before :each do
       # with section=foo we'll call Etc.getfoonam instead of getpwnam or getgrnam
-      allow(described_class).to receive(:section).and_return('foo')
+      allow(provider.class).to receive(:section).and_return('foo')
       resource # initialize the resource so our provider has a @resource instance variable
     end
 
@@ -296,13 +309,13 @@ describe Puppet::Provider::NameService do
     # overriding to UTF-8, in @canonical_name for querying that state on disk
     # again if needed
     it "should use the instance's @canonical_name to query the system" do
-      provider_instance = described_class.new(:name => 'foo', :canonical_name => 'original_foo', :ensure => :present)
+      provider_instance = provider.class.new(:name => 'foo', :canonical_name => 'original_foo', :ensure => :present)
       expect(Puppet::Etc).to receive(:send).with(:getfoonam, 'original_foo')
       provider_instance.getinfo(true)
     end
 
     it "should use the instance's name instead of canonical_name if not supplied during instantiation" do
-      provider_instance = described_class.new(:name => 'foo', :ensure => :present)
+      provider_instance = provider.class.new(:name => 'foo', :ensure => :present)
       expect(Puppet::Etc).to receive(:send).with(:getfoonam, 'foo')
       provider_instance.getinfo(true)
     end
@@ -310,16 +323,6 @@ describe Puppet::Provider::NameService do
 
   describe "info2hash" do
     it "should return a hash with all properties" do
-      # we have to have an implementation of posixmethod which has to
-      # convert a propertyname (e.g. comment) into a fieldname of our
-      # Struct (e.g. gecos). I do not want to test posixmethod here so
-      # let's fake an implementation which does not do any translation. We
-      # expect two method invocations because info2hash calls the method
-      # twice if the Struct responds to the propertyname (our fake Struct
-      # provides values for :foo and :bar) TODO: Fix that
-      expect(provider).to receive(:posixmethod).with(:foo).and_return(:foo).twice
-      expect(provider).to receive(:posixmethod).with(:bar).and_return(:bar).twice
-      expect(provider).to receive(:posixmethod).with(:ensure).and_return(:ensure)
       expect(provider.info2hash(fakeetcobject)).to eq({ :foo => 'fooval', :bar => 'barval' })
     end
   end
@@ -330,7 +333,7 @@ describe Puppet::Provider::NameService do
     end
 
     it "should return the munged value otherwise" do
-      described_class.options(:foo, :munge => proc { |x| x*2 })
+      provider.class.options(:foo, :munge => proc { |x| x*2 })
       expect(provider.munge(:foo, 100)).to eq(200)
     end
   end
@@ -341,7 +344,7 @@ describe Puppet::Provider::NameService do
     end
 
     it "should return the unmunged value otherwise" do
-      described_class.options(:foo, :unmunge => proc { |x| x/2 })
+      provider.class.options(:foo, :unmunge => proc { |x| x/2 })
       expect(provider.unmunge(:foo, 200)).to eq(100)
     end
   end
@@ -359,15 +362,13 @@ describe Puppet::Provider::NameService do
   end
 
   describe "get" do
-    before(:each) {described_class.resource_type = faketype }
-
     it "should return the correct getinfo value" do
       expect(provider).to receive(:getinfo).with(false).and_return(:foo => 'fooval', :bar => 'barval')
       expect(provider.get(:bar)).to eq('barval')
     end
 
     it "should unmunge the value first" do
-      described_class.options(:bar, :munge => proc { |x| x*2}, :unmunge => proc {|x| x/2})
+      provider.class.options(:bar, :munge => proc { |x| x*2}, :unmunge => proc {|x| x/2})
       expect(provider).to receive(:getinfo).with(false).and_return(:foo => 200, :bar => 500)
       expect(provider.get(:bar)).to eq(250)
     end
@@ -382,7 +383,7 @@ describe Puppet::Provider::NameService do
   describe "set" do
     before :each do
       resource # initialize resource so our provider has a @resource object
-      described_class.verify(:foo, 'Must be 100') { |val| val == 100 }
+      provider.class.verify(:foo, 'Must be 100') { |val| val == 100 }
     end
 
     it "should raise an error on invalid values" do
@@ -396,7 +397,7 @@ describe Puppet::Provider::NameService do
     end
 
     it "should munge the value first" do
-      described_class.options(:foo, :munge => proc { |x| x*2}, :unmunge => proc {|x| x/2})
+      provider.class.options(:foo, :munge => proc { |x| x*2}, :unmunge => proc {|x| x/2})
       expect(provider).to receive(:modifycmd).with(:foo, 200).and_return(['/bin/modify', '-f', '200' ])
       expect(provider).to receive(:execute).with(['/bin/modify', '-f', '200'], hash_including(custom_environment: {}))
       provider.set(:foo, 100)

--- a/spec/unit/provider/package/apt_spec.rb
+++ b/spec/unit/provider/package/apt_spec.rb
@@ -11,9 +11,7 @@ describe Puppet::Type.type(:package).provider(:apt) do
   end
 
   let(:provider) do
-    provider = subject()
-    provider.resource = resource
-    provider
+    resource.provider
   end
 
   it "should be the default provider on :osfamily => Debian" do
@@ -88,7 +86,7 @@ Version table:
 
   describe ".instances" do
     before do
-      allow(Puppet::Type::Package::ProviderDpkg).to receive(:instances).and_return([resource])
+      allow(Puppet::Type::Package::ProviderDpkg).to receive(:instances).and_return([provider])
     end
 
     context "when package is manual marked" do
@@ -97,8 +95,7 @@ Version table:
       end
 
       it 'sets mark to manual' do
-        expect(resource).to receive(:mark=).with(:manual)
-        described_class.instances
+        expect(described_class.instances.map(&:mark)).to eq([:manual])
       end
     end
 
@@ -108,8 +105,7 @@ Version table:
       end
 
       it 'does not set mark to manual' do
-        expect(resource).not_to receive(:mark=).with(:manual)
-        described_class.instances
+        expect(described_class.instances.map(&:mark)).to eq([nil])
       end
     end
   end

--- a/spec/unit/provider/package/base_spec.rb
+++ b/spec/unit/provider/package/base_spec.rb
@@ -1,17 +1,18 @@
 require 'spec_helper'
 require 'puppet/provider/package'
 
+Puppet::Type.type(:package).provide(:test_base_provider, parent: Puppet::Provider::Package) do
+  def query; end
+end
+
 describe Puppet::Provider::Package do
+  let(:provider) {  Puppet::Type.type(:package).provider(:test_base_provider).new }
+
   it 'returns absent for uninstalled packages when not purgeable' do
-    provider = Puppet::Provider::Package.new
-    expect(provider).to receive(:query).and_return(nil)
-    expect(provider.class).to receive(:feature?).with(:purgeable).and_return(false)
     expect(provider.properties[:ensure]).to eq(:absent)
   end
 
   it 'returns purged for uninstalled packages when purgeable' do
-    provider = Puppet::Provider::Package.new
-    expect(provider).to receive(:query).and_return(nil)
     expect(provider.class).to receive(:feature?).with(:purgeable).and_return(true)
     expect(provider.properties[:ensure]).to eq(:purged)
   end

--- a/spec/unit/provider/package/pacman_spec.rb
+++ b/spec/unit/provider/package/pacman_spec.rb
@@ -32,10 +32,12 @@ describe Puppet::Type.type(:package).provider(:pacman) do
     end
 
     it "should call yaourt to install the right package quietly when yaourt is installed" do
-      allow(described_class).to receive(:yaourt?).and_return(true)
-      args = ['--noconfirm', '--needed', '--noprogressbar', '-S', resource[:name]]
-      expect(provider).to receive(:yaourt).at_least(:once).with(*args).and_return('')
-      provider.install
+      without_partial_double_verification do
+        allow(described_class).to receive(:yaourt?).and_return(true)
+        args = ['--noconfirm', '--needed', '--noprogressbar', '-S', resource[:name]]
+        expect(provider).to receive(:yaourt).at_least(:once).with(*args).and_return('')
+        provider.install
+      end
     end
 
     it "should raise an Puppet::Error if the installation failed" do
@@ -74,10 +76,12 @@ describe Puppet::Type.type(:package).provider(:pacman) do
       end
 
       it "should call yaourt to install the right package quietly when yaourt is installed" do
-        expect(described_class).to receive(:yaourt?).and_return(true)
-        args = ['--noconfirm', '--needed', '--noprogressbar', '-x', '--arg=value', '-S', resource[:name]]
-        expect(provider).to receive(:yaourt).at_least(:once).with(*args).and_return('')
-        provider.install
+        without_partial_double_verification do
+          expect(described_class).to receive(:yaourt?).and_return(true)
+          args = ['--noconfirm', '--needed', '--noprogressbar', '-x', '--arg=value', '-S', resource[:name]]
+          expect(provider).to receive(:yaourt).at_least(:once).with(*args).and_return('')
+          provider.install
+        end
       end
     end
 
@@ -172,10 +176,12 @@ describe Puppet::Type.type(:package).provider(:pacman) do
     end
 
     it "should call yaourt to remove the right package quietly" do
-      allow(described_class).to receive(:yaourt?).and_return(true)
-      args = ["--noconfirm", "--noprogressbar", "-R", resource[:name]]
-      expect(provider).to receive(:yaourt).with(*args)
-      provider.uninstall
+      without_partial_double_verification do
+        allow(described_class).to receive(:yaourt?).and_return(true)
+        args = ["--noconfirm", "--noprogressbar", "-R", resource[:name]]
+        expect(provider).to receive(:yaourt).with(*args)
+        provider.uninstall
+      end
     end
 
     it "adds any uninstall_options" do

--- a/spec/unit/provider/package/pkgdmg_spec.rb
+++ b/spec/unit/provider/package/pkgdmg_spec.rb
@@ -8,10 +8,6 @@ describe Puppet::Type.type(:package).provider(:pkgdmg) do
   it { is_expected.not_to be_uninstallable }
 
   describe "when installing it should fail when" do
-    before :each do
-      expect(Puppet::Util).not_to receive(:execute)
-    end
-
     it "no source is specified" do
       expect { provider.install }.to raise_error(Puppet::Error, /must specify a package source/)
     end

--- a/spec/unit/provider/user/hpux_spec.rb
+++ b/spec/unit/provider/user/hpux_spec.rb
@@ -33,7 +33,7 @@ describe Puppet::Type.type(:user).provider(:hpuxuseradd),
     before :each do
       allow(Etc).to receive(:getpwent).and_return(pwent)
       allow(Etc).to receive(:getpwnam).and_return(pwent)
-      allow(resource).to receive(:command).with(:modify).and_return('/usr/sam/lbin/usermod.sam')
+      allow(provider).to receive(:command).with(:modify).and_return('/usr/sam/lbin/usermod.sam')
     end
 
     it "should have feature manages_passwords" do

--- a/spec/unit/provider_spec.rb
+++ b/spec/unit/provider_spec.rb
@@ -648,39 +648,37 @@ describe Puppet::Provider do
     it "delegates instance execute to Puppet::Util::Execution" do
       expect(Puppet::Util::Execution).to receive(:execute).with("a_command", { :option => "value" })
 
-      provider.new.send(:execute, "a_command", { :option => "value" })
+      provider.new.execute("a_command", { :option => "value" })
     end
 
     it "delegates class execute to Puppet::Util::Execution" do
       expect(Puppet::Util::Execution).to receive(:execute).with("a_command", { :option => "value" })
 
-      provider.send(:execute, "a_command", { :option => "value" })
+      provider.execute("a_command", { :option => "value" })
     end
 
     it "delegates instance execpipe to Puppet::Util::Execution" do
-      block = Proc.new { }
-      expect(Puppet::Util::Execution).to receive(:execpipe).with("a_command", true, block)
+      allow(Puppet::Util::Execution).to receive(:execpipe).with("a_command", true).and_yield('some output')
 
-      provider.new.send(:execpipe, "a_command", true, block)
+      expect { |b| provider.new.execpipe("a_command", true, &b) }.to yield_with_args('some output')
     end
 
     it "delegates class execpipe to Puppet::Util::Execution" do
-      block = Proc.new { }
-      expect(Puppet::Util::Execution).to receive(:execpipe).with("a_command", true, block)
+      allow(Puppet::Util::Execution).to receive(:execpipe).with("a_command", true).and_yield('some output')
 
-      provider.send(:execpipe, "a_command", true, block)
+      expect { |b| provider.execpipe("a_command", true, &b) }.to yield_with_args('some output')
     end
 
     it "delegates instance execfail to Puppet::Util::Execution" do
       expect(Puppet::Util::Execution).to receive(:execfail).with("a_command", "an exception to raise")
 
-      provider.new.send(:execfail, "a_command", "an exception to raise")
+      provider.new.execfail("a_command", "an exception to raise")
     end
 
     it "delegates class execfail to Puppet::Util::Execution" do
       expect(Puppet::Util::Execution).to receive(:execfail).with("a_command", "an exception to raise")
 
-      provider.send(:execfail, "a_command", "an exception to raise")
+      provider.execfail("a_command", "an exception to raise")
     end
   end
 

--- a/spec/unit/resource/capability_finder_spec.rb
+++ b/spec/unit/resource/capability_finder_spec.rb
@@ -16,7 +16,12 @@ describe Puppet::Resource::CapabilityFinder do
       Puppet.push_context({:loaders => loaders, :current_environment => env})
       if mock_pdb
         module Puppet::Util::Puppetdb
-          class Http; end
+          def query_puppetdb(query); end
+          module_function :query_puppetdb
+
+          class Http
+            def self.action(url); end
+          end
         end
       end
       make_cap_type

--- a/spec/unit/resource/type_spec.rb
+++ b/spec/unit/resource/type_spec.rb
@@ -554,7 +554,7 @@ describe Puppet::Resource::Type do
 
     it "should not create a subscope for the :main class" do
       allow(@resource).to receive(:title).and_return(:main)
-      expect(@type).not_to receive(:subscope)
+      expect(@scope).not_to receive(:newscope)
       expect(@type).to receive(:set_resource_parameters).with(@resource, @scope)
 
       @type.evaluate_code(@resource)

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -321,7 +321,7 @@ describe Puppet::Resource do
 
     describe "when the resource type is :hostclass" do
       let(:environment_name) { "testing env" }
-      let(:fact_values) { { :a => 1 } }
+      let(:fact_values) { { 'a' => 1 } }
       let(:port) { Puppet::Parser::AST::Leaf.new(:value => '80') }
 
       def inject_and_set_defaults(resource, scope)
@@ -330,10 +330,7 @@ describe Puppet::Resource do
 
       before do
         environment.known_resource_types.add(apache)
-
-        allow(scope).to receive(:host).and_return('host')
-        allow(scope).to receive(:environment).and_return(environment)
-        allow(scope).to receive(:facts).and_return(Puppet::Node::Facts.new("facts", fact_values))
+        scope.set_facts(fact_values)
       end
 
       context 'with a default value expression' do
@@ -627,11 +624,15 @@ describe Puppet::Resource do
       expect(resource.to_hash[:myvar]).to eq("bob")
     end
 
-    it "should set :name to the title if :name is not present for non-builtin types" do
-      krt = Puppet::Resource::TypeCollection.new("myenv")
-      krt.add Puppet::Resource::Type.new(:definition, :foo)
-      resource = Puppet::Resource.new :foo, "bar"
-      allow(resource).to receive(:known_resource_types).and_return(krt)
+    it "should set :name to the title if :name is not present for non-existent types" do
+      resource = Puppet::Resource.new :doesnotexist, "bar"
+      expect(resource.to_hash[:name]).to eq("bar")
+    end
+
+    it "should set :name to the title if :name is not present for a definition" do
+      type = Puppet::Resource::Type.new(:definition, :foo)
+      environment.known_resource_types.add(type)
+      resource = Puppet::Resource.new :foo, "bar", :environment => environment
       expect(resource.to_hash[:name]).to eq("bar")
     end
   end

--- a/spec/unit/ssl/base_spec.rb
+++ b/spec/unit/ssl/base_spec.rb
@@ -47,7 +47,6 @@ describe Puppet::SSL::Certificate do
   describe "when initializing wrapped class from a file with #read" do
     it "should open the file with ASCII encoding" do
       path = '/foo/bar/cert'
-      allow(Puppet::SSL::Base).to receive(:valid_certname).and_return(true)
       expect(Puppet::FileSystem).to receive(:read).with(path, :encoding => Encoding::ASCII).and_return("bar")
       @base.read(path)
     end

--- a/spec/unit/ssl/host_spec.rb
+++ b/spec/unit/ssl/host_spec.rb
@@ -263,8 +263,6 @@ describe Puppet::SSL::Host, if: !Puppet::Util::Platform.jruby? do
     end
 
     it "should send a new request to the CA for signing" do
-      @http = double("http")
-      allow(@host).to receive(:http_client).and_return(@http)
       allow(@host).to receive(:ssl_store).and_return(double("ssl store"))
       allow(@host).to receive(:key).and_return(key)
       request = double("request")
@@ -307,7 +305,6 @@ describe Puppet::SSL::Host, if: !Puppet::Util::Platform.jruby? do
       Puppet[:certdir] = tmpdir('certs')
       allow(@host).to receive(:key).and_return(double("key"))
       allow(@host).to receive(:validate_certificate_with_key)
-      allow(@host).to receive(:http_client).and_return(@http)
       allow(@host).to receive(:ssl_store).and_return(double("ssl store"))
     end
 
@@ -464,8 +461,6 @@ describe Puppet::SSL::Host, if: !Puppet::Util::Platform.jruby? do
         @revoked_cert = @pki[:revoked_root_node_cert]
         localcacert = Puppet.settings[:localcacert]
         Puppet::Util.replace_file(localcacert, 0644) {|f| f.write @pki[:ca_bundle] }
-        @http = double('http')
-        allow(@host).to receive(:http_client).and_return(@http)
       end
 
       after do

--- a/spec/unit/transaction/additional_resource_generator_spec.rb
+++ b/spec/unit/transaction/additional_resource_generator_spec.rb
@@ -33,10 +33,6 @@ describe Puppet::Transaction::AdditionalResourceGenerator do
 
       newparam(:code)
 
-      def respond_to?(method_name)
-        method_name == self[:kind] || super
-      end
-
       def eval_generate
         eval_code
       end
@@ -314,13 +310,13 @@ describe Puppet::Transaction::AdditionalResourceGenerator do
 
     it "sets resources_failed_to_generate to true if resource#eval_generate raises an exception" do
       catalog = compile_to_ral(<<-MANIFEST)
-        notify { 'hello': }
+        generator { thing: }
       MANIFEST
 
-      allow(catalog.resource("Notify[hello]")).to receive(:eval_generate).and_raise(RuntimeError)
+      allow(catalog.resource("Generator[thing]")).to receive(:eval_generate).and_raise(RuntimeError)
       relationship_graph = relationship_graph_for(catalog)
       generator = Puppet::Transaction::AdditionalResourceGenerator.new(catalog, relationship_graph, prioritizer)
-      generator.eval_generate(catalog.resource("Notify[hello]"))
+      generator.eval_generate(catalog.resource("Generator[thing]"))
 
       expect(generator.resources_failed_to_generate).to be_truthy
     end

--- a/spec/unit/transaction_spec.rb
+++ b/spec/unit/transaction_spec.rb
@@ -792,6 +792,9 @@ describe Puppet::Transaction do
           def self.is_selinux_enabled
             true
           end
+
+          def self.matchpathcon_fini
+          end
         end
       end
 

--- a/spec/unit/transaction_spec.rb
+++ b/spec/unit/transaction_spec.rb
@@ -5,6 +5,13 @@ require 'puppet_spec/compiler'
 require 'puppet/transaction'
 require 'fileutils'
 
+Puppet::Type.newtype(:generator) do
+  newparam(:name) { isnamevar }
+
+  def generate
+  end
+end
+
 describe Puppet::Transaction do
   include PuppetSpec::Files
   include PuppetSpec::Compiler
@@ -323,9 +330,9 @@ describe Puppet::Transaction do
   describe "when generating resources before traversal" do
     let(:catalog) { Puppet::Resource::Catalog.new }
     let(:transaction) { Puppet::Transaction.new(catalog, nil, Puppet::Graph::SequentialPrioritizer.new) }
-    let(:generator) { Puppet::Type.type(:notify).new :title => "generator" }
+    let(:generator) { Puppet::Type.type(:generator).new :title => "generator" }
     let(:generated) do
-      %w[a b c].map { |name| Puppet::Type.type(:notify).new(:name => name) }
+      %w[a b c].map { |name| Puppet::Type.type(:generator).new(:name => name) }
     end
 
     before :each do
@@ -666,7 +673,7 @@ describe Puppet::Transaction do
         end
 
         describe "and new resources are generated" do
-          let(:generator) { Puppet::Type.type(:notify).new :title => "generator" }
+          let(:generator) { Puppet::Type.type(:generator).new :title => "generator" }
           let(:generated) do
             %w[a b c].map { |name| Puppet::Type.type(:package).new :title => "foo", :name => name, :provider => :apt }
           end

--- a/spec/unit/transaction_spec.rb
+++ b/spec/unit/transaction_spec.rb
@@ -828,7 +828,6 @@ describe Puppet::Transaction do
       before do
         @resource = Puppet::Type.type(:notify).new :title => "foobar"
         @catalog.add_resource @resource
-        allow(@transaction).to receive(:add_dynamically_generated_resources)
       end
 
       it 'should stop processing if :stop_processing? is true' do

--- a/spec/unit/type/file/content_spec.rb
+++ b/spec/unit/type/file/content_spec.rb
@@ -11,7 +11,6 @@ describe Puppet::Type.type(:file).attrclass(:content), :uses_checksums => true d
 
   before do
     File.open(filename, 'w') {|f| f.write "initial file content"}
-    allow(described_class).to receive(:standalone?).and_return(false)
   end
 
   around do |example|

--- a/spec/unit/type/file/selinux_spec.rb
+++ b/spec/unit/type/file/selinux_spec.rb
@@ -9,8 +9,6 @@ require 'spec_helper'
       @path = make_absolute("/my/file")
       @resource = Puppet::Type.type(:file).new :path => @path
       @sel = property.new :resource => @resource
-      allow(@sel).to receive(:normalize_selinux_category).with("s0").and_return("s0")
-      allow(@sel).to receive(:normalize_selinux_category).with(nil).and_return(nil)
     end
 
     it "retrieve on #{param} should return :absent if the file isn't statable" do

--- a/spec/unit/type/file_spec.rb
+++ b/spec/unit/type/file_spec.rb
@@ -344,12 +344,6 @@ describe Puppet::Type.type(:file) do
   end
 
   describe "#flush" do
-    it "should flush all properties that respond to :flush" do
-      file[:source] = File.expand_path(__FILE__)
-      expect(file.parameter(:source)).to receive(:flush)
-      file.flush
-    end
-
     it "should reset its stat reference" do
       FileUtils.touch(path)
       stat1 = file.stat

--- a/spec/unit/type/resources_spec.rb
+++ b/spec/unit/type/resources_spec.rb
@@ -6,6 +6,9 @@ Puppet::Type.newtype(:purgeable_test) do
   newparam(:name) {}
 end
 Puppet::Type.type(:purgeable_test).provide(:purgeable_test) do
+  def self.instances
+    []
+  end
 end
 
 resources = Puppet::Type.type(:resources)
@@ -46,19 +49,16 @@ describe resources do
     end
 
     it "cannot be set to true for a resource type that does not accept ensure" do
-      allow(instance.resource_type).to receive(:respond_to?).and_return(true)
-      allow(instance.resource_type).to receive(:validproperty?).and_return(false)
-      expect { instance[:purge] = 'yes' }.to raise_error Puppet::Error
+      allow(instance.resource_type).to receive(:validproperty?).with(:ensure).and_return(false)
+      expect { instance[:purge] = 'yes' }.to raise_error Puppet::Error, /Purging is only supported on types that accept 'ensure'/
     end
 
     it "cannot be set to true for a resource type that does not have instances" do
-      allow(instance.resource_type).to receive(:respond_to?).and_return(false)
-      allow(instance.resource_type).to receive(:validproperty?).and_return(true)
-      expect { instance[:purge] = 'yes' }.to raise_error Puppet::Error
+      allow(instance.resource_type).to receive(:respond_to?).with(:instances).and_return(false)
+      expect { instance[:purge] = 'yes' }.to raise_error Puppet::Error, /Purging resources of type file is not supported/
     end
 
     it "can be set to true for a resource type that has instances and can accept ensure" do
-      allow(instance.resource_type).to receive(:respond_to?).and_return(true)
       allow(instance.resource_type).to receive(:validproperty?).and_return(true)
       expect { instance[:purge] = 'yes' }.to_not raise_error
     end

--- a/spec/unit/type/service_spec.rb
+++ b/spec/unit/type/service_spec.rb
@@ -488,7 +488,7 @@ describe test_title, "when changing the host" do
   it "insyncness should be resolved by provider instead of superclass implementation when provider responds to the 'enabled_insync?' method" do
     allow(@service.provider.class).to receive(:supports_parameter?).and_return(true)
     @service[:enable] = true
-    allow(@service.provider).to receive(:respond_to?).with(:enabled_insync?).and_return(true)
+    allow(@service.provider).to receive(:respond_to?).with(:enabled_insync?, any_args).and_return(true)
     allow(@service.provider).to receive(:enabled_insync?).and_return(false)
 
     expect(@service.property(:enable).insync?(:true)).to eq(false)

--- a/spec/unit/type/tidy_spec.rb
+++ b/spec/unit/type/tidy_spec.rb
@@ -191,7 +191,6 @@ describe tidy do
     describe "and recursion is used" do
       before do
         @tidy[:recurse] = true
-        allow_any_instance_of(Puppet::FileServing::Fileset).to receive(:stat).and_return(double("stat"))
         @fileset = Puppet::FileServing::Fileset.new(@basepath)
         allow(Puppet::FileServing::Fileset).to receive(:new).and_return(@fileset)
       end

--- a/spec/unit/type_spec.rb
+++ b/spec/unit/type_spec.rb
@@ -912,8 +912,8 @@ describe Puppet::Type, :unless => Puppet::Util::Platform.windows? do
 
     it "should always retrieve the ensure value by default" do
       @ensurable_resource = Puppet::Type.type(:file).new(:name => "/not/existent", :mode => "0644")
-      allow(Puppet::Type::File::Ensure).to receive(:ensure).and_return(:absent)
-      expect_any_instance_of(Puppet::Type::File::Ensure).to receive(:retrieve).once
+      # the ensure property is lazily metaprogrammed...
+      allow_any_instance_of(Puppet::Type::File::Ensure).to receive(:retrieve).and_return(:absent)
       @ensurable_resource.retrieve_resource
     end
 

--- a/spec/unit/util/at_fork_spec.rb
+++ b/spec/unit/util/at_fork_spec.rb
@@ -50,8 +50,8 @@ describe 'Puppet::Util::AtFork' do
               const_set(:TYPE_VOID,  nil)
               const_set(:TYPE_INT,   nil)
               const_set(:DLError,    Class.new(StandardError))
-              const_set(:Handle,     Class.new)
-              const_set(:Function,   Class.new)
+              const_set(:Handle,     Class.new { def initialize(library = nil, flags = 0); end })
+              const_set(:Function,   Class.new { def initialize(ptr, args, ret_type, abi = 0); end })
             end)
           end
         end

--- a/spec/unit/util/autoload_spec.rb
+++ b/spec/unit/util/autoload_spec.rb
@@ -157,7 +157,7 @@ describe Puppet::Util::Autoload do
     end
 
     it "should load the first file in the searchpath" do
-      allow(@autoload).to receive(:search_directories).and_return([make_absolute("/a"), make_absolute("/b")])
+      allow(@autoload.class).to receive(:search_directories).and_return([make_absolute("/a"), make_absolute("/b")])
       allow(FileTest).to receive(:directory?).and_return(true)
       allow(Puppet::FileSystem).to receive(:exist?).and_return(true)
       expect(Kernel).to receive(:load).with(make_absolute("/a/tmp/myfile.rb"), any_args)

--- a/spec/unit/util/backups_spec.rb
+++ b/spec/unit/util/backups_spec.rb
@@ -119,8 +119,7 @@ describe Puppet::Util::Backups do
       file = Puppet::Type.type(:file).new(:name => path, :backup => 'foo', :recurse => true)
 
       expect(bucket).not_to receive(:backup)
-      stub_file = double('file', :stat => double('stat', :ftype => 'directory'))
-      allow(Puppet::FileSystem).to receive(:new).with(path).and_return(stub_file)
+      allow(Puppet::FileSystem).to receive(:stat).with(path).and_return(double('stat', :ftype => 'directory'))
       expect(Find).not_to receive(:find)
 
       file.perform_backup

--- a/spec/unit/util/execution_spec.rb
+++ b/spec/unit/util/execution_spec.rb
@@ -639,6 +639,8 @@ describe Puppet::Util::Execution, if: !Puppet::Util::Platform.jruby? do
 
     describe "#execute (debug logging)" do
       before :each do
+        Puppet[:log_level] = 'debug'
+
         stub_process_wait(0)
 
         if Puppet::Util::Platform.windows?
@@ -649,47 +651,47 @@ describe Puppet::Util::Execution, if: !Puppet::Util::Platform.jruby? do
       end
 
       it "should log if no uid or gid specified" do
-        expect(Puppet::Util::Execution).to receive(:debug).with("Executing: 'echo hello'")
+        expect(Puppet).to receive(:send_log).with(:debug, "Executing: 'echo hello'")
         Puppet::Util::Execution.execute('echo hello')
       end
 
       it "should log numeric uid if specified" do
-        expect(Puppet::Util::Execution).to receive(:debug).with("Executing with uid=100: 'echo hello'")
+        expect(Puppet).to receive(:send_log).with(:debug, "Executing with uid=100: 'echo hello'")
         Puppet::Util::Execution.execute('echo hello', {:uid => 100})
       end
 
       it "should log numeric gid if specified" do
-        expect(Puppet::Util::Execution).to receive(:debug).with("Executing with gid=500: 'echo hello'")
+        expect(Puppet).to receive(:send_log).with(:debug, "Executing with gid=500: 'echo hello'")
         Puppet::Util::Execution.execute('echo hello', {:gid => 500})
       end
 
       it "should log numeric uid and gid if specified" do
-        expect(Puppet::Util::Execution).to receive(:debug).with("Executing with uid=100 gid=500: 'echo hello'")
+        expect(Puppet).to receive(:send_log).with(:debug, "Executing with uid=100 gid=500: 'echo hello'")
         Puppet::Util::Execution.execute('echo hello', {:uid => 100, :gid => 500})
       end
 
       it "should log string uid if specified" do
-        expect(Puppet::Util::Execution).to receive(:debug).with("Executing with uid=myuser: 'echo hello'")
+        expect(Puppet).to receive(:send_log).with(:debug, "Executing with uid=myuser: 'echo hello'")
         Puppet::Util::Execution.execute('echo hello', {:uid => 'myuser'})
       end
 
       it "should log string gid if specified" do
-        expect(Puppet::Util::Execution).to receive(:debug).with("Executing with gid=mygroup: 'echo hello'")
+        expect(Puppet).to receive(:send_log).with(:debug, "Executing with gid=mygroup: 'echo hello'")
         Puppet::Util::Execution.execute('echo hello', {:gid => 'mygroup'})
       end
 
       it "should log string uid and gid if specified" do
-        expect(Puppet::Util::Execution).to receive(:debug).with("Executing with uid=myuser gid=mygroup: 'echo hello'")
+        expect(Puppet).to receive(:send_log).with(:debug, "Executing with uid=myuser gid=mygroup: 'echo hello'")
         Puppet::Util::Execution.execute('echo hello', {:uid => 'myuser', :gid => 'mygroup'})
       end
 
       it "should log numeric uid and string gid if specified" do
-        expect(Puppet::Util::Execution).to receive(:debug).with("Executing with uid=100 gid=mygroup: 'echo hello'")
+        expect(Puppet).to receive(:send_log).with(:debug, "Executing with uid=100 gid=mygroup: 'echo hello'")
         Puppet::Util::Execution.execute('echo hello', {:uid => 100, :gid => 'mygroup'})
       end
 
       it 'should redact commands in debug output when passed sensitive option' do
-        expect(Puppet::Util::Execution).to receive(:debug).with("Executing: '[redacted]'")
+        expect(Puppet).to receive(:send_log).with(:debug, "Executing: '[redacted]'")
         Puppet::Util::Execution.execute('echo hello', {:sensitive => true})
       end
     end
@@ -903,14 +905,16 @@ describe Puppet::Util::Execution, if: !Puppet::Util::Platform.jruby? do
     end
 
     it "should print meaningful debug message for string argument" do
-      expect(Puppet::Util::Execution).to receive(:debug).with("Executing 'echo hello'")
+      Puppet[:log_level] = 'debug'
+      expect(Puppet).to receive(:send_log).with(:debug, "Executing 'echo hello'")
       expect(Puppet::Util::Execution).to receive(:open).with('| echo hello 2>&1').and_return('hello')
       expect(Puppet::Util::Execution).to receive(:exitstatus).and_return(0)
       Puppet::Util::Execution.execpipe('echo hello')
     end
 
     it "should print meaningful debug message for array argument" do
-      expect(Puppet::Util::Execution).to receive(:debug).with("Executing 'echo hello'")
+      Puppet[:log_level] = 'debug'
+      expect(Puppet).to receive(:send_log).with(:debug, "Executing 'echo hello'")
       expect(Puppet::Util::Execution).to receive(:open).with('| echo hello 2>&1').and_return('hello')
       expect(Puppet::Util::Execution).to receive(:exitstatus).and_return(0)
       Puppet::Util::Execution.execpipe(['echo','hello'])

--- a/spec/unit/util/inifile_spec.rb
+++ b/spec/unit/util/inifile_spec.rb
@@ -443,13 +443,9 @@ describe Puppet::Util::IniConfig::FileCollection do
     end
 
     it "yields every section from every file" do
-      [sect_a1, sect_a2, sect_b1, sect_b2].each do |sect|
-        expect(sect).to receive(:touch).once
-      end
-
-      subject.each_section do |sect|
-        sect.touch
-      end
+      expect { |b|
+        subject.each_section(&b)
+      }.to yield_successive_args(sect_a1, sect_a2, sect_b1, sect_b2)
     end
   end
 
@@ -460,13 +456,9 @@ describe Puppet::Util::IniConfig::FileCollection do
     end
 
     it "yields the path to every file in the collection" do
-      seen = []
-      subject.each_file do |file|
-        seen << file
-      end
-
-      expect(seen).to include(path_a)
-      expect(seen).to include(path_b)
+      expect { |b|
+        subject.each_file(&b)
+      }.to yield_successive_args(path_a, path_b)
     end
   end
 

--- a/spec/unit/util/log_spec.rb
+++ b/spec/unit/util/log_spec.rb
@@ -228,9 +228,6 @@ describe Puppet::Util::Log do
   describe Puppet::Util::Log::DestEventlog, :if => Puppet.features.eventlog? do
     before :each do
       allow(Puppet::Util::Windows::EventLog).to receive(:open).and_return(double('mylog', :close => nil))
-      allow(Puppet::Util::Windows::EventLog).to receive(:report_event)
-      allow(Puppet::Util::Windows::EventLog).to receive(:close)
-      allow(Puppet.features).to receive(:eventlog?).and_return(true)
     end
 
     it "should restrict its suitability to Windows" do

--- a/spec/unit/util/log_spec.rb
+++ b/spec/unit/util/log_spec.rb
@@ -111,16 +111,20 @@ describe Puppet::Util::Log do
     end
 
     it "should fall back to :eventlog" do
-      allow(Puppet.features).to receive(:syslog?).and_return(false)
-      allow(Puppet.features).to receive(:eventlog?).and_return(true)
+      without_partial_double_verification do
+        allow(Puppet.features).to receive(:syslog?).and_return(false)
+        allow(Puppet.features).to receive(:eventlog?).and_return(true)
+      end
       expect(Puppet::Util::Log).to receive(:newdestination).with(:eventlog)
 
       Puppet::Util::Log.setup_default
     end
 
     it "should fall back to :file" do
-      allow(Puppet.features).to receive(:syslog?).and_return(false)
-      allow(Puppet.features).to receive(:eventlog?).and_return(false)
+      without_partial_double_verification do
+        allow(Puppet.features).to receive(:syslog?).and_return(false)
+        allow(Puppet.features).to receive(:eventlog?).and_return(false)
+      end
       expect(Puppet::Util::Log).to receive(:newdestination).with(Puppet[:puppetdlog])
 
       Puppet::Util::Log.setup_default

--- a/spec/unit/util/logging_spec.rb
+++ b/spec/unit/util/logging_spec.rb
@@ -552,7 +552,7 @@ original
 
     describe 'does support debugging' do
       before :each do
-        allow(Facter).to receive(:respond_to?).with(:debugging).and_return(true)
+        allow(Facter).to receive(:respond_to?).with(:debugging, any_args).and_return(true)
       end
 
       it 'enables Facter debugging when debug level' do
@@ -568,7 +568,7 @@ original
 
     describe 'does support trace' do
       before :each do
-        allow(Facter).to receive(:respond_to?).with(:trace).and_return(true)
+        allow(Facter).to receive(:respond_to?).with(:trace, any_args).and_return(true)
       end
 
       it 'enables Facter trace when enabled' do
@@ -584,7 +584,7 @@ original
 
     describe 'does support on_message' do
       before :each do
-        allow(Facter).to receive(:respond_to?).with(:on_message).and_return(true)
+        allow(Facter).to receive(:respond_to?).with(:on_message, any_args).and_return(true)
       end
 
       def setup(level, message)

--- a/spec/unit/util/posix_spec.rb
+++ b/spec/unit/util/posix_spec.rb
@@ -63,7 +63,7 @@ describe Puppet::Util::POSIX do
     end
 
     before(:each) do
-      allow(Puppet::FFI::POSIX::Functions).to receive(:respond_to?).with(:getgrouplist).and_return(true)
+      allow(Puppet::FFI::POSIX::Functions).to receive(:respond_to?).with(:getgrouplist, any_args).and_return(true)
     end
 
     describe 'when it uses FFI function getgrouplist' do
@@ -77,7 +77,7 @@ describe Puppet::Util::POSIX do
         context 'for user1' do
           let(:user) { 'user1' }
           let(:expected_groups) { ['group1', 'group3'] }
-          
+
           before(:each) do
             prepare_user_and_groups_env(user, expected_groups)
             allow(Puppet::FFI::POSIX::Functions).to receive(:getgrouplist).and_return(1)
@@ -96,9 +96,10 @@ describe Puppet::Util::POSIX do
         context 'for user2' do
           let(:user) { 'user2' }
           let(:expected_groups) { ['group1', 'group2', 'group4'] }
-          
+
           before(:each) do
             prepare_user_and_groups_env(user, expected_groups)
+            allow(Puppet::FFI::POSIX::Functions).to receive(:respond_to?).with(:getgrouplist, any_args).and_return(true)
             allow(Puppet::FFI::POSIX::Functions).to receive(:getgrouplist).and_return(1)
           end
 
@@ -116,9 +117,10 @@ describe Puppet::Util::POSIX do
       describe 'when there are no groups' do
         let(:user) { 'nomembers' }
         let(:expected_groups) { [] }
-        
+
         before(:each) do
           prepare_user_and_groups_env(user, expected_groups)
+          allow(Puppet::FFI::POSIX::Functions).to receive(:respond_to?).with(:getgrouplist, any_args).and_return(true)
           allow(Puppet::FFI::POSIX::Functions).to receive(:getgrouplist).and_return(1)
         end
 
@@ -138,6 +140,7 @@ describe Puppet::Util::POSIX do
 
         before(:each) do
           prepare_user_and_groups_env(user, expected_groups)
+          allow(Puppet::FFI::POSIX::Functions).to receive(:respond_to?).with(:getgrouplist, any_args).and_return(true)
           allow(Puppet::FFI::POSIX::Functions).to receive(:getgrouplist).and_return(1)
         end
 
@@ -157,6 +160,7 @@ describe Puppet::Util::POSIX do
 
         before(:each) do
           prepare_user_and_groups_env(user, expected_groups)
+          allow(Puppet::FFI::POSIX::Functions).to receive(:respond_to?).with(:getgrouplist, any_args).and_return(true)
           allow(Puppet::FFI::POSIX::Functions).to receive(:getgrouplist).and_return(1)
         end
 
@@ -184,6 +188,7 @@ describe Puppet::Util::POSIX do
           let(:expected_groups) { ['root'] }
 
           before(:each) do
+            allow(Puppet::FFI::POSIX::Functions).to receive(:respond_to?).with(:getgrouplist, any_args).and_return(true)
             allow(Puppet::FFI::POSIX::Functions).to receive(:getgrouplist).and_return(1)
           end
 
@@ -206,6 +211,7 @@ describe Puppet::Util::POSIX do
             allow(FFI::MemoryPointer).to receive(:new).with(:uint, Puppet::FFI::POSIX::Constants::MAXIMUM_NUMBER_OF_GROUPS * 2).and_yield(groups_ptr)
             allow(ngroups_ptr).to receive(:write_int).with(Puppet::FFI::POSIX::Constants::MAXIMUM_NUMBER_OF_GROUPS * 2).and_return(ngroups_ptr)
 
+            allow(Puppet::FFI::POSIX::Functions).to receive(:respond_to?).with(:getgrouplist, any_args).and_return(true)
             allow(Puppet::FFI::POSIX::Functions).to receive(:getgrouplist).and_return(-1, 1)
           end
 
@@ -233,7 +239,7 @@ describe Puppet::Util::POSIX do
         allow(Puppet::Etc).to receive(:getpwnam).with(user).and_raise(ArgumentError, "can't find user for #{user}")
         allow(Puppet).to receive(:debug)
 
-        expect(Puppet::FFI::POSIX::Functions).not_to receive(:getgrouplist)
+        allow(Puppet::FFI::POSIX::Functions).to receive(:respond_to?).with(:getgrouplist, any_args).and_return(false)
       end
 
       describe 'when there are groups' do
@@ -246,7 +252,7 @@ describe Puppet::Util::POSIX do
           end
 
           it 'logs a debug message' do
-            expect(Puppet).to receive(:debug).with("Falling back to Puppet::Etc.group: can't find user for #{user}")
+            expect(Puppet).to receive(:debug).with("Falling back to Puppet::Etc.group: The 'getgrouplist' method is not available")
             Puppet::Util::POSIX.groups_of(user)
           end
         end
@@ -260,7 +266,7 @@ describe Puppet::Util::POSIX do
           end
 
           it 'logs a debug message' do
-            expect(Puppet).to receive(:debug).with("Falling back to Puppet::Etc.group: can't find user for #{user}")
+            expect(Puppet).to receive(:debug).with("Falling back to Puppet::Etc.group: The 'getgrouplist' method is not available")
             Puppet::Util::POSIX.groups_of(user)
           end
         end
@@ -275,7 +281,7 @@ describe Puppet::Util::POSIX do
         end
 
         it 'logs a debug message' do
-          expect(Puppet).to receive(:debug).with("Falling back to Puppet::Etc.group: can't find user for #{user}")
+          expect(Puppet).to receive(:debug).with("Falling back to Puppet::Etc.group: The 'getgrouplist' method is not available")
           Puppet::Util::POSIX.groups_of(user)
         end
       end
@@ -289,7 +295,7 @@ describe Puppet::Util::POSIX do
         end
 
         it 'logs a debug message' do
-          expect(Puppet).to receive(:debug).with("Falling back to Puppet::Etc.group: can't find user for #{user}")
+          expect(Puppet).to receive(:debug).with("Falling back to Puppet::Etc.group: The 'getgrouplist' method is not available")
           Puppet::Util::POSIX.groups_of(user)
         end
       end
@@ -303,7 +309,7 @@ describe Puppet::Util::POSIX do
         end
 
         it 'logs a debug message' do
-          expect(Puppet).to receive(:debug).with("Falling back to Puppet::Etc.group: can't find user for #{user}")
+          expect(Puppet).to receive(:debug).with("Falling back to Puppet::Etc.group: The 'getgrouplist' method is not available")
           Puppet::Util::POSIX.groups_of(user)
         end
       end

--- a/spec/unit/util/selinux_spec.rb
+++ b/spec/unit/util/selinux_spec.rb
@@ -111,15 +111,19 @@ describe Puppet::Util::SELinux do
     end
 
     it "should return a context" do
-      expect(self).to receive(:selinux_support?).and_return(true)
-      expect(Selinux).to receive(:lgetfilecon).with("/foo").and_return([0, "user_u:role_r:type_t:s0"])
-      expect(get_selinux_current_context("/foo")).to eq("user_u:role_r:type_t:s0")
+      without_partial_double_verification do
+        expect(self).to receive(:selinux_support?).and_return(true)
+        expect(Selinux).to receive(:lgetfilecon).with("/foo").and_return([0, "user_u:role_r:type_t:s0"])
+        expect(get_selinux_current_context("/foo")).to eq("user_u:role_r:type_t:s0")
+      end
     end
 
     it "should return nil if lgetfilecon fails" do
-      expect(self).to receive(:selinux_support?).and_return(true)
-      expect(Selinux).to receive(:lgetfilecon).with("/foo").and_return(-1)
-      expect(get_selinux_current_context("/foo")).to be_nil
+      without_partial_double_verification do
+        expect(self).to receive(:selinux_support?).and_return(true)
+        expect(Selinux).to receive(:lgetfilecon).with("/foo").and_return(-1)
+        expect(get_selinux_current_context("/foo")).to be_nil
+      end
     end
   end
 
@@ -130,47 +134,57 @@ describe Puppet::Util::SELinux do
     end
 
     it "should return a context if a default context exists" do
-      expect(self).to receive(:selinux_support?).and_return(true)
-      fstat = double('File::Stat', :mode => 0)
-      expect(Puppet::FileSystem).to receive(:lstat).with('/foo').and_return(fstat)
-      expect(self).to receive(:find_fs).with("/foo").and_return("ext3")
-      expect(Selinux).to receive(:matchpathcon).with("/foo", 0).and_return([0, "user_u:role_r:type_t:s0"])
+      without_partial_double_verification do
+        expect(self).to receive(:selinux_support?).and_return(true)
+        fstat = double('File::Stat', :mode => 0)
+        expect(Puppet::FileSystem).to receive(:lstat).with('/foo').and_return(fstat)
+        expect(self).to receive(:find_fs).with("/foo").and_return("ext3")
+        expect(Selinux).to receive(:matchpathcon).with("/foo", 0).and_return([0, "user_u:role_r:type_t:s0"])
 
-      expect(get_selinux_default_context("/foo")).to eq("user_u:role_r:type_t:s0")
+        expect(get_selinux_default_context("/foo")).to eq("user_u:role_r:type_t:s0")
+      end
     end
 
     it "handles permission denied errors by issuing a warning" do
-      allow(self).to receive(:selinux_support?).and_return(true)
-      allow(self).to receive(:selinux_label_support?).and_return(true)
-      allow(Selinux).to receive(:matchpathcon).with("/root/chuj", 0).and_return(-1)
-      allow(self).to receive(:file_lstat).with("/root/chuj").and_raise(Errno::EACCES, "/root/chuj")
+      without_partial_double_verification do
+        allow(self).to receive(:selinux_support?).and_return(true)
+        allow(self).to receive(:selinux_label_support?).and_return(true)
+        allow(Selinux).to receive(:matchpathcon).with("/root/chuj", 0).and_return(-1)
+        allow(self).to receive(:file_lstat).with("/root/chuj").and_raise(Errno::EACCES, "/root/chuj")
 
-      expect(get_selinux_default_context("/root/chuj")).to be_nil
+        expect(get_selinux_default_context("/root/chuj")).to be_nil
+      end
     end
 
     it "handles no such file or directory errors by issuing a warning" do
-      allow(self).to receive(:selinux_support?).and_return(true)
-      allow(self).to receive(:selinux_label_support?).and_return(true)
-      allow(Selinux).to receive(:matchpathcon).with("/root/chuj", 0).and_return(-1)
-      allow(self).to receive(:file_lstat).with("/root/chuj").and_raise(Errno::ENOENT, "/root/chuj")
+      without_partial_double_verification do
+        allow(self).to receive(:selinux_support?).and_return(true)
+        allow(self).to receive(:selinux_label_support?).and_return(true)
+        allow(Selinux).to receive(:matchpathcon).with("/root/chuj", 0).and_return(-1)
+        allow(self).to receive(:file_lstat).with("/root/chuj").and_raise(Errno::ENOENT, "/root/chuj")
 
-      expect(get_selinux_default_context("/root/chuj")).to be_nil
+        expect(get_selinux_default_context("/root/chuj")).to be_nil
+      end
     end
 
     it "should return nil if matchpathcon returns failure" do
-      expect(self).to receive(:selinux_support?).and_return(true)
-      fstat = double('File::Stat', :mode => 0)
-      expect(Puppet::FileSystem).to receive(:lstat).with('/foo').and_return(fstat)
-      expect(self).to receive(:find_fs).with("/foo").and_return("ext3")
-      expect(Selinux).to receive(:matchpathcon).with("/foo", 0).and_return(-1)
+      without_partial_double_verification do
+        expect(self).to receive(:selinux_support?).and_return(true)
+        fstat = double('File::Stat', :mode => 0)
+        expect(Puppet::FileSystem).to receive(:lstat).with('/foo').and_return(fstat)
+        expect(self).to receive(:find_fs).with("/foo").and_return("ext3")
+        expect(Selinux).to receive(:matchpathcon).with("/foo", 0).and_return(-1)
 
-      expect(get_selinux_default_context("/foo")).to be_nil
+        expect(get_selinux_default_context("/foo")).to be_nil
+      end
     end
 
     it "should return nil if selinux_label_support returns false" do
-      expect(self).to receive(:selinux_support?).and_return(true)
-      expect(self).to receive(:find_fs).with("/foo").and_return("nfs")
-      expect(get_selinux_default_context("/foo")).to be_nil
+      without_partial_double_verification do
+        expect(self).to receive(:selinux_support?).and_return(true)
+        expect(self).to receive(:find_fs).with("/foo").and_return("nfs")
+        expect(get_selinux_default_context("/foo")).to be_nil
+      end
     end
   end
 
@@ -261,37 +275,47 @@ describe Puppet::Util::SELinux do
     end
 
     it "should use lsetfilecon to set a context" do
-      expect(self).to receive(:selinux_support?).and_return(true)
-      expect(Selinux).to receive(:lsetfilecon).with("/foo", "user_u:role_r:type_t:s0").and_return(0)
-      expect(set_selinux_context("/foo", "user_u:role_r:type_t:s0")).to be_truthy
+      without_partial_double_verification do
+        expect(self).to receive(:selinux_support?).and_return(true)
+        expect(Selinux).to receive(:lsetfilecon).with("/foo", "user_u:role_r:type_t:s0").and_return(0)
+        expect(set_selinux_context("/foo", "user_u:role_r:type_t:s0")).to be_truthy
+      end
     end
 
     it "should use lsetfilecon to set user_u user context" do
-      expect(self).to receive(:selinux_support?).and_return(true)
-      expect(Selinux).to receive(:lgetfilecon).with("/foo").and_return([0, "foo:role_r:type_t:s0"])
-      expect(Selinux).to receive(:lsetfilecon).with("/foo", "user_u:role_r:type_t:s0").and_return(0)
-      expect(set_selinux_context("/foo", "user_u", :seluser)).to be_truthy
+      without_partial_double_verification do
+        expect(self).to receive(:selinux_support?).and_return(true)
+        expect(Selinux).to receive(:lgetfilecon).with("/foo").and_return([0, "foo:role_r:type_t:s0"])
+        expect(Selinux).to receive(:lsetfilecon).with("/foo", "user_u:role_r:type_t:s0").and_return(0)
+        expect(set_selinux_context("/foo", "user_u", :seluser)).to be_truthy
+      end
     end
 
     it "should use lsetfilecon to set role_r role context" do
-      expect(self).to receive(:selinux_support?).and_return(true)
-      expect(Selinux).to receive(:lgetfilecon).with("/foo").and_return([0, "user_u:foo:type_t:s0"])
-      expect(Selinux).to receive(:lsetfilecon).with("/foo", "user_u:role_r:type_t:s0").and_return(0)
-      expect(set_selinux_context("/foo", "role_r", :selrole)).to be_truthy
+      without_partial_double_verification do
+        expect(self).to receive(:selinux_support?).and_return(true)
+        expect(Selinux).to receive(:lgetfilecon).with("/foo").and_return([0, "user_u:foo:type_t:s0"])
+        expect(Selinux).to receive(:lsetfilecon).with("/foo", "user_u:role_r:type_t:s0").and_return(0)
+        expect(set_selinux_context("/foo", "role_r", :selrole)).to be_truthy
+      end
     end
 
     it "should use lsetfilecon to set type_t type context" do
-      expect(self).to receive(:selinux_support?).and_return(true)
-      expect(Selinux).to receive(:lgetfilecon).with("/foo").and_return([0, "user_u:role_r:foo:s0"])
-      expect(Selinux).to receive(:lsetfilecon).with("/foo", "user_u:role_r:type_t:s0").and_return(0)
-      expect(set_selinux_context("/foo", "type_t", :seltype)).to be_truthy
+      without_partial_double_verification do
+        expect(self).to receive(:selinux_support?).and_return(true)
+        expect(Selinux).to receive(:lgetfilecon).with("/foo").and_return([0, "user_u:role_r:foo:s0"])
+        expect(Selinux).to receive(:lsetfilecon).with("/foo", "user_u:role_r:type_t:s0").and_return(0)
+        expect(set_selinux_context("/foo", "type_t", :seltype)).to be_truthy
+      end
     end
 
     it "should use lsetfilecon to set s0:c3,c5 range context" do
-      expect(self).to receive(:selinux_support?).and_return(true)
-      expect(Selinux).to receive(:lgetfilecon).with("/foo").and_return([0, "user_u:role_r:type_t:s0"])
-      expect(Selinux).to receive(:lsetfilecon).with("/foo", "user_u:role_r:type_t:s0:c3,c5").and_return(0)
-      expect(set_selinux_context("/foo", "s0:c3,c5", :selrange)).to be_truthy
+      without_partial_double_verification do
+        expect(self).to receive(:selinux_support?).and_return(true)
+        expect(Selinux).to receive(:lgetfilecon).with("/foo").and_return([0, "user_u:role_r:type_t:s0"])
+        expect(Selinux).to receive(:lsetfilecon).with("/foo", "user_u:role_r:type_t:s0:c3,c5").and_return(0)
+        expect(set_selinux_context("/foo", "s0:c3,c5", :selrange)).to be_truthy
+      end
     end
   end
 

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -315,7 +315,7 @@ describe Puppet::Util do
 
     describe "when using platform :posix" do
       before :each do
-        allow(Puppet.features).to receive(:posix).and_return(true)
+        allow(Puppet.features).to receive(:posix?).and_return(true)
         allow(Puppet::Util::Platform).to receive(:windows?).and_return(false)
       end
 
@@ -328,7 +328,7 @@ describe Puppet::Util do
 
     describe "when using platform :windows" do
       before :each do
-        allow(Puppet.features).to receive(:posix).and_return(false)
+        allow(Puppet.features).to receive(:posix?).and_return(false)
         allow(Puppet::Util::Platform).to receive(:windows?).and_return(true)
       end
 
@@ -462,7 +462,7 @@ describe Puppet::Util do
 
     describe "when using platform :posix" do
       before :each do
-        allow(Puppet.features).to receive(:posix).and_return(true)
+        allow(Puppet.features).to receive(:posix?).and_return(true)
         allow(Puppet::Util::Platform).to receive(:windows?).and_return(false)
       end
 
@@ -501,7 +501,7 @@ describe Puppet::Util do
 
     describe "when using platform :windows" do
       before :each do
-        allow(Puppet.features).to receive(:posix).and_return(false)
+        allow(Puppet.features).to receive(:posix?).and_return(false)
         allow(Puppet::Util::Platform).to receive(:windows?).and_return(true)
       end
 

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -539,7 +539,6 @@ describe Puppet::Util do
       expect(Puppet::Util.uri_to_path(URI.parse('http://foo/bar%20baz'))).to eq('/bar baz')
     end
 
-
     [
       "http://foo/A%DB%BF%E1%9A%A0%F0%A0%9C%8E",
       "http://foo/A%DB%BF%E1%9A%A0%F0%A0%9C%8E".force_encoding(Encoding::ASCII)
@@ -589,7 +588,15 @@ describe Puppet::Util do
     end
   end
 
-  describe "safe_posix_fork" do
+  describe "safe_posix_fork on Windows and JRuby", if: Puppet::Util::Platform.windows? || Puppet::Util::Platform.jruby? do
+    it "raises not implemented error" do
+      expect {
+        Puppet::Util.safe_posix_fork
+      }.to raise_error(NotImplementedError, /fork/)
+    end
+  end
+
+  describe "safe_posix_fork", unless: Puppet::Util::Platform.windows? || Puppet::Util::Platform.jruby? do
     let(:pid) { 5501 }
 
     before :each do


### PR DESCRIPTION
Verify that an object implements an allowed or expected method. This only affects
partial doubles (real objects with a stubbed method), not objects created via
`double`. In doing so, it uncovered two bugs: PUP-10779 and FACT-2859.