### PR TITLE
(PUP-8110) Increase size of private key in CSR tests

### DIFF
--- a/spec/unit/ssl/certificate_request_spec.rb
+++ b/spec/unit/ssl/certificate_request_spec.rb
@@ -320,11 +320,8 @@ describe Puppet::SSL::CertificateRequest do
       expect(csr.verify(key)).to be_truthy
     end
 
-    # Attempts to use SHA512 and SHA384 for signing certificates don't seem to work
-    # So commenting it out till it is sorted out
-    # The problem seems to be with the ability to sign a CSR when using either of
-    # these hash algorithms
-    pending "should use SHA512 to sign the csr when SHA256 and SHA1 aren't available" do
+    it "should use SHA512 to sign the csr when SHA256 and SHA1 aren't available" do
+      key = OpenSSL::PKey::RSA.new(2048)
       csr = OpenSSL::X509::Request.new
       expect(OpenSSL::Digest).to receive(:const_defined?).with("SHA256").and_return(false)
       expect(OpenSSL::Digest).to receive(:const_defined?).with("SHA1").and_return(false)
@@ -334,11 +331,8 @@ describe Puppet::SSL::CertificateRequest do
       expect(csr.verify(key)).to be_truthy
     end
 
-    # Attempts to use SHA512 and SHA384 for signing certificates don't seem to work
-    # So commenting it out till it is sorted out
-    # The problem seems to be with the ability to sign a CSR when using either of
-    # these hash algorithms
-    pending "should use SHA384 to sign the csr when SHA256/SHA1/SHA512 aren't available" do
+    it "should use SHA384 to sign the csr when SHA256/SHA1/SHA512 aren't available" do
+      key = OpenSSL::PKey::RSA.new(2048)
       csr = OpenSSL::X509::Request.new
       expect(OpenSSL::Digest).to receive(:const_defined?).with("SHA256").and_return(false)
       expect(OpenSSL::Digest).to receive(:const_defined?).with("SHA1").and_return(false)


### PR DESCRIPTION
We set the keylength setting to 512 during tests to reduce the amount of time
spent generating RSA private keys. However, the CSR signing tests fail with the
following error when using a 512-bit RSA key and digests SHA384 and 512:

     OpenSSL::X509::RequestError:
       EVP lib

So use 2048-bit keys for those tests.