### PR TITLE
(maint) Merge up 6.x into main

### DIFF
--- a/lib/puppet/application/apply.rb
+++ b/lib/puppet/application/apply.rb
@@ -237,7 +237,7 @@ Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
         end
 
         # Resolve all deferred values and replace them / mutate the catalog
-        Puppet::Pops::Evaluator::DeferredResolver.resolve_and_replace(node.facts, catalog)
+        Puppet::Pops::Evaluator::DeferredResolver.resolve_and_replace(node.facts, catalog, apply_environment)
 
         # Translate it to a RAL catalog
         catalog = catalog.to_ral
@@ -331,7 +331,7 @@ Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
         raise Puppet::Error, _("Could not deserialize catalog from %{format}: %{detail}") % { format: format, detail: detail }, detail.backtrace
       end
       # Resolve all deferred values and replace them / mutate the catalog
-      Puppet::Pops::Evaluator::DeferredResolver.resolve_and_replace(node.facts, catalog)
+      Puppet::Pops::Evaluator::DeferredResolver.resolve_and_replace(node.facts, catalog, configured_environment)
 
       catalog.to_ral
     end

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -112,7 +112,7 @@ class Puppet::Configurer
     catalog_conversion_time = thinmark do
       # Will mutate the result and replace all Deferred values with resolved values
       if facts
-        Puppet::Pops::Evaluator::DeferredResolver.resolve_and_replace(facts, result)
+        Puppet::Pops::Evaluator::DeferredResolver.resolve_and_replace(facts, result, Puppet.lookup(:current_environment))
       end
 
       catalog = result.to_ral

--- a/lib/puppet/pops/evaluator/deferred_resolver.rb
+++ b/lib/puppet/pops/evaluator/deferred_resolver.rb
@@ -16,10 +16,12 @@ class DeferredResolver
   #
   # @param facts [Puppet::Node::Facts] the facts object for the node
   # @param catalog [Puppet::Resource::Catalog] the catalog where all deferred values should be replaced
+  # @param environment [Puppet::Node::Environment] the environment whose anonymous module methods
+  #  are to be mixed into the scope
   # @return [nil] does not return anything - the catalog is modified as a side effect
   #
-  def self.resolve_and_replace(facts, catalog)
-    compiler = Puppet::Parser::ScriptCompiler.new(catalog.environment_instance, catalog.name, true)
+  def self.resolve_and_replace(facts, catalog, environment)
+    compiler = Puppet::Parser::ScriptCompiler.new(environment, catalog.name, true)
     resolver = new(compiler)
     resolver.set_facts_variable(facts)
     # TODO:
@@ -108,7 +110,7 @@ class DeferredResolver
     # If any of the arguments to a future is a future it needs to be resolved first
     func_name = f.name
     mapped_arguments = map_arguments(f.arguments)
-    # if name starts with $ then this is a call to dig 
+    # if name starts with $ then this is a call to dig
     if func_name[0] == DOLLAR
       var_name = func_name[1..-1]
       func_name = DIG

--- a/spec/integration/application/apply_spec.rb
+++ b/spec/integration/application/apply_spec.rb
@@ -663,4 +663,23 @@ class amod::bad_type {
       end
     end
   end
+
+  context 'rich data' do
+    it "calls a deferred 4x function" do
+      apply.command_line.args = ['-e', 'notify { "deferred3x": message => Deferred("join", [[1,2,3], ":"]) }']
+
+      expect {
+        apply.run
+      }.to exit_with(0) # for some reason apply returns 0 instead of 2
+       .and output(%r{Notice: /Stage\[main\]/Main/Notify\[deferred3x\]/message: defined 'message' as '1:2:3'}).to_stdout
+    end
+
+    it "calls a deferred 3x function" do
+      apply.command_line.args = ['-e', 'notify { "deferred4x": message => Deferred("sprintf", ["%s", "I am deferred"]) }']
+      expect {
+        apply.run
+      }.to exit_with(0) # for some reason apply returns 0 instead of 2
+       .and output(%r{Notice: /Stage\[main\]/Main/Notify\[deferred4x\]/message: defined 'message' as 'I am deferred'}).to_stdout
+    end
+  end
 end


### PR DESCRIPTION
* Commits:
  (PUP-10815) Add `puppet facts diff` command
  (PUP-10819) Define and call 3x functions using the same Module object
  (PUP-10815) Added Facter diff util

* Conflicts:
  lib/puppet/face/facts.rb - the `diff` action has no purpose in Puppet 7

* Removed:
  lib/puppet/util/fact_dif.rb
  acceptance/tests/face/facts_face_diff.rb
  
  Only changes from `(PUP-10819) Define and call 3x functions using the same Module object` (#8477) get merged up.