### PR TITLE
(PUP-10951) Allow splat operator inside overridden resource collectors

### DIFF
--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -236,7 +236,6 @@ class Checker4_0 < Evaluator::LiteralEvaluator
     case p
     when Model::AbstractResource
     when Model::CollectExpression
-      acceptor.accept(Issues::UNSUPPORTED_OPERATOR_IN_CONTEXT, p, :operator=>'* =>')
     else
       # protect against just testing a snippet that has no parent, error message will be a bit strange
       # but it is not for a real program.

--- a/spec/integration/parser/collection_spec.rb
+++ b/spec/integration/parser/collection_spec.rb
@@ -235,6 +235,16 @@ describe 'collectors' do
         MANIFEST
       end
 
+      it "splats attributes from a hash" do
+        expect_the_message_to_be(["overridden message"], <<-MANIFEST)
+          @notify { "testing": message => "original message" }
+
+          Notify <| |> {
+            * => { message => "overridden message" }
+          }
+        MANIFEST
+      end
+
       it "collects with override when inside a class (#10963)" do
         expect_the_message_to_be(["overridden message"], <<-MANIFEST)
           @notify { "testing": message => "original message" }


### PR DESCRIPTION
Commit 8bdaaecdce removed the `when CapabilityMapping` statement, but didn't
remove the corresponding issue. I was thinking of Java switch/case, where
multiple cases fall through. This makes it possible to use the splat operator to
override attributes for collected resources.