### PR TITLE
(maint) Merge 6.x to main

### DIFF
--- a/lib/puppet/parser/ast/leaf.rb
+++ b/lib/puppet/parser/ast/leaf.rb
@@ -50,8 +50,9 @@ class Puppet::Parser::AST::HostName < Puppet::Parser::AST::Leaf
 end
 
 class Puppet::Parser::AST::Regex < Puppet::Parser::AST::Leaf
-  def initialize(hash)
-    super(**hash)
+  def initialize(value: nil, file: nil, line: nil, pos: nil)
+    super(value: value, file: file, line: line, pos: pos)
+
     # transform value from hash options unless it is already a regular expression
     @value = Regexp.new(@value) unless @value.is_a?(Regexp)
   end

--- a/lib/puppet/pops/model/ast_transformer.rb
+++ b/lib/puppet/pops/model/ast_transformer.rb
@@ -31,7 +31,7 @@ class Puppet::Pops::Model::AstTransformer
   def ast(o, klass, hash={})
     # create and pass hash with file and line information
     # PUP-3274 - still needed since hostname transformation requires AST::HostName, and AST::Regexp
-    klass.new(merge_location(hash, o))
+    klass.new(**merge_location(hash, o))
   end
 
   # THIS IS AN EXPENSIVE OPERATION


### PR DESCRIPTION
Merge remote-tracking branch 'upstream/6.x' into 6x_main_mergeup

* upstream/6.x:
  (maint) Verify partial doubles
  (maint) Allow additional respond_to arguments
  (maint) Don't stub nonexistent methods on Windows/JRuby
  (maint) Handle Puppet.debug with block
  (maint) Don't stub nonexistent compiler methods
  (maint) StringIO doesn't have a path method
  (maint) Define callback method(s)
  (maint) Cleanup indirector tests
  (maint) Selectively disable partial double verification
  (maint) Use builtin yield matchers
  (maint) Make sure test classes implement the interface
  (maint) Return instances of Puppet::Type::Provider::PackageApt
  (maint) Remove stubs for non-existent methods
  (maint) Use a facter double
  (maint) Call set_facts on the scope in test
  (PUP-10845) Eliminate keyword parameter warning

Conflicts:
	spec/unit/provider/nameservice_spec.rb: listbyname was removed in 3d3ac2f
	spec/unit/provider_spec.rb: execfail was removed in c9e2afa
	spec/unit/transaction_spec.rb: use provider instead of described_class

These files were deleted in 7.0:
	spec/unit/indirector/key/file_spec.rb
	spec/unit/resource/capability_finder_spec.rb
	spec/unit/ssl/host_spec.rb