### PR TITLE
(PUP-10774) Do not query all groups/users

### DIFF
--- a/lib/puppet/util/posix.rb
+++ b/lib/puppet/util/posix.rb
@@ -144,8 +144,17 @@ module Puppet::Util::POSIX
       name = get_posix_field(location, :name, id)
       check_value = name
     end
+
     if check_value != field
-      return search_posix_field(location, id_field, field)
+      check_value_id = get_posix_field(location, id_field, check_value)
+
+      if id == check_value_id
+        Puppet.debug("Multiple entries found for resource: '#{location}' with #{id_field}: #{id}")
+        return id
+      else
+        Puppet.debug("The value retrieved: '#{check_value}' is different than the required state: '#{field}', searching in all entries")
+        return search_posix_field(location, id_field, field)
+      end
     else
       return id
     end

--- a/spec/unit/util/posix_spec.rb
+++ b/spec/unit/util/posix_spec.rb
@@ -189,6 +189,16 @@ describe Puppet::Util::POSIX do
         expect(@posix.gid("asdf")).to eq(100)
       end
 
+      it "returns the id without full groups query if multiple groups have the same id" do
+        expect(@posix).to receive(:get_posix_field).with(:group, :gid, "asdf").and_return(100)
+        expect(@posix).to receive(:get_posix_field).with(:group, :name, 100).and_return("boo")
+        expect(@posix).to receive(:get_posix_field).with(:group, :gid, "boo").and_return(100)
+
+        expect(@posix).not_to receive(:search_posix_field)
+        expect(@posix.gid("asdf")).to eq(100)
+      end
+
+
       it "should use :search_posix_field if the discovered name does not match the passed-in name" do
         expect(@posix).to receive(:get_posix_field).with(:group, :gid, "asdf").and_return(100)
         expect(@posix).to receive(:get_posix_field).with(:group, :name, 100).and_return("boo")
@@ -262,6 +272,15 @@ describe Puppet::Util::POSIX do
         expect(@posix).to receive(:get_posix_field).with(:passwd, :uid, "asdf").and_return(100)
         expect(@posix).to receive(:get_posix_field).with(:passwd, :name, 100).and_return("asdf")
 
+        expect(@posix.uid("asdf")).to eq(100)
+      end
+
+      it "returns the id without full users query if multiple users have the same id" do
+        expect(@posix).to receive(:get_posix_field).with(:passwd, :uid, "asdf").and_return(100)
+        expect(@posix).to receive(:get_posix_field).with(:passwd, :name, 100).and_return("boo")
+        expect(@posix).to receive(:get_posix_field).with(:passwd, :uid, "boo").and_return(100)
+
+        expect(@posix).not_to receive(:search_posix_field)
         expect(@posix.uid("asdf")).to eq(100)
       end
 


### PR DESCRIPTION
`get_posix_value` method checks if the user/group
that is added in the manifest corresponds with the
user/group retrieved from system. If they differ,
a full query is executed to retrieve all the
users/groups and match them with the required value.

This commit adds an extra check, for the case when
multiple users/groups have a same identifier(uid/gid)
In this case a full query is not needed, and the found
identifier is returned.