### PR TITLE
(PUP-10854) allow apt to install local packages

### DIFF
--- a/lib/puppet/provider/package/apt.rb
+++ b/lib/puppet/provider/package/apt.rb
@@ -147,7 +147,13 @@ Puppet::Type.type(:package).provide :apt, :parent => :dpkg, :source => :dpkg do
     end
 
     cmd += install_options if @resource[:install_options]
-    cmd << :install << str
+    cmd << :install
+
+    if source
+      cmd << source
+    else
+      cmd << str
+    end
 
     self.unhold if self.properties[:mark] == :hold
     begin
@@ -155,6 +161,18 @@ Puppet::Type.type(:package).provide :apt, :parent => :dpkg, :source => :dpkg do
     ensure
       self.hold if @resource[:mark] == :hold
     end
+
+    # If a source file was specified, we must make sure the expected version was installed from specified file
+    if source && !%i(present installed).include?(should)
+      is = self.query
+      raise Puppet::Error, _("Could not find package %{name}") % { name: self.name } unless is
+
+      version = is[:ensure]
+
+      raise Puppet::Error, _("Failed to update to version %{should}, got version %{version} instead") % { should: should, version: version } unless
+        insync?(version)
+    end
+
   end
 
   # What's the latest package version available?
@@ -230,5 +248,11 @@ Puppet::Type.type(:package).provide :apt, :parent => :dpkg, :source => :dpkg do
       return false
     end
     should_range.include?(is_version)
+  end
+
+  private
+
+  def source
+    @source ||= @resource[:source]
   end
 end

--- a/lib/puppet/provider/package/aptitude.rb
+++ b/lib/puppet/provider/package/aptitude.rb
@@ -26,4 +26,10 @@ Puppet::Type.type(:package).provide :aptitude, :parent => :apt, :source => :dpkg
   def purge
     aptitude '-y', 'purge', @resource[:name]
   end
+
+  private
+
+  def source
+    nil
+  end
 end

--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -426,10 +426,10 @@ module Puppet
     end
 
     newparam(:source) do
-      desc "Where to find the package file. This is only used by providers that don't
+      desc "Where to find the package file. This is mostly used by providers that don't
         automatically download packages from a central repository. (For example:
-        the `yum` and `apt` providers ignore this attribute, but the `rpm` and
-        `dpkg` providers require it.)
+        the `yum` provider ignores this attribute, `apt` provider uses it if present
+        and the `rpm` and `dpkg` providers require it.)
 
         Different providers accept different values for `source`. Most providers
         accept paths to local files stored on the target system. Some providers

--- a/spec/unit/provider/package/apt_spec.rb
+++ b/spec/unit/provider/package/apt_spec.rb
@@ -289,5 +289,26 @@ Version table:
 
       provider.install
     end
+
+    it "should install using the source attribute if present" do
+      resource[:ensure] = :installed
+      resource[:source] = '/my/local/package/file'
+
+      expect(provider).to receive(:aptget).with(any_args, :install, resource[:source])
+      expect(provider).to receive(:properties).and_return({:mark => :none})
+
+      provider.install
+    end
+
+    it "should install specific version using the source attribute if present" do
+      resource[:ensure] = '1.2.3'
+      resource[:source] = '/my/local/package/file'
+
+      expect(provider).to receive(:aptget).with(any_args, :install, resource[:source])
+      expect(provider).to receive(:properties).and_return({:mark => :none})
+      expect(provider).to receive(:query).and_return({:ensure => '1.2.3'})
+
+      provider.install
+    end
   end
 end


### PR DESCRIPTION
Before puppet-18.0, using an absolute path as package name allowed
users to install local packages using apt. While this was working,
the functionality was unintended and incomplete(eg. puppet will execute
package install command each run and will report changes).

This commit enables the usage of `source` parameter with `apt` provider
and now a user can install a local package using a manifest like bellow:
```
package { 'helloworld':
    source => '/tmp/helloworld_1.0-1.deb'
    ensure => installed,
}
```