### PR TITLE
Revert "(maint) Lock bundler version in GitHub Actions"

### DIFF
--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -36,8 +36,7 @@ jobs:
 
       - name: Install bundler and gems
         run: |
-          gem uninstall bundler
-          gem install bundler -v '2.1.4'
+          gem install bundler
           bundle config set without packaging documentation
           bundle install --jobs 4 --retry 3
 


### PR DESCRIPTION
This reverts commit a898ffe934460bce0930205e0430bdf2693ff619 since the bundler regression was recently fixed[1].

[1] https://github.com/rubygems/rubygems/commit/6a8791c6000f6a20982e37db302432ddaa3fb916