### PR TITLE
(PUP-10840) Remove cleanpath workaround

### DIFF
--- a/lib/puppet/util/autoload.rb
+++ b/lib/puppet/util/autoload.rb
@@ -166,14 +166,7 @@ class Puppet::Util::Autoload
     # Normalize a path. This converts ALT_SEPARATOR to SEPARATOR on Windows
     # and eliminates unnecessary parts of a path.
     def cleanpath(path)
-      # There are two cases here because cleanpath does not handle absolute
-      # paths correctly on windows (c:\ and c:/ are treated as distinct) but
-      # we don't want to convert relative paths to absolute
-      if Puppet::Util.absolute_path?(path)
-        File.expand_path(path)
-      else
-        Pathname.new(path).cleanpath.to_s
-      end
+      Pathname.new(path).cleanpath.to_s
     end
   end
 

--- a/spec/unit/util/autoload_spec.rb
+++ b/spec/unit/util/autoload_spec.rb
@@ -298,6 +298,10 @@ describe Puppet::Util::Autoload do
       it "should convert c:\ to c:/" do
         expect(Puppet::Util::Autoload.cleanpath('c:\\')).to eq('c:/')
       end
+
+      it "should convert all backslashes to forward slashes" do
+        expect(Puppet::Util::Autoload.cleanpath('c:\projects\ruby\bug\test.rb')).to eq('c:/projects/ruby/bug/test.rb')
+      end
     end
   end
 


### PR DESCRIPTION
Pathname#cleanpath correctly replaces all backslashes to forward slashes
on Windows, so remove our workaround. The workaround is required in 5.5.x
because we "support" 1.9.3.

[1] https://bugs.ruby-lang.org/issues/9618