### PR TITLE
(PUP-10725) add aliasing mechanism for settings

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1371,23 +1371,15 @@ EOT
       by `puppet`, and should only be set if you're writing your own Puppet
       executable.",
     },
-    :serverport => {
-      :default    => 8140,
-      :desc       => "The default port puppet subcommands use to communicate
-      with Puppet Server. (eg `puppet facts upload`, `puppet agent`). May be
-      overridden by more specific settings (see `ca_port`, `report_port`).",
-      :hook       => proc do |value|
-        Puppet[:masterport] = value unless Puppet.settings.set_by_config?(:masterport)
-      end
-    },
     :masterport => {
       :default    => 8140,
       :desc       => "The default port puppet subcommands use to communicate
       with Puppet Server. (eg `puppet facts upload`, `puppet agent`). May be
       overridden by more specific settings (see `ca_port`, `report_port`).",
-      :hook => proc do |value|
-        Puppet[:serverport] = value unless Puppet.settings.set_by_config?(:serverport)
-      end
+    },
+    :serverport => {
+      :type => :alias,
+      :alias_for => :masterport
     },
     :node_name => {
       :default    => 'cert',

--- a/lib/puppet/settings/alias_setting.rb
+++ b/lib/puppet/settings/alias_setting.rb
@@ -1,0 +1,37 @@
+class Puppet::Settings::AliasSetting
+  attr_reader :name, :alias_name
+
+  def initialize(args = {})
+    @name = args[:name]
+    @alias_name = args[:alias_for]
+    @alias_for = Puppet.settings.setting(alias_name)
+  end
+
+  def optparse_args
+    args = @alias_for.optparse_args
+    args[0].gsub!(alias_name.to_s, name.to_s)
+    args
+  end
+
+  def getopt_args
+    args = @alias_for.getopt_args
+    args[0].gsub!(alias_name.to_s, name.to_s)
+    args
+  end
+
+  def type
+    :alias
+  end
+
+  def method_missing(method, *args)
+    begin
+      alias_for.send(method, *args)
+    rescue => e
+      Puppet.log_exception(self.class, e.message)
+    end
+  end
+
+  private
+
+  attr_reader :alias_for
+end

--- a/spec/integration/defaults_spec.rb
+++ b/spec/integration/defaults_spec.rb
@@ -36,13 +36,6 @@ describe "Puppet defaults" do
     end
   end
 
-  describe "when setting the :serverport" do
-    it "should also set the :masterport to the same value" do
-      Puppet.settings[:serverport] = 9000
-      expect(Puppet.settings[:masterport]).to eq(9000)
-    end
-  end
-
   describe "when setting the :factpath" do
     it "should add the :factpath to Facter's search paths" do
       expect(Facter).to receive(:search).with("/my/fact/path")

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -1088,7 +1088,7 @@ describe Puppet::Settings do
       before(:each) do
         @settings.define_settings :main, PuppetSpec::Settings::TEST_APP_DEFAULT_DEFINITIONS
         @settings.define_settings :server, :masterport => { :desc => "a", :default => 1000 }
-        @settings.define_settings :server, :serverport => { :desc => "a", :default => 1000 }
+        @settings.define_settings :server, :serverport => { :type => :alias, :alias_for => :masterport }
         @settings.define_settings :server, :ca_port => { :desc => "a", :default => "$serverport" }
         @settings.define_settings :server, :report_port => { :desc => "a", :default => "$serverport" }
 
@@ -1110,9 +1110,10 @@ describe Puppet::Settings do
       "
         end
 
-        it { expect(@settings[:serverport]).to eq(445) }
-        it { expect(@settings[:ca_port]).to eq("445") }
-        it { expect(@settings[:report_port]).to eq("445") }
+        it { expect(@settings[:serverport]).to eq(444) }
+        it { expect(@settings[:ca_port]).to eq("444") }
+        it { expect(@settings[:report_port]).to eq("444") }
+        it { expect(@settings[:masterport]).to eq(445) }
       end
 
       context 'with serverport and masterport in main' do
@@ -1126,6 +1127,7 @@ describe Puppet::Settings do
         it { expect(@settings[:serverport]).to eq(445) }
         it { expect(@settings[:ca_port]).to eq("445") }
         it { expect(@settings[:report_port]).to eq("445") }
+        it { expect(@settings[:masterport]).to eq(444) }
       end
 
       context 'with serverport and masterport in agent' do
@@ -1139,6 +1141,7 @@ describe Puppet::Settings do
         it { expect(@settings[:serverport]).to eq(445) }
         it { expect(@settings[:ca_port]).to eq("445") }
         it { expect(@settings[:report_port]).to eq("445") }
+        it { expect(@settings[:masterport]).to eq(444) }
       end
 
       context 'with both serverport and masterport in main and agent' do
@@ -1155,6 +1158,7 @@ describe Puppet::Settings do
         it { expect(@settings[:serverport]).to eq(445) }
         it { expect(@settings[:ca_port]).to eq("445") }
         it { expect(@settings[:report_port]).to eq("445") }
+        it { expect(@settings[:masterport]).to eq(444) }
       end
 
       context 'with serverport in agent and masterport in main' do
@@ -1169,6 +1173,7 @@ describe Puppet::Settings do
         it { expect(@settings[:serverport]).to eq(444) }
         it { expect(@settings[:ca_port]).to eq("444") }
         it { expect(@settings[:report_port]).to eq("444") }
+        it { expect(@settings[:masterport]).to eq(445) }
       end
 
       context 'with masterport in main' do
@@ -1181,6 +1186,7 @@ describe Puppet::Settings do
         it { expect(@settings[:serverport]).to eq(445) }
         it { expect(@settings[:ca_port]).to eq("445") }
         it { expect(@settings[:report_port]).to eq("445") }
+        it { expect(@settings[:masterport]).to eq(445) }
       end
 
       context 'with masterport in agent' do
@@ -1193,6 +1199,7 @@ describe Puppet::Settings do
         it { expect(@settings[:serverport]).to eq(445) }
         it { expect(@settings[:ca_port]).to eq("445") }
         it { expect(@settings[:report_port]).to eq("445") }
+        it { expect(@settings[:masterport]).to eq(445) }
       end
 
       context 'with serverport in agent' do
@@ -1203,7 +1210,7 @@ describe Puppet::Settings do
         end
 
         it { expect(@settings[:serverport]).to eq(445) }
-        it { expect(@settings[:masterport]).to eq(445) }
+        it { expect(@settings[:masterport]).to eq(1000) }
         it { expect(@settings[:ca_port]).to eq("445") }
         it { expect(@settings[:report_port]).to eq("445") }
       end
@@ -1216,7 +1223,7 @@ describe Puppet::Settings do
         end
 
         it { expect(@settings[:serverport]).to eq(445) }
-        it { expect(@settings[:masterport]).to eq(445) }
+        it { expect(@settings[:masterport]).to eq(1000) }
         it { expect(@settings[:ca_port]).to eq("445") }
         it { expect(@settings[:report_port]).to eq("445") }
       end


### PR DESCRIPTION
Added a new settings type, alias, and updates :serverport to be an alias for :masterport