### PR TITLE
(maint) Merge 6.x to main

### DIFF
--- a/lib/puppet/reference/configuration.rb
+++ b/lib/puppet/reference/configuration.rb
@@ -57,11 +57,12 @@ config.header = <<EOT
 * Each of these settings can be specified in `puppet.conf` or on the
   command line.
 * Puppet Enterprise (PE) and open source Puppet share the configuration settings
-  that are documented here. However, PE defaults for some settings differ from
-  the open source Puppet defaults. Some examples of settings that have different
-  PE defaults include `disable18n`, `environment_timeout`, `always_retry_plugins`,
-  and the Puppet Server JRuby `max-active-instances` setting. To verify PE
-  configuration defaults, check the `puppet.conf` file after installation.
+  documented here. However, PE defaults differ from open source defaults for some
+  settings, such as `node_terminus`, `storeconfigs`, `always_retry_plugins`,
+  `disable18n`, `environment_timeout` (when Code Manager is enabled), and the
+  Puppet Server JRuby `max-active-instances` setting. To verify PE configuration
+  defaults, check the `puppet.conf` or `pe-puppet-server.conf` file after
+  installation.
 * When using boolean settings on the command line, use `--setting` and
   `--no-setting` instead of `--setting (true|false)`. (Using `--setting false`
   results in "Error: Could not parse application options: needless argument".)

--- a/spec/unit/ssl/ssl_provider_spec.rb
+++ b/spec/unit/ssl/ssl_provider_spec.rb
@@ -271,8 +271,11 @@ describe Puppet::SSL::SSLProvider do
     end
 
     # This option is only available in openssl 1.1
-    # TODO PUP-10689 behavior changed in openssl 1.1.1h
-    if Puppet::Util::Package.versioncmp(OpenSSL::OPENSSL_LIBRARY_VERSION.split[1], '1.1.1h') < 0
+    # OpenSSL 1.1.1h no longer reports expired root CAs when using "verify".
+    # This regression was fixed in 1.1.1i, so only skip this test if we're on
+    # the affected version.
+    # See: https://github.com/openssl/openssl/pull/13585
+    if Puppet::Util::Package.versioncmp(OpenSSL::OPENSSL_LIBRARY_VERSION.split[1], '1.1.1h') != 0
       it 'raises if root cert signature is invalid', if: defined?(OpenSSL::X509::V_FLAG_CHECK_SS_SIGNATURE) do
         ca = global_cacerts.first
         ca.sign(wrong_key, OpenSSL::Digest::SHA256.new)


### PR DESCRIPTION
* commit 'de32c1e053621dee5ad3e822b8779849de7485da':
  (packaging) Updating manpage file for 6.x
  (maint) Trigger on PRs and pushes to 6.x
  (DOCS) Update PE defaults note in configuration.rb
  (maint) Skip SSL spec only when running with openssl 1.1.1h

Conflicts (keep ours):
  .github/workflows/checks.yaml
  .github/workflows/rspec_tests.yaml