### PR TITLE
(PUP-10889) Explicitly set ciphersuite and allow it to be configurable

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1085,6 +1085,14 @@ EOT
           certificate revocation checking and does not attempt to download the CRL.
         EOT
     },
+    :ciphers => {
+      :default => 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256',
+      :type => :string,
+      :desc => "The list of ciphersuites for TLS connections initiated by puppet. The
+                default value is chosen to support TLS 1.0 and up, but can be made
+                more restrictive if needed. The ciphersuites must be specified in OpenSSL
+                format, not IANA."
+    },
     :key_type => {
       :default => 'rsa',
       :type    => :enum,

--- a/lib/puppet/network/http/factory.rb
+++ b/lib/puppet/network/http/factory.rb
@@ -27,6 +27,10 @@ class Puppet::Network::HTTP::Factory
 
     http = Puppet::Util::HttpProxy.proxy(URI(site.addr))
     http.use_ssl = site.use_ssl?
+    if site.use_ssl?
+      http.min_version = OpenSSL::SSL::TLS1_VERSION
+      http.ciphers = Puppet[:ciphers]
+    end
     http.read_timeout = Puppet[:http_read_timeout]
     http.open_timeout = Puppet[:http_connect_timeout]
     http.keep_alive_timeout = KEEP_ALIVE_TIMEOUT if http.respond_to?(:keep_alive_timeout=)

--- a/lib/puppet/network/http/factory.rb
+++ b/lib/puppet/network/http/factory.rb
@@ -28,7 +28,7 @@ class Puppet::Network::HTTP::Factory
     http = Puppet::Util::HttpProxy.proxy(URI(site.addr))
     http.use_ssl = site.use_ssl?
     if site.use_ssl?
-      http.min_version = OpenSSL::SSL::TLS1_VERSION
+      http.min_version = OpenSSL::SSL::TLS1_VERSION if http.respond_to?(:min_version)
       http.ciphers = Puppet[:ciphers]
     end
     http.read_timeout = Puppet[:http_read_timeout]

--- a/lib/puppet/util/monkey_patches.rb
+++ b/lib/puppet/util/monkey_patches.rb
@@ -32,6 +32,13 @@ end
 # (#19151) Reject all SSLv2 ciphers and handshakes
 require 'puppet/ssl/openssl_loader'
 unless Puppet::Util::Platform.jruby_fips?
+  unless defined?(OpenSSL::SSL::TLS1_VERSION)
+    module OpenSSL::SSL
+      # see https://github.com/ruby/ruby/commit/609103dbb5fb182eec12f052226c43e39b907682#diff-09f822c26289f5347111795ca22ed7ed1cfadd6ebd28f987991d1d414eef565aR2755-R2759
+      OpenSSL::SSL::TLS1_VERSION = 0x301
+    end
+  end
+
   class OpenSSL::SSL::SSLContext
     if DEFAULT_PARAMS[:options]
       DEFAULT_PARAMS[:options] |= OpenSSL::SSL::OP_NO_SSLv2 | OpenSSL::SSL::OP_NO_SSLv3

--- a/spec/integration/application/plugin_spec.rb
+++ b/spec/integration/application/plugin_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'puppet/face'
 require 'puppet_spec/puppetserver'
 
-describe "puppet plugin" do
+describe "puppet plugin", unless: Puppet::Util::Platform.jruby? do
   include_context "https client"
 
   let(:server) { PuppetSpec::Puppetserver.new }

--- a/spec/integration/http/client_spec.rb
+++ b/spec/integration/http/client_spec.rb
@@ -159,7 +159,7 @@ describe Puppet::HTTP::Client, unless: Puppet::Util::Platform.jruby? do
       https_server.start_server do |port|
         expect {
           client.get(URI("https://127.0.0.1:#{port}"), options: {ssl_context: root_context})
-        }.to raise_error(Puppet::HTTP::ConnectionError, /no cipher match/)
+        }.to raise_error(Puppet::HTTP::ConnectionError, /no cipher match|sslv3 alert handshake failure/)
       end
     end
   end

--- a/spec/integration/http/client_spec.rb
+++ b/spec/integration/http/client_spec.rb
@@ -151,4 +151,16 @@ describe Puppet::HTTP::Client, unless: Puppet::Util::Platform.jruby? do
       end
     end
   end
+
+  context 'ciphersuites' do
+    it "does not connect when using an SSLv3 ciphersuite" do
+      Puppet[:ciphers] = "DES-CBC3-SHA"
+
+      https_server.start_server do |port|
+        expect {
+          client.get(URI("https://127.0.0.1:#{port}"), options: {ssl_context: root_context})
+        }.to raise_error(Puppet::HTTP::ConnectionError, /no cipher match/)
+      end
+    end
+  end
 end

--- a/spec/unit/network/http/factory_spec.rb
+++ b/spec/unit/network/http/factory_spec.rb
@@ -146,7 +146,7 @@ describe Puppet::Network::HTTP::Factory do
   end
 
   context 'tls' do
-    it "sets the minimum version to TLS 1.0" do
+    it "sets the minimum version to TLS 1.0", if: RUBY_VERSION.to_f >= 2.5 do
       conn = create_connection(site)
       expect(conn.min_version).to eq(OpenSSL::SSL::TLS1_VERSION)
     end

--- a/spec/unit/network/http/factory_spec.rb
+++ b/spec/unit/network/http/factory_spec.rb
@@ -144,4 +144,23 @@ describe Puppet::Network::HTTP::Factory do
       expect(conn.local_host).to eq('127.0.0.1')
     end
   end
+
+  context 'tls' do
+    it "sets the minimum version to TLS 1.0" do
+      conn = create_connection(site)
+      expect(conn.min_version).to eq(OpenSSL::SSL::TLS1_VERSION)
+    end
+
+    it "defaults to ciphersuites providing 128 bits of security or greater" do
+      conn = create_connection(site)
+      expect(conn.ciphers).to eq("ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256")
+    end
+
+    it "can be restricted to TLSv1.3 ciphers" do
+      tls13_ciphers = "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256"
+      Puppet[:ciphers] = tls13_ciphers
+      conn = create_connection(site)
+      expect(conn.ciphers).to eq(tls13_ciphers)
+    end
+  end
 end


### PR DESCRIPTION
Previously puppet's ciphersuite depended on the ruby+openssl version in use.
This commit makes it explicit by adding a `ciphers` setting and defaulting to
Mozilla's "backward compatibility" option. All of the ciphers supported in
puppet-agent 6.x (with ruby 2.5.8 and openssl 1.1.1i) are still supported:

    > old_ciphers = OpenSSL::SSL::SSLContext.new.ciphers
    > ctx = OpenSSL::SSL::SSLContext.new
    > ctx.ciphers = Puppet[:ciphers]
    > pp ctx.ciphers - old_ciphers
    []
    > pp ctx.ciphers
    [["TLS_AES_256_GCM_SHA384", "TLSv1.3", 256, 256],
     ["TLS_CHACHA20_POLY1305_SHA256", "TLSv1.3", 256, 256],
     ["TLS_AES_128_GCM_SHA256", "TLSv1.3", 128, 128],
     ["ECDHE-ECDSA-AES128-GCM-SHA256", "TLSv1.2", 128, 128],
     ["ECDHE-RSA-AES128-GCM-SHA256", "TLSv1.2", 128, 128],
     ["ECDHE-ECDSA-AES256-GCM-SHA384", "TLSv1.2", 256, 256],
     ["ECDHE-RSA-AES256-GCM-SHA384", "TLSv1.2", 256, 256],
     ["ECDHE-ECDSA-CHACHA20-POLY1305", "TLSv1.2", 256, 256],
     ["ECDHE-RSA-CHACHA20-POLY1305", "TLSv1.2", 256, 256],
     ["DHE-RSA-AES128-GCM-SHA256", "TLSv1.2", 128, 128],
     ["DHE-RSA-AES256-GCM-SHA384", "TLSv1.2", 256, 256],
     ["DHE-RSA-CHACHA20-POLY1305", "TLSv1.2", 256, 256],
     ["ECDHE-ECDSA-AES128-SHA256", "TLSv1.2", 128, 128],
     ["ECDHE-RSA-AES128-SHA256", "TLSv1.2", 128, 128],
     ["ECDHE-ECDSA-AES128-SHA", "TLSv1.0", 128, 128],
     ["ECDHE-RSA-AES128-SHA", "TLSv1.0", 128, 128],
     ["ECDHE-ECDSA-AES256-SHA384", "TLSv1.2", 256, 256],
     ["ECDHE-RSA-AES256-SHA384", "TLSv1.2", 256, 256],
     ["ECDHE-ECDSA-AES256-SHA", "TLSv1.0", 256, 256],
     ["ECDHE-RSA-AES256-SHA", "TLSv1.0", 256, 256],
     ["DHE-RSA-AES128-SHA256", "TLSv1.2", 128, 128],
     ["DHE-RSA-AES256-SHA256", "TLSv1.2", 256, 256],
     ["AES128-GCM-SHA256", "TLSv1.2", 128, 128],
     ["AES256-GCM-SHA384", "TLSv1.2", 256, 256],
     ["AES128-SHA256", "TLSv1.2", 128, 128],
     ["AES256-SHA256", "TLSv1.2", 256, 256]]

Although puppet never makes use of DSA keys, it's possible for a 3rd party
HTTPS server to use them, so we include them in the list.

The following ciphers are dropped, but that is ok because they only apply
to SSLv3 or preshared key (PSK), neither of which we support or use:

    > pp old_ciphers - ctx.ciphers
    [["DHE-RSA-AES256-SHA", "SSLv3", 256, 256],
     ["DHE-RSA-AES128-SHA", "SSLv3", 128, 128],
     ["RSA-PSK-AES256-GCM-SHA384", "TLSv1.2", 256, 256],
     ["DHE-PSK-AES256-GCM-SHA384", "TLSv1.2", 256, 256],
     ["RSA-PSK-CHACHA20-POLY1305", "TLSv1.2", 256, 256],
     ["DHE-PSK-CHACHA20-POLY1305", "TLSv1.2", 256, 256],
     ["ECDHE-PSK-CHACHA20-POLY1305", "TLSv1.2", 256, 256],
     ["PSK-AES256-GCM-SHA384", "TLSv1.2", 256, 256],
     ["PSK-CHACHA20-POLY1305", "TLSv1.2", 256, 256],
     ["RSA-PSK-AES128-GCM-SHA256", "TLSv1.2", 128, 128],
     ["DHE-PSK-AES128-GCM-SHA256", "TLSv1.2", 128, 128],
     ["PSK-AES128-GCM-SHA256", "TLSv1.2", 128, 128],
     ["ECDHE-PSK-AES256-CBC-SHA384", "TLSv1.0", 256, 256],
     ["ECDHE-PSK-AES256-CBC-SHA", "TLSv1.0", 256, 256],
     ["SRP-RSA-AES-256-CBC-SHA", "SSLv3", 256, 256],
     ["SRP-AES-256-CBC-SHA", "SSLv3", 256, 256],
     ["RSA-PSK-AES256-CBC-SHA384", "TLSv1.0", 256, 256],
     ["DHE-PSK-AES256-CBC-SHA384", "TLSv1.0", 256, 256],
     ["RSA-PSK-AES256-CBC-SHA", "SSLv3", 256, 256],
     ["DHE-PSK-AES256-CBC-SHA", "SSLv3", 256, 256],
     ["AES256-SHA", "SSLv3", 256, 256],
     ["PSK-AES256-CBC-SHA384", "TLSv1.0", 256, 256],
     ["PSK-AES256-CBC-SHA", "SSLv3", 256, 256],
     ["ECDHE-PSK-AES128-CBC-SHA256", "TLSv1.0", 128, 128],
     ["ECDHE-PSK-AES128-CBC-SHA", "TLSv1.0", 128, 128],
     ["SRP-RSA-AES-128-CBC-SHA", "SSLv3", 128, 128],
     ["SRP-AES-128-CBC-SHA", "SSLv3", 128, 128],
     ["RSA-PSK-AES128-CBC-SHA256", "TLSv1.0", 128, 128],
     ["DHE-PSK-AES128-CBC-SHA256", "TLSv1.0", 128, 128],
     ["RSA-PSK-AES128-CBC-SHA", "SSLv3", 128, 128],
     ["DHE-PSK-AES128-CBC-SHA", "SSLv3", 128, 128],
     ["AES128-SHA", "SSLv3", 128, 128],
     ["PSK-AES128-CBC-SHA256", "TLSv1.0", 128, 128],
     ["PSK-AES128-CBC-SHA", "SSLv3", 128, 128]]

This also sets the minimum version to TLS 1.0. Our openssl builds don't include
SSLv3 support, but at least we're explicit about not downgrading.