### PR TITLE
(PUP-10850)Add --no-legacy option for puppet facts

### DIFF
--- a/lib/puppet/face/facts.rb
+++ b/lib/puppet/face/facts.rb
@@ -124,8 +124,8 @@ Puppet::Indirector::Face.define(:facts, '0.0.1') do
       summary _("Disable fact caching mechanism.")
     end
 
-    option("--show-legacy") do
-      summary _("Show legacy facts when querying all facts.")
+    option("--no-legacy") do
+      summary _("Disable legacy facts when querying all facts.")
     end
 
     when_invoked do |*args|

--- a/lib/puppet/indirector/facts/facter.rb
+++ b/lib/puppet/indirector/facts/facter.rb
@@ -100,7 +100,7 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
     options_for_facter = String.new
     options_for_facter += options[:user_query].join(' ')
     options_for_facter += " --config #{options[:config_file]}" if options[:config_file]
-    options_for_facter += " --show-legacy" if options[:show_legacy]
+    options_for_facter +=  options[:no_legacy] == false ? " --show-legacy false" : " --show-legacy"
     options_for_facter += " --no-block" if options[:no_block] == false
     options_for_facter += " --no-cache" if options[:no_cache] == false
 

--- a/spec/unit/indirector/facts/facter_spec.rb
+++ b/spec/unit/indirector/facts/facter_spec.rb
@@ -153,7 +153,7 @@ describe Puppet::Node::Facts::Facter do
   end
 
   describe 'when :resolve_options is true' do
-    let(:options) { { resolve_options: true, user_query: ["os", "timezone"], show_legacy: true } }
+    let(:options) { { resolve_options: true, user_query: ["os", "timezone"] } }
     let(:facts) { Puppet::Node::Facts.new("foo") }
 
     before :each do
@@ -171,6 +171,15 @@ describe Puppet::Node::Facts::Facter do
       expect(facts).not_to receive(:add_local_facts)
 
       @facter.find(@request)
+    end
+
+    context 'when --no-legacy flag is present' do
+      let(:options) { { resolve_options: true, user_query: ["os", "timezone"], no_legacy: false } }
+
+      it 'should call Facter.resolve method with show-legacy false' do
+        expect(Facter).to receive(:resolve).with("os timezone --show-legacy false")
+        @facter.find(@request)
+      end
     end
 
     describe 'when Facter version is lower than 4.0.40' do


### PR DESCRIPTION
By default, `puppet facts show` application displays all facts, including legacy facts. This PR adds an option, `--no-legacy` to disable legacy facts when querying for all facts. 