### PR TITLE
(maint) Add show legacy option for puppet facts

### DIFF
--- a/lib/puppet/face/facts.rb
+++ b/lib/puppet/face/facts.rb
@@ -128,6 +128,10 @@ Puppet::Indirector::Face.define(:facts, '0.0.1') do
       summary _("Disable legacy facts when querying all facts.")
     end
 
+    option("--show-legacy") do
+      summary _("Show legacy facts when querying all facts.")
+    end
+
     when_invoked do |*args|
       options = args.pop
 


### PR DESCRIPTION
This option has no effect and is needed for backwards compatibility.