### PR TITLE
(PUP-10861) Don't JSON.dump single fact values

### DIFF
--- a/lib/puppet/face/facts.rb
+++ b/lib/puppet/face/facts.rb
@@ -151,17 +151,23 @@ Puppet::Indirector::Face.define(:facts, '0.0.1') do
       options[:resolve_options] = true
       result = Puppet::Node::Facts.indirection.find(Puppet.settings[:certname], options)
 
-      facts = result.values
-
       if options[:value_only]
-        facts.values.first
+        result.values.values.first
       else
-        facts
+        result.values
       end
     end
 
     when_rendering :console do |result|
-      Puppet::Util::Json.dump(result, :pretty => true)
+      # VALID_TYPES = [Integer, Float, TrueClass, FalseClass, NilClass, Symbol, String, Array, Hash].freeze
+      # from https://github.com/puppetlabs/facter/blob/4.0.49/lib/facter/custom_facts/util/normalization.rb#L8
+
+      case result
+      when Array, Hash
+        Puppet::Util::Json.dump(result, :pretty => true)
+      else # one of VALID_TYPES above
+        result
+      end
     end
   end
 end

--- a/spec/unit/application/facts_spec.rb
+++ b/spec/unit/application/facts_spec.rb
@@ -52,7 +52,12 @@ describe Puppet::Application::Facts do
   end
 
   context 'when show action is called' do
-    let(:expected) { "{\n  \"filesystems\": \"apfs,autofs,devfs\",\n  \"macaddress\": \"64:52:11:22:03:25\"\n}\n" }
+    let(:expected) { <<~END }
+      {
+        "filesystems": "apfs,autofs,devfs",
+        "macaddress": "64:52:11:22:03:25"
+      }
+    END
 
     before :each do
       Puppet::Node::Facts.indirection.terminus_class = :facter
@@ -64,12 +69,17 @@ describe Puppet::Application::Facts do
       expect {
         app.run
       }.to exit_with(0)
-               .and output(expected).to_stdout
+       .and output(expected).to_stdout
+    end
     end
   end
 
   context 'when default action is called' do
-    let(:expected) { "---\nfilesystems: apfs,autofs,devfs\nmacaddress: 64:52:11:22:03:25\n" }
+    let(:expected) { <<~END }
+      ---
+      filesystems: apfs,autofs,devfs
+      macaddress: 64:52:11:22:03:25
+    END
 
     before :each do
       Puppet::Node::Facts.indirection.terminus_class = :facter
@@ -81,7 +91,7 @@ describe Puppet::Application::Facts do
       expect {
         app.run
       }.to exit_with(0)
-               .and output(expected).to_stdout
+       .and output(expected).to_stdout
       expect(app.action.name).to eq(:show)
     end
   end


### PR DESCRIPTION
The `puppet facts show --value-only` option prints just the value for a single
fact. Previously, the value was pretty printed using JSON.dump, which emitted a
quoted string. Now just print the string, so that the value can be parsed via
automation, like export OSFAMILY=`puppet facts show os.family --value-only`

Also add a test for multiple fact names as the `--value-only` option.