### PR TITLE
(FACT-2941) puppet facts diff facter-ng reload

### DIFF
--- a/lib/puppet/face/facts.rb
+++ b/lib/puppet/face/facts.rb
@@ -133,13 +133,15 @@ Puppet::Indirector::Face.define(:facts, '0.0.1') do
 
       if Puppet::Util::Package.versioncmp(Facter.value('facterversion'), '4.0.0') < 0
         facter3_result = Puppet::Node::Facts.indirection.find(Puppet.settings[:certname])
-        begin
-          require 'facter-ng'
-          facter4_result = Puppet::Node::Facts.indirection.find(Puppet.settings[:certname])
-        rescue LoadError
-          raise ArgumentError, 'facter-ng could not be loaded'
+
+        # puppet/ruby are in PATH since were added in wrapper script
+        puppet_cmd = 'puppet facts show --facterng --render-as json'
+        if Puppet::Util::Platform.windows?
+          puppet_cmd = "ruby -S -- puppet facts show --render-as json"
         end
-        fact_diff = FactDif.new(facter3_result.to_json, facter4_result.to_json, EXCLUDE_LIST)
+        facter4_result = Puppet::Util::Execution.execute(puppet_cmd)
+
+        fact_diff = FactDif.new(facter3_result.to_json, facter4_result, EXCLUDE_LIST)
         fact_diff.difs
       else
         Puppet.warning _("Already using Facter 4. To use `puppet facts diff` remove facterng from the .conf file or run `puppet config set facterng false`.")


### PR DESCRIPTION
 On facts diff command we run both facter 3 and facter 4 in the same run
 When apt module is installed, this leads to errors in output

 This commit adds more cleanup to be done before facter 4 is used:
 * remove :Facter const
 * reload all `.rb` files that are not part of `facter-ng` and contain `/facter/`
 in theirs path (as they may define classes/modules in :Facter namespace)