### PR TITLE
(PUP-10922) Convert hostnames to lowercase for use in fqdn_rand() function

### DIFF
--- a/lib/puppet/parser/functions/fqdn_rand.rb
+++ b/lib/puppet/parser/functions/fqdn_rand.rb
@@ -26,10 +26,12 @@ Puppet::Parser::Functions::newfunction(:fqdn_rand, :arity => -2, :type => :rvalu
     # Restoring previous fqdn_rand behavior of calculating its seed value using MD5
     # when running on a non-FIPS enabled platform and only using SHA256 on FIPS enabled
     # platforms.
+    # First convert to lowercase, as DNS hostnames are case-insensitive.
+    longstring = [self['::fqdn'].to_s.downcase,max,args].join(':')
     if Puppet::Util::Platform.fips_enabled?
-      seed = Digest::SHA256.hexdigest([self['::fqdn'],max,args].join(':')).hex
+      seed = Digest::SHA256.hexdigest(longstring).hex
     else
-      seed = Digest::MD5.hexdigest([self['::fqdn'],max,args].join(':')).hex
+      seed = Digest::MD5.hexdigest(longstring).hex
     end
 
     Puppet::Util.deterministic_rand_int(seed,max)


### PR DESCRIPTION
DNS standards do not guarantee that hostnames will have a consistent case (upper or lower) on different servers authoritative for the same domain.

Therefore, the [fqdn_rand](https://puppet.com/docs/puppet/latest/function.html#fqdn_rand) function should not assume that the FQDN of a given server, (which may rely on DNS lookup via [getaddrinfo](https://man7.org/linux/man-pages/man3/getaddrinfo.3.html)) will always be returned with identical case.

See https://tickets.puppetlabs.com/browse/PUP-10922 for discussion.
