### PR TITLE
(maint) Backport latest changes from main

### DIFF
--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -36,7 +36,8 @@ jobs:
 
       - name: Install bundler and gems
         run: |
-          gem install bundler
+          gem uninstall bundler
+          gem install bundler -v '2.1.4'
           bundle config set without packaging documentation
           bundle install --jobs 4 --retry 3
 

--- a/lib/puppet/application_support.rb
+++ b/lib/puppet/application_support.rb
@@ -53,6 +53,13 @@ module Puppet
       route_file = Puppet[:route_file]
       if Puppet::FileSystem.exist?(route_file)
         routes = Puppet::Util::Yaml.safe_load_file(route_file, [Symbol])
+        if routes["server"] && routes["master"]
+          Puppet.warning("Route file #{route_file} contains both server and master route settings.")
+        elsif routes["server"] && !routes["master"]
+          routes["master"] = routes["server"]
+        elsif routes["master"] && !routes["server"]
+          routes["server"] = routes["master"]
+        end
         application_routes = routes[application_name]
         Puppet::Indirector.configure_routes(application_routes) if application_routes
       end

--- a/lib/puppet/util/posix.rb
+++ b/lib/puppet/util/posix.rb
@@ -186,7 +186,7 @@ module Puppet::Util::POSIX
     end
 
     if check_value != field
-      check_value_id = get_posix_field(location, id_field, check_value)
+      check_value_id = get_posix_field(location, id_field, check_value) if check_value
 
       if id == check_value_id
         Puppet.debug("Multiple entries found for resource: '#{location}' with #{id_field}: #{id}")

--- a/lib/puppet/util/posix.rb
+++ b/lib/puppet/util/posix.rb
@@ -184,8 +184,17 @@ module Puppet::Util::POSIX
       name = get_posix_field(location, :name, id)
       check_value = name
     end
+
     if check_value != field
-      return search_posix_field(location, id_field, field)
+      check_value_id = get_posix_field(location, id_field, check_value)
+
+      if id == check_value_id
+        Puppet.debug("Multiple entries found for resource: '#{location}' with #{id_field}: #{id}")
+        return id
+      else
+        Puppet.debug("The value retrieved: '#{check_value}' is different than the required state: '#{field}', searching in all entries")
+        return search_posix_field(location, id_field, field)
+      end
     else
       return id
     end

--- a/spec/unit/application_spec.rb
+++ b/spec/unit/application_spec.rb
@@ -511,6 +511,40 @@ describe Puppet::Application do
 
       expect { @app.configure_indirector_routes }.to raise_error(Puppet::Error, /mapping values are not allowed/)
     end
+
+    it "should treat master routes on server application" do
+      allow(@app).to receive(:name).and_return("server")
+
+      Puppet[:route_file] = tmpfile('routes')
+      File.open(Puppet[:route_file], 'w') do |f|
+        f.print <<-ROUTES
+          master:
+            node:
+              terminus: exec
+        ROUTES
+      end
+
+      @app.configure_indirector_routes
+
+      expect(Puppet::Node.indirection.terminus_class).to eq('exec')
+    end
+
+    it "should treat server routes on master application" do
+      allow(@app).to receive(:name).and_return("master")
+
+      Puppet[:route_file] = tmpfile('routes')
+      File.open(Puppet[:route_file], 'w') do |f|
+        f.print <<-ROUTES
+          server:
+            node:
+              terminus: exec
+        ROUTES
+      end
+
+      @app.configure_indirector_routes
+
+      expect(Puppet::Node.indirection.terminus_class).to eq('exec')
+    end
   end
 
   describe "when running" do

--- a/spec/unit/util/posix_spec.rb
+++ b/spec/unit/util/posix_spec.rb
@@ -493,6 +493,16 @@ describe Puppet::Util::POSIX do
         expect(@posix.gid("asdf")).to eq(100)
       end
 
+      it "returns the id without full groups query if multiple groups have the same id" do
+        expect(@posix).to receive(:get_posix_field).with(:group, :gid, "asdf").and_return(100)
+        expect(@posix).to receive(:get_posix_field).with(:group, :name, 100).and_return("boo")
+        expect(@posix).to receive(:get_posix_field).with(:group, :gid, "boo").and_return(100)
+
+        expect(@posix).not_to receive(:search_posix_field)
+        expect(@posix.gid("asdf")).to eq(100)
+      end
+
+
       it "should use :search_posix_field if the discovered name does not match the passed-in name" do
         expect(@posix).to receive(:get_posix_field).with(:group, :gid, "asdf").and_return(100)
         expect(@posix).to receive(:get_posix_field).with(:group, :name, 100).and_return("boo")
@@ -566,6 +576,15 @@ describe Puppet::Util::POSIX do
         expect(@posix).to receive(:get_posix_field).with(:passwd, :uid, "asdf").and_return(100)
         expect(@posix).to receive(:get_posix_field).with(:passwd, :name, 100).and_return("asdf")
 
+        expect(@posix.uid("asdf")).to eq(100)
+      end
+
+      it "returns the id without full users query if multiple users have the same id" do
+        expect(@posix).to receive(:get_posix_field).with(:passwd, :uid, "asdf").and_return(100)
+        expect(@posix).to receive(:get_posix_field).with(:passwd, :name, 100).and_return("boo")
+        expect(@posix).to receive(:get_posix_field).with(:passwd, :uid, "boo").and_return(100)
+
+        expect(@posix).not_to receive(:search_posix_field)
         expect(@posix.uid("asdf")).to eq(100)
       end
 

--- a/spec/unit/util/posix_spec.rb
+++ b/spec/unit/util/posix_spec.rb
@@ -502,6 +502,15 @@ describe Puppet::Util::POSIX do
         expect(@posix.gid("asdf")).to eq(100)
       end
 
+      it "returns the id with full groups query if name is nil" do
+        expect(@posix).to receive(:get_posix_field).with(:group, :gid, "asdf").and_return(100)
+        expect(@posix).to receive(:get_posix_field).with(:group, :name, 100).and_return(nil)
+        expect(@posix).not_to receive(:get_posix_field).with(:group, :gid, nil)
+
+
+        expect(@posix).to receive(:search_posix_field).with(:group, :gid, "asdf").and_return(100)
+        expect(@posix.gid("asdf")).to eq(100)
+      end
 
       it "should use :search_posix_field if the discovered name does not match the passed-in name" do
         expect(@posix).to receive(:get_posix_field).with(:group, :gid, "asdf").and_return(100)
@@ -585,6 +594,16 @@ describe Puppet::Util::POSIX do
         expect(@posix).to receive(:get_posix_field).with(:passwd, :uid, "boo").and_return(100)
 
         expect(@posix).not_to receive(:search_posix_field)
+        expect(@posix.uid("asdf")).to eq(100)
+      end
+
+      it "returns the id with full users query if name is nil" do
+        expect(@posix).to receive(:get_posix_field).with(:passwd, :uid, "asdf").and_return(100)
+        expect(@posix).to receive(:get_posix_field).with(:passwd, :name, 100).and_return(nil)
+        expect(@posix).not_to receive(:get_posix_field).with(:passwd, :uid, nil)
+
+
+        expect(@posix).to receive(:search_posix_field).with(:passwd, :uid, "asdf").and_return(100)
         expect(@posix.uid("asdf")).to eq(100)
       end
 

--- a/spec/unit/util/storage_spec.rb
+++ b/spec/unit/util/storage_spec.rb
@@ -143,9 +143,11 @@ describe Puppet::Util::Storage do
       end
 
       it "should raise an error if the state file does not contain valid YAML and cannot be renamed" do
+        allow(File).to receive(:rename).and_call_original
+
         write_state_file('{ invalid')
 
-        expect(File).to receive(:rename).and_raise(SystemCallError)
+        expect(File).to receive(:rename).with(@state_file, "#{@state_file}.bad").and_raise(SystemCallError)
 
         expect { Puppet::Util::Storage.load }.to raise_error(Puppet::Error, /Could not rename/)
       end


### PR DESCRIPTION
This pull request backports a couple of changes from main:
- (PUP-10774) Do not query all groups/users e15685f
- (maint) Fix parallel:spec, 0 failures but exit code 1 cf16ce4
- (maint) Lock bundler version in GitHub Actions a898ffe
- (maint) Skip SSL spec when openssl >= 1.1.1h  f7b30f1eac702c7e8c6dc22b943666832e26918f
- (PUP-10773) Reroute master settings to server dee7247e90280491d42886320a1ad8589bdc3736

It also adds:
- (PUP-10821) Avoid unwanted nil id for posix user/group 1b82e79
This commit has been cherry-picked from #8451 

Changes done in #8444 caused a Puppet::DevError to be raised (in the get_posix_value method when calling the get_posix_field method) and silently catched without returning any value. Unit test failures on puppetlabs-sshkeys_core were seen due to receiving nil id for posix fields (from a previous get_posix_field method call) and expected resources could not be resolved.

This commit adds a guard against nil values to be checked and allows the code to do a full resource query in all entries.