### PR TITLE
(PUP-10786) Update puppet node clean for ca-cli 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ group(:features) do
   # gem 'ruby-augeas', require: false, platforms: [:ruby]
   # requires native ldap headers/libs
   # gem 'ruby-ldap', '~> 0.9', require: false, platforms: [:ruby]
-  gem 'puppetserver-ca', '~> 1.1', require: false
+  gem 'puppetserver-ca', '~> 2.0', require: false
 end
 
 group(:test) do

--- a/lib/puppet/face/node/clean.rb
+++ b/lib/puppet/face/node/clean.rb
@@ -47,6 +47,14 @@ Puppet::Face.define(:node, '0.0.1') do
   end
 
   class LoggerIO
+    def debug(message)
+      Puppet.debug(message)
+    end
+
+    def warn(message)
+      Puppet.warning(message) unless message =~ /cadir is currently configured to be inside/
+    end
+
     def err(message)
       Puppet.err(message) unless message =~ /^\s*Error:\s*/
     end


### PR DESCRIPTION
Previously, the puppet node clean action called the PuppetServer CA CLI
as a library to clean certs. To do so it implemented a bridge between
the CA library's logger and Puppet's logger. That implementation only
included those methods used by the CA's clean action. However, in the
most recent version of the CA it will now also `warn` if the cadir is in
the legacy location (like Puppet proper does).

This patch implements the remaining API for the CA's logger (debug
and warn). It also filters out the warning from the CA library for a
cadir nested w/in the ssldir, as Puppet should have already warned about
that if needed.