### PR TITLE
(PUP-9176) List failed module install dependencies

### DIFF
--- a/lib/puppet/module_tool/errors/shared.rb
+++ b/lib/puppet/module_tool/errors/shared.rb
@@ -7,6 +7,7 @@ module Puppet::ModuleTool::Errors
       @installed_version = options[:installed_version]
       @conditions        = options[:conditions]
       @action            = options[:action]
+      @unsatisfied       = options[:unsatisfied]
 
       super _("Could not %{action} '%{module_name}' (%{version}); no version satisfies all dependencies") % { action: @action, module_name: @requested_name, version: vstring }
     end
@@ -14,9 +15,16 @@ module Puppet::ModuleTool::Errors
     def multiline
       message = []
       message << _("Could not %{action} module '%{module_name}' (%{version})") % { action: @action, module_name: @requested_name, version: vstring }
-      message << _("  No version of '%{module_name}' can satisfy all dependencies") % { module_name: @requested_name }
+
+      if @unsatisfied
+        message << _("  The requested version cannot satisfy the following dependency: %{name}") % { name: @unsatisfied[:name] }
+        message << _("    Installed: %{current_version}, expected: %{constraints}") % { current_version: @unsatisfied[:current_version], constraints: @unsatisfied[:constraints] }
+      else
+        message << _("  The requested version cannot satisfy all dependencies")
+      end
+
       #TRANSLATORS `puppet module %{action} --ignore-dependencies` is a command line and should not be translated
-      message << _("    Use `puppet module %{action} --ignore-dependencies` to %{action} only this module") % { action: @action }
+      message << _("    Use `puppet module %{action} '%{module_name}' --ignore-dependencies` to %{action} only this module") % { action: @action, module_name: @requested_name }
       message.join("\n")
     end
   end


### PR DESCRIPTION

Depends on puppetlabs/semantic_puppet#34.

The changes are backwards compatible so they shouldn't break users with
older versions of semantic_puppet.

Fixed a bug where we wouldn't print the version of the module we're
installing when raising this specific error.

Also, when installing a module without specifying its version, the error
message will show the best candidate instead of `(???)`.

Before (assuming puppetlabs-concat 6.4.0 is installed prior to this):

```
Error: Could not install module 'trepasi-debnet' (???)
  No version of 'trepasi-debnet' can satisfy all dependencies
    Use `puppet module install --ignore-dependencies` to install only this module
```

After:

```
Error: Could not install module 'trepasi-debnet' (v1.5.2)
  The requested version cannot satisfy the following dependency: puppetlabs-concat
    Installed: 6.4.0, expected: >= 1.2.0 < 3.0.0
    Use `puppet module install 'trepasi-debnet' --ignore-dependencies` to install only this module
```

Before merging this:

- [ ] Merge puppetlabs/semantic_puppet#34
- [x] Squash b821eff69898b862f9e401bbf39718f7ee52d801 into original commit

Co-authored-by: Luchian Nemes <luchian.nemes@puppet.com>