### PR TITLE
(PUP-10812) Remove chatty CA dir deprecation

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -32,20 +32,6 @@ module Puppet
       %w[sha256 sha256lite sha384 sha512 sha224 sha1 sha1lite md5 md5lite mtime ctime]
   end
 
-  def self.log_ca_migration_warning
-    urge_to_migrate = <<-UTM
-The cadir is currently configured to be inside the #{Puppet[:ssldir]} directory. This config
-setting and the directory location will not be used in a future version of puppet. Please run the
-puppetserver ca tool to migrate out from the puppet confdir to the /etc/puppetlabs/puppetserver/ca
-directory. Use `puppetserver ca migrate --help` for more info.
-UTM
-    Puppet.warn_once('deprecations',
-                     'CA migration message',
-                     urge_to_migrate,
-                     :default,
-                     :default)
-  end
-
   def self.default_cadir
     return "" if Puppet::Util::Platform.windows?
     old_ca_dir = "#{Puppet[:ssldir]}/ca"
@@ -53,13 +39,8 @@ UTM
 
     if File.exist?(old_ca_dir)
       if File.symlink?(old_ca_dir)
-        target = File.readlink(old_ca_dir)
-        if target.start_with?(Puppet[:ssldir])
-          Puppet.log_ca_migration_warning
-        end
-        target
+        File.readlink(old_ca_dir)
       else
-        Puppet.log_ca_migration_warning
         old_ca_dir
       end
     else
@@ -1112,13 +1093,6 @@ EOT
       :default => lambda { default_cadir },
       :type => :directory,
       :desc => "The root directory for the certificate authority.",
-      :call_hook => :on_initialize_and_write,
-      :hook => proc do |value|
-        if value.start_with?(Puppet[:ssldir])
-          Puppet.log_ca_migration_warning
-        end
-        value
-      end
     },
     :cacert => {
       :default => "$cadir/ca_crt.pem",

--- a/lib/puppet/face/node/clean.rb
+++ b/lib/puppet/face/node/clean.rb
@@ -52,7 +52,7 @@ Puppet::Face.define(:node, '0.0.1') do
     end
 
     def warn(message)
-      Puppet.warning(message) unless message =~ /cadir is currently configured to be inside/
+      Puppet.warning(message)
     end
 
     def err(message)


### PR DESCRIPTION
This change stops puppet from emitting CA dir deprecation warnings,
but it still keeps the cadir defaulted to the puppetserver dir
unless it already exists within the puppet/ssl dir.