### PR TITLE
(PUP-10774) Add faster user groups query on posix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ group(:features) do
 end
 
 group(:test) do
+  gem "ffi", require: false
   gem "json-schema", "~> 2.0", require: false
   gem "rake", *location_for(ENV['RAKE_LOCATION'] || '~> 12.2')
   gem "rspec", "~> 3.1", require: false

--- a/lib/puppet/ffi/posix.rb
+++ b/lib/puppet/ffi/posix.rb
@@ -1,0 +1,10 @@
+require 'ffi'
+
+module Puppet
+  module FFI
+    module POSIX
+      require 'puppet/ffi/posix/functions'
+      require 'puppet/ffi/posix/constants'
+    end
+  end
+end

--- a/lib/puppet/ffi/posix/constants.rb
+++ b/lib/puppet/ffi/posix/constants.rb
@@ -1,0 +1,14 @@
+require 'puppet/ffi/posix'
+
+module Puppet::FFI::POSIX
+  module Constants
+    extend FFI::Library
+  
+    # Maximum number of supplementary groups (groups
+    # that a user can be in plus its primary group)
+    # (64 + 1 primary group)
+    # Chosen a reasonable middle number from the list
+    # https://www.j3e.de/ngroups.html
+    MAXIMUM_NUMBER_OF_GROUPS = 65
+  end
+end

--- a/lib/puppet/ffi/posix/functions.rb
+++ b/lib/puppet/ffi/posix/functions.rb
@@ -1,0 +1,24 @@
+require 'puppet/ffi/posix'
+
+module Puppet::FFI::POSIX
+  module Functions
+
+    extend FFI::Library
+
+    ffi_convention :stdcall
+
+    # https://man7.org/linux/man-pages/man3/getgrouplist.3.html
+    # int getgrouplist (
+    #   const char *user,
+    #   gid_t group,
+    #   gid_t *groups,
+    #   int *ngroups
+    # );
+    begin
+      ffi_lib FFI::Library::LIBC
+      attach_function :getgrouplist, [:string, :uint, :pointer, :pointer], :int
+    rescue FFI::NotFoundError
+      # Do nothing
+    end
+  end
+end

--- a/spec/unit/provider/user/pw_spec.rb
+++ b/spec/unit/provider/user/pw_spec.rb
@@ -53,12 +53,14 @@ describe Puppet::Type.type(:user).provider(:pw) do
 
     it "should use -G with the correct argument when the groups property is set" do
       resource[:groups] = "group1"
+      allow(Puppet::Util::POSIX).to receive(:groups_of).with('testuser').and_return([])
       expect(provider).to receive(:execute).with(include("-G").and(include("group1")), kind_of(Hash))
       provider.create
     end
 
     it "should use -G with all the given groups when the groups property is set to an array" do
       resource[:groups] = ["group1", "group2"]
+      allow(Puppet::Util::POSIX).to receive(:groups_of).with('testuser').and_return([])
       expect(provider).to receive(:execute).with(include("-G").and(include("group1,group2")), kind_of(Hash))
       provider.create
     end

--- a/spec/unit/provider/user/useradd_spec.rb
+++ b/spec/unit/provider/user/useradd_spec.rb
@@ -4,6 +4,7 @@ RSpec::Matchers.define_negated_matcher :excluding, :include
 
 describe Puppet::Type.type(:user).provider(:useradd) do
   before :each do
+    allow(Puppet::Util::POSIX).to receive(:groups_of).and_return([])
     allow(described_class).to receive(:command).with(:password).and_return('/usr/bin/chage')
     allow(described_class).to receive(:command).with(:localpassword).and_return('/usr/sbin/lchage')
     allow(described_class).to receive(:command).with(:add).and_return('/usr/sbin/useradd')

--- a/spec/unit/util/posix_spec.rb
+++ b/spec/unit/util/posix_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
+require 'puppet/ffi/posix'
 require 'puppet/util/posix'
 
 class PosixTest
@@ -11,35 +12,338 @@ describe Puppet::Util::POSIX do
     @posix = PosixTest.new
   end
 
-  describe '.groups_of' do
+  describe '.groups_of' do 
+    let(:mock_user_data) { double(user, :gid => 1000) }
+
+    let(:ngroups_ptr) { double('FFI::MemoryPointer', :address => 0x0001, :size => 4) }
+    let(:groups_ptr) { double('FFI::MemoryPointer', :address => 0x0002, :size => Puppet::FFI::POSIX::Constants::MAXIMUM_NUMBER_OF_GROUPS) }
+
     let(:mock_groups) do
       [
-        ['group1', ['user1', 'user2']],
-        ['group2', ['user2']],
-        ['group1', ['user1', 'user2']],
-        ['group3', ['user1']],
-        ['group4', ['user2']]
-      ].map do |(name, members)|
+        ['root', ['root'], 0],
+        ['nomembers', [], 5 ],
+        ['group1', ['user1', 'user2'], 1001],
+        ['group2', ['user2'], 2002],
+        ['group1', ['user1', 'user2'], 1001],
+        ['group3', ['user1'], 3003],
+        ['group4', ['user2'], 4004],
+        ['user1', [], 1111],
+        ['user2', [], 2222]
+      ].map do |(name, members, gid)|
         group_struct = double("Group #{name}")
         allow(group_struct).to receive(:name).and_return(name)
         allow(group_struct).to receive(:mem).and_return(members)
+        allow(group_struct).to receive(:gid).and_return(gid)
 
         group_struct
       end
     end
 
-    before(:each) do
-      etc_stub = receive(:group)
-      mock_groups.each do |mock_group|
-        etc_stub = etc_stub.and_yield(mock_group)
+    def prepare_user_and_groups_env(user, groups)
+      groups_gids = []
+      groups_and_user = []
+      groups_and_user.replace(groups)
+      groups_and_user.push(user)
+
+      groups_and_user.each do |group|
+        mock_group = mock_groups.find { |m| m.name == group }
+        groups_gids.push(mock_group.gid)
+
+        allow(Puppet::Etc).to receive(:getgrgid).with(mock_group.gid).and_return(mock_group)
       end
-      allow(Puppet::Etc).to etc_stub
+
+      if groups_and_user.size > Puppet::FFI::POSIX::Constants::MAXIMUM_NUMBER_OF_GROUPS
+        allow(ngroups_ptr).to receive(:read_int).and_return(Puppet::FFI::POSIX::Constants::MAXIMUM_NUMBER_OF_GROUPS, groups_and_user.size)
+      else
+        allow(ngroups_ptr).to receive(:read_int).and_return(groups_and_user.size)
+      end
+
+      allow(groups_ptr).to receive(:get_array_of_uint).with(0, groups_and_user.size).and_return(groups_gids)
+      allow(Puppet::Etc).to receive(:getpwnam).with(user).and_return(mock_user_data)
     end
 
-    it 'returns the groups of the given user' do
-      expect(Puppet::Util::POSIX.groups_of('user1')).to eql(
-        ['group1', 'group3']
-      )
+    before(:each) do
+      allow(Puppet::FFI::POSIX::Functions).to receive(:respond_to?).with(:getgrouplist).and_return(true)
+    end
+
+    describe 'when it uses FFI function getgrouplist' do
+      before(:each) do
+        allow(FFI::MemoryPointer).to receive(:new).with(:int).and_yield(ngroups_ptr)
+        allow(FFI::MemoryPointer).to receive(:new).with(:uint, Puppet::FFI::POSIX::Constants::MAXIMUM_NUMBER_OF_GROUPS).and_yield(groups_ptr)
+        allow(ngroups_ptr).to receive(:write_int).with(Puppet::FFI::POSIX::Constants::MAXIMUM_NUMBER_OF_GROUPS).and_return(ngroups_ptr)
+      end
+
+      describe 'when there are groups' do
+        context 'for user1' do
+          let(:user) { 'user1' }
+          let(:expected_groups) { ['group1', 'group3'] }
+          
+          before(:each) do
+            prepare_user_and_groups_env(user, expected_groups)
+            allow(Puppet::FFI::POSIX::Functions).to receive(:getgrouplist).and_return(1)
+          end
+
+          it "should return the groups for given user" do
+            expect(Puppet::Util::POSIX.groups_of(user)).to eql(expected_groups)
+          end
+
+          it 'should not print any debug message about falling back to Puppet::Etc.group' do
+            expect(Puppet).not_to receive(:debug).with(/Falling back to Puppet::Etc.group:/)
+            Puppet::Util::POSIX.groups_of(user)
+          end
+        end
+
+        context 'for user2' do
+          let(:user) { 'user2' }
+          let(:expected_groups) { ['group1', 'group2', 'group4'] }
+          
+          before(:each) do
+            prepare_user_and_groups_env(user, expected_groups)
+            allow(Puppet::FFI::POSIX::Functions).to receive(:getgrouplist).and_return(1)
+          end
+
+          it "should return the groups for given user" do
+            expect(Puppet::Util::POSIX.groups_of(user)).to eql(expected_groups)
+          end
+
+          it 'should not print any debug message about falling back to Puppet::Etc.group' do
+            expect(Puppet).not_to receive(:debug).with(/Falling back to Puppet::Etc.group:/)
+            Puppet::Util::POSIX.groups_of(user)
+          end
+        end
+      end
+
+      describe 'when there are no groups' do
+        let(:user) { 'nomembers' }
+        let(:expected_groups) { [] }
+        
+        before(:each) do
+          prepare_user_and_groups_env(user, expected_groups)
+          allow(Puppet::FFI::POSIX::Functions).to receive(:getgrouplist).and_return(1)
+        end
+
+        it "should return no groups for given user" do
+          expect(Puppet::Util::POSIX.groups_of(user)).to eql(expected_groups)
+        end
+
+        it 'should not print any debug message about falling back to Puppet::Etc.group' do
+          expect(Puppet).not_to receive(:debug).with(/Falling back to Puppet::Etc.group:/)
+          Puppet::Util::POSIX.groups_of(user)
+        end
+      end
+
+      describe 'when primary group explicitly contains user' do
+        let(:user) { 'root' }
+        let(:expected_groups) { ['root'] }
+
+        before(:each) do
+          prepare_user_and_groups_env(user, expected_groups)
+          allow(Puppet::FFI::POSIX::Functions).to receive(:getgrouplist).and_return(1)
+        end
+
+        it "should return the groups, including primary group, for given user" do
+          expect(Puppet::Util::POSIX.groups_of(user)).to eql(expected_groups)
+        end
+
+        it 'should not print any debug message about falling back to Puppet::Etc.group' do
+          expect(Puppet).not_to receive(:debug).with(/Falling back to Puppet::Etc.group:/)
+          Puppet::Util::POSIX.groups_of(user)
+        end
+      end
+
+      describe 'when primary group does not explicitly contain user' do
+        let(:user) { 'user1' }
+        let(:expected_groups) { ['group1', 'group3'] }
+
+        before(:each) do
+          prepare_user_and_groups_env(user, expected_groups)
+          allow(Puppet::FFI::POSIX::Functions).to receive(:getgrouplist).and_return(1)
+        end
+
+        it "should not return primary group for given user" do
+          expect(Puppet::Util::POSIX.groups_of(user)).not_to include(user)
+        end
+
+        it 'should not print any debug message about falling back to Puppet::Etc.group' do
+          expect(Puppet).not_to receive(:debug).with(/Falling back to Puppet::Etc.group:/)
+          Puppet::Util::POSIX.groups_of(user)
+        end
+      end
+
+      context 'number of groups' do
+        before(:each) do
+          stub_const("Puppet::FFI::POSIX::Constants::MAXIMUM_NUMBER_OF_GROUPS", 2)
+          prepare_user_and_groups_env(user, expected_groups)
+
+          allow(FFI::MemoryPointer).to receive(:new).with(:uint, Puppet::FFI::POSIX::Constants::MAXIMUM_NUMBER_OF_GROUPS).and_yield(groups_ptr)
+          allow(ngroups_ptr).to receive(:write_int).with(Puppet::FFI::POSIX::Constants::MAXIMUM_NUMBER_OF_GROUPS).and_return(ngroups_ptr)
+        end
+
+        describe 'when there are less than maximum expected number of groups' do
+          let(:user) { 'root' }
+          let(:expected_groups) { ['root'] }
+
+          before(:each) do
+            allow(Puppet::FFI::POSIX::Functions).to receive(:getgrouplist).and_return(1)
+          end
+
+          it "should return the groups for given user, after one 'getgrouplist' call" do
+            expect(Puppet::FFI::POSIX::Functions).to receive(:getgrouplist).once
+            expect(Puppet::Util::POSIX.groups_of(user)).to eql(expected_groups)
+          end
+
+          it 'should not print any debug message about falling back to Puppet::Etc.group' do
+            expect(Puppet).not_to receive(:debug).with(/Falling back to Puppet::Etc.group:/)
+            Puppet::Util::POSIX.groups_of(user)
+          end
+        end
+
+        describe 'when there are more than maximum expected number of groups' do
+          let(:user) { 'user1' }
+          let(:expected_groups) { ['group1', 'group3'] }
+
+          before(:each) do
+            allow(FFI::MemoryPointer).to receive(:new).with(:uint, Puppet::FFI::POSIX::Constants::MAXIMUM_NUMBER_OF_GROUPS * 2).and_yield(groups_ptr)
+            allow(ngroups_ptr).to receive(:write_int).with(Puppet::FFI::POSIX::Constants::MAXIMUM_NUMBER_OF_GROUPS * 2).and_return(ngroups_ptr)
+
+            allow(Puppet::FFI::POSIX::Functions).to receive(:getgrouplist).and_return(-1, 1)
+          end
+
+          it "should return the groups for given user, after two 'getgrouplist' calls" do
+            expect(Puppet::FFI::POSIX::Functions).to receive(:getgrouplist).twice
+            expect(Puppet::Util::POSIX.groups_of(user)).to eql(expected_groups)
+          end
+
+          it 'should not print any debug message about falling back to Puppet::Etc.group' do
+            expect(Puppet).not_to receive(:debug).with(/Falling back to Puppet::Etc.group:/)
+            Puppet::Util::POSIX.groups_of(user)
+          end
+        end
+      end
+    end
+
+    describe 'when it falls back to Puppet::Etc.group method' do
+      before(:each) do
+        etc_stub = receive(:group)
+        mock_groups.each do |mock_group|
+          etc_stub = etc_stub.and_yield(mock_group)
+        end
+        allow(Puppet::Etc).to etc_stub
+
+        allow(Puppet::Etc).to receive(:getpwnam).with(user).and_raise(ArgumentError, "can't find user for #{user}")
+        allow(Puppet).to receive(:debug)
+
+        expect(Puppet::FFI::POSIX::Functions).not_to receive(:getgrouplist)
+      end
+
+      describe 'when there are groups' do
+        context 'for user1' do
+          let(:user) { 'user1' }
+          let(:expected_groups) { ['group1', 'group3'] }
+
+          it "should return the groups for given user" do
+            expect(Puppet::Util::POSIX.groups_of(user)).to eql(expected_groups)
+          end
+
+          it 'logs a debug message' do
+            expect(Puppet).to receive(:debug).with("Falling back to Puppet::Etc.group: can't find user for #{user}")
+            Puppet::Util::POSIX.groups_of(user)
+          end
+        end
+
+        context 'for user2' do
+          let(:user) { 'user2' }
+          let(:expected_groups) { ['group1', 'group2', 'group4'] }
+
+          it "should return the groups for given user" do
+            expect(Puppet::Util::POSIX.groups_of(user)).to eql(expected_groups)
+          end
+
+          it 'logs a debug message' do
+            expect(Puppet).to receive(:debug).with("Falling back to Puppet::Etc.group: can't find user for #{user}")
+            Puppet::Util::POSIX.groups_of(user)
+          end
+        end
+      end
+
+      describe 'when there are no groups' do
+        let(:user) { 'nomembers' }
+        let(:expected_groups) { [] }
+
+        it "should return no groups for given user" do
+          expect(Puppet::Util::POSIX.groups_of(user)).to eql(expected_groups)
+        end
+
+        it 'logs a debug message' do
+          expect(Puppet).to receive(:debug).with("Falling back to Puppet::Etc.group: can't find user for #{user}")
+          Puppet::Util::POSIX.groups_of(user)
+        end
+      end
+
+      describe 'when primary group explicitly contains user' do
+        let(:user) { 'root' }
+        let(:expected_groups) { ['root'] }
+
+        it "should return the groups, including primary group, for given user" do
+          expect(Puppet::Util::POSIX.groups_of(user)).to eql(expected_groups)
+        end
+
+        it 'logs a debug message' do
+          expect(Puppet).to receive(:debug).with("Falling back to Puppet::Etc.group: can't find user for #{user}")
+          Puppet::Util::POSIX.groups_of(user)
+        end
+      end
+
+      describe 'when primary group does not explicitly contain user' do
+        let(:user) { 'user1' }
+        let(:expected_groups) { ['group1', 'group3'] }
+
+        it "should not return primary group for given user" do
+          expect(Puppet::Util::POSIX.groups_of(user)).not_to include(user)
+        end
+
+        it 'logs a debug message' do
+          expect(Puppet).to receive(:debug).with("Falling back to Puppet::Etc.group: can't find user for #{user}")
+          Puppet::Util::POSIX.groups_of(user)
+        end
+      end
+
+      describe "when the 'getgrouplist' method is not available" do
+        let(:user) { 'user1' }
+        let(:expected_groups) { ['group1', 'group3'] }
+
+        before(:each) do
+          allow(Puppet::FFI::POSIX::Functions).to receive(:respond_to?).with(:getgrouplist).and_return(false)
+        end
+
+        it "should return the groups" do
+          expect(Puppet::Util::POSIX.groups_of(user)).to eql(expected_groups)
+        end
+
+        it 'logs a debug message' do
+          expect(Puppet).to receive(:debug).with("Falling back to Puppet::Etc.group: The 'getgrouplist' method is not available")
+          Puppet::Util::POSIX.groups_of(user)
+        end
+      end
+
+
+      describe "when ffi is not available on the machine" do
+        let(:user) { 'user1' }
+        let(:expected_groups) { ['group1', 'group3'] }
+
+        before(:each) do
+          allow(Puppet::Util::POSIX).to receive(:require).with('puppet/ffi/posix').and_raise(LoadError, 'cannot load such file -- ffi')
+        end
+
+        it "should return the groups" do
+          expect(Puppet::Util::POSIX.groups_of(user)).to eql(expected_groups)
+        end
+
+        it 'logs a debug message' do
+          expect(Puppet).to receive(:debug).with("Falling back to Puppet::Etc.group: cannot load such file -- ffi")
+          Puppet::Util::POSIX.groups_of(user)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Due to performance issues on systems with big number of user groups, this commit adds ffi method `getgrouplist` as primary method of listing the groups of a user resource on posix. On systems without ffi, the `groups_of` method falls back to previous implementation with `Etc.groups` (which is very inefficient because it's checking all available groups for given user membership).

Gemfile now also contains `ffi` for testing purposes.

Before merging this we should have:
- [x]  all tests passing
- [x]  temporary commits removed (https://github.com/puppetlabs/puppet/pull/8442/commits/69ba3cb4ae33d221b4c643ae5027dafd7d1d7189 and https://github.com/puppetlabs/puppet/pull/8442/commits/663100aae743eeb4d4bd288f183d2e9ccf30d8b9)

After completing above, we can also merge #8444 and leave a comment on internal ticket regarding this.