### PR TITLE
(maint) Fix parallel:spec finishing with  0 failures but exit code 1

### DIFF
--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -33,7 +33,8 @@ jobs:
 
       - name: Install bundler and gems
         run: |
-          gem install bundler
+          gem uninstall bundler
+          gem install bundler -v '2.1.4'
           bundle config set without packaging documentation
           bundle install --jobs 4 --retry 3
 

--- a/spec/unit/util/storage_spec.rb
+++ b/spec/unit/util/storage_spec.rb
@@ -143,9 +143,11 @@ describe Puppet::Util::Storage do
       end
 
       it "should raise an error if the state file does not contain valid YAML and cannot be renamed" do
+        allow(File).to receive(:rename).and_call_original
+
         write_state_file('{ invalid')
 
-        expect(File).to receive(:rename).and_raise(SystemCallError)
+        expect(File).to receive(:rename).with(@state_file, "#{@state_file}.bad").and_raise(SystemCallError)
 
         expect { Puppet::Util::Storage.load }.to raise_error(Puppet::Error, /Could not rename/)
       end


### PR DESCRIPTION
Running the `parallel:spec` rake task on **Windows** with **Ruby v2.5** recently started to surface a constant issue in our tests: passing with **0 failures** but always completing with **exit code 1**. Overall checks in our investigation:

- managed to reproduce the issue on Windows GitHub Actions runners (on both versions available at the moment: `windows-2016` and `windows-2019`) as well as on our own virtual machines, thus eliminating the possibility of _changes in the GitHub Actions environment_ as a root cause
- compared the version of installed gems in a failing run against a passing one from previous GitHub Actions runs but we didn't find any difference
- while using `git bisect` we didn't find any **good** commit; using a random 5 months old commit (even though the issue was first seen only a few days ago) still managed to reproduce it
- running each test individually with `rspec .\test_folder\test_name_spec.rb` (using a script to gather all test files and check the exit code after each run) or entire test folders with `rspec test_folder` didn't reproduce it, so we continued our investigation with how the tests run in parallel (found that the final exit code to be given by [this](https://github.com/puppetlabs/puppet/blob/main/tasks/parallel.rake#L407) and how the tests are being splitted [here](https://github.com/puppetlabs/puppet/blob/main/tasks/parallel.rake#L218))
- started removing tests to reduce time for running the tests and narrow down to as few problematic tests as possible; we got to the most barebones scenario where [storage_spec.rb](https://github.com/puppetlabs/puppet/blob/main/spec/unit/util/storage_spec.rb) and any other test is run in parallel reproduces the issue
- while having a minimal reproduction case, we observed that less tests are run when it fails than when it passes

Example when it fails:

> Finished in 17 minutes 44 seconds
> 23851 examples, 0 failures, 77 pending
> 
> Error: Process completed with exit code 1.

Example when it succeeds:

> Finished in 13 minutes 42 seconds
> 24716 examples, 0 failures, 77 pending


We concluded with '`should raise an error if the state file does not contain valid YAML and cannot be renamed`' from [storage_spec.rb](https://github.com/puppetlabs/puppet/blob/main/spec/unit/util/storage_spec.rb) as being the root cause of the `exit code 1`. The more in depth explanations is that the test was forcing the `File.rename` method to raise a `SystemException` any time it was called as it didn't mention any specific arguments (`expect(File).to receive(:rename).and_raise(SystemCallError)`). Since this is a fairly common method, it was surely called more than once, before and apart from the case that the test was expecting, causing the code to quit unexpectedly.

When running the tests in parallel we can see that they are split into groups and workers:
> Processing 22 spec group(s) with 2 worker(s)

Each group contains a list of test files to run. Every time the group containing the [storage_spec.rb](https://github.com/puppetlabs/puppet/blob/main/spec/unit/util/storage_spec.rb) file reached the problematic test, it raised said exception (which was not expected to happen by neither the test or the code) and forcefully exited, causing the rest of the tests in the group to not be run anymore and the parent rspec Thread to also be terminated (causing in the end less tests to be run).

This commit fixes the test by raising the needed `SystemException` when specific arguments are found and allowing the original `File.rename` method to be called.
> expect(File).to receive(:rename).with(@state_file, "#{@state_file}.bad").and_raise(SystemCallError)

instead of:
> expect(File).to receive(:rename).and_raise(SystemCallError)