### PR TITLE
(PUP-10844) Continue when server_list server fails

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -433,6 +433,18 @@ class Puppet::Configurer
       apply_catalog(ral_catalog, options)
       true
     rescue => detail
+      # Puppet.log_exception(detail, _("Failed to apply catalog: %{detail}") % { detail: detail })
+      # return nil
+# binding.pry
+#       @transaction_uuid = SecureRandom.uuid
+#       server, port = find_functional_server_no_cache
+#       options[:report] ||= Puppet::Transaction::Report.new(nil, @environment, @transaction_uuid, @job_id, options[:start_time] || Time.now)
+#       report = options[:report]
+#       report.server_used = "#{server}:#{port}"
+#       init_storage
+#       completed = run_internal(options)
+#       return completed
+      # retry
       Puppet.log_exception(detail, _("Failed to apply catalog: %{detail}") % { detail: detail })
       return nil
     ensure

--- a/lib/puppet/http/resolver/server_list.rb
+++ b/lib/puppet/http/resolver/server_list.rb
@@ -66,8 +66,14 @@ class Puppet::HTTP::Resolver::ServerList < Puppet::HTTP::Resolver
       rescue Puppet::HTTP::ResponseError => detail
         Puppet.log_exception(detail, _("Puppet server %{host}:%{port} is unavailable: %{code} %{reason}") %
                              { host: service.url.host, port: service.url.port, code: detail.response.code, reason: detail.response.reason })
+
+        # clear cached server
+        @resolved_url = nil
       rescue Puppet::HTTP::HTTPError => detail
         Puppet.log_exception(detail, _("Unable to connect to server from server_list setting: %{detail}") % {detail: detail})
+
+        # clear cached server
+        @resolved_url = nil
       end
     end
 

--- a/lib/puppet/http/resolver/settings.rb
+++ b/lib/puppet/http/resolver/settings.rb
@@ -19,7 +19,7 @@ class Puppet::HTTP::Resolver::Settings < Puppet::HTTP::Resolver
   # @return [Puppet::HTTP::Service] if the service successfully connects,
   #   return it. Otherwise, return nil.
   #
-  def resolve(session, name, ssl_context: nil, canceled_handler: nil)
+  def resolve(session, name, ssl_context: nil, canceled_handler: nil, server_failed: false)
     service = Puppet::HTTP::Service.create_service(@client, session, name)
     check_connection?(session, service, ssl_context: ssl_context) ? service : nil
   end

--- a/lib/puppet/http/resolver/srv.rb
+++ b/lib/puppet/http/resolver/srv.rb
@@ -31,7 +31,7 @@ class Puppet::HTTP::Resolver::SRV < Puppet::HTTP::Resolver
   # @return [Puppet::HTTP::Service] if an available service is found, return
   #   it. Return nil otherwise.
   #
-  def resolve(session, name, ssl_context: nil, canceled_handler: nil)
+  def resolve(session, name, ssl_context: nil, canceled_handler: nil, server_failed: false)
     # Here we pass our HTTP service name as the DNS SRV service name
     # This is fine for :ca, but note that :puppet and :file are handled
     # specially in `each_srv_record`.

--- a/lib/puppet/transaction/additional_resource_generator.rb
+++ b/lib/puppet/transaction/additional_resource_generator.rb
@@ -57,6 +57,8 @@ class Puppet::Transaction::AdditionalResourceGenerator
       return false if generated.empty?
     rescue => detail
       @resources_failed_to_generate = true
+      session = Puppet.lookup(:http_session)
+      session.server_failed(true)
       #TRANSLATORS eval_generate is a method name and should be left untranslated
       resource.log_exception(detail, _("Failed to generate additional resources using 'eval_generate': %{detail}") % { detail: detail })
       return false

--- a/spec/integration/application/agent_spec.rb
+++ b/spec/integration/application/agent_spec.rb
@@ -39,7 +39,7 @@ describe "puppet agent", unless: Puppet::Util::Platform.jruby? do
           agent.run
         }.to exit_with(0)
          .and output(%r{Notice: Applied catalog}).to_stdout
-         .and output(%r{Unable to connect to server from server_list setting: Request to https://puppet.example.com:#{port}/status/v1/simple/master failed}).to_stderr
+         .and output(%r{Warning: Could not connect to server puppet.example.com:#{port}. Trying next server in server_list.}).to_stderr
 
         report = Puppet::Transaction::Report.convert_from(:yaml, File.read(Puppet[:lastrunreport]))
         expect(report.master_used).to eq("127.0.0.1:#{port}")

--- a/spec/unit/http/session_spec.rb
+++ b/spec/unit/http/session_spec.rb
@@ -26,7 +26,7 @@ describe Puppet::HTTP::Session do
       @count = 0
     end
 
-    def resolve(session, name, ssl_context: nil, canceled_handler: nil)
+    def resolve(session, name, ssl_context: nil, canceled_handler: nil, server_failed: false)
       @count += 1
       return @service if check_connection?(session, @service, ssl_context: ssl_context)
     end


### PR DESCRIPTION
When a server from server_list is available at the beginning of the run,
it will be cached, and the cached server will be used even if it is no
longer reachable.

Now, when a server from server_list becomes unavailable, the cached
server is invalidated and a new reachable server from server_list will
be selected.