### PR TITLE
(maint) Merge branch 6.x into main

### DIFF
--- a/lib/puppet/application/ssl.rb
+++ b/lib/puppet/application/ssl.rb
@@ -74,6 +74,9 @@ ACTIONS
   `--localca` is specified, then also remove this host's local copy of the
   CA certificate(s) and CRL bundle. if `--target CERTNAME` is specified, then
   remove the files for the specified device on this host instead of this host.
+
+ * show:
+  Print the full-text version of this host's certificate.
 HELP
   end
 
@@ -142,9 +145,17 @@ HELP
       end
       @machine.ensure_client_certificate
       Puppet.notice(_("Completed SSL initialization"))
+    when 'show'
+      show(certname)
     else
       raise Puppet::Error, _("Unknown action '%{action}'") % { action: action }
     end
+  end
+
+  def show(certname)
+    password = @cert_provider.load_private_key_password
+    ssl_context = @ssl_provider.load_context(certname: certname, password: password)
+    puts ssl_context.client_cert.to_text
   end
 
   def submit_request(ssl_context)

--- a/lib/puppet/file_system/windows.rb
+++ b/lib/puppet/file_system/windows.rb
@@ -128,6 +128,8 @@ class Puppet::FileSystem::Windows < Puppet::FileSystem::Posix
     end
 
     current_sid = Puppet::Util::Windows::SID.name_to_sid(Puppet::Util::Windows::ADSI::User.current_user_name)
+    current_sid = Puppet::Util::Windows::SID.name_to_sid(Puppet::Util::Windows::ADSI::User.current_sam_compatible_user_name) unless current_sid
+
     dacl = case mode
            when 0644
              dacl = secure_dacl(current_sid)

--- a/lib/puppet/util/windows/sid.rb
+++ b/lib/puppet/util/windows/sid.rb
@@ -74,11 +74,13 @@ module Puppet::Util::Windows
         string_to_sid_ptr(name) do |sid_ptr|
           raw_sid_bytes = sid_ptr.read_array_of_uchar(get_length_sid(sid_ptr))
         end
-      rescue
+      rescue => e
+        Puppet.debug("Could not retrieve raw SID bytes from '#{name}': #{e.message}")
       end
 
       raw_sid_bytes ? Principal.lookup_account_sid(raw_sid_bytes) : Principal.lookup_account_name(name)
-    rescue
+    rescue => e
+      Puppet.debug("#{e.message}")
       (allow_unresolved && raw_sid_bytes) ? unresolved_principal(name, raw_sid_bytes) : nil
     end
     module_function :name_to_principal

--- a/spec/integration/util/windows/adsi_spec.rb
+++ b/spec/integration/util/windows/adsi_spec.rb
@@ -55,6 +55,24 @@ describe Puppet::Util::Windows::ADSI::User,
       end
     end
   end
+
+  describe '.current_user_name_with_format' do
+    context 'when desired format is NameSamCompatible' do
+      it 'should get the same user name as the current_user_name method but fully qualified' do
+        user_name = Puppet::Util::Windows::ADSI::User.current_user_name
+        fully_qualified_user_name = Puppet::Util::Windows::ADSI::User.current_sam_compatible_user_name
+
+        expect(fully_qualified_user_name).to match(/^.+\\#{user_name}$/)
+      end
+
+      it 'should have the same SID as with the current_user_name method' do
+        user_name = Puppet::Util::Windows::ADSI::User.current_user_name
+        fully_qualified_user_name = Puppet::Util::Windows::ADSI::User.current_sam_compatible_user_name
+
+        expect(Puppet::Util::Windows::SID.name_to_sid(user_name)).to eq(Puppet::Util::Windows::SID.name_to_sid(fully_qualified_user_name))
+      end
+    end
+  end
 end
 
 describe Puppet::Util::Windows::ADSI::Group,

--- a/spec/unit/application/ssl_spec.rb
+++ b/spec/unit/application/ssl_spec.rb
@@ -432,4 +432,27 @@ describe Puppet::Application::Ssl, unless: Puppet::Util::Platform.jruby? do
       expects_command_to_pass
     end
   end
+
+  context 'when showing' do
+    before do
+      ssl.command_line.args << 'show'
+      File.write(Puppet[:hostcert], @host[:cert].to_pem)
+    end
+
+    it 'reports if the key is missing' do
+      File.delete(Puppet[:hostprivkey])
+
+      expects_command_to_fail(/The private key is missing from/)
+    end
+
+    it 'reports if the cert is missing' do
+      File.delete(Puppet[:hostcert])
+
+      expects_command_to_fail(/The client certificate is missing from/)
+    end
+
+    it 'prints certificate information' do
+      expects_command_to_pass(@host[:cert].to_text)
+    end
+  end
 end

--- a/spec/unit/util/windows/sid_spec.rb
+++ b/spec/unit/util/windows/sid_spec.rb
@@ -158,6 +158,12 @@ describe "Puppet::Util::Windows::SID", :if => Puppet::Util::Platform.windows? do
       # this works in French Windows, even though the account is really AUTORITE NT\\Syst\u00E8me
       expect(subject.name_to_principal('NT AUTHORITY\SYSTEM').sid).to eq(sid)
     end
+
+    it "should print a debug message on failures" do
+      expect(Puppet).to receive(:debug).with(/Could not retrieve raw SID bytes from 'NonExistingUser'/)
+      expect(Puppet).to receive(:debug).with(/No mapping between account names and security IDs was done/)
+      subject.name_to_principal('NonExistingUser')
+    end
   end
 
   context "#ads_to_principal" do


### PR DESCRIPTION
* 6.x:
  (PUP-10940) use `puppet facts show` command to compare facts
  (packaging) Updating manpage file for 6.x
  (PUP-10898) Get fully qualified current user name as fallback
  (packaging) Updating manpage file for 6.x
  (PUP-10888) Added puppet ssl show action
  (maint) Add debug messages for silently catched errors
  (PUP-10940) puppet facts diff facter-ng reload  On facts diff command we run both facter 3 and facter 4 in the same run

