### PR TITLE
(PUP-10851) Omit error when parsing 'allow *' in fileserver.conf

### DIFF
--- a/lib/puppet/file_serving/configuration/parser.rb
+++ b/lib/puppet/file_serving/configuration/parser.rb
@@ -33,8 +33,11 @@ class Puppet::FileServing::Configuration::Parser
           when "path"
             path(mount, value)
           when "allow", "deny"
-            error_location_str = Puppet::Util::Errors.error_location(@file.filename, @count)
-            Puppet.err("Entry '#{line.chomp}' is unsupported and will be ignored at #{error_location_str}")
+            # ignore `allow *`, otherwise report error
+            if var != 'allow' || value != '*'
+              error_location_str = Puppet::Util::Errors.error_location(@file.filename, @count)
+              Puppet.err("Entry '#{line.chomp}' is unsupported and will be ignored at #{error_location_str}")
+            end
           else
             error_location_str = Puppet::Util::Errors.error_location(@file.filename, @count)
             raise ArgumentError.new(_("Invalid argument '%{var}' at %{error_location}") %

--- a/spec/unit/file_serving/configuration/parser_spec.rb
+++ b/spec/unit/file_serving/configuration/parser_spec.rb
@@ -121,6 +121,14 @@ describe Puppet::FileServing::Configuration::Parser do
       end
     }
 
+    it "should not generate an error when parsing 'allow *'" do
+      write_config_file "[one]\nallow *\n"
+
+      expect(Puppet).to receive(:err).never
+
+      @parser.parse
+    end
+
     it "should return comprehensible error message, if failed on invalid attribute" do
       write_config_file "[one]\ndo something\n"
 


### PR DESCRIPTION
Legacy auth was removed in 7, so if we parse an authz rule in fileserver.conf,
then we want to alert the user that it will be ignored by puppet. However,
`allow *` rules are harmless and match puppet's current behavior, so ignore
those, but continue logging an error for other allow/deny rules.