### PR TITLE
(PUP-10842) Fix production environment folder creation

### DIFF
--- a/acceptance/tests/environment/should_find_existing_production_environment.rb
+++ b/acceptance/tests/environment/should_find_existing_production_environment.rb
@@ -1,0 +1,139 @@
+test_name "should find existing production environment"
+tag 'audit:high'
+
+require 'puppet/acceptance/i18ndemo_utils'
+extend Puppet::Acceptance::I18nDemoUtils
+
+agents.each do |agent|
+  path_separator = agent.platform_defaults[:pathseparator]
+  initial_environment = on(agent, puppet("config print environment")).stdout.chomp
+  initial_environment_paths = on(agent, puppet("config print environmentpath")).stdout.chomp.split(path_separator)
+
+  default_environment_path = ''
+  custom_environment_path = agent.tmpdir('custom_environment')
+
+  teardown do
+    step 'uninstall the module' do
+      uninstall_i18n_demo_module(master)
+      uninstall_i18n_demo_module(agent)
+    end
+
+    step 'Remove custom environment paths' do
+      environment_paths = on(agent, puppet("config print environmentpath")).stdout.chomp
+      environment_paths.split(path_separator).each do |path|
+        agent.rm_rf(path) unless initial_environment_paths.include?(path)
+      end
+
+      agent.rm_rf(custom_environment_path)
+    end
+
+    step 'Reset environment settings' do
+      on(agent, puppet("config set environmentpath #{initial_environment_paths.join(path_separator)}"))
+
+      if initial_environment == 'production'
+        on(agent, puppet("config delete environment"))
+      else
+        on(agent, puppet("config set environment #{initial_environment}"))
+      end
+
+      on(agent, puppet("agent -t"))
+    end
+  end
+
+  step 'Ensure a clean environment with default settings' do
+    step 'Change to the default environment setting' do
+      on(agent, puppet("config delete environment"))
+      on(agent, puppet("config print environment")) do |result|
+        assert_match('production', result.stdout, "Default environment is not 'production' as expected")
+      end
+    end
+
+    step 'Change to the default environmentpath setting and remove production folder' do
+      on(agent, puppet("config delete environmentpath"))
+      default_environment_path = on(agent, puppet("config print environmentpath")).stdout.chomp
+      agent.rm_rf("#{default_environment_path}/production")
+    end
+
+    step 'Apply changes and expect puppet to create the production folder back' do
+      on(agent, puppet("agent -t"))
+      on(agent, "ls #{default_environment_path}") do |result|
+        assert_match('production', result.stdout, "Default environment folder was not generated in last puppet run")
+      end
+    end
+  end
+
+  step 'Install a module' do
+    install_i18n_demo_module(master)
+  end
+
+  step 'Expect output from the custom fact of the module' do
+    on(agent, puppet("agent -t"), :acceptable_exit_codes => [0, 2]) do |result|
+      assert_match(/Error:.*i18ndemo/, result.stderr)
+    end
+  end
+
+  step 'Add a custom environment path before the current one' do
+    current_environment_path = on(agent, puppet("config print environmentpath")).stdout.chomp
+    on(agent, puppet("config set environmentpath '#{custom_environment_path}#{path_separator}#{current_environment_path}'"))
+  end
+
+  step 'Expect the module to still be found' do
+    on(agent, puppet("agent -t"), :acceptable_exit_codes => [0, 2]) do |result|
+      assert_match(/Error:.*i18ndemo/, result.stderr)
+    end
+  end
+
+  step 'Expect no production environment folder changes' do
+    on(agent, "ls #{custom_environment_path}") do |result|
+      assert_no_match(/production/, result.stdout)
+    end
+
+    on(agent, "ls #{default_environment_path}") do |result|
+      assert_match('production', result.stdout)
+    end
+  end
+
+  step 'Remove production folder' do
+    agent.rm_rf("#{default_environment_path}/production")
+  end
+
+  step 'Expect production environment folder to be recreated in the custom path' do
+    on(agent, puppet("agent -t"), :acceptable_exit_codes => [0, 2]) do |result|
+      step 'Expect the module to be gone on the server node' do
+        assert_no_match(/Error:.*i18ndemo/, result.stderr)
+      end if agent == master
+
+      step 'Expect the production environment, along with the module, to be synced back on the agent node' do
+        assert_match(/Error:.*i18ndemo/, result.stderr)
+      end if agent != master
+    end
+
+    on(agent, "ls #{custom_environment_path}") do |result|
+      assert_match('production', result.stdout, "Default environment folder was not generated in last puppet run")
+    end
+
+    on(agent, "ls #{default_environment_path}") do |result|
+      assert_no_match(/production/, result.stdout)
+    end
+  end
+
+  step 'Set back to just default environmentpath setting' do
+    on(agent, puppet("config delete environmentpath"))
+  end
+
+  step 'Expect production environment folder to be found in both paths but use the default one' do
+    on(agent, puppet("agent -t"), :acceptable_exit_codes => [0, 2]) do |result|
+      step 'Expect the module to be gone' do
+        assert_no_match(/Error:.*i18ndemo/, result.stderr)
+      end if agent == master
+    end
+
+    on(agent, "ls #{default_environment_path}") do |result|
+      assert_match('production', result.stdout, "Default environment folder was not generated in last puppet run")
+    end
+
+    on(agent, "ls #{custom_environment_path}") do |result|
+      assert_match('production', result.stdout)
+    end
+  end
+end

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -1262,24 +1262,34 @@ Generated on #{Time.now}.
   end
 
   def add_environment_resources(catalog, sections)
-    path = self[:environmentpath]
-    envdir = path.split(File::PATH_SEPARATOR).first if path
     configured_environment = self[:environment]
-    if configured_environment == "production" && envdir && Puppet::FileSystem.exist?(envdir)
-      configured_environment_path = File.join(envdir, configured_environment)
-      # If configured_environment_path is a symlink, assume the source path is being managed
-      # elsewhere, so don't do any of this configuration
-      if !Puppet::FileSystem.symlink?(configured_environment_path)
+
+    if configured_environment == "production" && !production_environment_exists?
+      environment_path = self[:environmentpath]
+      first_environment_path = environment_path.split(File::PATH_SEPARATOR).first
+
+      if Puppet::FileSystem.exist?(first_environment_path)
+        production_environment_path = File.join(first_environment_path, configured_environment)
         parameters = { :ensure => 'directory' }
-        unless Puppet::FileSystem.exist?(configured_environment_path)
-          parameters[:mode] = '0750'
-          if Puppet.features.root?
-            parameters[:owner] = Puppet[:user] if service_user_available?
-            parameters[:group] = Puppet[:group] if service_group_available?
-          end
+        parameters[:mode] = '0750'
+        if Puppet.features.root?
+          parameters[:owner] = Puppet[:user] if service_user_available?
+          parameters[:group] = Puppet[:group] if service_group_available?
         end
-        catalog.add_resource(Puppet::Resource.new(:file, configured_environment_path, :parameters => parameters))
+        catalog.add_resource(Puppet::Resource.new(:file, production_environment_path, :parameters => parameters))
       end
+    end
+  end
+
+  def production_environment_exists?
+    environment_path = self[:environmentpath]
+    paths = environment_path.split(File::PATH_SEPARATOR)
+
+    paths.any? do |path|
+      # If expected_path is a symlink, assume the source path is being managed
+      # elsewhere, so accept it also as a valid production environment path
+      expected_path = File.join(path, 'production')
+      Puppet::FileSystem.directory?(expected_path) || Puppet::FileSystem.symlink?(expected_path)
     end
   end
 


### PR DESCRIPTION
Before this commit puppet expected the default `production` environment folder to always be in the first path of the `environmentpath` setting and was being automatically created if not found there.

This commit adds a check to make sure it was not already created in any of the other environment paths given before automatically creating a new one. This can happen if a new path is inserted at the beginning of the `environmentpath` setting after the `production` folder was already created. This change aligns with custom environment behaviour where it searches in the given environment paths and uses the first one it matches, from left to right, the environment name given.