### PR TITLE
(PUP-10952) Stop clearing envs on `rich_data` setting change

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -2157,15 +2157,13 @@ EOT
     :rich_data => {
       :default  => true,
       :type     => :boolean,
-      :hook    => proc do |value|
-        envs = Puppet.lookup(:environments) { nil }
-        envs.clear_all unless envs.nil?
-      end,
       :desc     => <<-'EOT'
         Enables having extended data in the catalog by storing them as a hash with the special key
         `__ptype`. When enabled, resource containing values of the data types `Binary`, `Regexp`,
         `SemVer`, `SemVerRange`, `Timespan` and `Timestamp`, as well as instances of types derived
         from `Object` retain their data type.
+
+        To ensure proper behavior, it is recommended to clear the environment cache when toggling this setting.
       EOT
     }
   )


### PR DESCRIPTION
The `rich_data` setting has been true by default since Puppet 6.0, and
all of the places that currently set it in code are also setting it to
true. So this commit removes the hook that clears all envs when the
setting is configured, since at this point that is very unlikely to
actually change its value, and reloading all environments is expensive.
If a consumer wants to actually toggle `rich_data`, they should take
responsiblity for clearing out the environment cache, to ensure things
are properly reloaded.

Note that removing this hook avoids an issue with multithreaded Puppet.
In that mode, any request that overrides a setting will cause a new
settings object to be created. When that happens, setting are
reinitialized, and hooks like this one are called, which in this case
could cause all environments to be cleared on every compile.