### PR TITLE
(PUP-10856) avoid unnecessary calls to aptmark

### DIFF
--- a/lib/puppet/provider/package/apt.rb
+++ b/lib/puppet/provider/package/apt.rb
@@ -42,7 +42,11 @@ Puppet::Type.type(:package).provide :apt, :parent => :dpkg, :source => :dpkg do
 
   def query
     hash = super
-    hash[:mark] = :manual if aptmark('showmanual').split("\n").include?(@resource[:name])
+
+    if !%i(absent purged).include?(hash[:ensure]) && aptmark('showmanual', @resource[:name]).strip == @resource[:name]
+      hash[:mark] = :manual
+    end
+
     hash
   end
 

--- a/spec/unit/provider/package/apt_spec.rb
+++ b/spec/unit/provider/package/apt_spec.rb
@@ -115,24 +115,12 @@ Version table:
       allow(provider).to receive(:dpkgquery).and_return("name: #{resource.name}" )
     end
 
-    context "when package is manual marked" do
-      before do
-        allow(described_class).to receive(:aptmark).with('showmanual').and_return("#{resource.name}\n")
-      end
 
-      it 'sets mark to manual' do
-        result = provider.query
-        expect(result[:mark]).to eql(:manual)
-      end
-    end
-
-    context 'when package is not manual marked ' do
-      before do
-        allow(described_class).to receive(:aptmark).with('showmanual').and_return('')
-      end
-
+    context 'when package is not installed on the system' do
       it 'does not set mark to manual' do
         result = provider.query
+
+        expect(described_class).not_to receive(:aptmark)
         expect(result[:mark]).to be_nil
       end
     end

--- a/spec/unit/provider/package/aptitude_spec.rb
+++ b/spec/unit/provider/package/aptitude_spec.rb
@@ -13,7 +13,7 @@ describe Puppet::Type.type(:package).provider(:aptitude) do
 
     before do
       allow(Puppet::Util).to receive(:which).with('/usr/bin/dpkg-query').and_return(dpkgquery_path)
-      allow(described_class).to receive(:aptmark).with('showmanual').and_return("")
+      allow(described_class).to receive(:aptmark).with('showmanual', 'faff').and_return("")
     end
 
     { :absent   => "deinstall ok config-files faff 1.2.3-1\n",


### PR DESCRIPTION
This improves the performance of apt package provider by skipping the `apt-mark` calls when removing resources that does not exist.