### PR TITLE
(PUP-10845) Eliminate keyword parameter warning

### DIFF
--- a/lib/puppet/parser/ast/leaf.rb
+++ b/lib/puppet/parser/ast/leaf.rb
@@ -50,8 +50,9 @@ class Puppet::Parser::AST::HostName < Puppet::Parser::AST::Leaf
 end
 
 class Puppet::Parser::AST::Regex < Puppet::Parser::AST::Leaf
-  def initialize(hash)
-    super(**hash)
+  def initialize(value: nil, file: nil, line: nil, pos: nil)
+    super(value: value, file: file, line: line, pos: pos)
+
     # transform value from hash options unless it is already a regular expression
     @value = Regexp.new(@value) unless @value.is_a?(Regexp)
   end

--- a/lib/puppet/pops/model/ast_transformer.rb
+++ b/lib/puppet/pops/model/ast_transformer.rb
@@ -31,7 +31,7 @@ class Puppet::Pops::Model::AstTransformer
   def ast(o, klass, hash={})
     # create and pass hash with file and line information
     # PUP-3274 - still needed since hostname transformation requires AST::HostName, and AST::Regexp
-    klass.new(merge_location(hash, o))
+    klass.new(**merge_location(hash, o))
   end
 
   # THIS IS AN EXPENSIVE OPERATION


### PR DESCRIPTION
Puppet emitted a deprecation warning when parsing a `node` definition containing
a hostname, because it passed a hash to `Puppet::Parser::AST::HostName.new`, but
the initialize method expected keyword arguments. The error is only reproducible
using ruby 2.7.1, but not 2.7.2. The error doesn't happen with `AST::Regex`,
because its `initialize` method accepted a hash.

This commit double splats the hash prior to calling `klass.new` and it updates
`AST::Regex` to expect keyword arguments like `AST::HostName`. Note the
superclass `AST::Leaf` already expects keyword arguments.