### PR TITLE
(PUP-10821) Avoid unwanted nil id for posix user/group

### DIFF
--- a/lib/puppet/util/posix.rb
+++ b/lib/puppet/util/posix.rb
@@ -186,7 +186,7 @@ module Puppet::Util::POSIX
     end
 
     if check_value != field
-      check_value_id = get_posix_field(location, id_field, check_value)
+      check_value_id = get_posix_field(location, id_field, check_value) if check_value
 
       if id == check_value_id
         Puppet.debug("Multiple entries found for resource: '#{location}' with #{id_field}: #{id}")

--- a/spec/unit/util/posix_spec.rb
+++ b/spec/unit/util/posix_spec.rb
@@ -502,6 +502,15 @@ describe Puppet::Util::POSIX do
         expect(@posix.gid("asdf")).to eq(100)
       end
 
+      it "returns the id with full groups query if name is nil" do
+        expect(@posix).to receive(:get_posix_field).with(:group, :gid, "asdf").and_return(100)
+        expect(@posix).to receive(:get_posix_field).with(:group, :name, 100).and_return(nil)
+        expect(@posix).not_to receive(:get_posix_field).with(:group, :gid, nil)
+
+
+        expect(@posix).to receive(:search_posix_field).with(:group, :gid, "asdf").and_return(100)
+        expect(@posix.gid("asdf")).to eq(100)
+      end
 
       it "should use :search_posix_field if the discovered name does not match the passed-in name" do
         expect(@posix).to receive(:get_posix_field).with(:group, :gid, "asdf").and_return(100)
@@ -585,6 +594,16 @@ describe Puppet::Util::POSIX do
         expect(@posix).to receive(:get_posix_field).with(:passwd, :uid, "boo").and_return(100)
 
         expect(@posix).not_to receive(:search_posix_field)
+        expect(@posix.uid("asdf")).to eq(100)
+      end
+
+      it "returns the id with full users query if name is nil" do
+        expect(@posix).to receive(:get_posix_field).with(:passwd, :uid, "asdf").and_return(100)
+        expect(@posix).to receive(:get_posix_field).with(:passwd, :name, 100).and_return(nil)
+        expect(@posix).not_to receive(:get_posix_field).with(:passwd, :uid, nil)
+
+
+        expect(@posix).to receive(:search_posix_field).with(:passwd, :uid, "asdf").and_return(100)
         expect(@posix.uid("asdf")).to eq(100)
       end
 


### PR DESCRIPTION
Changes done in #8444 caused a `Puppet::DevError` to be raised (in the `get_posix_value` method when calling the `get_posix_field` method) and silently catched without returning any value. Unit test failures on [puppetlabs-sshkeys_core](https://github.com/puppetlabs/puppetlabs-sshkeys_core/runs/1521934892?check_suite_focus=true) were seen due to receiving `nil` id for posix fields (from a previous `get_posix_field` method call) and expected resources could not be resolved.

This commit adds a guard against `nil` values to be checked and allows the code to do a full resource query in all entries.