### PR TITLE
(PUP-10898) Get fully qualified current user name as fallback

### DIFF
--- a/lib/puppet/file_system/windows.rb
+++ b/lib/puppet/file_system/windows.rb
@@ -128,6 +128,8 @@ class Puppet::FileSystem::Windows < Puppet::FileSystem::Posix
     end
 
     current_sid = Puppet::Util::Windows::SID.name_to_sid(Puppet::Util::Windows::ADSI::User.current_user_name)
+    current_sid = Puppet::Util::Windows::SID.name_to_sid(Puppet::Util::Windows::ADSI::User.current_sam_compatible_user_name) unless current_sid
+
     dacl = case mode
            when 0644
              dacl = secure_dacl(current_sid)

--- a/lib/puppet/util/windows/sid.rb
+++ b/lib/puppet/util/windows/sid.rb
@@ -74,11 +74,13 @@ module Puppet::Util::Windows
         string_to_sid_ptr(name) do |sid_ptr|
           raw_sid_bytes = sid_ptr.read_array_of_uchar(get_length_sid(sid_ptr))
         end
-      rescue
+      rescue => e
+        Puppet.debug("Could not retrieve raw SID bytes from '#{name}': #{e.message}")
       end
 
       raw_sid_bytes ? Principal.lookup_account_sid(raw_sid_bytes) : Principal.lookup_account_name(name)
-    rescue
+    rescue => e
+      Puppet.debug("#{e.message}")
       (allow_unresolved && raw_sid_bytes) ? unresolved_principal(name, raw_sid_bytes) : nil
     end
     module_function :name_to_principal

--- a/spec/integration/util/windows/adsi_spec.rb
+++ b/spec/integration/util/windows/adsi_spec.rb
@@ -55,6 +55,24 @@ describe Puppet::Util::Windows::ADSI::User,
       end
     end
   end
+
+  describe '.current_user_name_with_format' do
+    context 'when desired format is NameSamCompatible' do
+      it 'should get the same user name as the current_user_name method but fully qualified' do
+        user_name = Puppet::Util::Windows::ADSI::User.current_user_name
+        fully_qualified_user_name = Puppet::Util::Windows::ADSI::User.current_sam_compatible_user_name
+
+        expect(fully_qualified_user_name).to match(/^.+\\#{user_name}$/)
+      end
+
+      it 'should have the same SID as with the current_user_name method' do
+        user_name = Puppet::Util::Windows::ADSI::User.current_user_name
+        fully_qualified_user_name = Puppet::Util::Windows::ADSI::User.current_sam_compatible_user_name
+
+        expect(Puppet::Util::Windows::SID.name_to_sid(user_name)).to eq(Puppet::Util::Windows::SID.name_to_sid(fully_qualified_user_name))
+      end
+    end
+  end
 end
 
 describe Puppet::Util::Windows::ADSI::Group,

--- a/spec/unit/util/windows/sid_spec.rb
+++ b/spec/unit/util/windows/sid_spec.rb
@@ -158,6 +158,12 @@ describe "Puppet::Util::Windows::SID", :if => Puppet::Util::Platform.windows? do
       # this works in French Windows, even though the account is really AUTORITE NT\\Syst\u00E8me
       expect(subject.name_to_principal('NT AUTHORITY\SYSTEM').sid).to eq(sid)
     end
+
+    it "should print a debug message on failures" do
+      expect(Puppet).to receive(:debug).with(/Could not retrieve raw SID bytes from 'NonExistingUser'/)
+      expect(Puppet).to receive(:debug).with(/No mapping between account names and security IDs was done/)
+      subject.name_to_principal('NonExistingUser')
+    end
   end
 
   context "#ads_to_principal" do


### PR DESCRIPTION
This pull request adds a fallback to retrieving the current Windows user name SID by retrying with the fully qualified user name when said SID returns as `nil` the first try. This is done via the `GetUserNameExW` function.

A debug message is also added where errors (in the `Puppet::Util::Windows::SID::name_to_principal` method) were caught silently and increased debugging difficulty (`Puppet::Util::Windows::SID::Principal::lookup_account_name` in particular).