### PR TITLE
(PUP-10847) Add flat output format

### DIFF
--- a/spec/unit/network/formats_spec.rb
+++ b/spec/unit/network/formats_spec.rb
@@ -534,4 +534,45 @@ EOT
       end
     end
   end
+
+  describe ":flat format" do
+    let(:flat) { Puppet::Network::FormatHandler.format(:flat) }
+
+    it "should include a flat format" do
+      expect(flat).to be_an_instance_of Puppet::Network::Format
+    end
+
+    [:intern, :intern_multiple].each do |method|
+      it "should not implement #{method}" do
+        expect { flat.send(method, String, 'blah') }.to raise_error NotImplementedError
+      end
+    end
+
+    context "when rendering arrays" do
+      {
+          []                           => "",
+          [1, 2]                       => "0=1\n1=2\n",
+          ["one"]                      => "0=one\n",
+          [{"one" => 1}, {"two" => 2}] => "0.one=1\n1.two=2\n",
+          [['something', 'for'], ['the', 'test']]  => "0=[\"something\", \"for\"]\n1=[\"the\", \"test\"]\n"
+      }.each_pair do |input, output|
+        it "should render #{input.inspect} as one item per line" do
+          expect(flat.render(input)).to eq(output)
+        end
+      end
+    end
+
+    context "when rendering hashes" do
+      {
+          {}                                   => "",
+          {1 => 2}                             => "1=2\n",
+          {"one" => "two"}                     => "one=two\n",
+          {[1,2] => 3, [2,3] => 5, [3,4] => 7} => "[1, 2]=3\n[2, 3]=5\n[3, 4]=7\n",
+      }.each_pair do |input, output|
+        it "should render #{input.inspect}" do
+          expect(flat.render(input)).to eq(output)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Description of the problem:** The output format is different between Facter and `puppet facts` when a query for a single fact is provided:
`~~ puppet facts facterversion`
`{
  "facterversion": "4.0.47"
}`
vs
`~~ facter facterversion`
`4.0.47`
**Description of the fix:**
**Added `--value-only` command argument:**
 When there is a single query, only display the value of the fact without it's name:
`~~ puppet facts facterversion --value-only`
`"4.0.47"`
Also this generates a warning message if the argument is used with multiple queries or with no query at all:
`puppet facts show facterversion  os --value-only`
`Warning: Incorect use of --value-only argument! The argument must be used when quering for a single fact!`

**Added `flat` render format:**
When there is a query for a simple fact:
`puppet facts show facterversion --render-as flat`
`facterversion=4.0.47`
and with `--value-only`
`puppet facts show facterversion --render-as flat --value-only`
`4.0.47`

When there is a query for a more complex fact (ex. `os`) the output will be:
```
~~ puppet facts os --render-as flat
os.architecture=x86_64
os.family=Darwin
os.hardware=x86_64
os.macosx.build=18G95
os.macosx.product=Mac OS X
os.macosx.version.full=10.14.6
os.macosx.version.major=10.14
os.macosx.version.minor=6
os.name=Darwin
os.release.full=18.7.0
os.release.major=18
os.release.minor=7
```
and with `--value-only`
```
~~ puppet facts os --render-as flat --value-only
architecture=x86_64
family=Darwin
hardware=x86_64
macosx.build=18G95
macosx.product=Mac OS X
macosx.version.full=10.14.6
macosx.version.major=10.14
macosx.version.minor=6
name=Darwin
release.full=18.7.0
release.major=18
release.minor=7
```

For multiple user queries the output is :
```
~~ puppet facts show os.name facterversion --render-as flat
facterversion=4.0.47
os.name=Darwin
```

When the result is an array, the index of each element is also displayed:
```
~~ puppet facts show processors.models --render-as flat
processors.models.0=Intel(R) Core(TM) i7-4980HQ CPU @ 2.80GHz
processors.models.1=Intel(R) Core(TM) i7-4980HQ CPU @ 2.80GHz
processors.models.2=Intel(R) Core(TM) i7-4980HQ CPU @ 2.80GHz
processors.models.3=Intel(R) Core(TM) i7-4980HQ CPU @ 2.80GHz
processors.models.4=Intel(R) Core(TM) i7-4980HQ CPU @ 2.80GHz
processors.models.5=Intel(R) Core(TM) i7-4980HQ CPU @ 2.80GHz
processors.models.6=Intel(R) Core(TM) i7-4980HQ CPU @ 2.80GHz
processors.models.7=Intel(R) Core(TM) i7-4980HQ CPU @ 2.80GHz
```

```
~~ puppet facts show networking.interfaces.interface_name.bindings6 --render-as flat --value-only
0.address=fe80::...
0.netmask=ffff:ffff:ffff:ffff::
0.network=fe80::
0.scope6=link
```
