### PR TITLE
(PUP-10857) Correctly retrieve the groups of an user

### DIFF
--- a/acceptance/tests/resource/user/should_manage_groups.rb
+++ b/acceptance/tests/resource/user/should_manage_groups.rb
@@ -8,7 +8,7 @@ test_name "should correctly manage the groups property for the User resource" do
   confine :except, :platform => /eos-/ # See ARISTA-37
   confine :except, :platform => /cisco_/ # See PUP-5828
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:acceptance' # Could be done as integration tests, but would
                          # require changing the system running the test
                          # in ways that might require special permissions

--- a/lib/puppet/provider/user/useradd.rb
+++ b/lib/puppet/provider/user/useradd.rb
@@ -71,7 +71,7 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
 
   def groups
      return localgroups if @resource.forcelocal?
-     get(:groups)
+     super
   end
 
   def finduser(key, value)

--- a/spec/unit/provider/user/useradd_spec.rb
+++ b/spec/unit/provider/user/useradd_spec.rb
@@ -392,7 +392,7 @@ describe Puppet::Type.type(:user).provider(:useradd) do
 
     it "should fall back to nameservice groups when forcelocal is false" do
       resource[:forcelocal] = false
-      allow(provider).to receive(:get).with(:groups).and_return('remote groups')
+      allow(Puppet::Util::POSIX).to receive(:groups_of).with('myuser').and_return(['remote groups'])
       expect(provider).not_to receive(:localgroups)
       expect(provider.groups).to eq('remote groups')
     end


### PR DESCRIPTION
In a previous commit we mistakenly called the wrong method to get the
groups of an user, as `get` retrieves information from an user's passwd
structure, and the groups of an user are not present in that structure.

To fix this, call the superclass method, which should call
`Puppet::Util::POSIX.groups_of`.

Also reenable the `should_manage_groups` acceptance test.