### PR TITLE
(PUP-10818) Cache the deferred function, not its result

### DIFF
--- a/spec/fixtures/integration/application/agent/cached_deferred_catalog.json
+++ b/spec/fixtures/integration/application/agent/cached_deferred_catalog.json
@@ -1,0 +1,91 @@
+{
+  "tags": [
+    "settings"
+  ],
+  "name": "127.0.0.1",
+  "version": 1607629733,
+  "code_id": null,
+  "catalog_uuid": "afc8472a-306b-4b24-b060-e956dffb79b8",
+  "catalog_format": 1,
+  "environment": "production",
+  "resources": [
+    {
+      "type": "Stage",
+      "title": "main",
+      "tags": [
+        "stage"
+      ],
+      "exported": false,
+      "parameters": {
+        "name": "main"
+      }
+    },
+    {
+      "type": "Class",
+      "title": "Settings",
+      "tags": [
+        "class",
+        "settings"
+      ],
+      "exported": false
+    },
+    {
+      "type": "Class",
+      "title": "main",
+      "tags": [
+        "class"
+      ],
+      "exported": false,
+      "parameters": {
+        "name": "main"
+      }
+    },
+    {
+      "type": "Notify",
+      "title": "deferred",
+      "tags": [
+        "notify",
+        "deferred",
+        "class"
+      ],
+      "file": "",
+      "line": 1,
+      "exported": false,
+      "parameters": {
+        "message": {
+          "__ptype": "Deferred",
+          "name": "new",
+          "arguments": [
+            {
+              "__ptype": "Pcore::StringType"
+            },
+            {
+              "__ptype": "Deferred",
+              "name": "binary_file",
+              "arguments": [
+                "__SOURCE_PATH__"
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "edges": [
+    {
+      "source": "Stage[main]",
+      "target": "Class[Settings]"
+    },
+    {
+      "source": "Stage[main]",
+      "target": "Class[main]"
+    },
+    {
+      "source": "Class[main]",
+      "target": "Notify[deferred]"
+    }
+  ],
+  "classes": [
+    "settings"
+  ]
+}


### PR DESCRIPTION
Merge commit a17761d60b introduced a semantic conflict between the environment
convergence changes in 5.5.x and the deferred function support in 6.x. As a
result puppet evaluated deferred functions before caching the result. This
regression was first introduced in 6.12.0. As a result, if the agent ran
from a cached catalog, it would use the result from last time, instead of
re-evaluating the deferred function.

This commit switches the order of those operations and adds a test. We have
to use `binary_file` because `file` is a 3x function and there are issues
with 3x functions and deferred values.