### PR TITLE
(PUP-1357) Only skip a class scope if the previous instance wasn't a node scope

### DIFF
--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -471,7 +471,7 @@ class Puppet::Parser::Compiler
     newly_included = []
     hostclasses.each do |klass|
       class_scope = scope.class_scope(klass)
-      if class_scope
+      if class_scope && !class_scope.is_nodescope?
         already_included << class_scope.resource
       else
         newly_included << klass.ensure_in_catalog(scope)

--- a/spec/unit/parser/compiler_spec.rb
+++ b/spec/unit/parser/compiler_spec.rb
@@ -862,6 +862,19 @@ describe Puppet::Parser::Compiler do
 
           expect(catalog.resource('Class', 'Something')).not_to be_nil
         end
+
+        it "includes the class when its name is the same as the node definition" do
+          node.classes = [node.name]
+
+          catalog = compile_to_catalog(<<-MANIFEST, node)
+            class #{node.name} {}
+            node #{node.name} {
+              include #{node.name}
+            }
+          MANIFEST
+
+          expect(catalog.resource('Class', node.name.capitalize)).not_to be_nil
+        end
       end
 
       it "should fail if the class doesn't exist" do


### PR DESCRIPTION
Previously, puppet did not include a class if the class name happened to be the
same as the enclosing node definition, such as:

     node abc { include abc }

This occurred because puppet added the node scope to the `Scope#class_scope`
hash while evaluating the node definintion[1]. Later, puppet checked to see if a
class scope with the same name had already been added, and if so, puppet ignored
it[2]. However, that logic didn't account for the presence of a node scope with
the same name.

This commit causes puppet to exclude the node scope from its `already_included`
resources, so that it doesn't skip the class with the same name. It preserves
the behavior of only including a class once as implemented in[3].

[1] https://github.com/puppetlabs/puppet/blob/6.20.0/lib/puppet/resource/type.rb#L339
[2] https://github.com/puppetlabs/puppet/blob/6.20.0/lib/puppet/parser/compiler.rb#L473-L478
[3] https://github.com/puppetlabs/puppet/commit/927dff41df8f1c236c54eaee9fa1db7a3efaf02af