### PR TITLE
(RE-13432) Remove reference to old GPG key

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -1,6 +1,5 @@
 ---
 packager: 'puppetlabs'
-gpg_key: '7F438280EF8D349F'
 
 # These are the build targets used by the packaging repo. Uncomment to allow use.
 #final_mocks: 'pl-el-5-i386 pl-el-6-i386 pl-el-7-x86_64'


### PR DESCRIPTION
More of a formality, but also for clarity: remove the reference to the
old GPG signing key.

This is normally overridden by the key in the build-data repo.