### PR TITLE
(PUP-10819) Preserve deferred evaluator API compatibility

### DIFF
--- a/lib/puppet/pops/evaluator/deferred_resolver.rb
+++ b/lib/puppet/pops/evaluator/deferred_resolver.rb
@@ -20,7 +20,7 @@ class DeferredResolver
   #  are to be mixed into the scope
   # @return [nil] does not return anything - the catalog is modified as a side effect
   #
-  def self.resolve_and_replace(facts, catalog, environment)
+  def self.resolve_and_replace(facts, catalog, environment = catalog.environment_instance)
     compiler = Puppet::Parser::ScriptCompiler.new(environment, catalog.name, true)
     resolver = new(compiler)
     resolver.set_facts_variable(facts)

--- a/spec/unit/pops/evaluator/deferred_resolver_spec.rb
+++ b/spec/unit/pops/evaluator/deferred_resolver_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+require 'puppet_spec/compiler'
+
+describe Puppet::Pops::Evaluator::DeferredResolver do
+  include PuppetSpec::Compiler
+
+  let(:environment) { Puppet::Node::Environment.create(:testing, []) }
+  let(:facts) { Puppet::Node::Facts.new('node.example.com') }
+
+  it 'resolves deferred values in a catalog' do
+    catalog = compile_to_catalog(<<~END)
+      notify { "deferred":
+        message => Deferred("join", [[1,2,3], ":"])
+      }
+    END
+    described_class.resolve_and_replace(facts, catalog)
+
+    expect(catalog.resource(:notify, 'deferred')[:message]).to eq('1:2:3')
+  end
+end


### PR DESCRIPTION
Commit 321f04b2d0 added a mandatory environment parameter to the
DeferredResolver.resolve_and_replace method, but apparently that is a public API
called by bolt[1] and pxp-agent's apply module[2]. So make the environment
parameter optional and default to the catalog's environment, like it did before.

[1] https://github.com/puppetlabs/bolt/blob/2.40.2/libexec/apply_catalog.rb#L99
[2] https://github.com/puppetlabs/pxp-agent/blob/1.15.9/lib/src/modules/apply.cc#L164