### PR TITLE
(maint) disable debian service provider if systemd is running with PID 1 

### DIFF
--- a/lib/puppet/provider/service/debian.rb
+++ b/lib/puppet/provider/service/debian.rb
@@ -17,6 +17,8 @@ Puppet::Type.type(:service).provide :debian, :parent => :init do
   commands :invoke_rc => "/usr/sbin/invoke-rc.d"
   commands :service => "/usr/sbin/service"
 
+  confine :false => Puppet::FileSystem.exist?('/proc/1/comm') && Puppet::FileSystem.read('/proc/1/comm').include?('systemd')
+
   defaultfor :operatingsystem => :cumuluslinux, :operatingsystemmajrelease => ['1','2']
   defaultfor :operatingsystem => :debian, :operatingsystemmajrelease => ['5','6','7']
   defaultfor :operatingsystem => :devuan


### PR DESCRIPTION
When we deliver both systemd and systemv init scripts, sometimes
puppet decides to use debian provider on `puppet resource service puppet`
commands, even when system is running with systemd.

The change confines debian provider to systems where `systemd` is not
running with PID 1 and is complementary to the confine from systemd provider