### PR TITLE
(PUP-10857) Find groups locally with useradd provider

### DIFF
--- a/lib/puppet/property/list.rb
+++ b/lib/puppet/property/list.rb
@@ -47,7 +47,7 @@ module Puppet
         #ok, some 'convention' if the list property is named groups, provider should implement a groups method
         tmp = provider.send(name) if provider
         if tmp && tmp != :absent
-          return tmp.split(delimiter)
+          return tmp.instance_of?(Array) ? tmp : tmp.split(delimiter)
         else
           return :absent
         end

--- a/lib/puppet/provider/user/useradd.rb
+++ b/lib/puppet/provider/user/useradd.rb
@@ -59,6 +59,11 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
      get(:uid)
   end
 
+  def gid
+     return localgid if @resource.forcelocal?
+     get(:gid)
+  end
+
   def comment
      return localcomment if @resource.forcelocal?
      get(:comment)
@@ -85,6 +90,12 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
   def localuid
     user = finduser(:account, resource[:name])
     return user[:uid] if user
+    false
+  end
+
+  def localgid
+    user = finduser(:account, resource[:name])
+    return user[:gid] if user
     false
   end
 

--- a/spec/unit/provider/group/groupadd_spec.rb
+++ b/spec/unit/provider/group/groupadd_spec.rb
@@ -198,7 +198,10 @@ describe Puppet::Type.type(:group).provider(:groupadd) do
   end
 
   describe "#findgroup" do
-    before { allow(File).to receive(:read).with('/etc/group').and_return(content) }
+    before do
+      allow(Puppet::FileSystem).to receive(:exist?).with('/etc/group').and_return(true)
+      allow(Puppet::FileSystem).to receive(:each_line).with('/etc/group').and_yield(content)
+    end
 
     let(:content) { "sample_group_name:sample_password:sample_gid:sample_user_list" }
     let(:output) do
@@ -221,7 +224,7 @@ describe Puppet::Type.type(:group).provider(:groupadd) do
     end
 
     it "reads the group file only once per resource" do
-      expect(File).to receive(:read).with('/etc/group').once
+      expect(Puppet::FileSystem).to receive(:each_line).with('/etc/group').once
       5.times { provider.send(:findgroup, :group_name, 'sample_group_name') }
     end
   end


### PR DESCRIPTION
Before this commit, `forcelocal` had no effect on the `groups` field from the `useradd` provider. This change allows to get groups from `/etc/groups` when `forcelocal` is set to `true`.

This PR also adds `forcelocal` option effect on user gid from the `useradd` provider and fixes the retrieval of arrays from the property list.