### PR TITLE
(PUP-10844) Add puppet facts show on 6.x

### DIFF
--- a/lib/puppet/indirector/facts/facter.rb
+++ b/lib/puppet/indirector/facts/facter.rb
@@ -32,8 +32,14 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
     # Initialize core Puppet facts, such as puppetversion
     Puppet.initialize_facts
 
-    result = Puppet::Node::Facts.new(request.key, Facter.to_hash)
-    result.add_local_facts
+    result = if request.options[:resolve_options]
+               raise(Puppet::Error, _("puppet facts show requires version 4.0.40 or greater of Facter.")) unless Facter.respond_to?(:resolve)
+               find_with_options(request)
+             else
+               Puppet::Node::Facts.new(request.key, Facter.to_hash)
+             end
+
+    result.add_local_facts unless request.options[:resolve_options]
     result.sanitize
     result
   end
@@ -61,7 +67,7 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
 
       true
     end
-
+    dirs << request.options[:custom_dir] if request.options[:custom_dir]
     Facter.search(*dirs)
   end
 
@@ -83,6 +89,21 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
       dirs << dir
     end
 
+    dirs << request.options[:external_dir] if request.options[:external_dir]
     Facter.search_external dirs
+  end
+
+  private
+
+  def find_with_options(request)
+    options = request.options
+    options_for_facter = String.new
+    options_for_facter += options[:user_query].join(' ')
+    options_for_facter += " --config #{options[:config_file]}" if options[:config_file]
+    options_for_facter += " --show-legacy" if options[:show_legacy]
+    options_for_facter += " --no-block" if options[:no_block] == false
+    options_for_facter += " --no-cache" if options[:no_cache] == false
+
+    Puppet::Node::Facts.new(request.key, Facter.resolve(options_for_facter))
   end
 end

--- a/spec/unit/application/facts_spec.rb
+++ b/spec/unit/application/facts_spec.rb
@@ -3,7 +3,7 @@ require 'puppet/application/facts'
 
 describe Puppet::Application::Facts do
   let(:app) { Puppet::Application[:facts] }
-  let(:values) { {"filesystems" => "apfs,autofs,devfs", "macaddress" => "64:52:11:22:03:25"} }
+  let(:values) { {"filesystems" => "apfs,autofs,devfs", "macaddress" => "64:52:11:22:03:2e"} }
 
   before :each do
     Puppet::Node::Facts.indirection.terminus_class = :memory
@@ -21,7 +21,7 @@ describe Puppet::Application::Facts do
       name: whatever
       values:
         filesystems: apfs,autofs,devfs
-        macaddress: "64:52:11:22:03:25"
+        macaddress: "64:52:11:22:03:2e"
     END
 
     expect {
@@ -42,12 +42,92 @@ describe Puppet::Application::Facts do
       name: #{Puppet[:certname]}
       values:
         filesystems: apfs,autofs,devfs
-        macaddress: "64:52:11:22:03:25"
+        macaddress: "64:52:11:22:03:2e"
     END
 
     expect {
       app.run
     }.to exit_with(0)
      .and output(expected).to_stdout
+  end
+
+  context 'when show action is called' do
+    let(:expected) { <<~END }
+      {
+        "filesystems": "apfs,autofs,devfs",
+        "macaddress": "64:52:11:22:03:2e"
+      }
+    END
+
+    before :each do
+      Puppet::Node::Facts.indirection.terminus_class = :facter
+      allow(Facter).to receive(:resolve).and_return(values)
+      app.command_line.args = %w{show}
+    end
+
+    it 'correctly displays facts with default formatting' do
+      expect {
+        app.run
+      }.to exit_with(0)
+       .and output(expected).to_stdout
+    end
+
+    it 'displays a single fact value' do
+      app.command_line.args << 'filesystems' << '--value-only'
+      expect {
+        app.run
+      }.to exit_with(0)
+       .and output("apfs,autofs,devfs\n").to_stdout
+    end
+
+    it "warns and ignores value-only when multiple fact names are specified" do
+      app.command_line.args << 'filesystems' << 'macaddress' << '--value-only'
+      expect {
+        app.run
+      }.to exit_with(0)
+       .and output(expected).to_stdout
+       .and output(/it can only be used when querying for a single fact/).to_stderr
+    end
+
+    {
+      "type_hash" => [{'a' => 2}, "{\n  \"a\": 2\n}"],
+      "type_array" => [[], "[\n\n]"],
+      "type_string" => ["str", "str"],
+      "type_int" => [1, "1"],
+      "type_float" => [1.0, "1.0"],
+      "type_true" => [true, "true"],
+      "type_false" => [false, "false"],
+      "type_nil" => [nil, ""],
+      "type_sym" => [:sym, "sym"]
+    }.each_pair do |name, values|
+      it "renders '#{name}' as '#{values.last}'" do
+        fact_value = values.first
+        fact_output = values.last
+
+        allow(Facter).to receive(:resolve).and_return({name => fact_value})
+
+        app.command_line.args << name << '--value-only'
+        expect {
+          app.run
+        }.to exit_with(0)
+         .and output("#{fact_output}\n").to_stdout
+      end
+    end
+  end
+
+  context 'when default action is called' do
+    before :each do
+      Puppet::Node::Facts.indirection.terminus_class = :memory
+      facts = Puppet::Node::Facts.new('whatever', values)
+      Puppet::Node::Facts.indirection.save(facts)
+    end
+
+    it 'calls find action' do
+      expect {
+        app.run
+      }.to exit_with(0)
+       .and output(anything).to_stdout
+      expect(app.action.name).to eq(:find)
+    end
   end
 end

--- a/spec/unit/face/facts_spec.rb
+++ b/spec/unit/face/facts_spec.rb
@@ -71,4 +71,8 @@ CONF
                                log.message =~ /Uploading facts for '.*' to 'puppet\.server\.test'/}
     end
   end
+
+  describe "#show" do
+    it { is_expected.to be_action :show }
+  end
 end

--- a/spec/unit/indirector/facts/facter_spec.rb
+++ b/spec/unit/indirector/facts/facter_spec.rb
@@ -28,6 +28,7 @@ describe Puppet::Node::Facts::Facter do
     @request = double('request', :key => @name)
     @environment = double('environment')
     allow(@request).to receive(:environment).and_return(@environment)
+    allow(@request).to receive(:options).and_return({})
     allow(@request.environment).to receive(:modules).and_return([])
     allow(@request.environment).to receive(:modulepath).and_return([])
   end
@@ -104,6 +105,7 @@ describe Puppet::Node::Facts::Facter do
       expect(FileTest).to receive(:directory?).with(factpath1).and_return(true)
       expect(FileTest).to receive(:directory?).with(factpath2).and_return(true)
       allow(@request.environment).to receive(:modulepath).and_return([modulepath])
+      allow(@request).to receive(:options).and_return({})
       expect(Dir).to receive(:glob).with("#{modulepath}/*/lib/facter").and_return([modulelibfacter])
       expect(Dir).to receive(:glob).with("#{modulepath}/*/plugins/facter").and_return([modulepluginsfacter])
 
@@ -147,6 +149,99 @@ describe Puppet::Node::Facts::Facter do
       expect(File).to receive(:directory?).with(modulefactsd).and_return(true)
       expect(Facter).to receive(:search_external).with([modulefactsd, pluginfactdest])
       Puppet::Node::Facts::Facter.setup_external_search_paths @request
+    end
+  end
+
+  describe 'when :resolve_options is true' do
+    let(:options) { { resolve_options: true, user_query: ["os", "timezone"], show_legacy: true } }
+    let(:facts) { Puppet::Node::Facts.new("foo") }
+
+    before :each do
+      allow(@request).to receive(:options).and_return(options)
+      allow(Puppet::Node::Facts).to receive(:new).and_return(facts)
+      allow(facts).to receive(:add_local_facts)
+    end
+
+    it 'should call Facter.resolve method' do
+      expect(Facter).to receive(:resolve).with("os timezone --show-legacy")
+      @facter.find(@request)
+    end
+
+    it 'should NOT add local facts' do
+      expect(facts).not_to receive(:add_local_facts)
+
+      @facter.find(@request)
+    end
+
+    describe 'when Facter version is lower than 4.0.40' do
+      before :each do
+        allow(Facter).to receive(:respond_to?).and_return(false)
+        allow(Facter).to receive(:respond_to?).with(:resolve).and_return(false)
+      end
+
+      it 'raises an error' do
+        expect { @facter.find(@request) }.to raise_error(Puppet::Error, "puppet facts show requires version 4.0.40 or greater of Facter.")
+      end
+    end
+
+    describe 'when setting up external search paths' do
+      let(:options) { { resolve_options: true, user_query: ["os", "timezone"], external_dir: 'some/dir' } }
+      let(:pluginfactdest) { File.expand_path 'plugin/dest' }
+      let(:modulepath) { File.expand_path 'module/foo' }
+      let(:modulefactsd) { File.expand_path 'module/foo/facts.d'  }
+
+      before :each do
+        expect(FileTest).to receive(:directory?).with(pluginfactdest).and_return(true)
+        mod = Puppet::Module.new('foo', modulepath, @request.environment)
+        allow(@request.environment).to receive(:modules).and_return([mod])
+        Puppet[:pluginfactdest] = pluginfactdest
+      end
+
+      it 'should skip files' do
+        expect(File).to receive(:directory?).with(modulefactsd).and_return(false)
+        expect(Facter).to receive(:search_external).with([pluginfactdest, options[:external_dir]])
+        Puppet::Node::Facts::Facter.setup_external_search_paths @request
+      end
+
+      it 'should add directories' do
+        expect(File).to receive(:directory?).with(modulefactsd).and_return(true)
+        expect(Facter).to receive(:search_external).with([modulefactsd, pluginfactdest, options[:external_dir]])
+        Puppet::Node::Facts::Facter.setup_external_search_paths @request
+      end
+    end
+
+    describe 'when setting up search paths' do
+      let(:factpath1) { File.expand_path 'one' }
+      let(:factpath2) { File.expand_path 'two' }
+      let(:factpath) { [factpath1, factpath2].join(File::PATH_SEPARATOR) }
+      let(:modulepath) { File.expand_path 'module/foo' }
+      let(:modulelibfacter) { File.expand_path 'module/foo/lib/facter' }
+      let(:modulepluginsfacter) { File.expand_path 'module/foo/plugins/facter' }
+      let(:options) { { resolve_options: true, custom_dir: 'some/dir' } }
+
+      before :each do
+        expect(FileTest).to receive(:directory?).with(factpath1).and_return(true)
+        expect(FileTest).to receive(:directory?).with(factpath2).and_return(true)
+        allow(@request.environment).to receive(:modulepath).and_return([modulepath])
+        expect(Dir).to receive(:glob).with("#{modulepath}/*/lib/facter").and_return([modulelibfacter])
+        expect(Dir).to receive(:glob).with("#{modulepath}/*/plugins/facter").and_return([modulepluginsfacter])
+
+        Puppet[:factpath] = factpath
+      end
+
+      it 'should skip files' do
+        expect(FileTest).to receive(:directory?).with(modulelibfacter).and_return(false)
+        expect(FileTest).to receive(:directory?).with(modulepluginsfacter).and_return(false)
+        expect(Facter).to receive(:search).with(factpath1, factpath2, options[:custom_dir])
+        Puppet::Node::Facts::Facter.setup_search_paths @request
+      end
+
+      it 'should add directories' do
+        expect(FileTest).to receive(:directory?).with(modulelibfacter).and_return(true)
+        expect(FileTest).to receive(:directory?).with(modulepluginsfacter).and_return(false)
+        expect(Facter).to receive(:search).with(modulelibfacter, factpath1, factpath2, options[:custom_dir])
+        Puppet::Node::Facts::Facter.setup_search_paths @request
+      end
     end
   end
 end

--- a/spec/unit/network/formats_spec.rb
+++ b/spec/unit/network/formats_spec.rb
@@ -534,4 +534,45 @@ EOT
       end
     end
   end
+
+  describe ":flat format" do
+    let(:flat) { Puppet::Network::FormatHandler.format(:flat) }
+
+    it "should include a flat format" do
+      expect(flat).to be_an_instance_of Puppet::Network::Format
+    end
+
+    [:intern, :intern_multiple].each do |method|
+      it "should not implement #{method}" do
+        expect { flat.send(method, String, 'blah') }.to raise_error NotImplementedError
+      end
+    end
+
+    context "when rendering arrays" do
+      {
+          []                           => "",
+          [1, 2]                       => "0=1\n1=2\n",
+          ["one"]                      => "0=one\n",
+          [{"one" => 1}, {"two" => 2}] => "0.one=1\n1.two=2\n",
+          [['something', 'for'], ['the', 'test']]  => "0=[\"something\", \"for\"]\n1=[\"the\", \"test\"]\n"
+      }.each_pair do |input, output|
+        it "should render #{input.inspect} as one item per line" do
+          expect(flat.render(input)).to eq(output)
+        end
+      end
+    end
+
+    context "when rendering hashes" do
+      {
+          {}                                   => "",
+          {1 => 2}                             => "1=2\n",
+          {"one" => "two"}                     => "one=two\n",
+          {[1,2] => 3, [2,3] => 5, [3,4] => 7} => "[1, 2]=3\n[2, 3]=5\n[3, 4]=7\n",
+      }.each_pair do |input, output|
+        it "should render #{input.inspect}" do
+          expect(flat.render(input)).to eq(output)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is mostly a cherry-pick of the following commits
that added `puppet facts show` on main:

- 88fbc32
- eafff42
- c9dfabb
- cac4677
- fdbcce0
- 3a8626f
- 0de8cfc

The changes that were made after the cherry-pick:
 - find is set back to default action, instead of show
 - the macaddress for tests was changed to work on ruby 2.3/2.4