### PR TITLE
(PUP-10896) Fix user gid property when forcelocal is true

### DIFF
--- a/lib/puppet/provider/user/useradd.rb
+++ b/lib/puppet/provider/user/useradd.rb
@@ -98,7 +98,7 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
 
   def localuid
     user = finduser(:account, resource[:name])
-    return user[:uid] if user
+    return user[:uid].to_i if user
     false
   end
 

--- a/spec/unit/provider/user/useradd_spec.rb
+++ b/spec/unit/provider/user/useradd_spec.rb
@@ -360,14 +360,14 @@ describe Puppet::Type.type(:user).provider(:useradd) do
       resource[:forcelocal] = true
       allow(Puppet::FileSystem).to receive(:exist?).with('/etc/passwd').and_return(true)
       allow(Puppet::FileSystem).to receive(:each_line).with('/etc/passwd').and_yield(content)
-      expect(provider.gid).to eq('999')
+      expect(provider.gid).to eq(999)
     end
 
     it "should fall back to nameservice GID when forcelocal is false" do
       resource[:forcelocal] = false
       allow(provider).to receive(:get).with(:gid).and_return('1234')
       expect(provider).not_to receive(:localgid)
-      expect(provider.gid).to eq('1234')
+      expect(provider.gid).to eq(1234)
     end
   end
 


### PR DESCRIPTION
Ensure that the user gid property with forcelocal set to true will work with the type's comparison of GID values