### PR TITLE
(PUP-10850)Fix show_legacy option for puppet facts

### DIFF
--- a/lib/puppet/face/facts.rb
+++ b/lib/puppet/face/facts.rb
@@ -124,10 +124,6 @@ Puppet::Indirector::Face.define(:facts, '0.0.1') do
       summary _("Disable fact caching mechanism.")
     end
 
-    option("--no-legacy") do
-      summary _("Disable legacy facts when querying all facts.")
-    end
-
     option("--show-legacy") do
       summary _("Show legacy facts when querying all facts.")
     end

--- a/lib/puppet/indirector/facts/facter.rb
+++ b/lib/puppet/indirector/facts/facter.rb
@@ -100,7 +100,7 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
     options_for_facter = String.new
     options_for_facter += options[:user_query].join(' ')
     options_for_facter += " --config #{options[:config_file]}" if options[:config_file]
-    options_for_facter +=  options[:no_legacy] == false ? " --show-legacy false" : " --show-legacy"
+    options_for_facter += " --show-legacy" if options[:show_legacy]
     options_for_facter += " --no-block" if options[:no_block] == false
     options_for_facter += " --no-cache" if options[:no_cache] == false
 

--- a/spec/unit/indirector/facts/facter_spec.rb
+++ b/spec/unit/indirector/facts/facter_spec.rb
@@ -163,7 +163,7 @@ describe Puppet::Node::Facts::Facter do
     end
 
     it 'should call Facter.resolve method' do
-      expect(Facter).to receive(:resolve).with("os timezone --show-legacy")
+      expect(Facter).to receive(:resolve).with("os timezone")
       @facter.find(@request)
     end
 
@@ -173,11 +173,11 @@ describe Puppet::Node::Facts::Facter do
       @facter.find(@request)
     end
 
-    context 'when --no-legacy flag is present' do
-      let(:options) { { resolve_options: true, user_query: ["os", "timezone"], no_legacy: false } }
+    context 'when --show-legacy flag is present' do
+      let(:options) { { resolve_options: true, user_query: ["os", "timezone"], show_legacy: true } }
 
-      it 'should call Facter.resolve method with show-legacy false' do
-        expect(Facter).to receive(:resolve).with("os timezone --show-legacy false")
+      it 'should call Facter.resolve method with show-legacy' do
+        expect(Facter).to receive(:resolve).with("os timezone --show-legacy")
         @facter.find(@request)
       end
     end


### PR DESCRIPTION
**Description of the problem:** Legacy facts were displayed by default without a mechanism to opt-out. An opt-out mechanism was introduced in  https://github.com/puppetlabs/puppet/pull/8475 but this also introduced some breaking changes.
**Description of the fix:** Implemented a mechanism to opt-in for legacy facts and the `--show-legacy` option was fixed. 