### PR TITLE
(PUP-10858) Add `--timing` to puppet facts show

### DIFF
--- a/lib/puppet/face/facts.rb
+++ b/lib/puppet/face/facts.rb
@@ -127,9 +127,13 @@ Puppet::Indirector::Face.define(:facts, '0.0.1') do
     option("--show-legacy") do
       summary _("Show legacy facts when querying all facts.")
     end
-    
+
     option("--value-only") do
       summary _("Show only the value when the action is called with a single query")
+    end
+
+    option("--timing") do
+      summary _("Show how much time it took to resolve each fact.")
     end
 
     when_invoked do |*args|

--- a/lib/puppet/indirector/facts/facter.rb
+++ b/lib/puppet/indirector/facts/facter.rb
@@ -103,6 +103,7 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
     options_for_facter += " --show-legacy" if options[:show_legacy]
     options_for_facter += " --no-block" if options[:no_block] == false
     options_for_facter += " --no-cache" if options[:no_cache] == false
+    options_for_facter += " --timing" if options[:timing]
 
     Puppet::Node::Facts.new(request.key, Facter.resolve(options_for_facter))
   end

--- a/spec/unit/indirector/facts/facter_spec.rb
+++ b/spec/unit/indirector/facts/facter_spec.rb
@@ -182,6 +182,15 @@ describe Puppet::Node::Facts::Facter do
       end
     end
 
+    context 'when --timing flag is present' do
+      let(:options) { { resolve_options: true, user_query: ["os", "timezone"], timing: true } }
+
+      it 'calls Facter.resolve with --timing' do
+        expect(Facter).to receive(:resolve).with("os timezone --timing")
+        @facter.find(@request)
+      end
+    end
+
     describe 'when Facter version is lower than 4.0.40' do
       before :each do
         allow(Facter).to receive(:respond_to?).and_return(false)


### PR DESCRIPTION
This will print information for all the facts used(time is printed by facter), not only the queried ones:
```
❯ bx puppet facts show timezone --timing
fact 'operatingsystem', took: (0.022100) seconds
fact 'osfamily', took: (0.000022) seconds
fact 'operatingsystem', took: (0.000018) seconds
fact 'osfamily', took: (0.000012) seconds
fact 'operatingsystem', took: (0.000013) seconds
fact 'operatingsystem', took: (0.000009) seconds
fact 'timezone', took: (0.000052) seconds
{
  "timezone": "EET"
}
```