### PR TITLE
(PUP-9176) Requested module breaks existing module dependency

### DIFF
--- a/lib/puppet/module_tool/errors/shared.rb
+++ b/lib/puppet/module_tool/errors/shared.rb
@@ -17,14 +17,21 @@ module Puppet::ModuleTool::Errors
       message << _("Could not %{action} module '%{module_name}' (%{version})") % { action: @action, module_name: @requested_name, version: vstring }
 
       if @unsatisfied
-        message << _("  The requested version cannot satisfy the following dependency: %{name}") % { name: @unsatisfied[:name] }
-        message << _("    Installed: %{current_version}, expected: %{constraints}") % { current_version: @unsatisfied[:current_version], constraints: @unsatisfied[:constraints] }
+        message << _("  The requested version cannot satisfy one or more of the following installed modules:")
+        if @unsatisfied[:current_version]
+          message << _("    %{name}, installed: %{current_version}, expected: %{constraints}") % { name: @unsatisfied[:name], current_version: @unsatisfied[:current_version], constraints: @unsatisfied[:constraints][@unsatisfied[:name]] }
+        else
+          @unsatisfied[:constraints].each do |mod, range|
+            message << _("    %{mod}, expects '%{name}': %{range}") % { mod: mod, name: @requested_name, range: range }
+          end
+        end
+        message << _("")
       else
         message << _("  The requested version cannot satisfy all dependencies")
       end
 
       #TRANSLATORS `puppet module %{action} --ignore-dependencies` is a command line and should not be translated
-      message << _("    Use `puppet module %{action} '%{module_name}' --ignore-dependencies` to %{action} only this module") % { action: @action, module_name: @requested_name }
+      message << _("  Use `puppet module %{action} '%{module_name}' --ignore-dependencies` to %{action} only this module") % { action: @action, module_name: @requested_name }
       message.join("\n")
     end
   end


### PR DESCRIPTION
In 9822a26bf we only handled the case where a module that is to be installed cannot satisfy one or more of its dependencies.

Spec tests uncovered a case that we missed, where the module satisfies all of its constraints, but an existing installed module would become unsatisfied after the installation.

I think this has a low chance of occuring in practice. To reproduce this, one has to:

1. Install a module with fixed upper dependencies:
`> puppet module install --target-dir tmpdir trepasi-debnet -v 1.5.1`
This version has puppetlabs-stdlib bound to `>= 3.2.0 < 5.0.0`

2. Forcibly remove the `stdlib` module
`> rm -rf tmpdir/stdlib`

3. Attempt to install a version of stdlib that breaks the above-stated dependency
`> puppet module install --target-dir tmpdir puppetlabs-stdlib -v "> 5"`

Without this PR, the command fails with a cryptic NilClass error, due to assumptions we made in the original fix for this ticket.

This commit handles this type of installation failure, and prints out a list of all installed modules that do not match the range of the module we're installing, along with their constraints.

The error message then becomes:

```
Error: Could not install module 'puppetlabs-stdlib' (> 5)
  The requested version cannot satisfy one or more of the following installed modules:
    puppetlabs-concat, expects 'puppetlabs-stdlib': >= 4.2.0 < 5.0.0
    trepasi-debnet, expects 'puppetlabs-stdlib': >= 3.2.0 < 5.0.0

  Use `puppet module install 'puppetlabs-stdlib' --ignore-dependencies` to install only this module
```