### PR TITLE
(PUP-10797) Add runtime dependency on scanf

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency(%q<multi_json>, "~> 1.13")
   s.add_runtime_dependency(%q<concurrent-ruby>, "~> 1.0")
   s.add_runtime_dependency(%q<deep_merge>, "~> 1.0")
+  s.add_runtime_dependency(%q<scanf>, "~> 1.0")
 
   # loads platform specific gems like ffi, win32 platform gems
   # as additional runtime dependencies

--- a/Gemfile
+++ b/Gemfile
@@ -18,8 +18,6 @@ gem "hiera", *location_for(ENV['HIERA_LOCATION']) if ENV.has_key?('HIERA_LOCATIO
 gem "semantic_puppet", *location_for(ENV['SEMANTIC_PUPPET_LOCATION'] || ["~> 1.0"])
 gem "puppet-resource_api", *location_for(ENV['RESOURCE_API_LOCATION'] || ["~> 1.5"])
 
-gem "scanf" if RUBY_VERSION.to_f >= 2.7
-
 group(:features) do
   gem 'diff-lcs', '~> 1.3', require: false
   gem 'hiera-eyaml', *location_for(ENV['HIERA_EYAML_LOCATION'])

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -26,6 +26,7 @@ gem_runtime_dependencies:
   puppet-resource_api: '~>1.5'
   concurrent-ruby: '~> 1.0'
   deep_merge: '~> 1.0'
+  scanf: '~> 1.0'
 gem_rdoc_options:
   - --title
   - "Puppet - Configuration Management"


### PR DESCRIPTION
Previously, puppet had a dependency on the ruby `scanf` gem when running
puppet from source, but not when running as a gem. To ensure transitive
dependencies are resolved correctly, like when running puppetlabs-puppetdb
specs against puppet as a gem, move the `scanf` dependency to
`project_data.yaml`.

Note the runtime dependency is only needed when running ruby 2.7 or up. If
running on 2.5 or 2.6, then the `scanf` gem will be ignored, so there's no
harm in including it.