### PR TITLE
(PUP-10923) Fix acceptance tests on main branch

### DIFF
--- a/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
+++ b/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
@@ -84,7 +84,7 @@ test_name "ticket 1073: common package name in two different providers should be
   MANIFEST
 
   apply_manifest_on(agents, collide1_manifest, :acceptable_exit_codes => [1]) do |result|
-    assert_match(/Error while evaluating a Resource Statement, Cannot alias Package\[other-guid\] to \["guid", nil\]/, "#{result.host}: #{result.stderr}")
+    assert_match(/Error while evaluating a Resource Statement, Cannot alias Package\[other-guid\] to \[nil, "guid", nil\]/, "#{result.host}: #{result.stderr}")
   end
 
   verify_absent agents, 'guid'
@@ -96,7 +96,7 @@ test_name "ticket 1073: common package name in two different providers should be
   MANIFEST
 
   apply_manifest_on(agents, collide2_manifest, :acceptable_exit_codes => [1]) do |result|
-    assert_match(/Error while evaluating a Resource Statement, Cannot alias Package\[other-guid\] to \["guid", "#{gem_provider}"\]/, "#{result.host}: #{result.stderr}")
+    assert_match(/Error while evaluating a Resource Statement, Cannot alias Package\[other-guid\] to \[nil, "guid", "#{gem_provider}"\]/, "#{result.host}: #{result.stderr}")
   end
 
   verify_absent agents, 'guid'

--- a/acceptance/tests/ticket_1334_clientbucket_corrupted.rb
+++ b/acceptance/tests/ticket_1334_clientbucket_corrupted.rb
@@ -7,11 +7,7 @@ test_name 'C99977 corrupted clientbucket' do
     tmpfile = agent.tmpfile('c99977file')
     unmanaged_content = "unmanaged\n"
     
-    if on(agent, facter("fips_enabled")).stdout =~ /true/
-      unmanaged_sha = Digest::SHA256.hexdigest(unmanaged_content)
-    else
-      unmanaged_sha = Digest::MD5.hexdigest(unmanaged_content)
-    end
+    unmanaged_sha = Digest::SHA256.hexdigest(unmanaged_content)
 
     managed_content = "managed\n"
     manifest = "file { '#{tmpfile}': content => '#{managed_content}', backup => 'puppet' }"


### PR DESCRIPTION
- common_package_name_in_different_providers
Not really sure why the error message changed between 6.x and 7.x, but apart from this the functionality appears to be the same.

- ticket_1334_clientbucket_corrupted.rb
This failed due to PUP-10583 which changed the default digest algorithm to SHA256 for Puppet 7