### PR TITLE
(PUP-10790) Fix regex warnings introduced in Ruby 2.7

### DIFF
--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -465,7 +465,7 @@ module Puppet
       groups = obj.shouldorig if obj
       if groups
         groups = groups.collect { |group|
-          if group =~ /^\d+$/
+          if group.is_a?(String) && group =~/^\d+$/
             Integer(group)
           else
             group


### PR DESCRIPTION
Ruby 2.7 introduced a warning for checking invalid objects (such as `Integer` in our case) against a regular expression. The check in this case always returns nil even though a valid String would respect the given regular expression, resulting in the possibility of unwanted behaviour.

This commit replaces the check accordingly in the user type and keeps previous logic. Example of the removed warning:
> /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/type/user.rb:468: warning: deprecated Object#=~ is called on Integer; it always returns nil