### PR TITLE
(PUP-10943) Puppet read registry until WCHAR_NULL

### DIFF
--- a/lib/puppet/ffi/windows/api_types.rb
+++ b/lib/puppet/ffi/windows/api_types.rb
@@ -20,7 +20,7 @@ module Puppet::FFI::Windows
 
     class ::FFI::Pointer
       NULL_HANDLE = 0
-      WCHAR_NULL = "\0\0".encode('UTF-16LE').freeze
+      WCHAR_NULL = "\0\0".force_encoding('UTF-16LE').freeze
 
       def self.from_string_to_wide_string(str, &block)
         str = Puppet::Util::Windows::String.wide_string(str)

--- a/spec/integration/util/windows/registry_spec.rb
+++ b/spec/integration/util/windows/registry_spec.rb
@@ -263,6 +263,12 @@ describe Puppet::Util::Windows::Registry do
           type: Win32::Registry::REG_EXPAND_SZ,
           value: "\0\0\0reg expand string",
           expected_value: ""
+        },
+        {
+          name: 'REG_EXPAND_SZ_2',
+          type: Win32::Registry::REG_EXPAND_SZ,
+          value: "1\x002\x003\x004\x00\x00\x00\x90\xD8UoY".force_encoding("UTF-16LE"),
+          expected_value: "1234"
         }
       ].each do |pair|
         it 'reads up to the first wide null' do


### PR DESCRIPTION
On Windows, it is possible to have a registry that contains corrupted
data after the WCHAR_NULL characters, that can break puppet when reading
the registy.

Part of the fix was done in PUP-10536, but when the WCHAR_NULL from the
registry is \u0000 instead of \u0000\u0000, the split did not work.

Now WCHAR_NULL is forced encoded to UTF-16LE, meaning `\u000` so puppet
will now stop at the WCHAR_NULL char.

The initial issue can be reproduced by importing file.reg using
`reg import  .\file.reg`

----file.reg----

Windows Registry Editor Version 5.00

[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\PUP105360000]
"DisplayName"="PUP105"
"DisplayVersion"=hex(2):32,0,0,0,f3,23,8a,bc,fa,7f,0,0,10,65,74,b9,fa,7f,0,0,90,d8,55,6f,59