### PR TITLE
Revert "Merge pull request #8492 from GabrielNagy/PUP-10853/remove-le…

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.summary = "Puppet, an automated configuration management tool"
   s.specification_version = 3
-  s.add_runtime_dependency(%q<facter>, [">= 4.0.0", "< 5"])
+  s.add_runtime_dependency(%q<facter>, [">= 2.4.0", "< 5"])
   s.add_runtime_dependency(%q<hiera>, [">= 3.2.1", "< 4"])
   s.add_runtime_dependency(%q<semantic_puppet>, "~> 1.0")
   s.add_runtime_dependency(%q<fast_gettext>, "~> 1.1")

--- a/acceptance/lib/puppet/acceptance/agent_fqdn_utils.rb
+++ b/acceptance/lib/puppet/acceptance/agent_fqdn_utils.rb
@@ -7,7 +7,7 @@ module Puppet
       # convert from an Beaker::Host (agent) to the systems fqdn as returned by facter
       def agent_to_fqdn(agent)
         unless @@hostname_to_fqdn.has_key?(agent.hostname)
-          @@hostname_to_fqdn[agent.hostname] = on(agent, facter('networking.fqdn')).stdout.chomp
+          @@hostname_to_fqdn[agent.hostname] = on(agent, facter('fqdn')).stdout.chomp
         end
         @@hostname_to_fqdn[agent.hostname]
       end

--- a/acceptance/tests/aix/nim_package_provider.rb
+++ b/acceptance/tests/aix/nim_package_provider.rb
@@ -8,7 +8,7 @@ confine :to, :platform => "aix" do |aix|
   version = on(aix, 'puppet --version').stdout
   version &&
     Gem::Version.new(version) > Gem::Version.new('6.4.0') &&
-    on(aix, 'facter os.release.full').stdout == '7.2'
+    on(aix, 'facter operatingsystemrelease').stdout == '7.2'
 end
 
 teardown do

--- a/acceptance/tests/catalog_with_binary_data.rb
+++ b/acceptance/tests/catalog_with_binary_data.rb
@@ -34,7 +34,7 @@ test_name "C100300: Catalog containing binary data is applied correctly" do
     manifest = <<-MANIFEST
       class #{test_num}(
       ) {
-        \$test_path = \$facts['networking']['fqdn'] ? #{agent_tmp_dirs}
+        \$test_path = \$::fqdn ? #{agent_tmp_dirs}
         file { '#{test_num}':
           path   => "\$test_path/#{test_num}",
           content => file('#{test_num}/binary_data'),

--- a/acceptance/tests/direct_puppet/supports_utf8.rb
+++ b/acceptance/tests/direct_puppet/supports_utf8.rb
@@ -34,7 +34,7 @@ test_name "C97172: static catalogs support utf8" do
 file { '#{environmentpath}/#{tmp_environment}/manifests/site.pp':
   ensure => file,
   content => '
-\$test_path = \$facts["networking"]["fqdn"] ? #{tmp_file}
+\$test_path = \$::fqdn ? #{tmp_file}
 file { \$test_path:
   content => @(UTF8)
     #{file_contents}

--- a/acceptance/tests/language/binary_data_type.rb
+++ b/acceptance/tests/language/binary_data_type.rb
@@ -53,7 +53,7 @@ test_name 'C98346: Binary data type' do
         :assertions => { :assert_match => 'Notice: A:\\xF0\\x9F\\x91\\x92' } },
       { :type       => 'notify', :parameters => { :namevar => "B:${type($bin_file)}" }, :pre_code => '$bin_file=binary_file("empty/blah.txt")',
         :assertions => { :assert_match => 'Notice: B:Binary' } },
-      { :type       => 'file', :parameters => { :namevar => "$pup_tmp_filename", :content => "$relaxed" }, :pre_code => "$pup_tmp_filename = if $facts['os']['family'] == 'windows' { '#{tmp_filename_win}' } else { '#{tmp_filename_else}' }",
+      { :type       => 'file', :parameters => { :namevar => "$pup_tmp_filename", :content => "$relaxed" }, :pre_code => "$pup_tmp_filename = if $osfamily == 'windows' { '#{tmp_filename_win}' } else { '#{tmp_filename_else}' }",
         :assertions => { :assert_match => /#{base64_relaxed}/ } },
   ]
 

--- a/acceptance/tests/language/sensitive_data_type.rb
+++ b/acceptance/tests/language/sensitive_data_type.rb
@@ -58,7 +58,7 @@ tag 'audit:high',
     {:type => 'notify', :parameters => {:namevar => "C:meh", :message => '"C:${$mehC.unwrap |$unwrapped| { "blk_${unwrapped}_blk" } } nonblk_${mehC}_nonblk"'}, :pre_code => '$mehC=Sensitive.new("sekritC")',
        :assertions => {:assert_match => ["C:blk_sekritC_blk", "nonblk_#{notify_redacted}_nonblk"]}},
     # for --show_diff
-    {:type => 'file', :parameters => {:namevar => "$pup_tmp_filename", :content => "Sensitive.new('sekritD')"}, :pre_code => "$pup_tmp_filename = if $facts['os']['family'] == 'windows' { '#{tmp_filename_win}' } else { '#{tmp_filename_else}' }",
+    {:type => 'file', :parameters => {:namevar => "$pup_tmp_filename", :content => "Sensitive.new('sekritD')"}, :pre_code => "$pup_tmp_filename = if $osfamily == 'windows' { '#{tmp_filename_win}' } else { '#{tmp_filename_else}' }",
        :assertions => [{:refute_match => 'sekritD'}, {:assert_match => /#{tmp_environment}\.txt..content. #{file_redacted}/}]},
 
   ]

--- a/acceptance/tests/loader/autoload_from_resource_type_decl.rb
+++ b/acceptance/tests/loader/autoload_from_resource_type_decl.rb
@@ -41,7 +41,7 @@ test_name 'C100303: Resource type statement triggered auto-loading works both wi
     custom_type = <<-END
     Puppet::Type.newtype(:type_tst) do
       newparam(:name, :namevar => true) do
-        fqdn = Facter.value('networking.fqdn')
+        fqdn = Facter.value(:fqdn)
         if fqdn == '#{agent_to_fqdn(master)}'
           File.open("#{execution_log[agent_to_fqdn(master)]}", 'a+') { |f| f.puts("found_type_tst: " + Time.now.to_s) }
         end

--- a/acceptance/tests/lookup/merge_strategies.rb
+++ b/acceptance/tests/lookup/merge_strategies.rb
@@ -37,9 +37,9 @@ tag 'audit:medium',
   - "host"
   - "roles"
   - "profiles"
-  - "%{facts.os.name}"
-  - "%{facts.os.family}"
-  - "%{facts.kernel}"
+  - "%{::operatingsystem}"
+  - "%{::osfamily}"
+  - "%{::kernel}"
   - "common"
 :merge_behavior: deeper
 :deep_merge_options:

--- a/acceptance/tests/parser_functions/hiera_in_templates.rb
+++ b/acceptance/tests/parser_functions/hiera_in_templates.rb
@@ -100,7 +100,7 @@ node default {
   \\$msgs = hiera_array('message')
   notify {\\$msgs:}
   class {'#{@module_name}':
-    result_dir => hiera('result_dir')[\\$facts['networking']['hostname']],
+    result_dir => hiera('result_dir')[\\$::hostname],
   }
 }
 ",
@@ -188,7 +188,7 @@ class #{@module_name} (
 file { "#{moduledir}/manifests/mod_default.pp":
   content => "
 class #{@module_name}::mod_default {
-  \\$result_dir = hiera('result_dir')[\\$facts['networking']['hostname']]
+  \\$result_dir = hiera('result_dir')[\\$::hostname]
   notify{\\"module mod_default invoked.\\\\n\\":}
   file {\\\"\\\${result_dir}/mod_default\\\":
     ensure  => 'file',
@@ -202,7 +202,7 @@ class #{@module_name}::mod_default {
 file { "#{moduledir}/manifests/mod_osfamily.pp":
   content => "
 class #{@module_name}::mod_osfamily {
-  \\$result_dir = hiera('result_dir')[\\$facts['networking']['hostname']]
+  \\$result_dir = hiera('result_dir')[\\$::hostname]
   notify{\\"module mod_osfamily invoked.\\\\n\\":}
   file {\\\"\\\${result_dir}/mod_osfamily\\\":
     ensure  => 'file',
@@ -216,7 +216,7 @@ class #{@module_name}::mod_osfamily {
 file { "#{moduledir}/manifests/mod_production.pp":
   content => "
 class #{@module_name}::mod_production {
-  \\$result_dir = hiera('result_dir')[\\$facts['networking']['hostname']]
+  \\$result_dir = hiera('result_dir')[\\$::hostname]
   notify{\\"module mod_production invoked.\\\\n\\":}
   file {\\\"\\\${result_dir}/mod_production\\\":
     ensure  => 'file',
@@ -230,7 +230,7 @@ class #{@module_name}::mod_production {
 file { "#{moduledir}/manifests/mod_fqdn.pp":
   content => "
 class #{@module_name}::mod_fqdn {
-  \\$result_dir = hiera('result_dir')[\\$facts['networking']['hostname']]
+  \\$result_dir = hiera('result_dir')[\\$::hostname]
   notify{\\"module mod_fqdn invoked.\\\\n\\":}
   file {\\\"\\\${result_dir}/mod_fqdn\\\":
     ensure  => 'file',
@@ -271,7 +271,7 @@ end
 def find_osfamilies
   family_hash = {}
   agents.each do |agent|
-    res = on(agent, facter('os.family'))
+    res = on(agent, facter("osfamily"))
     osf = res.stdout.chomp
     family_hash[osf] = 1
   end
@@ -282,7 +282,7 @@ def find_tmp_dirs
   tmp_dirs = ""
   host_to_result_dir = {}
   agents.each do |agent|
-    h = on(agent, facter('networking.hostname')).stdout.chomp
+    h = on(agent, facter("hostname")).stdout.chomp
     t = agent.tmpdir("#{@module_name}_results")
     tmp_dirs += "  #{h}: '#{t}'\n"
     host_to_result_dir[h] = t
@@ -304,7 +304,7 @@ with_puppet_running_on master, @master_opts, @coderoot do
   env_manifest = create_environment(find_osfamilies, tmp_dirs)
   apply_manifest_on(master, env_manifest, :catch_failures => true)
   agents.each do |agent|
-    resultdir = host_to_result_dir[on(agent, facter('networking.hostname')).stdout.chomp]
+    resultdir = host_to_result_dir[on(agent, facter("hostname")).stdout.chomp]
     step "Applying catalog to agent: #{agent}. result files in #{resultdir}"
     on(
       agent,

--- a/acceptance/tests/reports/corrective_change_new_resource.rb
+++ b/acceptance/tests/reports/corrective_change_new_resource.rb
@@ -36,7 +36,7 @@ test_name "C98092 - a new resource should not be reported as a corrective change
     file { '#{environmentpath}/#{tmp_environment}/manifests/site.pp':
       ensure => file,
       content => '
-    \$test_path = \$facts["networking"]["fqdn"] ? #{tmp_file}
+    \$test_path = \$::fqdn ? #{tmp_file}
     file { \$test_path:
       content => @(UTF8)
         #{file_contents}

--- a/acceptance/tests/reports/corrective_change_outside_puppet.rb
+++ b/acceptance/tests/reports/corrective_change_outside_puppet.rb
@@ -37,7 +37,7 @@ test_name "C98093 - a resource changed outside of Puppet will be reported as a c
       file { '#{environmentpath}/#{tmp_environment}/manifests/site.pp':
         ensure => file,
         content => '
-      \$test_path = \$facts["networking"]["fqdn"] ? #{tmp_file}
+      \$test_path = \$::fqdn ? #{tmp_file}
       file { \$test_path:
         content => @(UTF8)
           #{file_contents}

--- a/acceptance/tests/reports/corrective_change_via_puppet.rb
+++ b/acceptance/tests/reports/corrective_change_via_puppet.rb
@@ -39,7 +39,7 @@ test_name "C98094 - a resource changed via Puppet manifest will not be reported 
       file { '#{environmentpath}/#{environment_name}/manifests/site.pp':
         ensure => file,
         content => '
-      \$test_path = \$facts["networking"]["fqdn"] ? #{file_resource}
+      \$test_path = \$::fqdn ? #{file_resource}
       file { \$test_path:
         content => @(UTF8)
           #{file_contents}

--- a/acceptance/tests/resource/file/ticket_6448_file_with_utf8_source.rb
+++ b/acceptance/tests/resource/file/ticket_6448_file_with_utf8_source.rb
@@ -49,7 +49,7 @@ test_name 'Ensure a file resource can have a UTF-8 source attribute, content, an
 
   step 'create a site.pp on master containing a unicode file resource' do
     site_pp_contents = <<-SITE_PP
-      \$test_path = \$facts['networking']['fqdn'] ? #{agent_tmp_dirs}
+      \$test_path = \$::fqdn ? #{agent_tmp_dirs}
       file { "\$test_path/\uff72\uff67\u30d5\u30eb":
         ensure => present,
         source => "puppet:///modules/utf8_file_module/\u9759\u7684",

--- a/acceptance/tests/resource/service/service_enable_linux.rb
+++ b/acceptance/tests/resource/service/service_enable_linux.rb
@@ -22,7 +22,7 @@ package_name = {'el'     => 'httpd',
 agents.each do |agent|
   platform = agent.platform.variant
   osname = on(agent, facter('os.name')).stdout.chomp
-  majrelease = on(agent, facter('os.release.major')).stdout.chomp.to_i
+  majrelease = on(agent, facter('operatingsystemmajrelease')).stdout.chomp.to_i
 
   init_script_systemd = "/usr/lib/systemd/system/#{package_name[platform]}.service"
   symlink_systemd     = "/etc/systemd/system/multi-user.target.wants/#{package_name[platform]}.service"

--- a/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
+++ b/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
@@ -43,7 +43,7 @@ agents.each do |agent|
     package { '#{package_name[platform]}':
       ensure => present,
     }
-    if ($os['name'] == 'Fedora') and ($os['release']['major'] == '23') {
+    if ($::operatingsystem == 'Fedora') and ($::operatingsystemmajrelease == '23') {
       package{'libnghttp2':
         ensure => latest,
         install_options => '--best',

--- a/acceptance/tests/ssl/certificate_extensions.rb
+++ b/acceptance/tests/ssl/certificate_extensions.rb
@@ -11,17 +11,17 @@ test_name "certificate extensions available as trusted data" do
   initialize_temp_dirs
 
   agent_certnames = []
-  hostname = master.execute('facter networking.hostname')
-  fqdn = master.execute('facter networking.fqdn')
+  hostname = master.execute('facter hostname')
+  fqdn = master.execute('facter fqdn')
 
   teardown do
     step "Cleanup the test agent certs"
-    server_config = {
+    master_config = {
       'main' => { 'server' => fqdn },
-      'server' => { 'dns_alt_names' => "puppet,#{hostname},#{fqdn}" }
+      'master' => { 'dns_alt_names' => "puppet,#{hostname},#{fqdn}" }
     }
 
-    with_puppet_running_on(master, server_config) do
+    with_puppet_running_on(master, master_config) do
       on(master,
          "puppetserver ca clean --certname #{agent_certnames.join(',')}",
          :acceptable_exit_codes => [0,24])
@@ -29,11 +29,11 @@ test_name "certificate extensions available as trusted data" do
   end
 
   environments_dir = get_test_file_path(master, "environments")
-  server_config = {
+  master_config = {
     'main' => {
       'environmentpath' => environments_dir,
     },
-    'server' => {
+    'master' => {
       'autosign' => true,
       'dns_alt_names' => "puppet,#{hostname},#{fqdn}",
     }
@@ -74,7 +74,7 @@ test_name "certificate extensions available as trusted data" do
     }
   MANIFEST
 
-  with_puppet_running_on(master, server_config) do
+  with_puppet_running_on(master, master_config) do
     agents.each do |agent|
       next if agent == master
 

--- a/acceptance/tests/ticket_15560_managehome.rb
+++ b/acceptance/tests/ticket_15560_managehome.rb
@@ -30,7 +30,7 @@ agents.each do |host|
 
   deleteable_profile = true
 
-  version = on(host, facter('os.release.full')).stdout.chomp
+  version = on(host, facter('operatingsystemrelease')).stdout.chomp
   if version =~ /^5\.[012]|2003/
     homedir = "C:/Documents and Settings/#{username}"
     deleteable_profile = false

--- a/acceptance/tests/windows/QA-506_windows_exit_codes_test.rb
+++ b/acceptance/tests/windows/QA-506_windows_exit_codes_test.rb
@@ -58,7 +58,7 @@ agents.each do |agent|
   native_modules_path = on(agent, puppet("config print #{module_path_config_property}")).stdout.gsub('C:', '/cygdrive/c').strip
 
   #Check to see if we are running on Windows 2003. Do a crazy hack to get around SCP issues.
-  if (on(agent, facter("os.release.major")).stdout =~ /2003/)
+  if (on(agent, facter("find operatingsystemmajrelease")).stdout =~ /2003/)
     on(agent, "ln -s #{native_modules_path.gsub(/ /, '\ ')} /tmp/puppet_etc")
     modules_path = '/tmp/puppet_etc'
   else

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -17,7 +17,7 @@ gem_forge_project: 'puppet'
 gem_required_ruby_version: '>= 2.5.0'
 gem_required_rubygems_version: '> 1.3.1'
 gem_runtime_dependencies:
-  facter: ['>= 4.0.0', '< 5']
+  facter: ['> 2.0.1', '< 5']
   hiera: ['>= 3.2.1', '< 4']
   semantic_puppet: '~> 1.0'
   fast_gettext: '~> 1.1'

--- a/install.rb
+++ b/install.rb
@@ -45,7 +45,7 @@ rescue LoadError
 end
 
 PREREQS = %w{openssl facter cgi hiera}
-MIN_FACTER_VERSION = 4.0
+MIN_FACTER_VERSION = 1.5
 
 InstallOptions = OpenStruct.new
 
@@ -242,7 +242,7 @@ def prepare_installation
   # Otherwise facter won't be guaranteed to be present.
   if InstallOptions.check_prereqs
     check_prereqs
-    $operatingsystem = Facter.value('os.name')
+    $operatingsystem = Facter.value :operatingsystem
   end
 
   if not InstallOptions.configdir.nil?

--- a/lib/puppet/confiner.rb
+++ b/lib/puppet/confiner.rb
@@ -16,7 +16,7 @@ module Puppet::Confiner
   # * `:any` => an array of expressions that will be ORed together
   #
   # @example
-  #   confine 'os.name' => [:redhat, :fedora]
+  #   confine :operatingsystem => [:redhat, :fedora]
   #   confine :true { ... }
   #
   # @param hash [Hash<{Symbol => Object}>] hash of confines

--- a/lib/puppet/file_serving/mount/file.rb
+++ b/lib/puppet/file_serving/mount/file.rb
@@ -3,12 +3,12 @@ require 'puppet/file_serving/mount'
 class Puppet::FileServing::Mount::File < Puppet::FileServing::Mount
   def self.localmap
     @localmap ||= {
-      "h" => Facter.value('networking.hostname'),
+      "h" => Facter.value("hostname"),
       "H" => [
-               Facter.value('networking.hostname'),
-               Facter.value('networking.domain')
+               Facter.value("hostname"),
+               Facter.value("domain")
              ].join("."),
-      "d" => Facter.value('networking.domain')
+      "d" => Facter.value("domain")
     }
   end
 

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -410,9 +410,9 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
     @server_facts["serverversion"] = Puppet.version.to_s
 
     # And then add the server name and IP
-    {"servername" => "networking.fqdn",
-     "serverip"   => "networking.ip",
-     "serverip6"  => "networking.ip6"
+    {"servername" => "fqdn",
+      "serverip"  => "ipaddress",
+      "serverip6" => "ipaddress6"
     }.each do |var, fact|
       value = Facter.value(fact)
       if !value.nil?
@@ -421,10 +421,10 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
     end
 
     if @server_facts["servername"].nil?
-      host = Facter.value('networking.hostname')
+      host = Facter.value(:hostname)
       if host.nil?
         Puppet.warning _("Could not retrieve fact servername")
-      elsif (domain = Facter.value('networking.domain'))
+      elsif domain = Facter.value(:domain) #rubocop:disable Lint/AssignmentInCondition
         @server_facts["servername"] = [host, domain].join(".")
       else
         @server_facts["servername"] = host

--- a/lib/puppet/provider/exec/windows.rb
+++ b/lib/puppet/provider/exec/windows.rb
@@ -2,8 +2,8 @@ require 'puppet/provider/exec'
 
 Puppet::Type.type(:exec).provide :windows, :parent => Puppet::Provider::Exec do
 
-  confine    'os.name' => :windows
-  defaultfor 'os.name' => :windows
+  confine    :operatingsystem => :windows
+  defaultfor :operatingsystem => :windows
 
   desc <<-'EOT'
     Execute external binaries on Windows systems. As with the `posix`

--- a/lib/puppet/provider/file/windows.rb
+++ b/lib/puppet/provider/file/windows.rb
@@ -1,7 +1,7 @@
 Puppet::Type.type(:file).provide :windows do
   desc "Uses Microsoft Windows functionality to manage file ownership and permissions."
 
-  confine 'os.name' => :windows
+  confine :operatingsystem => :windows
   has_feature :manages_symlinks if Puppet.features.manages_symlinks?
 
   include Puppet::Util::Warnings

--- a/lib/puppet/provider/group/aix.rb
+++ b/lib/puppet/provider/group/aix.rb
@@ -6,8 +6,8 @@ Puppet::Type.type(:group).provide :aix, :parent => Puppet::Provider::AixObject d
   desc "Group management for AIX."
 
   # This will the default provider for this platform
-  defaultfor 'os.name' => :aix
-  confine 'os.name' => :aix
+  defaultfor :operatingsystem => :aix
+  confine :operatingsystem => :aix
 
   # Commands that manage the element
   commands :list      => "/usr/sbin/lsgroup"

--- a/lib/puppet/provider/group/directoryservice.rb
+++ b/lib/puppet/provider/group/directoryservice.rb
@@ -6,8 +6,8 @@ Puppet::Type.type(:group).provide :directoryservice, :parent => Puppet::Provider
   "
 
   commands :dscl => "/usr/bin/dscl"
-  confine 'os.name' => :darwin
-  defaultfor 'os.name' => :darwin
+  confine :operatingsystem => :darwin
+  defaultfor :operatingsystem => :darwin
   has_feature :manages_members
 
   def members_insync?(current, should)

--- a/lib/puppet/provider/group/groupadd.rb
+++ b/lib/puppet/provider/group/groupadd.rb
@@ -6,7 +6,7 @@ Puppet::Type.type(:group).provide :groupadd, :parent => Puppet::Provider::NameSe
 
   commands :add => "groupadd", :delete => "groupdel", :modify => "groupmod"
 
-  has_feature :system_groups unless %w{HP-UX Solaris}.include? Facter.value('os.name')
+  has_feature :system_groups unless %w{HP-UX Solaris}.include? Facter.value(:operatingsystem)
 
   verify :gid, _("GID must be an integer") do |value|
     value.is_a? Integer

--- a/lib/puppet/provider/group/pw.rb
+++ b/lib/puppet/provider/group/pw.rb
@@ -6,8 +6,8 @@ Puppet::Type.type(:group).provide :pw, :parent => Puppet::Provider::NameService:
   commands :pw => "pw"
   has_features :manages_members
 
-  defaultfor 'os.name' => [:freebsd, :dragonfly]
-  confine    'os.name' => [:freebsd, :dragonfly]
+  defaultfor :operatingsystem => [:freebsd, :dragonfly]
+  confine    :operatingsystem => [:freebsd, :dragonfly]
 
   options :members, :flag => "-M", :method => :mem
 

--- a/lib/puppet/provider/group/windows_adsi.rb
+++ b/lib/puppet/provider/group/windows_adsi.rb
@@ -4,8 +4,8 @@ Puppet::Type.type(:group).provide :windows_adsi do
   desc "Local group management for Windows. Group members can be both users and groups.
     Additionally, local groups can contain domain users."
 
-  defaultfor 'os.name' => :windows
-  confine    'os.name' => :windows
+  defaultfor :operatingsystem => :windows
+  confine    :operatingsystem => :windows
 
   has_features :manages_members
 

--- a/lib/puppet/provider/nameservice/directoryservice.rb
+++ b/lib/puppet/provider/nameservice/directoryservice.rb
@@ -18,9 +18,9 @@ class Puppet::Provider::NameService::DirectoryService < Puppet::Provider::NameSe
   commands :dscl => "/usr/bin/dscl"
   commands :dseditgroup => "/usr/sbin/dseditgroup"
   commands :sw_vers => "/usr/bin/sw_vers"
-  confine 'os.name' => :darwin
-  confine :feature => :cfpropertylist
-  defaultfor 'os.name' => :darwin
+  confine :operatingsystem => :darwin
+  confine :feature         => :cfpropertylist
+  defaultfor :operatingsystem => :darwin
 
   # There is no generalized mechanism for provider cache management, but we can
   # use post_resource_eval, which will be run for each suitable provider at the

--- a/lib/puppet/provider/package/aix.rb
+++ b/lib/puppet/provider/package/aix.rb
@@ -24,8 +24,8 @@ Puppet::Type.type(:package).provide :aix, :parent => Puppet::Provider::Package d
   # AIX supports versionable packages with and without a NIM server
   has_feature :versionable
 
-  confine  'os.name' => [ :aix ]
-  defaultfor 'os.name' => :aix
+  confine  :operatingsystem => [ :aix ]
+  defaultfor :operatingsystem => :aix
 
   attr_accessor   :latest_info
 

--- a/lib/puppet/provider/package/appdmg.rb
+++ b/lib/puppet/provider/package/appdmg.rb
@@ -17,8 +17,8 @@ require 'puppet/util/plist' if Puppet.features.cfpropertylist?
 Puppet::Type.type(:package).provide(:appdmg, :parent => Puppet::Provider::Package) do
   desc "Package management which copies application bundles to a target."
 
-  confine 'os.name' => :darwin
-  confine :feature  => :cfpropertylist
+  confine :operatingsystem => :darwin
+  confine :feature         => :cfpropertylist
 
   commands :hdiutil => "/usr/bin/hdiutil"
   commands :curl => "/usr/bin/curl"

--- a/lib/puppet/provider/package/apple.rb
+++ b/lib/puppet/provider/package/apple.rb
@@ -8,7 +8,7 @@ Puppet::Type.type(:package).provide :apple, :parent => Puppet::Provider::Package
     automatically add the `.pkg` extension, so leave that off when specifying
     the package name."
 
-  confine 'os.name' => :darwin
+  confine :operatingsystem => :darwin
   commands :installer => "/usr/sbin/installer"
 
   def self.instances

--- a/lib/puppet/provider/package/apt.rb
+++ b/lib/puppet/provider/package/apt.rb
@@ -19,7 +19,7 @@ Puppet::Type.type(:package).provide :apt, :parent => :dpkg, :source => :dpkg do
   commands :aptmark => "/usr/bin/apt-mark"
   commands :preseed => "/usr/bin/debconf-set-selections"
 
-  defaultfor 'os.family' => :debian
+  defaultfor :osfamily => :debian
 
   ENV['DEBIAN_FRONTEND'] = "noninteractive"
 

--- a/lib/puppet/provider/package/blastwave.rb
+++ b/lib/puppet/provider/package/blastwave.rb
@@ -4,7 +4,7 @@ Puppet::Type.type(:package).provide :blastwave, :parent => :sun, :source => :sun
   pkgget = "pkg-get"
   pkgget = "/opt/csw/bin/pkg-get" if FileTest.executable?("/opt/csw/bin/pkg-get")
 
-  confine 'os.family' => :solaris
+  confine :osfamily => :solaris
 
   commands :pkgget => pkgget
 

--- a/lib/puppet/provider/package/dnf.rb
+++ b/lib/puppet/provider/package/dnf.rb
@@ -28,10 +28,10 @@ Puppet::Type.type(:package).provide :dnf, :parent => :yum do
       end
   end
 
-  defaultfor 'os.name' => :fedora
-  notdefaultfor 'os.name' => :fedora, 'os.release.major' => (19..21).to_a
-  defaultfor 'os.family' => :redhat
-  notdefaultfor 'os.family' => :redhat, 'os.release.major' => (4..7).to_a
+  defaultfor :operatingsystem => :fedora
+  notdefaultfor :operatingsystem => :fedora, :operatingsystemmajrelease => (19..21).to_a
+  defaultfor :osfamily => :redhat
+  notdefaultfor :osfamily => :redhat, :operatingsystemmajrelease => (4..7).to_a
 
   def self.update_command
     # In DNF, update is deprecated for upgrade

--- a/lib/puppet/provider/package/freebsd.rb
+++ b/lib/puppet/provider/package/freebsd.rb
@@ -9,7 +9,7 @@ Puppet::Type.type(:package).provide :freebsd, :parent => :openbsd do
     :pkgadd => "/usr/sbin/pkg_add",
     :pkgdelete => "/usr/sbin/pkg_delete"
 
-  confine 'os.name' => :freebsd
+  confine :operatingsystem => :freebsd
 
   def self.listcmd
     command(:pkginfo)

--- a/lib/puppet/provider/package/hpux.rb
+++ b/lib/puppet/provider/package/hpux.rb
@@ -10,9 +10,9 @@ Puppet::Type.type(:package).provide :hpux, :parent => Puppet::Provider::Package 
     :swlist => "/usr/sbin/swlist",
     :swremove => "/usr/sbin/swremove"
 
-  confine 'os.name' => "hp-ux"
+  confine :operatingsystem => "hp-ux"
 
-  defaultfor 'os.name' => "hp-ux"
+  defaultfor :operatingsystem => "hp-ux"
 
   def self.instances
     # TODO:  This is very hard on HP-UX!

--- a/lib/puppet/provider/package/macports.rb
+++ b/lib/puppet/provider/package/macports.rb
@@ -12,7 +12,7 @@ Puppet::Type.type(:package).provide :macports, :parent => Puppet::Provider::Pack
     Revisions are only used internally for ensuring the latest version/revision of a port.
   "
 
-  confine 'os.name' => :darwin
+  confine :operatingsystem => :darwin
 
   has_command(:port, "/opt/local/bin/port") do
     environment :HOME => "/opt/local"

--- a/lib/puppet/provider/package/openbsd.rb
+++ b/lib/puppet/provider/package/openbsd.rb
@@ -13,8 +13,8 @@ Puppet::Type.type(:package).provide :openbsd, :parent => Puppet::Provider::Packa
            :pkgadd    => "pkg_add",
            :pkgdelete => "pkg_delete"
 
-  defaultfor 'os.name' => :openbsd
-  confine 'os.name' => :openbsd
+  defaultfor :operatingsystem => :openbsd
+  confine :operatingsystem => :openbsd
 
   has_feature :versionable
   has_feature :install_options

--- a/lib/puppet/provider/package/opkg.rb
+++ b/lib/puppet/provider/package/opkg.rb
@@ -5,8 +5,8 @@ Puppet::Type.type(:package).provide :opkg, :source => :opkg, :parent => Puppet::
 
   commands :opkg => "opkg"
 
-  confine     'os.name' => :openwrt
-  defaultfor  'os.name' => :openwrt
+  confine     :operatingsystem => :openwrt
+  defaultfor  :operatingsystem => :openwrt
 
   def self.instances
     packages = []

--- a/lib/puppet/provider/package/pacman.rb
+++ b/lib/puppet/provider/package/pacman.rb
@@ -17,8 +17,8 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
   # Yaourt is a common AUR helper which, if installed, we can use to query the AUR
   commands :yaourt => "/usr/bin/yaourt" if yaourt?
 
-  confine     'os.name' => [:archlinux, :manjarolinux]
-  defaultfor  'os.name' => [:archlinux, :manjarolinux]
+  confine     :operatingsystem => [:archlinux, :manjarolinux]
+  defaultfor  :operatingsystem => [:archlinux, :manjarolinux]
   has_feature :install_options
   has_feature :uninstall_options
   has_feature :upgradeable

--- a/lib/puppet/provider/package/pkg.rb
+++ b/lib/puppet/provider/package/pkg.rb
@@ -28,9 +28,9 @@ Puppet::Type.type(:package).provide :pkg, :parent => Puppet::Provider::Package d
 
   commands :pkg => "/usr/bin/pkg"
 
-  confine 'os.family' => :solaris
+  confine :osfamily => :solaris
 
-  defaultfor 'os.family' => :solaris, :kernelrelease => ['5.11', '5.12']
+  defaultfor :osfamily => :solaris, :kernelrelease => ['5.11', '5.12']
 
   def self.instances
     pkg(:list, '-Hv').split("\n").map{|l| new(parse_line(l))}
@@ -221,7 +221,7 @@ Puppet::Type.type(:package).provide :pkg, :parent => Puppet::Provider::Package d
       command = 'update'
     end
     args = ['--accept']
-    if Puppet::Util::Package.versioncmp(Facter.value('os.release.full'), '11.2') >= 0
+    if Puppet::Util::Package.versioncmp(Facter.value(:operatingsystemrelease), '11.2') >= 0
       args.push('--sync-actuators-timeout', '900')
     end
     args.concat(join_options(@resource[:install_options])) if @resource[:install_options]

--- a/lib/puppet/provider/package/pkgdmg.rb
+++ b/lib/puppet/provider/package/pkgdmg.rb
@@ -35,9 +35,9 @@ Puppet::Type.type(:package).provide :pkgdmg, :parent => Puppet::Provider::Packag
       whether a package has been installed. Thus, to install new a version of a
       package, you must create a new DMG with a different filename."
 
-  confine 'os.name' => :darwin
+  confine :operatingsystem => :darwin
   confine :feature         => :cfpropertylist
-  defaultfor 'os.name' => :darwin
+  defaultfor :operatingsystem => :darwin
   commands :installer => "/usr/sbin/installer"
   commands :hdiutil => "/usr/bin/hdiutil"
   commands :curl => "/usr/bin/curl"

--- a/lib/puppet/provider/package/pkgin.rb
+++ b/lib/puppet/provider/package/pkgin.rb
@@ -5,7 +5,7 @@ Puppet::Type.type(:package).provide :pkgin, :parent => Puppet::Provider::Package
 
   commands :pkgin => "pkgin"
 
-  defaultfor 'os.name' => [ :smartos, :netbsd ]
+  defaultfor :operatingsystem => [ :smartos, :netbsd ]
 
   has_feature :installable, :uninstallable, :upgradeable, :versionable
 

--- a/lib/puppet/provider/package/pkgng.rb
+++ b/lib/puppet/provider/package/pkgng.rb
@@ -5,9 +5,9 @@ Puppet::Type.type(:package).provide :pkgng, :parent => Puppet::Provider::Package
 
   commands :pkg => "/usr/local/sbin/pkg"
 
-  confine 'os.name' => [:freebsd, :dragonfly]
+  confine :operatingsystem => [:freebsd, :dragonfly]
 
-  defaultfor 'os.name' => [:freebsd, :dragonfly]
+  defaultfor :operatingsystem => [:freebsd, :dragonfly]
 
   has_feature :versionable
   has_feature :upgradeable

--- a/lib/puppet/provider/package/pkgutil.rb
+++ b/lib/puppet/provider/package/pkgutil.rb
@@ -7,7 +7,7 @@ Puppet::Type.type(:package).provide :pkgutil, :parent => :sun, :source => :sun d
     pkgutil_bin = "/opt/csw/bin/pkgutil"
   end
 
-  confine 'os.family' => :solaris
+  confine :osfamily => :solaris
 
   has_command(:pkguti, pkgutil_bin) do
     environment :HOME => ENV['HOME']

--- a/lib/puppet/provider/package/portage.rb
+++ b/lib/puppet/provider/package/portage.rb
@@ -20,9 +20,9 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
     end
   end
 
-  confine 'os.family' => :gentoo
+  confine :osfamily => :gentoo
 
-  defaultfor 'os.family' => :gentoo
+  defaultfor :osfamily => :gentoo
 
   def self.instances
     result_format = self.eix_result_format

--- a/lib/puppet/provider/package/portupgrade.rb
+++ b/lib/puppet/provider/package/portupgrade.rb
@@ -18,7 +18,7 @@ Puppet::Type.type(:package).provide :portupgrade, :parent => Puppet::Provider::P
   :portinfo      => "/usr/sbin/pkg_info"
 
   ## Activate this only once approved by someone important.
-  # defaultfor 'os.name' => :freebsd
+  # defaultfor :operatingsystem => :freebsd
 
   # Remove unwanted environment variables.
   %w{INTERACTIVE UNAME}.each do |var|

--- a/lib/puppet/provider/package/rug.rb
+++ b/lib/puppet/provider/package/rug.rb
@@ -5,7 +5,7 @@ Puppet::Type.type(:package).provide :rug, :parent => :rpm do
 
   commands :rug => "/usr/bin/rug"
   commands :rpm => "rpm"
-  confine  'os.name' => [:suse, :sles]
+  confine    :operatingsystem => [:suse, :sles]
 
   # Install a package using 'rug'.
   def install

--- a/lib/puppet/provider/package/sun.rb
+++ b/lib/puppet/provider/package/sun.rb
@@ -14,8 +14,8 @@ Puppet::Type.type(:package).provide :sun, :parent => Puppet::Provider::Package d
     :pkgadd => "/usr/sbin/pkgadd",
     :pkgrm => "/usr/sbin/pkgrm"
 
-  confine 'os.family' => :solaris
-  defaultfor 'os.family' => :solaris
+  confine :osfamily => :solaris
+  defaultfor :osfamily => :solaris
 
   has_feature :install_options
 

--- a/lib/puppet/provider/package/sunfreeware.rb
+++ b/lib/puppet/provider/package/sunfreeware.rb
@@ -5,5 +5,5 @@ Puppet::Type.type(:package).provide :sunfreeware, :parent => :blastwave, :source
     has not actually been tested."
   commands :pkgget => "pkg-get"
 
-  confine 'os.family' => :solaris
+  confine :osfamily => :solaris
 end

--- a/lib/puppet/provider/package/tdnf.rb
+++ b/lib/puppet/provider/package/tdnf.rb
@@ -24,5 +24,5 @@ Puppet::Type.type(:package).provide :tdnf, :parent => :dnf do
       end
   end
 
-  defaultfor 'os.name' => "PhotonOS"
+  defaultfor :operatingsystem => "PhotonOS" 
 end

--- a/lib/puppet/provider/package/up2date.rb
+++ b/lib/puppet/provider/package/up2date.rb
@@ -4,9 +4,9 @@ Puppet::Type.type(:package).provide :up2date, :parent => :rpm, :source => :rpm d
 
   commands :up2date => "/usr/sbin/up2date-nox"
 
-  defaultfor 'os.family' => :redhat, 'os.distro.release.full' => ["2.1", "3", "4"]
+  defaultfor :osfamily => :redhat, :lsbdistrelease => ["2.1", "3", "4"]
 
-  confine    'os.family' => :redhat
+  confine    :osfamily => :redhat
 
   # Install a package using 'up2date'.
   def install

--- a/lib/puppet/provider/package/urpmi.rb
+++ b/lib/puppet/provider/package/urpmi.rb
@@ -2,7 +2,7 @@ Puppet::Type.type(:package).provide :urpmi, :parent => :rpm, :source => :rpm do
   desc "Support via `urpmi`."
   commands :urpmi => "urpmi", :urpmq => "urpmq", :rpm => "rpm", :urpme => "urpme"
 
-  defaultfor 'os.name' => [:mandriva, :mandrake]
+  defaultfor :operatingsystem => [:mandriva, :mandrake]
 
   has_feature :versionable
 

--- a/lib/puppet/provider/package/windows.rb
+++ b/lib/puppet/provider/package/windows.rb
@@ -20,8 +20,8 @@ Puppet::Type.type(:package).provide(:windows, :parent => Puppet::Provider::Packa
     `install_options` or `uninstall_options` attributes, respectively.  Puppet
     will automatically quote any option that contains spaces."
 
-  confine    'os.name' => :windows
-  defaultfor 'os.name' => :windows
+  confine    :operatingsystem => :windows
+  defaultfor :operatingsystem => :windows
 
   has_feature :installable
   has_feature :uninstallable

--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -32,8 +32,8 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
       end
   end
 
-defaultfor 'os.name' => :amazon
-defaultfor 'os.family' => :redhat, 'os.release.major' => (4..7).to_a
+defaultfor :operatingsystem => :amazon
+defaultfor :osfamily => :redhat, :operatingsystemmajrelease => (4..7).to_a
 
   def insync?(is)
     return false if [:purged, :absent].include?(is)
@@ -298,7 +298,7 @@ defaultfor 'os.family' => :redhat, 'os.release.major' => (4..7).to_a
 
     # Yum on el-4 and el-5 returns exit status 0 when trying to install a package it doesn't recognize;
     # ensure we capture output to check for errors.
-    no_debug = if Facter.value('os.release.major').to_i > 5 then ["-d", "0"] else [] end
+    no_debug = if Facter.value(:operatingsystemmajrelease).to_i > 5 then ["-d", "0"] else [] end
     command = [command(:cmd)] + no_debug + ["-e", error_level, "-y", install_options, operation, wanted].compact
     output = execute(command)
 

--- a/lib/puppet/provider/package/zypper.rb
+++ b/lib/puppet/provider/package/zypper.rb
@@ -9,8 +9,8 @@ Puppet::Type.type(:package).provide :zypper, :parent => :rpm, :source => :rpm do
 
   commands :zypper => "/usr/bin/zypper"
 
-  defaultfor 'os.name' => [:suse, :sles, :sled, :opensuse]
-  confine    'os.name' => [:suse, :sles, :sled, :opensuse]
+  defaultfor :operatingsystem => [:suse, :sles, :sled, :opensuse]
+  confine    :operatingsystem => [:suse, :sles, :sled, :opensuse]
 
   # @api private
   # Reset the latest version hash to nil

--- a/lib/puppet/provider/service/base.rb
+++ b/lib/puppet/provider/service/base.rb
@@ -15,7 +15,7 @@ Puppet::Type.type(:service).provide :base, :parent => :service do
   # ported from the facter 2.x implementation, since facter 3.x
   # is dropping the fact (for which this was the only use)
   def getps
-    case Facter.value('os.name')
+    case Facter.value(:operatingsystem)
     when 'OpenWrt'
       'ps www'
     when 'FreeBSD', 'NetBSD', 'OpenBSD', 'Darwin', 'DragonFly'

--- a/lib/puppet/provider/service/bsd.rb
+++ b/lib/puppet/provider/service/bsd.rb
@@ -5,7 +5,7 @@ Puppet::Type.type(:service).provide :bsd, :parent => :init do
     Uses `rc.conf.d` for service enabling and disabling.
   EOT
 
-  confine 'os.name' => [:freebsd, :dragonfly]
+  confine :operatingsystem => [:freebsd, :dragonfly]
 
   def rcconf_dir
     '/etc/rc.conf.d'

--- a/lib/puppet/provider/service/debian.rb
+++ b/lib/puppet/provider/service/debian.rb
@@ -19,9 +19,9 @@ Puppet::Type.type(:service).provide :debian, :parent => :init do
 
   confine :false => Puppet::FileSystem.exist?('/proc/1/comm') && Puppet::FileSystem.read('/proc/1/comm').include?('systemd')
 
-  defaultfor 'os.name' => :cumuluslinux, 'os.release.major' => ['1','2']
-  defaultfor 'os.name' => :debian, 'os.release.major' => ['5','6','7']
-  defaultfor 'os.name' => :devuan
+  defaultfor :operatingsystem => :cumuluslinux, :operatingsystemmajrelease => ['1','2']
+  defaultfor :operatingsystem => :debian, :operatingsystemmajrelease => ['5','6','7']
+  defaultfor :operatingsystem => :devuan
 
   # Remove the symlinks
   def disable

--- a/lib/puppet/provider/service/freebsd.rb
+++ b/lib/puppet/provider/service/freebsd.rb
@@ -2,8 +2,8 @@ Puppet::Type.type(:service).provide :freebsd, :parent => :init do
 
   desc "Provider for FreeBSD and DragonFly BSD. Uses the `rcvar` argument of init scripts and parses/edits rc files."
 
-  confine 'os.name' => [:freebsd, :dragonfly]
-  defaultfor 'os.name' => [:freebsd, :dragonfly]
+  confine :operatingsystem => [:freebsd, :dragonfly]
+  defaultfor :operatingsystem => [:freebsd, :dragonfly]
 
   def rcconf()        '/etc/rc.conf' end
   def rcconf_local()  '/etc/rc.conf.local' end

--- a/lib/puppet/provider/service/gentoo.rb
+++ b/lib/puppet/provider/service/gentoo.rb
@@ -10,7 +10,7 @@ Puppet::Type.type(:service).provide :gentoo, :parent => :init do
 
   commands :update => "/sbin/rc-update"
 
-  confine 'os.name' => :gentoo
+  confine :operatingsystem => :gentoo
 
   def disable
       output = update :del, @resource[:name], :default

--- a/lib/puppet/provider/service/init.rb
+++ b/lib/puppet/provider/service/init.rb
@@ -4,7 +4,7 @@ Puppet::Type.type(:service).provide :init, :parent => :base do
   desc "Standard `init`-style service management."
 
   def self.defpath
-    case Facter.value('os.name')
+    case Facter.value(:operatingsystem)
     when "FreeBSD", "DragonFly"
       ["/etc/rc.d", "/usr/local/etc/rc.d"]
     when "HP-UX"
@@ -21,8 +21,8 @@ Puppet::Type.type(:service).provide :init, :parent => :base do
   # Debian and Ubuntu should use the Debian provider.
   # RedHat systems should use the RedHat provider.
   confine :true => begin
-      os = Facter.value('os.name').downcase
-      family = Facter.value('os.family').downcase
+      os = Facter.value(:operatingsystem).downcase
+      family = Facter.value(:osfamily).downcase
       !(os == 'debian' || os == 'ubuntu' || family == 'redhat')
   end
 
@@ -54,7 +54,7 @@ Puppet::Type.type(:service).provide :init, :parent => :base do
     # these excludes were found with grep -r -L start /etc/init.d
     excludes += %w{rcS module-init-tools}
     # Prevent puppet failing on unsafe scripts from Yocto Linux
-    if Facter.value('os.family') == "cisco-wrlinux"
+    if Facter.value(:osfamily) == "cisco-wrlinux"
       excludes += %w{banner.sh bootmisc.sh checkroot.sh devpts.sh dmesg.sh
                    hostname.sh mountall.sh mountnfs.sh populate-volatile.sh
                    rmnologin.sh save-rtc.sh sendsigs sysfs.sh umountfs
@@ -171,7 +171,7 @@ Puppet::Type.type(:service).provide :init, :parent => :base do
   end
 
   def texecute(type, command, fof = true, squelch = false, combine = true)
-    if type == :start && Facter.value('os.family') == "Solaris"
+    if type == :start && Facter.value(:osfamily) == "Solaris"
         command =  ["/usr/bin/ctrun -l child", command].flatten.join(" ")
     end
     super(type, command, fof, squelch, combine)

--- a/lib/puppet/provider/service/launchd.rb
+++ b/lib/puppet/provider/service/launchd.rb
@@ -42,9 +42,9 @@ Puppet::Type.type(:service).provide :launchd, :parent => :base do
 
   commands :launchctl => "/bin/launchctl"
 
-  defaultfor 'os.name' => :darwin
-  confine 'os.name'    => :darwin
-  confine :feature     => :cfpropertylist
+  defaultfor :operatingsystem => :darwin
+  confine :operatingsystem    => :darwin
+  confine :feature            => :cfpropertylist
 
   has_feature :enableable
   has_feature :refreshable
@@ -70,7 +70,7 @@ Puppet::Type.type(:service).provide :launchd, :parent => :base do
   #
   # @api private
   def self.get_os_version
-    @os_version ||= Facter.value('os.release.major').to_i
+    @os_version ||= Facter.value(:operatingsystemmajrelease).to_i
   end
 
   # Defines the path to the overrides plist file where service enabling

--- a/lib/puppet/provider/service/openbsd.rb
+++ b/lib/puppet/provider/service/openbsd.rb
@@ -4,8 +4,8 @@ Puppet::Type.type(:service).provide :openbsd, :parent => :init do
 
   commands :rcctl => '/usr/sbin/rcctl'
 
-  confine 'os.name' => :openbsd
-  defaultfor 'os.name' => :openbsd
+  confine :operatingsystem => :openbsd
+  defaultfor :operatingsystem => :openbsd
   has_feature :flaggable
 
   def startcmd

--- a/lib/puppet/provider/service/openrc.rb
+++ b/lib/puppet/provider/service/openrc.rb
@@ -7,8 +7,8 @@ Puppet::Type.type(:service).provide :openrc, :parent => :base do
 
   EOT
 
-  defaultfor 'os.name' => :gentoo
-  defaultfor 'os.name' => :funtoo
+  defaultfor :operatingsystem => :gentoo
+  defaultfor :operatingsystem => :funtoo
 
   has_command(:rcstatus, '/bin/rc-status') do
     environment :RC_SVCNAME => nil

--- a/lib/puppet/provider/service/openwrt.rb
+++ b/lib/puppet/provider/service/openwrt.rb
@@ -6,8 +6,8 @@ Puppet::Type.type(:service).provide :openwrt, :parent => :init, :source => :init
 
   EOT
 
-  defaultfor 'os.name' => :openwrt
-  confine 'os.name' => :openwrt
+  defaultfor :operatingsystem => :openwrt
+  confine :operatingsystem => :openwrt
 
   has_feature :enableable
 

--- a/lib/puppet/provider/service/rcng.rb
+++ b/lib/puppet/provider/service/rcng.rb
@@ -3,8 +3,8 @@ Puppet::Type.type(:service).provide :rcng, :parent => :bsd do
     RCng service management with rc.d
   EOT
 
-  defaultfor 'os.name' => [:netbsd, :cargos]
-  confine 'os.name' => [:netbsd, :cargos]
+  defaultfor :operatingsystem => [:netbsd, :cargos]
+  confine :operatingsystem => [:netbsd, :cargos]
 
   def self.defpath
     "/etc/rc.d"

--- a/lib/puppet/provider/service/redhat.rb
+++ b/lib/puppet/provider/service/redhat.rb
@@ -8,8 +8,8 @@ Puppet::Type.type(:service).provide :redhat, :parent => :init, :source => :init 
 
   commands :chkconfig => "/sbin/chkconfig", :service => "/sbin/service"
 
-  defaultfor 'os.family' => :redhat
-  defaultfor 'os.family' => :suse, 'os.release.major' => ["10", "11"]
+  defaultfor :osfamily => :redhat
+  defaultfor :osfamily => :suse, :operatingsystemmajrelease => ["10", "11"]
 
   # Remove the symlinks
   def disable
@@ -35,7 +35,7 @@ Puppet::Type.type(:service).provide :redhat, :parent => :init, :source => :init 
     # For Suse OS family, chkconfig returns 0 even if the service is disabled or non-existent
     # Therefore, check the output for '<name>  on' (or '<name>  B for boot services)
     # to see if it is enabled
-    return :false unless Facter.value('os.family') != 'Suse' || output =~ /^#{name}\s+(on|B)$/
+    return :false unless Facter.value(:osfamily) != 'Suse' || output =~ /^#{name}\s+(on|B)$/
 
     :true
   end

--- a/lib/puppet/provider/service/smf.rb
+++ b/lib/puppet/provider/service/smf.rb
@@ -18,9 +18,9 @@ Puppet::Type.type(:service).provide :smf, :parent => :base do
     be imported if it does not exist.
   EOT
 
-  defaultfor 'os.family' => :solaris
+  defaultfor :osfamily => :solaris
 
-  confine 'os.family' => :solaris
+  confine :osfamily => :solaris
 
   commands :adm => "/usr/sbin/svcadm",
            :svcs => "/usr/bin/svcs",
@@ -125,14 +125,14 @@ Puppet::Type.type(:service).provide :smf, :parent => :base do
 
   # Returns true if the provider supports incomplete services.
   def supports_incomplete_services?
-    Puppet::Util::Package.versioncmp(Facter.value('os.release.full'), '11.1') >= 0
+    Puppet::Util::Package.versioncmp(Facter.value(:operatingsystemrelease), '11.1') >= 0
   end
 
   # Returns true if the service is complete. A complete service is a service that
   # has the general/complete property defined.
   def complete_service?
     unless supports_incomplete_services?
-      raise Puppet::Error, _("Cannot query if the %{service} service is complete: The concept of complete/incomplete services was introduced in Solaris 11.1. You are on a Solaris %{release} machine.") % { service: @resource[:name], release: Facter.value('os.release.full') }
+      raise Puppet::Error, _("Cannot query if the %{service} service is complete: The concept of complete/incomplete services was introduced in Solaris 11.1. You are on a Solaris %{release} machine.") % { service: @resource[:name], release: Facter.value(:operatingsystemrelease) }
     end
 
     return @complete_service if @complete_service
@@ -162,7 +162,7 @@ Puppet::Type.type(:service).provide :smf, :parent => :base do
   end
 
   def restartcmd
-    if Puppet::Util::Package.versioncmp(Facter.value('os.release.full'), '11.2') >= 0
+    if Puppet::Util::Package.versioncmp(Facter.value(:operatingsystemrelease), '11.2') >= 0
       [command(:adm), :restart, "-s", self.service_fmri]
     else
       # Synchronous restart only supported in Solaris 11.2 and above

--- a/lib/puppet/provider/service/src.rb
+++ b/lib/puppet/provider/service/src.rb
@@ -13,8 +13,8 @@ Puppet::Type.type(:service).provide :src, :parent => :base do
   is not yet supported.
   "
 
-  defaultfor 'os.name' => :aix
-  confine 'os.name' => :aix
+  defaultfor :operatingsystem => :aix
+  confine :operatingsystem => :aix
 
   optional_commands :stopsrc  => "/usr/bin/stopsrc",
                     :startsrc => "/usr/bin/startsrc",

--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -13,19 +13,19 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
 
   confine :true => Puppet::FileSystem.exist?('/proc/1/comm') && Puppet::FileSystem.read('/proc/1/comm').include?('systemd')
 
-  defaultfor 'os.family' => [:archlinux]
-  defaultfor 'os.family' => :redhat, 'os.release.major' => ["7", "8"]
-  defaultfor 'os.family' => :redhat, 'os.name' => :fedora
-  defaultfor 'os.family' => :suse
-  defaultfor 'os.family' => :coreos
-  defaultfor 'os.name' => :amazon, 'os.release.major' => ["2"]
-  defaultfor 'os.name' => :debian
-  notdefaultfor 'os.name' => :debian, 'os.release.major' => ["5", "6", "7"] # These are using the "debian" method
-  defaultfor 'os.name' => :LinuxMint
-  notdefaultfor 'os.name' => :LinuxMint, 'os.release.major' => ["10", "11", "12", "13", "14", "15", "16", "17"] # These are using upstart
-  defaultfor 'os.name' => :ubuntu
-  notdefaultfor 'os.name' => :ubuntu, 'os.release.major' => ["10.04", "12.04", "14.04", "14.10"] # These are using upstart
-  defaultfor 'os.name' => :cumuluslinux, 'os.release.major' => ["3", "4"]
+  defaultfor :osfamily => [:archlinux]
+  defaultfor :osfamily => :redhat, :operatingsystemmajrelease => ["7", "8"]
+  defaultfor :osfamily => :redhat, :operatingsystem => :fedora
+  defaultfor :osfamily => :suse
+  defaultfor :osfamily => :coreos
+  defaultfor :operatingsystem => :amazon, :operatingsystemmajrelease => ["2"]
+  defaultfor :operatingsystem => :debian
+  notdefaultfor :operatingsystem => :debian, :operatingsystemmajrelease => ["5", "6", "7"] # These are using the "debian" method
+  defaultfor :operatingsystem => :LinuxMint
+  notdefaultfor :operatingsystem => :LinuxMint, :operatingsystemmajrelease => ["10", "11", "12", "13", "14", "15", "16", "17"] # These are using upstart
+  defaultfor :operatingsystem => :ubuntu
+  notdefaultfor :operatingsystem => :ubuntu, :operatingsystemmajrelease => ["10.04", "12.04", "14.04", "14.10"] # These are using upstart
+  defaultfor :operatingsystem => :cumuluslinux, :operatingsystemmajrelease => ["3", "4"]
 
   def self.instances
     i = []
@@ -105,7 +105,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
     # The indirect state indicates that the unit is not enabled.
     return :false if output == 'indirect'
     return :true if (code == 0)
-    if (output.empty?) && (code > 0) && (Facter.value('os.family').casecmp('debian').zero?)
+    if (output.empty?) && (code > 0) && (Facter.value(:osfamily).casecmp('debian').zero?)
       ret = debian_enabled?
       return ret if ret
     end

--- a/lib/puppet/provider/service/upstart.rb
+++ b/lib/puppet/provider/service/upstart.rb
@@ -10,14 +10,14 @@ Puppet::Type.type(:service).provide :upstart, :parent => :debian do
   "
 
   confine :any => [
-    Facter.value('os.name') == 'Ubuntu',
-    (Facter.value('os.family') == 'RedHat' and Facter.value('os.release.full') =~ /^6\./),
-    (Facter.value('os.name') == 'Amazon' and Facter.value('os.release.major') =~ /\d{4}/),
-    Facter.value('os.name') == 'LinuxMint',
+    Facter.value(:operatingsystem) == 'Ubuntu',
+    (Facter.value(:osfamily) == 'RedHat' and Facter.value(:operatingsystemrelease) =~ /^6\./),
+    (Facter.value(:operatingsystem) == 'Amazon' and Facter.value(:operatingsystemmajrelease) =~ /\d{4}/),
+    Facter.value(:operatingsystem) == 'LinuxMint',
   ]
 
-  defaultfor 'os.name' => :ubuntu, 'os.release.major' => ["10.04", "12.04", "14.04", "14.10"]
-  defaultfor 'os.name' => :LinuxMint, 'os.release.major' => ["10", "11", "12", "13", "14", "15", "16", "17"]
+  defaultfor :operatingsystem => :ubuntu, :operatingsystemmajrelease => ["10.04", "12.04", "14.04", "14.10"]
+  defaultfor :operatingsystem => :LinuxMint, :operatingsystemmajrelease => ["10", "11", "12", "13", "14", "15", "16", "17"]
 
   commands :start   => "/sbin/start",
            :stop    => "/sbin/stop",
@@ -57,7 +57,7 @@ Puppet::Type.type(:service).provide :upstart, :parent => :debian do
 
   def self.excludes
     excludes = super
-    if Facter.value('os.family') == 'RedHat'
+    if Facter.value(:osfamily) == 'RedHat'
       # Puppet cannot deal with services that have instances, so we have to
       # ignore these services using instances on redhat based systems.
       excludes += %w[serial tty]

--- a/lib/puppet/provider/service/windows.rb
+++ b/lib/puppet/provider/service/windows.rb
@@ -11,8 +11,8 @@ Puppet::Type.type(:service).provide :windows, :parent => :service do
     services as a specific user.
   EOT
 
-  defaultfor 'os.name' => :windows
-  confine    'os.name' => :windows
+  defaultfor :operatingsystem => :windows
+  confine    :operatingsystem => :windows
 
   has_feature :refreshable, :configurable_timeout, :manages_logon_credentials
 

--- a/lib/puppet/provider/user/aix.rb
+++ b/lib/puppet/provider/user/aix.rb
@@ -17,8 +17,8 @@ require 'date'
 Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
   desc "User management for AIX."
 
-  defaultfor 'os.name' => :aix
-  confine 'os.name' => :aix
+  defaultfor :operatingsystem => :aix
+  confine :operatingsystem => :aix
 
   # Commands that manage the element
   commands :list      => "/usr/sbin/lsuser"

--- a/lib/puppet/provider/user/directoryservice.rb
+++ b/lib/puppet/provider/user/directoryservice.rb
@@ -16,9 +16,9 @@ Puppet::Type.type(:user).provide :directoryservice do
   commands :dscacheutil  => '/usr/bin/dscacheutil'
 
   # Provider confines and defaults
-  confine    'os.name' => :darwin
-  confine    :feature  => :cfpropertylist
-  defaultfor 'os.name' => :darwin
+  confine    :operatingsystem => :darwin
+  confine    :feature         => :cfpropertylist
+  defaultfor :operatingsystem => :darwin
 
   # Need this to create getter/setter methods automagically
   # This command creates methods that return @property_hash[:value]
@@ -159,7 +159,7 @@ Puppet::Type.type(:user).provide :directoryservice do
   end
 
   def self.get_os_version
-    @os_version ||= Facter.value('os.macosx.version.major')
+    @os_version ||= Facter.value(:macosx_productversion_major)
   end
 
   # Use dscl to retrieve an array of hashes containing attributes about all

--- a/lib/puppet/provider/user/hpux.rb
+++ b/lib/puppet/provider/user/hpux.rb
@@ -5,8 +5,8 @@ Puppet::Type.type(:user).provide :hpuxuseradd, :parent => :useradd do
     New functionality provides for changing trusted computing passwords and
     resetting password expirations under trusted computing."
 
-  defaultfor 'os.name' => "hp-ux"
-  confine 'os.name' => "hp-ux"
+  defaultfor :operatingsystem => "hp-ux"
+  confine :operatingsystem => "hp-ux"
 
   commands :modify => "/usr/sam/lbin/usermod.sam", :delete => "/usr/sam/lbin/userdel.sam", :add => "/usr/sam/lbin/useradd.sam"
   options :comment, :method => :gecos

--- a/lib/puppet/provider/user/openbsd.rb
+++ b/lib/puppet/provider/user/openbsd.rb
@@ -10,8 +10,8 @@ Puppet::Type.type(:user).provide :openbsd, :parent => :useradd do
            :modify   => "usermod",
            :password => "passwd"
 
-  defaultfor 'os.name' => :openbsd
-  confine    'os.name' => :openbsd
+  defaultfor :operatingsystem => :openbsd
+  confine    :operatingsystem => :openbsd
 
   options :home, :flag => "-d", :method => :dir
   options :comment, :method => :gecos

--- a/lib/puppet/provider/user/pw.rb
+++ b/lib/puppet/provider/user/pw.rb
@@ -7,8 +7,8 @@ Puppet::Type.type(:user).provide :pw, :parent => Puppet::Provider::NameService::
   commands :pw => "pw"
   has_features :manages_homedir, :allows_duplicates, :manages_passwords, :manages_expiry, :manages_shell
 
-  defaultfor 'os.name' => [:freebsd, :dragonfly]
-  confine    'os.name' => [:freebsd, :dragonfly]
+  defaultfor :operatingsystem => [:freebsd, :dragonfly]
+  confine    :operatingsystem => [:freebsd, :dragonfly]
 
   options :home, :flag => "-d", :method => :dir
   options :comment, :method => :gecos

--- a/lib/puppet/provider/user/user_role_add.rb
+++ b/lib/puppet/provider/user/user_role_add.rb
@@ -6,7 +6,7 @@ Puppet::Type.type(:user).provide :user_role_add, :parent => :useradd, :source =>
 
   desc "User and role management on Solaris, via `useradd` and `roleadd`."
 
-  defaultfor 'os.family' => :solaris
+  defaultfor :osfamily => :solaris
 
   commands :add => "useradd", :delete => "userdel", :modify => "usermod", :password => "passwd", :role_add => "roleadd", :role_delete => "roledel", :role_modify => "rolemod"
   options :home, :flag => "-d", :method => :dir

--- a/lib/puppet/provider/user/useradd.rb
+++ b/lib/puppet/provider/user/useradd.rb
@@ -21,13 +21,13 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
   options :expiry, :method => :sp_expire,
     :munge => proc { |value|
       if value == :absent
-        if Facter.value('os.name') == 'SLES' && Facter.value('os.release.major') == "11"
+        if Facter.value(:operatingsystem)=='SLES' && Facter.value(:operatingsystemmajrelease) == "11"
           -1
         else
           ''
         end
       else
-        case Facter.value('os.name')
+        case Facter.value(:operatingsystem)
         when 'Solaris'
           # Solaris uses %m/%d/%Y for useradd/usermod
           expiry_year, expiry_month, expiry_day = value.split('-')
@@ -161,7 +161,7 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
   end
 
   has_features :manages_homedir, :allows_duplicates, :manages_expiry
-  has_features :system_users unless %w{HP-UX Solaris}.include? Facter.value('os.name')
+  has_features :system_users unless %w{HP-UX Solaris}.include? Facter.value(:operatingsystem)
 
   has_features :manages_passwords, :manages_password_age if Puppet.features.libshadow?
   has_features :manages_shell
@@ -196,8 +196,8 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
       # libuser does not implement the -m flag
       cmd << "-m" unless @resource.forcelocal?
     else
-      osfamily = Facter.value('os.family')
-      osversion = Facter.value('os.release.major').to_i
+      osfamily = Facter.value(:osfamily)
+      osversion = Facter.value(:operatingsystemmajrelease).to_i
       # SLES 11 uses pwdutils instead of shadow, which does not have -M
       # Solaris and OpenBSD use different useradd flavors
       unless osfamily =~ /Solaris|OpenBSD/ || osfamily == 'Suse' && osversion <= 11
@@ -293,7 +293,7 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
       cmd = [command(:delete)]
     end
     # Solaris `userdel -r` will fail if the homedir does not exist.
-    if @resource.managehome? && (('Solaris' != Facter.value('os.name')) || Dir.exist?(Dir.home(@resource[:name])))
+    if @resource.managehome? && (('Solaris' != Facter.value(:operatingsystem)) || Dir.exist?(Dir.home(@resource[:name])))
       cmd << '-r'
     end
     cmd << @resource[:name]

--- a/lib/puppet/provider/user/windows_adsi.rb
+++ b/lib/puppet/provider/user/windows_adsi.rb
@@ -3,8 +3,8 @@ require 'puppet/util/windows'
 Puppet::Type.type(:user).provide :windows_adsi do
   desc "Local user management for Windows."
 
-  defaultfor 'os.name' => :windows
-  confine    'os.name' => :windows
+  defaultfor :operatingsystem => :windows
+  confine    :operatingsystem => :windows
 
   has_features :manages_homedir, :manages_passwords, :manages_roles
 

--- a/lib/puppet/reference/providers.rb
+++ b/lib/puppet/reference/providers.rb
@@ -13,10 +13,11 @@ providers = Puppet::Util::Reference.newreference :providers, :title => "Provider
   ret = "Details about this host:\n\n"
 
   # Throw some facts in there, so we know where the report is from.
-  ret << option('Ruby Version', Facter.value('ruby.version'))
-  ret << option('Puppet Version', Facter.value('puppetversion'))
-  ret << option('Operating System', Facter.value('os.name'))
-  ret << option('Operating System Release', Facter.value('os.release.full'))
+  ["Ruby Version", "Puppet Version", "Operating System", "Operating System Release"].each do |label|
+    name = label.gsub(/\s+/, '')
+    value = Facter.value(name)
+    ret << option(label, value)
+  end
   ret << "\n"
 
   count = 1

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -66,7 +66,7 @@ class Puppet::Settings
     }
   end
 
-  def self.default_certname
+  def self.default_certname()
     hostname = hostname_fact
     domain = domain_fact
     if domain and domain != ""
@@ -77,12 +77,12 @@ class Puppet::Settings
     fqdn.to_s.gsub(/\.$/, '')
   end
 
-  def self.hostname_fact
-    Facter.value('networking.hostname')
+  def self.hostname_fact()
+    Facter.value :hostname
   end
 
-  def self.domain_fact
-    Facter.value('networking.domain')
+  def self.domain_fact()
+    Facter.value :domain
   end
 
   def self.default_config_file_name

--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -1405,7 +1405,7 @@ class Type
       provide a symbolic title and an explicit namevar value:
 
           file { 'sshdconfig':
-            path => $os['name'] ? {
+            path => $operatingsystem ? {
               solaris => '/usr/local/etc/ssh/sshd_config',
               default => '/etc/ssh/sshd_config',
             },

--- a/lib/puppet/type/file/source.rb
+++ b/lib/puppet/type/file/source.rb
@@ -72,7 +72,7 @@ module Puppet
           file { '/etc/nfs.conf':
             source => [
               "puppet:///modules/nfs/conf.${host}",
-              "puppet:///modules/nfs/conf.${os['name']}",
+              "puppet:///modules/nfs/conf.${operatingsystem}",
               'puppet:///modules/nfs/conf'
             ]
           }

--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -242,7 +242,7 @@ module Puppet
       conditionally:
 
           # In the 'openssl' class
-          $ssl = $os['name'] ? {
+          $ssl = $operatingsystem ? {
             solaris => SMCossl,
             default => openssl
           }
@@ -254,7 +254,7 @@ module Puppet
 
           ...
 
-          $ssh = $os['name'] ? {
+          $ssh = $operatingsystem ? {
             solaris => SMCossh,
             default => openssh
           }

--- a/lib/puppet/type/resources.rb
+++ b/lib/puppet/type/resources.rb
@@ -175,7 +175,7 @@ Puppet::Type.newtype(:resources) do
     end
 
     # Otherwise, use a sensible default based on the OS family
-    @system_users_max_uid ||= case Facter.value('os.family')
+    @system_users_max_uid ||= case Facter.value(:osfamily)
       when 'OpenBSD', 'FreeBSD'
         999
       else

--- a/lib/puppet/util/filetype.rb
+++ b/lib/puppet/util/filetype.rb
@@ -215,7 +215,7 @@ class Puppet::Util::FileType
     # Remove a specific @path's cron tab.
     def remove
       cmd = "#{cmdbase} -r"
-      if %w{Darwin FreeBSD DragonFly}.include?(Facter.value('os.name'))
+      if %w{Darwin FreeBSD DragonFly}.include?(Facter.value("operatingsystem"))
         cmd = "/bin/echo yes | #{cmd}"
       end
 
@@ -244,7 +244,7 @@ class Puppet::Util::FileType
     # Only add the -u flag when the @path is different.  Fedora apparently
     # does not think I should be allowed to set the @path to my own user name
     def cmdbase
-      if @uid == Puppet::Util::SUIDManager.uid || Facter.value('os.name') == "HP-UX"
+      if @uid == Puppet::Util::SUIDManager.uid || Facter.value(:operatingsystem) == "HP-UX"
         return "crontab"
       else
         return "crontab -u #{@path}"

--- a/lib/puppet/util/suidmanager.rb
+++ b/lib/puppet/util/suidmanager.rb
@@ -18,7 +18,7 @@ module Puppet::Util::SUIDManager
 
   def osx_maj_ver
     return @osx_maj_ver unless @osx_maj_ver.nil?
-    @osx_maj_ver = Facter.value('os.macosx.version.major') || false
+    @osx_maj_ver = Facter.value('macosx_productversion_major') || false
   end
   module_function :osx_maj_ver
 

--- a/spec/fixtures/releases/jamtur01-apache/lib/puppet/provider/a2mod/debian.rb
+++ b/spec/fixtures/releases/jamtur01-apache/lib/puppet/provider/a2mod/debian.rb
@@ -4,7 +4,7 @@ Puppet::Type.type(:a2mod).provide(:debian) do
     commands :encmd => "a2enmod"
     commands :discmd => "a2dismod"
 
-    defaultfor 'os.name' => [:debian, :ubuntu]
+    defaultfor :operatingsystem => [:debian, :ubuntu]
 
     def create
         encmd resource[:name]

--- a/spec/fixtures/releases/jamtur01-apache/manifests/init.pp
+++ b/spec/fixtures/releases/jamtur01-apache/manifests/init.pp
@@ -21,7 +21,7 @@ class apache {
    'headers' : ensure => present;
    'expires' : ensure => present;
   }
-  $vdir = $os['name'] ? {
+  $vdir = $operatingsystem? {
     'ubuntu' => '/etc/apache2/sites-enabled/',
     default => '/etc/httpd/conf.d',
   }

--- a/spec/fixtures/releases/jamtur01-apache/manifests/params.pp
+++ b/spec/fixtures/releases/jamtur01-apache/manifests/params.pp
@@ -2,7 +2,7 @@ class apache::params{
   $user  = 'www-data'
   $group = 'www-data'
 
-  case $os['name'] {
+  case $operatingsystem {
     "centos": {
        $apache_name = httpd
        $ssl_package = mod_ssl

--- a/spec/fixtures/releases/jamtur01-apache/manifests/ssl.pp
+++ b/spec/fixtures/releases/jamtur01-apache/manifests/ssl.pp
@@ -2,7 +2,7 @@ class apache::ssl {
   include apache
 
 
-  case $facts['os']['name'] {
+  case $operatingsystem {
      "centos": {
         package { $apache::params::ssl_package:
            require => Package['httpd'],

--- a/spec/fixtures/releases/jamtur01-apache/manifests/vhost.pp
+++ b/spec/fixtures/releases/jamtur01-apache/manifests/vhost.pp
@@ -1,6 +1,6 @@
 define apache::vhost( $port, $docroot, $ssl=true, $template='apache/vhost-default.conf.erb', $priority, $serveraliases = '' ) {
   include apache
-  $vdir = $os['name']? {
+  $vdir = $operatingsystem? {
     'ubuntu' => '/etc/apache2/sites-enabled/',
     default => '/etc/httpd/conf.d',
   }

--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -1710,11 +1710,11 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
 
   describe "when using validate_cmd" do
     test_cmd = '/bin/test'
-    if Facter.value('os.family') == 'Debian'
+    if Facter.value(:osfamily) == 'Debian'
       test_cmd = '/usr/bin/test'
     end
 
-    if Facter.value('os.name') == 'Darwin'
+    if Facter.value(:operatingsystem) == 'Darwin'
       stat_cmd = "stat -f '%Lp'"
     else
       stat_cmd = "stat --format=%a"

--- a/spec/integration/type/package_spec.rb
+++ b/spec/integration/type/package_spec.rb
@@ -21,19 +21,19 @@ describe Puppet::Type.type(:package), "when choosing a default package provider"
     when 'Darwin'
       :pkgdmg
     when 'RedHat'
-      if ['2.1', '3', '4'].include?(Facter.value('os.distro.release.full'))
+      if ['2.1', '3', '4'].include?(Facter.value(:lsbdistrelease))
         :up2date
       else
         :yum
       end
     when 'Fedora'
-      if Puppet::Util::Package.versioncmp(Facter.value('os.release.major'), '22') >= 0
+      if Puppet::Util::Package.versioncmp(Facter.value(:operatingsystemmajrelease), '22') >= 0
         :dnf
       else
         :yum
       end
     when 'Suse'
-      if Puppet::Util::Package.versioncmp(Facter.value('os.release.major'), '10') >= 0
+      if Puppet::Util::Package.versioncmp(Facter.value(:operatingsystemmajrelease), '10') >= 0
         :zypper
       else
         :rug
@@ -54,8 +54,8 @@ describe Puppet::Type.type(:package), "when choosing a default package provider"
   end
 
   it "should choose the correct provider each platform" do
-    unless default_provider = provider_name(Facter.value('os.name'))
-      pending("No default provider specified in this test for #{Facter.value('os.name')}")
+    unless default_provider = provider_name(Facter.value(:operatingsystem))
+      pending("No default provider specified in this test for #{Facter.value(:operatingsystem)}")
     end
     expect(Puppet::Type.type(:package).defaultprovider.name).to eq(default_provider)
   end

--- a/spec/shared_examples/rhel_package_provider.rb
+++ b/spec/shared_examples/rhel_package_provider.rb
@@ -69,7 +69,7 @@ shared_examples "RHEL package provider" do |provider_class, provider_name|
         allow(Puppet::Util).to receive(:which).with("rpm").and_return("/bin/rpm")
         allow(provider).to receive(:which).with("rpm").and_return("/bin/rpm")
         expect(Puppet::Util::Execution).to receive(:execute).with(["/bin/rpm", "--version"], {:combine => true, :custom_environment => {}, :failonfail => true}).and_return(Puppet::Util::Execution::ProcessOutput.new("4.10.1\n", 0)).at_most(:once)
-        allow(Facter).to receive(:value).with('os.release.major').and_return('6')
+        allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return('6')
       end
 
       it "should call #{provider_name} install for :installed" do
@@ -81,7 +81,7 @@ shared_examples "RHEL package provider" do |provider_class, provider_name|
       if provider_name == 'yum'
         context 'on el-5' do
           before(:each) do
-            allow(Facter).to receive(:value).with('os.release.major').and_return('5')
+            allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return('5')
           end
 
           it "should catch #{provider_name} install failures when status code is wrong" do

--- a/spec/unit/application/device_spec.rb
+++ b/spec/unit/application/device_spec.rb
@@ -482,10 +482,10 @@ describe Puppet::Application::Device do
         end
 
         it "retrieves facts" do
-          indirection_fact_values = {"os"=> {"name" => "cisco_ios"},"clientcert"=>"3750"}
+          indirection_fact_values = {"operatingsystem"=>"cisco_ios","clientcert"=>"3750"}
           indirection_facts = Puppet::Node::Facts.new("nil", indirection_fact_values)
           expect(Puppet::Node::Facts.indirection).to receive(:find).with(nil, anything()).and_return(indirection_facts)
-          expect(device).to receive(:puts).with(/name.*3750.*\n.*values.*\n.*os.*\n.*name.*cisco_ios/)
+          expect(device).to receive(:puts).with(/name.*3750.*\n.*values.*\n.*operatingsystem.*cisco_ios/)
           expect { device.main }.to exit_with 0
         end
       end

--- a/spec/unit/confine_spec.rb
+++ b/spec/unit/confine_spec.rb
@@ -84,16 +84,16 @@ describe Puppet::Confine do
   describe "when requiring" do
     it "does not cache failed requires when always_retry_plugins is true" do
       Puppet[:always_retry_plugins] = true
-      expect(Puppet::Confine).to receive(:require).with('puppet/confine/os.family').twice.and_raise(LoadError)
-      Puppet::Confine.test('os.family')
-      Puppet::Confine.test('os.family')
+      expect(Puppet::Confine).to receive(:require).with('puppet/confine/osfamily').twice.and_raise(LoadError)
+      Puppet::Confine.test(:osfamily)
+      Puppet::Confine.test(:osfamily)
     end
 
     it "caches failed requires when always_retry_plugins is false" do
       Puppet[:always_retry_plugins] = false
-      expect(Puppet::Confine).to receive(:require).with('puppet/confine/os.family').once.and_raise(LoadError)
-      Puppet::Confine.test('os.family')
-      Puppet::Confine.test('os.family')
+      expect(Puppet::Confine).to receive(:require).with('puppet/confine/osfamily').once.and_raise(LoadError)
+      Puppet::Confine.test(:osfamily)
+      Puppet::Confine.test(:osfamily)
     end
   end
 end

--- a/spec/unit/face/epp_face_spec.rb
+++ b/spec/unit/face/epp_face_spec.rb
@@ -311,8 +311,8 @@ describe Puppet::Face[:epp, :current] do
 
     it "facts can be overridden" do
       expect(eppface.render({
-        :facts => {'os' => {'name' => 'Merwin'} },
-        :e     => '<%= $facts[os][name] %>', 
+        :facts => {'operatingsystem' => 'Merwin'},
+        :e     => '<%= $facts[operatingsystem] %>', 
       })).to eql("Merwin")
     end
 

--- a/spec/unit/file_bucket/dipper_spec.rb
+++ b/spec/unit/file_bucket/dipper_spec.rb
@@ -104,8 +104,8 @@ describe Puppet::FileBucket::Dipper, :uses_checksums => true do
           # Diff without the context
           # Lines we need to see match 'Content' instead of trimming diff output filter out
           # surrounding noise...or hard code the check values
-          if Facter.value('os.family') == 'Solaris' &&
-            Puppet::Util::Package.versioncmp(Facter.value('os.release.full'), '11.0') >= 0
+          if Facter.value(:osfamily) == 'Solaris' &&
+            Puppet::Util::Package.versioncmp(Facter.value(:operatingsystemrelease), '11.0') >= 0
             # Use gdiff on Solaris
             diff12 = Puppet::Util::Execution.execute("gdiff -uN #{file1} #{file2}| grep Content")
             diff21 = Puppet::Util::Execution.execute("gdiff -uN #{file2} #{file1}| grep Content")

--- a/spec/unit/file_serving/mount/file_spec.rb
+++ b/spec/unit/file_serving/mount/file_spec.rb
@@ -3,8 +3,8 @@ require 'puppet/file_serving/mount/file'
 
 module FileServingMountTesting
   def stub_facter(hostname)
-    allow(Facter).to receive(:value).with('networking.hostname').and_return(hostname.sub(/\..+/, ''))
-    allow(Facter).to receive(:value).with('networking.domain').and_return(hostname.sub(/^[^.]+\./, ''))
+    allow(Facter).to receive(:value).with("hostname").and_return(hostname.sub(/\..+/, ''))
+    allow(Facter).to receive(:value).with("domain").and_return(hostname.sub(/^[^.]+\./, ''))
   end
 end
 

--- a/spec/unit/indirector/catalog/compiler_spec.rb
+++ b/spec/unit/indirector/catalog/compiler_spec.rb
@@ -389,10 +389,10 @@ describe Puppet::Resource::Catalog::Compiler do
     before do
       allow(Puppet).to receive(:version).and_return(1)
       set_facts({
-        'networking.fqdn' => "my.server.com",
-        'networking.ip'   => "my.ip.address",
-        'networking.ip6'  => nil
-      })
+        'fqdn'       => "my.server.com",
+        'ipaddress'  => "my.ip.address",
+        'ipaddress6' => nil
+        })
       @request = Puppet::Indirector::Request.new(:catalog, :find, node_name, nil)
       allow(compiler).to receive(:compile)
       allow(Puppet::Node.indirection).to receive(:find).with(node_name, anything).and_return(node)
@@ -424,16 +424,16 @@ describe Puppet::Resource::Catalog::Compiler do
     before do |example|
       allow(Puppet).to receive(:version).and_return(1)
       set_facts({
-        'networking.fqdn' => "my.server.com",
-        'networking.ip'   => nil,
+        'fqdn'       => "my.server.com",
+        'ipaddress'  => nil,
       })
       if example.metadata[:nil_ipv6]
         set_facts({
-          'networking.ip6' => nil
+          'ipaddress6' => nil
         })
       else
         set_facts({
-          'networking.ip6' => "my.ipv6.address"
+          'ipaddress6' => "my.ipv6.address"
         })
       end
       @request = Puppet::Indirector::Request.new(:catalog, :find, node_name, nil)

--- a/spec/unit/module_tool/tar_spec.rb
+++ b/spec/unit/module_tool/tar_spec.rb
@@ -7,7 +7,7 @@ describe Puppet::ModuleTool::Tar do
     { :name => 'Windows', :win => true }
   ].each do |os|
     it "always prefers minitar if it and zlib are present, even with tar available" do
-      allow(Facter).to receive(:value).with('os.family').and_return(os[:name])
+      allow(Facter).to receive(:value).with('osfamily').and_return(os[:name])
       allow(Puppet::Util).to receive(:which).with('tar').and_return('/usr/bin/tar')
       allow(Puppet::Util::Platform).to receive(:windows?).and_return(os[:win])
       allow(Puppet).to receive(:features).and_return(double(:minitar? => true, :zlib? => true))
@@ -17,7 +17,7 @@ describe Puppet::ModuleTool::Tar do
   end
 
   it "falls back to tar when minitar not present and not on Windows" do
-    allow(Facter).to receive(:value).with('os.family').and_return('ObscureLinuxDistro')
+    allow(Facter).to receive(:value).with('osfamily').and_return('ObscureLinuxDistro')
     allow(Puppet::Util).to receive(:which).with('tar').and_return('/usr/bin/tar')
     allow(Puppet::Util::Platform).to receive(:windows?).and_return(false)
     allow(Puppet).to receive(:features).and_return(double(:minitar? => false))
@@ -26,7 +26,7 @@ describe Puppet::ModuleTool::Tar do
   end
 
   it "fails when there is no possible implementation" do
-    allow(Facter).to receive(:value).with('os.family').and_return('Windows')
+    allow(Facter).to receive(:value).with('osfamily').and_return('Windows')
     allow(Puppet::Util).to receive(:which).with('tar')
     allow(Puppet::Util::Platform).to receive(:windows?).and_return(true)
     allow(Puppet).to receive(:features).and_return(double(:minitar? => false, :zlib? => false))

--- a/spec/unit/pops/serialization/serialization_spec.rb
+++ b/spec/unit/pops/serialization/serialization_spec.rb
@@ -298,7 +298,7 @@ module Serialization
 
       it 'nested Expression' do
         expr = parse(<<-CODE)
-          $rootgroup = $os['family'] ? {
+          $rootgroup = $osfamily ? {
               'Solaris'          => 'wheel',
               /(Darwin|FreeBSD)/ => 'wheel',
               default            => 'root',
@@ -435,7 +435,7 @@ module Serialization
 
     it 'can write and read an AST expression' do
       expr = parse(<<-CODE)
-        $rootgroup = $os['family'] ? {
+        $rootgroup = $osfamily ? {
             'Solaris'          => 'wheel',
             /(Darwin|FreeBSD)/ => 'wheel',
             default            => 'root',

--- a/spec/unit/pops/serialization/to_from_hr_spec.rb
+++ b/spec/unit/pops/serialization/to_from_hr_spec.rb
@@ -344,7 +344,7 @@ module Serialization
 
       it 'nested Expression' do
         expr = parse(<<-CODE)
-          $rootgroup = $os['family'] ? {
+          $rootgroup = $osfamily ? {
               'Solaris'          => 'wheel',
               /(Darwin|FreeBSD)/ => 'wheel',
               default            => 'root',

--- a/spec/unit/provider/package/apt_spec.rb
+++ b/spec/unit/provider/package/apt_spec.rb
@@ -14,8 +14,8 @@ describe Puppet::Type.type(:package).provider(:apt) do
     resource.provider
   end
 
-  it "should be the default provider on 'os.family' => Debian" do
-    expect(Facter).to receive(:value).with('os.family').and_return("Debian")
+  it "should be the default provider on :osfamily => Debian" do
+    expect(Facter).to receive(:value).with(:osfamily).and_return("Debian")
     expect(described_class.default?).to be_truthy
   end
 

--- a/spec/unit/provider/package/dnf_spec.rb
+++ b/spec/unit/provider/package/dnf_spec.rb
@@ -6,40 +6,40 @@ describe Puppet::Type.type(:package).provider(:dnf) do
   context 'default' do
     (19..21).each do |ver|
       it "should not be the default provider on fedora#{ver}" do
-        allow(Facter).to receive(:value).with('os.family').and_return(:redhat)
-        allow(Facter).to receive(:value).with('os.name').and_return(:fedora)
-        allow(Facter).to receive(:value).with('os.release.major').and_return("#{ver}")
+        allow(Facter).to receive(:value).with(:osfamily).and_return(:redhat)
+        allow(Facter).to receive(:value).with(:operatingsystem).and_return(:fedora)
+        allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return("#{ver}")
         expect(described_class).to_not be_default
       end
     end
 
     (22..26).each do |ver|
       it "should be the default provider on fedora#{ver}" do
-        allow(Facter).to receive(:value).with('os.family').and_return(:redhat)
-        allow(Facter).to receive(:value).with('os.name').and_return(:fedora)
-        allow(Facter).to receive(:value).with('os.release.major').and_return("#{ver}")
+        allow(Facter).to receive(:value).with(:osfamily).and_return(:redhat)
+        allow(Facter).to receive(:value).with(:operatingsystem).and_return(:fedora)
+        allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return("#{ver}")
         expect(described_class).to be_default
       end
     end
 
     it "should not be the default provider on rhel7" do
-      allow(Facter).to receive(:value).with('os.family').and_return(:redhat)
-      allow(Facter).to receive(:value).with('os.name').and_return(:redhat)
-      allow(Facter).to receive(:value).with('os.release.major').and_return("7")
+      allow(Facter).to receive(:value).with(:osfamily).and_return(:redhat)
+      allow(Facter).to receive(:value).with(:operatingsystem).and_return(:redhat)
+      allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return("7")
       expect(described_class).to_not be_default
     end
 
     it "should be the default provider on some random future fedora" do
-      allow(Facter).to receive(:value).with('os.family').and_return(:redhat)
-      allow(Facter).to receive(:value).with('os.name').and_return(:fedora)
-      allow(Facter).to receive(:value).with('os.release.major').and_return("8675")
+      allow(Facter).to receive(:value).with(:osfamily).and_return(:redhat)
+      allow(Facter).to receive(:value).with(:operatingsystem).and_return(:fedora)
+      allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return("8675")
       expect(described_class).to be_default
     end
 
     it "should be the default provider on rhel8" do
-      allow(Facter).to receive(:value).with('os.family').and_return(:redhat)
-      allow(Facter).to receive(:value).with('os.name').and_return(:redhat)
-      allow(Facter).to receive(:value).with('os.release.major').and_return("8")
+      allow(Facter).to receive(:value).with(:osfamily).and_return(:redhat)
+      allow(Facter).to receive(:value).with(:operatingsystem).and_return(:redhat)
+      allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return("8")
       expect(described_class).to be_default
     end
   end

--- a/spec/unit/provider/package/dnfmodule_spec.rb
+++ b/spec/unit/provider/package/dnfmodule_spec.rb
@@ -24,18 +24,18 @@ describe Puppet::Type.type(:package).provider(:dnfmodule) do
   before(:each) { allow(Puppet::Util).to receive(:which).with('/usr/bin/dnf').and_return(dnf_path) }
 
   it "should have lower specificity" do
-    allow(Facter).to receive(:value).with('os.family').and_return(:redhat)
-    allow(Facter).to receive(:value).with('os.name').and_return(:redhat)
-    allow(Facter).to receive(:value).with('os.release.major').and_return('8')
+    allow(Facter).to receive(:value).with(:osfamily).and_return(:redhat)
+    allow(Facter).to receive(:value).with(:operatingsystem).and_return(:redhat)
+    allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return('8')
     expect(described_class.specificity).to be < 200
   end
 
   describe "should be an opt-in provider" do
     Array(4..8).each do |ver|
       it "should not be default for redhat #{ver}" do
-        allow(Facter).to receive(:value).with('os.name').and_return('redhat')
-        allow(Facter).to receive(:value).with('os.family').and_return('redhat')
-        allow(Facter).to receive(:value).with('os.release.major').and_return(ver.to_s)
+        allow(Facter).to receive(:value).with(:operatingsystem).and_return('redhat')
+        allow(Facter).to receive(:value).with(:osfamily).and_return('redhat')
+        allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return(ver.to_s)
         expect(described_class).not_to be_default
       end
     end

--- a/spec/unit/provider/package/gem_spec.rb
+++ b/spec/unit/provider/package/gem_spec.rb
@@ -474,9 +474,9 @@ context Puppet::Type.type(:package).provider(:gem) do
     end
 
     context 'when is defaultfor' do
-      let(:os) {  Facter.value('os.name') }
+      let(:os) {  Facter.value(:operatingsystem) }
       subject do
-        described_class.defaultfor('os.name': os)
+        described_class.defaultfor(operatingsystem: os)
         described_class.specificity
       end
       it { is_expected.to be > 100 }

--- a/spec/unit/provider/package/pip2_spec.rb
+++ b/spec/unit/provider/package/pip2_spec.rb
@@ -24,9 +24,9 @@ describe Puppet::Type.type(:package).provider(:pip2) do
     end
 
     context 'when is defaultfor' do
-      let(:os) {  Facter.value('os.name') }
+      let(:os) {  Facter.value(:operatingsystem) }
       subject do
-        described_class.defaultfor('os.name': os)
+        described_class.defaultfor(operatingsystem: os)
         described_class.specificity
       end
       it { is_expected.to be > 100 }

--- a/spec/unit/provider/package/pip3_spec.rb
+++ b/spec/unit/provider/package/pip3_spec.rb
@@ -24,9 +24,9 @@ describe Puppet::Type.type(:package).provider(:pip3) do
     end
 
     context 'when is defaultfor' do
-      let(:os) {  Facter.value('os.name') }
+      let(:os) {  Facter.value(:operatingsystem) }
       subject do
-        described_class.defaultfor('os.name': os)
+        described_class.defaultfor(operatingsystem: os)
         described_class.specificity
       end
       it { is_expected.to be > 100 }

--- a/spec/unit/provider/package/pip_spec.rb
+++ b/spec/unit/provider/package/pip_spec.rb
@@ -454,9 +454,9 @@ describe Puppet::Type.type(:package).provider(:pip) do
     end
 
     context 'when is defaultfor' do
-      let(:os) {  Facter.value('os.name') }
+      let(:os) {  Facter.value(:operatingsystem) }
       subject do
-        described_class.defaultfor('os.name': os)
+        described_class.defaultfor(operatingsystem: os)
         described_class.specificity
       end
       it { is_expected.to be > 100 }

--- a/spec/unit/provider/package/pkg_spec.rb
+++ b/spec/unit/provider/package/pkg_spec.rb
@@ -31,20 +31,20 @@ describe Puppet::Type.type(:package).provider(:pkg), unless: Puppet::Util::Platf
   context 'default' do
     [ 10 ].each do |ver|
       it "should not be the default provider on Solaris #{ver}" do
-        allow(Facter).to receive(:value).with('os.family').and_return(:Solaris)
+        allow(Facter).to receive(:value).with(:osfamily).and_return(:Solaris)
         allow(Facter).to receive(:value).with(:kernelrelease).and_return("5.#{ver}")
-        allow(Facter).to receive(:value).with('os.name').and_return(:Solaris)
-        allow(Facter).to receive(:value).with('os.release.major').and_return("#{ver}")
+        allow(Facter).to receive(:value).with(:operatingsystem).and_return(:Solaris)
+        allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return("#{ver}")
         expect(described_class).to_not be_default
       end
     end
 
     [ 11, 12 ].each do |ver|
       it "should be the default provider on Solaris #{ver}" do
-        allow(Facter).to receive(:value).with('os.family').and_return(:Solaris)
+        allow(Facter).to receive(:value).with(:osfamily).and_return(:Solaris)
         allow(Facter).to receive(:value).with(:kernelrelease).and_return("5.#{ver}")
-        allow(Facter).to receive(:value).with('os.name').and_return(:Solaris)
-        allow(Facter).to receive(:value).with('os.release.major').and_return("#{ver}")
+        allow(Facter).to receive(:value).with(:operatingsystem).and_return(:Solaris)
+        allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return("#{ver}")
         expect(described_class).to be_default
       end
     end
@@ -254,9 +254,9 @@ describe Puppet::Type.type(:package).provider(:pkg), unless: Puppet::Util::Platf
         { :osrel => '11.0', :flags => ['--accept'] },
         { :osrel => '11.2', :flags => ['--accept', '--sync-actuators-timeout', '900'] },
       ].each do |hash|
-        context "with 'os.release.full' #{hash[:osrel]}" do
+        context "with :operatingsystemrelease #{hash[:osrel]}" do
           before :each do
-            allow(Facter).to receive(:value).with('os.release.full').and_return(hash[:osrel])
+            allow(Facter).to receive(:value).with(:operatingsystemrelease).and_return(hash[:osrel])
           end
 
           it "should support install options" do

--- a/spec/unit/provider/package/pkgng_spec.rb
+++ b/spec/unit/provider/package/pkgng_spec.rb
@@ -220,7 +220,7 @@ describe Puppet::Type.type(:package).provider(:pkgng) do
   describe "confine" do
     context "on FreeBSD" do
       it "should be the default provider" do
-        expect(Facter).to receive(:value).with('os.name').at_least(:once).and_return(:freebsd)
+        expect(Facter).to receive(:value).with(:operatingsystem).at_least(:once).and_return(:freebsd)
         expect(described_class).to be_default
       end
     end

--- a/spec/unit/provider/package/portage_spec.rb
+++ b/spec/unit/provider/package/portage_spec.rb
@@ -72,8 +72,8 @@ describe Puppet::Type.type(:package).provider(:portage) do
     expect(described_class).to be_reinstallable
   end
 
-  it "should be the default provider on 'os.family' => Gentoo" do
-    expect(Facter).to receive(:value).with('os.family').and_return("Gentoo")
+  it "should be the default provider on :osfamily => Gentoo" do
+    expect(Facter).to receive(:value).with(:osfamily).and_return("Gentoo")
     expect(described_class.default?).to be_truthy
   end
 

--- a/spec/unit/provider/package/puppet_gem_spec.rb
+++ b/spec/unit/provider/package/puppet_gem_spec.rb
@@ -88,9 +88,9 @@ describe Puppet::Type.type(:package).provider(:puppet_gem) do
     end
 
     context 'when is defaultfor' do
-      let(:os) {  Facter.value('os.name') }
+      let(:os) {  Facter.value(:operatingsystem) }
       subject do
-        described_class.defaultfor('os.name': os)
+        described_class.defaultfor(operatingsystem: os)
         described_class.specificity
       end
       it { is_expected.to be > 100 }

--- a/spec/unit/provider/package/puppetserver_gem_spec.rb
+++ b/spec/unit/provider/package/puppetserver_gem_spec.rb
@@ -125,9 +125,9 @@ describe Puppet::Type.type(:package).provider(:puppetserver_gem) do
     end
 
     context 'when is defaultfor' do
-      let(:os) {  Facter.value('os.name') }
+      let(:os) {  Facter.value(:operatingsystem) }
       subject do
-        described_class.defaultfor('os.name': os)
+        described_class.defaultfor(operatingsystem: os)
         described_class.specificity
       end
       it { is_expected.to be > 100 }

--- a/spec/unit/provider/package/tdnf_spec.rb
+++ b/spec/unit/provider/package/tdnf_spec.rb
@@ -7,8 +7,8 @@ describe Puppet::Type.type(:package).provider(:tdnf) do
 
   context 'default' do
     it 'should be the default provider on PhotonOS' do
-      allow(Facter).to receive(:value).with('os.family').and_return(:redhat)
-      allow(Facter).to receive(:value).with('os.name').and_return("PhotonOS")
+      allow(Facter).to receive(:value).with(:osfamily).and_return(:redhat)
+      allow(Facter).to receive(:value).with(:operatingsystem).and_return("PhotonOS")
       expect(described_class).to be_default
     end
   end

--- a/spec/unit/provider/package/up2date_spec.rb
+++ b/spec/unit/provider/package/up2date_spec.rb
@@ -13,8 +13,8 @@ describe 'up2date package provider' do
   osfamilies.each do |osfamily|
     releases.each do |release|
       it "should be the default provider on #{osfamily} #{release}" do
-        allow(Facter).to receive(:value).with('os.family').and_return(osfamily)
-        allow(Facter).to receive(:value).with('os.distro.release.full').and_return(release)
+        allow(Facter).to receive(:value).with(:osfamily).and_return(osfamily)
+        allow(Facter).to receive(:value).with(:lsbdistrelease).and_return(release)
         expect(subject.default?).to be_truthy
       end
     end

--- a/spec/unit/provider/package/yum_spec.rb
+++ b/spec/unit/provider/package/yum_spec.rb
@@ -17,42 +17,42 @@ describe Puppet::Type.type(:package).provider(:yum) do
   it_behaves_like 'RHEL package provider', described_class, 'yum'
 
   it "should have lower specificity" do
-    allow(Facter).to receive(:value).with('os.family').and_return(:redhat)
-    allow(Facter).to receive(:value).with('os.name').and_return(:fedora)
-    allow(Facter).to receive(:value).with('os.release.major').and_return("22")
+    allow(Facter).to receive(:value).with(:osfamily).and_return(:redhat)
+    allow(Facter).to receive(:value).with(:operatingsystem).and_return(:fedora)
+    allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return("22")
     expect(described_class.specificity).to be < 200
   end
 
   describe "should have logical defaults" do
     [2, 2018].each do |ver|
       it "should be the default provider on Amazon Linux #{ver}" do
-        allow(Facter).to receive(:value).with('os.name').and_return('amazon')
-        allow(Facter).to receive(:value).with('os.family').and_return('redhat')
-        allow(Facter).to receive(:value).with('os.release.major').and_return(ver)
+        allow(Facter).to receive(:value).with(:operatingsystem).and_return('amazon')
+        allow(Facter).to receive(:value).with(:osfamily).and_return('redhat')
+        allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return(ver)
         expect(described_class).to be_default
       end
     end
 
     Array(4..7).each do |ver|
       it "should be default for redhat #{ver}" do
-        allow(Facter).to receive(:value).with('os.name').and_return('redhat')
-        allow(Facter).to receive(:value).with('os.family').and_return('redhat')
-        allow(Facter).to receive(:value).with('os.release.major').and_return(ver.to_s)
+        allow(Facter).to receive(:value).with(:operatingsystem).and_return('redhat')
+        allow(Facter).to receive(:value).with(:osfamily).and_return('redhat')
+        allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return(ver.to_s)
         expect(described_class).to be_default
       end
     end
 
     it "should not be default for redhat 8" do
-      allow(Facter).to receive(:value).with('os.name').and_return('redhat')
-      allow(Facter).to receive(:value).with('os.family').and_return('redhat')
-      allow(Facter).to receive(:value).with('os.release.major').and_return('8')
+      allow(Facter).to receive(:value).with(:operatingsystem).and_return('redhat')
+      allow(Facter).to receive(:value).with(:osfamily).and_return('redhat')
+      allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return('8')
       expect(described_class).not_to be_default
     end
 
     it "should not be default for Ubuntu 16.04" do
-      allow(Facter).to receive(:value).with('os.name').and_return('ubuntu')
-      allow(Facter).to receive(:value).with('os.family').and_return('ubuntu')
-      allow(Facter).to receive(:value).with('os.release.major').and_return('16.04')
+      allow(Facter).to receive(:value).with(:operatingsystem).and_return('ubuntu')
+      allow(Facter).to receive(:value).with(:osfamily).and_return('ubuntu')
+      allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return('16.04')
       expect(described_class).not_to be_default
     end
   end
@@ -346,7 +346,7 @@ describe Puppet::Type.type(:package).provider(:yum) do
   describe 'install' do
     before do
       resource[:ensure] = ensure_value
-      allow(Facter).to receive(:value).with('os.release.major').and_return('7')
+      allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return('7')
       allow(described_class).to receive(:command).with(:cmd).and_return('/usr/bin/yum')
       allow(provider).to receive(:query).twice.and_return(nil, ensure: '18.3.2')
       allow(provider).to receive(:insync?).with('18.3.2').and_return(true)

--- a/spec/unit/provider/service/base_spec.rb
+++ b/spec/unit/provider/service/base_spec.rb
@@ -98,7 +98,7 @@ describe "base service provider" do
     end
 
     it "retrieves a PID from the process table" do
-      allow(Facter).to receive(:value).with('os.name').and_return("CentOS")
+      allow(Facter).to receive(:value).with(:operatingsystem).and_return("CentOS")
       ps_output = File.binread(my_fixture("ps_ef.mixed_encoding")).force_encoding(Encoding::UTF_8)
 
       expect(executor).to receive(:execute).with("ps -ef").and_return(ps_output)

--- a/spec/unit/provider/service/bsd_spec.rb
+++ b/spec/unit/provider/service/bsd_spec.rb
@@ -10,8 +10,8 @@ describe 'Puppet::Type::Service::Provider::Bsd',
 
   before :each do
     allow(Puppet::Type.type(:service)).to receive(:defaultprovider).and_return(provider_class)
-    allow(Facter).to receive(:value).with('os.name').and_return(:netbsd)
-    allow(Facter).to receive(:value).with('os.family').and_return('NetBSD')
+    allow(Facter).to receive(:value).with(:operatingsystem).and_return(:netbsd)
+    allow(Facter).to receive(:value).with(:osfamily).and_return('NetBSD')
     allow(provider_class).to receive(:defpath).and_return('/etc/rc.conf.d')
     @provider = provider_class.new
     allow(@provider).to receive(:initscript)

--- a/spec/unit/provider/service/debian_spec.rb
+++ b/spec/unit/provider/service/debian_spec.rb
@@ -34,20 +34,20 @@ describe 'Puppet::Type::Service::Provider::Debian',
 
   ['1','2'].each do |version|
     it "should be the default provider on CumulusLinux #{version}" do
-      expect(Facter).to receive(:value).with('os.name').at_least(:once).and_return('CumulusLinux')
-      expect(Facter).to receive(:value).with('os.release.major').and_return(version)
+      expect(Facter).to receive(:value).with(:operatingsystem).at_least(:once).and_return('CumulusLinux')
+      expect(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return(version)
       expect(provider_class.default?).to be_truthy
     end
   end
 
   it "should be the default provider on Devuan" do
-    expect(Facter).to receive(:value).with('os.name').at_least(:once).and_return('Devuan')
+    expect(Facter).to receive(:value).with(:operatingsystem).at_least(:once).and_return('Devuan')
     expect(provider_class.default?).to be_truthy
   end
 
   it "should be the default provider on Debian" do
-    expect(Facter).to receive(:value).with('os.name').at_least(:once).and_return('Debian')
-    expect(Facter).to receive(:value).with('os.release.major').and_return('7')
+    expect(Facter).to receive(:value).with(:operatingsystem).at_least(:once).and_return('Debian')
+    expect(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return('7')
     expect(provider_class.default?).to be_truthy
   end
 
@@ -151,8 +151,8 @@ describe 'Puppet::Type::Service::Provider::Debian',
 
   context "when checking service status" do
     it "should use the service command" do
-      allow(Facter).to receive(:value).with('os.name').and_return('Debian')
-      allow(Facter).to receive(:value).with('os.release.major').and_return('8')
+      allow(Facter).to receive(:value).with(:operatingsystem).and_return('Debian')
+      allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return('8')
       allow(@resource).to receive(:[]).with(:hasstatus).and_return(:true)
       expect(@provider.statuscmd).to eq(["service", @resource[:name], "status"])
     end

--- a/spec/unit/provider/service/freebsd_spec.rb
+++ b/spec/unit/provider/service/freebsd_spec.rb
@@ -7,7 +7,7 @@ describe 'Puppet::Type::Service::Provider::Freebsd',
   before :each do
     @provider = provider_class.new
     allow(@provider).to receive(:initscript)
-    allow(Facter).to receive(:value).with('os.family').and_return('FreeBSD')
+    allow(Facter).to receive(:value).with(:osfamily).and_return('FreeBSD')
   end
 
   it "should correctly parse rcvar for FreeBSD < 7" do

--- a/spec/unit/provider/service/gentoo_spec.rb
+++ b/spec/unit/provider/service/gentoo_spec.rb
@@ -12,8 +12,8 @@ describe 'Puppet::Type::Service::Provider::Gentoo',
     allow(Puppet::Type.type(:service)).to receive(:defaultprovider).and_return(provider_class)
     allow(FileTest).to receive(:file?).with('/sbin/rc-update').and_return(true)
     allow(FileTest).to receive(:executable?).with('/sbin/rc-update').and_return(true)
-    allow(Facter).to receive(:value).with('os.name').and_return('Gentoo')
-    allow(Facter).to receive(:value).with('os.family').and_return('Gentoo')
+    allow(Facter).to receive(:value).with(:operatingsystem).and_return('Gentoo')
+    allow(Facter).to receive(:value).with(:osfamily).and_return('Gentoo')
 
     # The initprovider (parent of the gentoo provider) does a stat call
     # before it even tries to execute an initscript. We use sshd in all the

--- a/spec/unit/provider/service/init_spec.rb
+++ b/spec/unit/provider/service/init_spec.rb
@@ -39,8 +39,8 @@ describe 'Puppet::Type::Service::Provider::Init',
 
   describe "when running on FreeBSD" do
     before :each do
-      allow(Facter).to receive(:value).with('os.name').and_return('FreeBSD')
-      allow(Facter).to receive(:value).with('os.family').and_return('FreeBSD')
+      allow(Facter).to receive(:value).with(:operatingsystem).and_return('FreeBSD')
+      allow(Facter).to receive(:value).with(:osfamily).and_return('FreeBSD')
     end
 
     it "should set its default path to include /etc/rc.d and /usr/local/etc/rc.d" do
@@ -50,7 +50,7 @@ describe 'Puppet::Type::Service::Provider::Init',
 
   describe "when running on HP-UX" do
     before :each do
-      allow(Facter).to receive(:value).with('os.name').and_return('HP-UX')
+      allow(Facter).to receive(:value).with(:operatingsystem).and_return('HP-UX')
     end
 
     it "should set its default path to include /sbin/init.d" do
@@ -60,7 +60,7 @@ describe 'Puppet::Type::Service::Provider::Init',
 
   describe "when running on Archlinux" do
     before :each do
-      allow(Facter).to receive(:value).with('os.name').and_return('Archlinux')
+      allow(Facter).to receive(:value).with(:operatingsystem).and_return('Archlinux')
     end
 
     it "should set its default path to include /etc/rc.d" do
@@ -70,7 +70,7 @@ describe 'Puppet::Type::Service::Provider::Init',
 
   describe "when not running on FreeBSD, HP-UX or Archlinux" do
     before :each do
-      allow(Facter).to receive(:value).with('os.name').and_return('RedHat')
+      allow(Facter).to receive(:value).with(:operatingsystem).and_return('RedHat')
     end
 
     it "should set its default path to include /etc/init.d" do
@@ -103,7 +103,7 @@ describe 'Puppet::Type::Service::Provider::Init',
     end
 
     it "should omit Yocto services on cisco-wrlinux" do
-      allow(Facter).to receive(:value).with('os.family').and_return('cisco-wrlinux')
+      allow(Facter).to receive(:value).with(:osfamily).and_return('cisco-wrlinux')
       exclude = 'umountfs'
       expect(provider_class.get_services(provider_class.defpath).map(&:name)).to eq(@services - [exclude])
     end
@@ -282,7 +282,7 @@ describe 'Puppet::Type::Service::Provider::Init',
 
     describe "when starting a service on Solaris" do
       it "should use ctrun" do
-        allow(Facter).to receive(:value).with('os.family').and_return('Solaris')
+        allow(Facter).to receive(:value).with(:osfamily).and_return('Solaris')
         expect(provider).to receive(:execute).with('/usr/bin/ctrun -l child /service/path/myservice start', {:failonfail => true, :override_locale => false, :squelch => false, :combine => true}).and_return("")
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
         provider.start
@@ -291,7 +291,7 @@ describe 'Puppet::Type::Service::Provider::Init',
 
     describe "when starting a service on RedHat" do
       it "should not use ctrun" do
-        allow(Facter).to receive(:value).with('os.family').and_return('RedHat')
+        allow(Facter).to receive(:value).with(:osfamily).and_return('RedHat')
         expect(provider).to receive(:execute).with(['/service/path/myservice', :start], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true}).and_return("")
         allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
         provider.start

--- a/spec/unit/provider/service/openbsd_spec.rb
+++ b/spec/unit/provider/service/openbsd_spec.rb
@@ -6,8 +6,8 @@ describe 'Puppet::Type::Service::Provider::Openbsd',
 
   before :each do
     allow(Puppet::Type.type(:service)).to receive(:defaultprovider).and_return(provider_class)
-    allow(Facter).to receive(:value).with('os.name').and_return(:openbsd)
-    allow(Facter).to receive(:value).with('os.family').and_return('OpenBSD')
+    allow(Facter).to receive(:value).with(:operatingsystem).and_return(:openbsd)
+    allow(Facter).to receive(:value).with(:osfamily).and_return('OpenBSD')
     allow(FileTest).to receive(:file?).with('/usr/sbin/rcctl').and_return(true)
     allow(FileTest).to receive(:executable?).with('/usr/sbin/rcctl').and_return(true)
   end

--- a/spec/unit/provider/service/openwrt_spec.rb
+++ b/spec/unit/provider/service/openwrt_spec.rb
@@ -38,7 +38,7 @@ describe 'Puppet::Type::Service::Provider::Openwrt',
 
   operatingsystem = 'openwrt'
   it "should be the default provider on #{operatingsystem}" do
-    expect(Facter).to receive(:value).with('os.name').and_return(operatingsystem)
+    expect(Facter).to receive(:value).with(:operatingsystem).and_return(operatingsystem)
     expect(provider_class.default?).to be_truthy
   end
 

--- a/spec/unit/provider/service/rcng_spec.rb
+++ b/spec/unit/provider/service/rcng_spec.rb
@@ -6,8 +6,8 @@ describe 'Puppet::Type::Service::Provider::Rcng',
 
   before :each do
     allow(Puppet::Type.type(:service)).to receive(:defaultprovider).and_return(provider_class)
-    allow(Facter).to receive(:value).with('os.name').and_return(:netbsd)
-    allow(Facter).to receive(:value).with('os.family').and_return('NetBSD')
+    allow(Facter).to receive(:value).with(:operatingsystem).and_return(:netbsd)
+    allow(Facter).to receive(:value).with(:osfamily).and_return('NetBSD')
     allow(provider_class).to receive(:defpath).and_return('/etc/rc.d')
     @provider = provider_class.new
     allow(@provider).to receive(:initscript)

--- a/spec/unit/provider/service/redhat_spec.rb
+++ b/spec/unit/provider/service/redhat_spec.rb
@@ -24,23 +24,23 @@ describe 'Puppet::Type::Service::Provider::Redhat',
     allow(@provider).to receive(:get).with(:hasstatus).and_return(false)
     allow(FileTest).to receive(:file?).with('/sbin/service').and_return(true)
     allow(FileTest).to receive(:executable?).with('/sbin/service').and_return(true)
-    allow(Facter).to receive(:value).with('os.name').and_return('CentOS')
-    allow(Facter).to receive(:value).with('os.family').and_return('RedHat')
+    allow(Facter).to receive(:value).with(:operatingsystem).and_return('CentOS')
+    allow(Facter).to receive(:value).with(:osfamily).and_return('RedHat')
   end
 
   osfamilies = [ 'RedHat' ]
 
   osfamilies.each do |osfamily|
     it "should be the default provider on #{osfamily}" do
-      expect(Facter).to receive(:value).with('os.family').and_return(osfamily)
+      expect(Facter).to receive(:value).with(:osfamily).and_return(osfamily)
       expect(provider_class.default?).to be_truthy
     end
   end
 
   it "should be the default provider on sles11" do
-    allow(Facter).to receive(:value).with('os.family').and_return(:suse)
-    allow(Facter).to receive(:value).with('os.name').and_return(:suse)
-    allow(Facter).to receive(:value).with('os.release.major').and_return("11")
+    allow(Facter).to receive(:value).with(:osfamily).and_return(:suse)
+    allow(Facter).to receive(:value).with(:operatingsystem).and_return(:suse)
+    allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return("11")
     expect(provider_class.default?).to be_truthy
   end
 
@@ -87,7 +87,7 @@ describe 'Puppet::Type::Service::Provider::Redhat',
 
   context "when checking enabled? on Suse" do
     before :each do
-      expect(Facter).to receive(:value).with('os.family').and_return('Suse')
+      expect(Facter).to receive(:value).with(:osfamily).and_return('Suse')
     end
 
     it "should check for on" do

--- a/spec/unit/provider/service/smf_spec.rb
+++ b/spec/unit/provider/service/smf_spec.rb
@@ -24,9 +24,9 @@ describe 'Puppet::Type::Service::Provider::Smf',
     allow(FileTest).to receive(:executable?).with('/usr/sbin/svcadm').and_return(true)
     allow(FileTest).to receive(:file?).with('/usr/bin/svcs').and_return(true)
     allow(FileTest).to receive(:executable?).with('/usr/bin/svcs').and_return(true)
-    allow(Facter).to receive(:value).with('os.name').and_return('Solaris')
-    allow(Facter).to receive(:value).with('os.family').and_return('Solaris')
-    allow(Facter).to receive(:value).with('os.release.full').and_return('11.2')
+    allow(Facter).to receive(:value).with(:operatingsystem).and_return('Solaris')
+    allow(Facter).to receive(:value).with(:osfamily).and_return('Solaris')
+    allow(Facter).to receive(:value).with(:operatingsystemrelease).and_return('11.2')
   end
   context ".instances" do
     it "should have an instances method" do
@@ -173,19 +173,19 @@ describe 'Puppet::Type::Service::Provider::Smf',
     end
 
     it 'returns the right command for restarting the service for Solaris versions newer than 11.2' do
-      expect(Facter).to receive(:value).with('os.release.full').and_return('11.3')
+      expect(Facter).to receive(:value).with(:operatingsystemrelease).and_return('11.3')
 
       expect(@provider.restartcmd).to eql([@provider.command(:adm), :restart, '-s', fmri])
     end
 
     it 'returns the right command for restarting the service on Solaris 11.2' do
-      expect(Facter).to receive(:value).with('os.release.full').and_return('11.2')
+      expect(Facter).to receive(:value).with(:operatingsystemrelease).and_return('11.2')
 
       expect(@provider.restartcmd).to eql([@provider.command(:adm), :restart, '-s', fmri])
     end
 
     it 'returns the right command for restarting the service for Solaris versions older than Solaris 11.2' do
-      expect(Facter).to receive(:value).with('os.release.full').and_return('10.3')
+      expect(Facter).to receive(:value).with(:operatingsystemrelease).and_return('10.3')
 
       expect(@provider.restartcmd).to eql([@provider.command(:adm), :restart, fmri])
     end
@@ -281,7 +281,7 @@ describe 'Puppet::Type::Service::Provider::Smf',
     before(:each) do
       allow(@provider).to receive(:service_states).and_return(states)
 
-      allow(Facter).to receive(:value).with('os.release.full').and_return('10.3')
+      allow(Facter).to receive(:value).with(:operatingsystemrelease).and_return('10.3')
     end
 
     it "should run the status command if it's passed in" do
@@ -336,7 +336,7 @@ describe 'Puppet::Type::Service::Provider::Smf',
     end
 
     it "should return stopped for an incomplete service on Solaris 11" do
-      allow(Facter).to receive(:value).with('os.release.full').and_return('11.3')
+      allow(Facter).to receive(:value).with(:operatingsystemrelease).and_return('11.3')
       allow(@provider).to receive(:complete_service?).and_return(false)
       expect(@provider.status).to eq(:stopped)
     end

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -27,149 +27,149 @@ describe 'Puppet::Type::Service::Provider::Systemd',
 
   osfamilies.each do |osfamily|
     it "should be the default provider on #{osfamily}" do
-      allow(Facter).to receive(:value).with('os.family').and_return(osfamily)
-      allow(Facter).to receive(:value).with('os.name').and_return(osfamily)
-      allow(Facter).to receive(:value).with('os.release.major').and_return("1234")
+      allow(Facter).to receive(:value).with(:osfamily).and_return(osfamily)
+      allow(Facter).to receive(:value).with(:operatingsystem).and_return(osfamily)
+      allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return("1234")
       expect(provider_class).to be_default
     end
   end
 
   [7, 8].each do |ver|
     it "should be the default provider on rhel#{ver}" do
-      allow(Facter).to receive(:value).with('os.family').and_return(:redhat)
-      allow(Facter).to receive(:value).with('os.name').and_return(:redhat)
-      allow(Facter).to receive(:value).with('os.release.major').and_return(ver.to_s)
+      allow(Facter).to receive(:value).with(:osfamily).and_return(:redhat)
+      allow(Facter).to receive(:value).with(:operatingsystem).and_return(:redhat)
+      allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return(ver.to_s)
       expect(provider_class).to be_default
     end
   end
 
   [ 4, 5, 6 ].each do |ver|
     it "should not be the default provider on rhel#{ver}" do
-      allow(Facter).to receive(:value).with('os.family').and_return(:redhat)
-      allow(Facter).to receive(:value).with('os.name').and_return(:redhat)
-      allow(Facter).to receive(:value).with('os.release.major').and_return("#{ver}")
+      allow(Facter).to receive(:value).with(:osfamily).and_return(:redhat)
+      allow(Facter).to receive(:value).with(:operatingsystem).and_return(:redhat)
+      allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return("#{ver}")
       expect(provider_class).not_to be_default
     end
   end
 
   [ 17, 18, 19, 20, 21, 22, 23 ].each do |ver|
     it "should be the default provider on fedora#{ver}" do
-      allow(Facter).to receive(:value).with('os.family').and_return(:redhat)
-      allow(Facter).to receive(:value).with('os.name').and_return(:fedora)
-      allow(Facter).to receive(:value).with('os.release.major').and_return("#{ver}")
+      allow(Facter).to receive(:value).with(:osfamily).and_return(:redhat)
+      allow(Facter).to receive(:value).with(:operatingsystem).and_return(:fedora)
+      allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return("#{ver}")
       expect(provider_class).to be_default
     end
   end
 
   it "should be the default provider on Amazon Linux 2.0" do
-    allow(Facter).to receive(:value).with('os.family').and_return(:redhat)
-    allow(Facter).to receive(:value).with('os.name').and_return(:amazon)
-    allow(Facter).to receive(:value).with('os.release.major').and_return("2")
+    allow(Facter).to receive(:value).with(:osfamily).and_return(:redhat)
+    allow(Facter).to receive(:value).with(:operatingsystem).and_return(:amazon)
+    allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return("2")
     expect(provider_class).to be_default
   end
 
   it "should not be the default provider on Amazon Linux 2017.09" do
-    allow(Facter).to receive(:value).with('os.family').and_return(:redhat)
-    allow(Facter).to receive(:value).with('os.name').and_return(:amazon)
-    allow(Facter).to receive(:value).with('os.release.major').and_return("2017")
+    allow(Facter).to receive(:value).with(:osfamily).and_return(:redhat)
+    allow(Facter).to receive(:value).with(:operatingsystem).and_return(:amazon)
+    allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return("2017")
     expect(provider_class).not_to be_default
   end
 
   it "should be the default provider on cumulus3" do
-    allow(Facter).to receive(:value).with('os.family').and_return(:debian)
-    allow(Facter).to receive(:value).with('os.name').and_return('CumulusLinux')
-    allow(Facter).to receive(:value).with('os.release.major').and_return("3")
+    allow(Facter).to receive(:value).with(:osfamily).and_return(:debian)
+    allow(Facter).to receive(:value).with(:operatingsystem).and_return('CumulusLinux')
+    allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return("3")
     expect(provider_class).to be_default
   end
 
   it "should be the default provider on sles12" do
-    allow(Facter).to receive(:value).with('os.family').and_return(:suse)
-    allow(Facter).to receive(:value).with('os.name').and_return(:suse)
-    allow(Facter).to receive(:value).with('os.release.major').and_return("12")
+    allow(Facter).to receive(:value).with(:osfamily).and_return(:suse)
+    allow(Facter).to receive(:value).with(:operatingsystem).and_return(:suse)
+    allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return("12")
     expect(provider_class).to be_default
   end
 
   it "should be the default provider on opensuse13" do
-    allow(Facter).to receive(:value).with('os.family').and_return(:suse)
-    allow(Facter).to receive(:value).with('os.name').and_return(:suse)
-    allow(Facter).to receive(:value).with('os.release.major').and_return("13")
+    allow(Facter).to receive(:value).with(:osfamily).and_return(:suse)
+    allow(Facter).to receive(:value).with(:operatingsystem).and_return(:suse)
+    allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return("13")
     expect(provider_class).to be_default
   end
 
   # tumbleweed is a rolling release with date-based major version numbers
   it "should be the default provider on tumbleweed" do
-    allow(Facter).to receive(:value).with('os.family').and_return(:suse)
-    allow(Facter).to receive(:value).with('os.name').and_return(:suse)
-    allow(Facter).to receive(:value).with('os.release.major').and_return("20150829")
+    allow(Facter).to receive(:value).with(:osfamily).and_return(:suse)
+    allow(Facter).to receive(:value).with(:operatingsystem).and_return(:suse)
+    allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return("20150829")
     expect(provider_class).to be_default
   end
 
   # leap is the next generation suse release
   it "should be the default provider on leap" do
-    allow(Facter).to receive(:value).with('os.family').and_return(:suse)
-    allow(Facter).to receive(:value).with('os.name').and_return(:leap)
-    allow(Facter).to receive(:value).with('os.release.major').and_return("42")
+    allow(Facter).to receive(:value).with(:osfamily).and_return(:suse)
+    allow(Facter).to receive(:value).with(:operatingsystem).and_return(:leap)
+    allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return("42")
     expect(provider_class).to be_default
   end
 
   it "should not be the default provider on debian7" do
-    allow(Facter).to receive(:value).with('os.family').and_return(:debian)
-    allow(Facter).to receive(:value).with('os.name').and_return(:debian)
-    allow(Facter).to receive(:value).with('os.release.major').and_return("7")
+    allow(Facter).to receive(:value).with(:osfamily).and_return(:debian)
+    allow(Facter).to receive(:value).with(:operatingsystem).and_return(:debian)
+    allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return("7")
     expect(provider_class).not_to be_default
   end
 
   it "should be the default provider on debian8" do
-    allow(Facter).to receive(:value).with('os.family').and_return(:debian)
-    allow(Facter).to receive(:value).with('os.name').and_return(:debian)
-    allow(Facter).to receive(:value).with('os.release.major').and_return("8")
+    allow(Facter).to receive(:value).with(:osfamily).and_return(:debian)
+    allow(Facter).to receive(:value).with(:operatingsystem).and_return(:debian)
+    allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return("8")
     expect(provider_class).to be_default
   end
 
   it "should be the default provider on debian11" do
-    allow(Facter).to receive(:value).with('os.family').and_return(:debian)
-    allow(Facter).to receive(:value).with('os.name').and_return(:debian)
-    allow(Facter).to receive(:value).with('os.release.major').and_return("11")
+    allow(Facter).to receive(:value).with(:osfamily).and_return(:debian)
+    allow(Facter).to receive(:value).with(:operatingsystem).and_return(:debian)
+    allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return("11")
     expect(provider_class).to be_default
   end
 
   it "should be the default provider on debian bookworm/sid" do
-    allow(Facter).to receive(:value).with('os.family').and_return(:debian)
-    allow(Facter).to receive(:value).with('os.name').and_return(:debian)
-    allow(Facter).to receive(:value).with('os.release.major').and_return("bookworm/sid")
+    allow(Facter).to receive(:value).with(:osfamily).and_return(:debian)
+    allow(Facter).to receive(:value).with(:operatingsystem).and_return(:debian)
+    allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return("bookworm/sid")
     expect(provider_class).to be_default
   end
 
   it "should not be the default provider on ubuntu14.04" do
-    allow(Facter).to receive(:value).with('os.family').and_return(:debian)
-    allow(Facter).to receive(:value).with('os.name').and_return(:ubuntu)
-    allow(Facter).to receive(:value).with('os.release.major').and_return("14.04")
+    allow(Facter).to receive(:value).with(:osfamily).and_return(:debian)
+    allow(Facter).to receive(:value).with(:operatingsystem).and_return(:ubuntu)
+    allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return("14.04")
     expect(provider_class).not_to be_default
   end
 
   [ '15.04', '15.10', '16.04', '16.10', '17.04', '17.10', '18.04' ].each do |ver|
     it "should be the default provider on ubuntu#{ver}" do
-      allow(Facter).to receive(:value).with('os.family').and_return(:debian)
-      allow(Facter).to receive(:value).with('os.name').and_return(:ubuntu)
-      allow(Facter).to receive(:value).with('os.release.major').and_return("#{ver}")
+      allow(Facter).to receive(:value).with(:osfamily).and_return(:debian)
+      allow(Facter).to receive(:value).with(:operatingsystem).and_return(:ubuntu)
+      allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return("#{ver}")
       expect(provider_class).to be_default
     end
   end
 
   [ '10', '11', '12', '13', '14', '15', '16', '17' ].each do |ver|
     it "should not be the default provider on LinuxMint#{ver}" do
-      allow(Facter).to receive(:value).with('os.family').and_return(:debian)
-      allow(Facter).to receive(:value).with('os.name').and_return(:LinuxMint)
-      allow(Facter).to receive(:value).with('os.release.major').and_return("#{ver}")
+      allow(Facter).to receive(:value).with(:osfamily).and_return(:debian)
+      allow(Facter).to receive(:value).with(:operatingsystem).and_return(:LinuxMint)
+      allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return("#{ver}")
       expect(provider_class).not_to be_default
     end
   end
 
   [ '18', '19' ].each do |ver|
     it "should be the default provider on LinuxMint#{ver}" do
-      allow(Facter).to receive(:value).with('os.family').and_return(:debian)
-      allow(Facter).to receive(:value).with('os.name').and_return(:LinuxMint)
-      allow(Facter).to receive(:value).with('os.release.major').and_return("#{ver}")
+      allow(Facter).to receive(:value).with(:osfamily).and_return(:debian)
+      allow(Facter).to receive(:value).with(:operatingsystem).and_return(:LinuxMint)
+      allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return("#{ver}")
       expect(provider_class).to be_default
     end
   end

--- a/spec/unit/provider/service/upstart_spec.rb
+++ b/spec/unit/provider/service/upstart_spec.rb
@@ -26,8 +26,8 @@ describe 'Puppet::Type::Service::Provider::Upstart',
   end
 
   it "should be the default provider on Ubuntu" do
-    expect(Facter).to receive(:value).with('os.name').and_return("Ubuntu")
-    expect(Facter).to receive(:value).with('os.release.major').and_return("12.04")
+    expect(Facter).to receive(:value).with(:operatingsystem).and_return("Ubuntu")
+    expect(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return("12.04")
     expect(provider_class.default?).to be_truthy
   end
 
@@ -55,7 +55,7 @@ describe 'Puppet::Type::Service::Provider::Upstart',
 
   describe "excluding services" do
     it "ignores tty and serial on Redhat systems" do
-      allow(Facter).to receive(:value).with('os.family').and_return('RedHat')
+      allow(Facter).to receive(:value).with(:osfamily).and_return('RedHat')
       expect(provider_class.excludes).to include 'serial'
       expect(provider_class.excludes).to include 'tty'
     end

--- a/spec/unit/provider/user/directoryservice_spec.rb
+++ b/spec/unit/provider/user/directoryservice_spec.rb
@@ -1111,9 +1111,9 @@ end
       provider.class.instance_variable_set(:@os_version, nil) if provider.class.instance_variable_defined? :@os_version
     end
 
-    it 'should call Facter.value("os.macosx.version.major") ONLY ONCE no matter how ' +
+    it 'should call Facter.value(:macosx_productversion_major) ONLY ONCE no matter how ' +
        'many times get_os_version() is called' do
-      expect(Facter).to receive(:value).with('os.macosx.version.major').once.and_return('10.8')
+      expect(Facter).to receive(:value).with(:macosx_productversion_major).once.and_return('10.8')
       expect(provider.class.get_os_version).to eq('10.8')
       expect(provider.class.get_os_version).to eq('10.8')
       expect(provider.class.get_os_version).to eq('10.8')

--- a/spec/unit/provider/user/openbsd_spec.rb
+++ b/spec/unit/provider/user/openbsd_spec.rb
@@ -44,8 +44,8 @@ describe Puppet::Type.type(:user).provider(:openbsd) do
 
   describe "#addcmd" do
     it "should return an array with the full command and expiry as MM/DD/YY" do
-      allow(Facter).to receive(:value).with('os.family').and_return('OpenBSD')
-      allow(Facter).to receive(:value).with('os.release.major')
+      allow(Facter).to receive(:value).with(:osfamily).and_return('OpenBSD')
+      allow(Facter).to receive(:value).with(:operatingsystemmajrelease)
       resource[:expiry] = "1997-06-01"
       expect(provider.addcmd).to eq(['/usr/sbin/useradd', '-e', 'June 01 1997', 'myuser'])
     end

--- a/spec/unit/provider/user/useradd_spec.rb
+++ b/spec/unit/provider/user/useradd_spec.rb
@@ -75,8 +75,8 @@ describe Puppet::Type.type(:user).provider(:useradd) do
 
     context "when setting groups" do
       it "uses -G to set groups" do
-        allow(Facter).to receive(:value).with('os.family').and_return('Solaris')
-        allow(Facter).to receive(:value).with('os.release.major')
+        allow(Facter).to receive(:value).with(:osfamily).and_return('Solaris')
+        allow(Facter).to receive(:value).with(:operatingsystemmajrelease)
         resource[:ensure] = :present
         resource[:groups] = ['group1', 'group2']
         expect(provider).to receive(:execute).with(['/usr/sbin/useradd', '-G', 'group1,group2', 'myuser'], kind_of(Hash))
@@ -84,8 +84,8 @@ describe Puppet::Type.type(:user).provider(:useradd) do
       end
 
       it "uses -G to set groups with -M on supported systems" do
-        allow(Facter).to receive(:value).with('os.family').and_return('RedHat')
-        allow(Facter).to receive(:value).with('os.release.major')
+        allow(Facter).to receive(:value).with(:osfamily).and_return('RedHat')
+        allow(Facter).to receive(:value).with(:operatingsystemmajrelease)
         resource[:ensure] = :present
         resource[:groups] = ['group1', 'group2']
         expect(provider).to receive(:execute).with(['/usr/sbin/useradd', '-G', 'group1,group2', '-M', 'myuser'], kind_of(Hash))
@@ -303,14 +303,14 @@ describe Puppet::Type.type(:user).provider(:useradd) do
 
   describe "#expiry=" do
     it "should pass expiry to usermod as MM/DD/YY when on Solaris" do
-      expect(Facter).to receive(:value).with('os.name').and_return('Solaris')
+      expect(Facter).to receive(:value).with(:operatingsystem).and_return('Solaris')
       resource[:expiry] = '2012-10-31'
       expect(provider).to receive(:execute).with(['/usr/sbin/usermod', '-e', '10/31/2012', 'myuser'], hash_including(custom_environment: {}))
       provider.expiry = '2012-10-31'
     end
 
     it "should pass expiry to usermod as YYYY-MM-DD when not on Solaris" do
-      expect(Facter).to receive(:value).with('os.name').and_return('not_solaris')
+      expect(Facter).to receive(:value).with(:operatingsystem).and_return('not_solaris')
       resource[:expiry] = '2012-10-31'
       expect(provider).to receive(:execute).with(['/usr/sbin/usermod', '-e', '2012-10-31', 'myuser'], hash_including(custom_environment: {}))
       provider.expiry = '2012-10-31'
@@ -323,8 +323,8 @@ describe Puppet::Type.type(:user).provider(:useradd) do
     end
 
     it "should use -e with -1 when the expiry property is removed on SLES11" do
-      allow(Facter).to receive(:value).with('os.name').and_return('SLES')
-      allow(Facter).to receive(:value).with('os.release.major').and_return('11')
+      allow(Facter).to receive(:value).with(:operatingsystem).and_return('SLES')
+      allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return('11')
       resource[:expiry] = :absent
       expect(provider).to receive(:execute).with(['/usr/sbin/usermod', '-e', -1, 'myuser'], hash_including(custom_environment: {}))
       provider.expiry = :absent
@@ -487,16 +487,16 @@ describe Puppet::Type.type(:user).provider(:useradd) do
     end
 
     it "should use -M flag if home is not managed on a supported system" do
-      allow(Facter).to receive(:value).with('os.family').and_return("RedHat")
-      allow(Facter).to receive(:value).with('os.release.major')
+      allow(Facter).to receive(:value).with(:osfamily).and_return("RedHat")
+      allow(Facter).to receive(:value).with(:operatingsystemmajrelease)
       resource[:managehome] = :false
       expect(provider).to receive(:execute).with(include('-M'), kind_of(Hash))
       provider.create
     end
 
     it "should not use -M flag if home is not managed on an unsupported system" do
-      allow(Facter).to receive(:value).with('os.family').and_return("Suse")
-      allow(Facter).to receive(:value).with('os.release.major').and_return("11")
+      allow(Facter).to receive(:value).with(:osfamily).and_return("Suse")
+      allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return("11")
       resource[:managehome] = :false
       expect(provider).to receive(:execute).with(excluding('-M'), kind_of(Hash))
       provider.create
@@ -557,14 +557,14 @@ describe Puppet::Type.type(:user).provider(:useradd) do
     end
 
     it "should return an array with the full command and expiry as MM/DD/YY when on Solaris" do
-      allow(Facter).to receive(:value).with('os.name').and_return('Solaris')
+      allow(Facter).to receive(:value).with(:operatingsystem).and_return('Solaris')
       expect(described_class).to receive(:system_users?).and_return(true)
       resource[:expiry] = "2012-08-18"
       expect(provider.addcmd).to eq(['/usr/sbin/useradd', '-e', '08/18/2012', '-G', 'somegroup', '-o', '-m', '-r', 'myuser'])
     end
 
     it "should return an array with the full command and expiry as YYYY-MM-DD when not on Solaris" do
-      allow(Facter).to receive(:value).with('os.name').and_return('not_solaris')
+      allow(Facter).to receive(:value).with(:operatingsystem).and_return('not_solaris')
       expect(described_class).to receive(:system_users?).and_return(true)
       resource[:expiry] = "2012-08-18"
       expect(provider.addcmd).to eq(['/usr/sbin/useradd', '-e', '2012-08-18', '-G', 'somegroup', '-o', '-m', '-r', 'myuser'])

--- a/spec/unit/provider_spec.rb
+++ b/spec/unit/provider_spec.rb
@@ -222,20 +222,20 @@ describe Puppet::Provider do
       { :true => false } => false,
       { :false => false } => true,
       { :false => true } => false,
-      { 'os.name' => Facter.value('os.name') } => true,
-      { 'os.name' => :yayness } => false,
+      { :operatingsystem => Facter.value(:operatingsystem) } => true,
+      { :operatingsystem => :yayness } => false,
       { :nothing => :yayness } => false,
       { :exists => Puppet::Util.which(existing_command) } => true,
       { :exists => "/this/file/does/not/exist" } => false,
       { :true => true, :exists => Puppet::Util.which(existing_command) } => true,
       { :true => true, :exists => "/this/file/does/not/exist" } => false,
-      { 'os.name' => Facter.value('os.name'),
+      { :operatingsystem => Facter.value(:operatingsystem),
         :exists => Puppet::Util.which(existing_command) } => true,
-      { 'os.name' => :yayness,
+      { :operatingsystem => :yayness,
         :exists => Puppet::Util.which(existing_command) } => false,
-      { 'os.name' => Facter.value('os.name'),
+      { :operatingsystem => Facter.value(:operatingsystem),
         :exists => "/this/file/does/not/exist" } => false,
-      { 'os.name' => :yayness,
+      { :operatingsystem => :yayness,
         :exists => "/this/file/does/not/exist" } => false,
     }.each do |confines, result|
       it "should confine #{confines.inspect} to #{result}" do
@@ -269,32 +269,32 @@ describe Puppet::Provider do
   end
 
   context "default providers" do
-    let :os do Facter.value('os.name') end
+    let :os do Facter.value(:operatingsystem) end
 
     it { is_expected.to respond_to :specificity }
 
     it "should find the default provider" do
       type.provide(:nondefault) {}
-      subject.defaultfor 'os.name' => os
+      subject.defaultfor :operatingsystem => os
       expect(subject.name).to eq(type.defaultprovider.name)
     end
 
     describe "regex matches" do
       it "should match a singular regex" do
-        expect(Facter).to receive(:value).with('os.family').at_least(:once).and_return("solaris")
+        expect(Facter).to receive(:value).with(:osfamily).at_least(:once).and_return("solaris")
 
         one = type.provide(:one) do
-          defaultfor 'os.family' => /solaris/
+          defaultfor :osfamily => /solaris/
         end
 
         expect(one).to be_default
       end
 
       it "should not match a non-matching regex " do
-        expect(Facter).to receive(:value).with('os.family').at_least(:once).and_return("redhat")
+        expect(Facter).to receive(:value).with(:osfamily).at_least(:once).and_return("redhat")
 
         one = type.provide(:one) do
-          defaultfor 'os.family' => /solaris/
+          defaultfor :osfamily => /solaris/
         end
 
         expect(one).to_not be_default
@@ -302,15 +302,15 @@ describe Puppet::Provider do
 
       it "should allow a mix of regex and string" do
 
-        expect(Facter).to receive(:value).with('os.name').at_least(:once).and_return("fedora")
-        expect(Facter).to receive(:value).with('os.release.major').at_least(:once).and_return("24")
+        expect(Facter).to receive(:value).with(:operatingsystem).at_least(:once).and_return("fedora")
+        expect(Facter).to receive(:value).with(:operatingsystemmajrelease).at_least(:once).and_return("24")
 
         one = type.provide(:one) do
-          defaultfor 'os.name' => "fedora", 'os.release.major' => /^2[2-9]$/
+          defaultfor :operatingsystem => "fedora", :operatingsystemmajrelease => /^2[2-9]$/
         end
 
         two = type.provide(:two) do
-          defaultfor 'os.name' => /fedora/, 'os.release.major' => '24'
+          defaultfor :operatingsystem => /fedora/, :operatingsystemmajrelease => '24'
         end
 
         expect(one).to be_default
@@ -320,21 +320,21 @@ describe Puppet::Provider do
 
     describe "when there are multiple defaultfor's of equal specificity" do
       before :each do
-        subject.defaultfor 'os.name' => :os1
-        subject.defaultfor 'os.name' => :os2
+        subject.defaultfor :operatingsystem => :os1
+        subject.defaultfor :operatingsystem => :os2
       end
 
       let(:alternate) { type.provide(:alternate) {} }
 
       it "should be default for the first defaultfor" do
-        expect(Facter).to receive(:value).with('os.name').at_least(:once).and_return(:os1)
+        expect(Facter).to receive(:value).with(:operatingsystem).at_least(:once).and_return(:os1)
 
         expect(provider).to be_default
         expect(alternate).not_to be_default
       end
 
       it "should be default for the last defaultfor" do
-        expect(Facter).to receive(:value).with('os.name').at_least(:once).and_return(:os2)
+        expect(Facter).to receive(:value).with(:operatingsystem).at_least(:once).and_return(:os2)
 
         expect(provider).to be_default
         expect(alternate).not_to be_default
@@ -343,31 +343,31 @@ describe Puppet::Provider do
 
     describe "when there are multiple defaultfor's with different specificity" do
       before :each do
-        subject.defaultfor 'os.name' => :os1
-        subject.defaultfor 'os.name' => :os2, 'os.release.major' => "42"
-        subject.defaultfor 'os.name' => :os3, 'os.release.major' => /^4[2-9]$/
+        subject.defaultfor :operatingsystem => :os1
+        subject.defaultfor :operatingsystem => :os2, :operatingsystemmajrelease => "42"
+        subject.defaultfor :operatingsystem => :os3, :operatingsystemmajrelease => /^4[2-9]$/
       end
 
       let(:alternate) { type.provide(:alternate) {} }
 
       it "should be default for a more specific, but matching, defaultfor" do
-        expect(Facter).to receive(:value).with('os.name').at_least(:once).and_return(:os2)
-        expect(Facter).to receive(:value).with('os.release.major').at_least(:once).and_return("42")
+        expect(Facter).to receive(:value).with(:operatingsystem).at_least(:once).and_return(:os2)
+        expect(Facter).to receive(:value).with(:operatingsystemmajrelease).at_least(:once).and_return("42")
 
         expect(provider).to be_default
         expect(alternate).not_to be_default
       end
 
       it "should be default for a more specific, but matching, defaultfor with regex" do
-        expect(Facter).to receive(:value).with('os.name').at_least(:once).and_return(:os3)
-        expect(Facter).to receive(:value).with('os.release.major').at_least(:once).and_return("42")
+        expect(Facter).to receive(:value).with(:operatingsystem).at_least(:once).and_return(:os3)
+        expect(Facter).to receive(:value).with(:operatingsystemmajrelease).at_least(:once).and_return("42")
 
         expect(provider).to be_default
         expect(alternate).not_to be_default
       end
 
       it "should be default for a less specific, but matching, defaultfor" do
-        expect(Facter).to receive(:value).with('os.name').at_least(:once).and_return(:os1)
+        expect(Facter).to receive(:value).with(:operatingsystem).at_least(:once).and_return(:os1)
 
         expect(provider).to be_default
         expect(alternate).not_to be_default
@@ -377,7 +377,7 @@ describe Puppet::Provider do
     it "should consider any true value enough to be default" do
       alternate = type.provide(:alternate) {}
 
-      subject.defaultfor 'os.name' => [:one, :two, :three, os]
+      subject.defaultfor :operatingsystem => [:one, :two, :three, os]
       expect(subject.name).to eq(type.defaultprovider.name)
 
       expect(subject).to be_default
@@ -386,29 +386,29 @@ describe Puppet::Provider do
 
     it "should not be default if the defaultfor doesn't match" do
       expect(subject).not_to be_default
-      subject.defaultfor 'os.name' => :one
+      subject.defaultfor :operatingsystem => :one
       expect(subject).not_to be_default
     end
 
     it "should not be default if the notdefaultfor does match" do
-      expect(Facter).to receive(:value).with('os.name').at_least(:once).and_return("fedora")
-      expect(Facter).to receive(:value).with('os.release.major').at_least(:once).and_return("24")
+      expect(Facter).to receive(:value).with(:operatingsystem).at_least(:once).and_return("fedora")
+      expect(Facter).to receive(:value).with(:operatingsystemmajrelease).at_least(:once).and_return("24")
 
       one = type.provide(:one) do
-        defaultfor 'os.name' => "fedora"
-        notdefaultfor 'os.name' => "fedora", 'os.release.major' => 24
+        defaultfor :operatingsystem => "fedora"
+        notdefaultfor :operatingsystem => "fedora", :operatingsystemmajrelease => 24
       end
 
       expect(one).not_to be_default
     end
 
     it "should be default if the notdefaultfor doesn't match" do
-      expect(Facter).to receive(:value).with('os.name').at_least(:once).and_return("fedora")
-      expect(Facter).to receive(:value).with('os.release.major').at_least(:once).and_return("24")
+      expect(Facter).to receive(:value).with(:operatingsystem).at_least(:once).and_return("fedora")
+      expect(Facter).to receive(:value).with(:operatingsystemmajrelease).at_least(:once).and_return("24")
 
       one = type.provide(:one) do
-        defaultfor 'os.name' => "fedora"
-        notdefaultfor 'os.name' => "fedora", 'os.release.major' => 42
+        defaultfor :operatingsystem => "fedora"
+        notdefaultfor :operatingsystem => "fedora", :operatingsystemmajrelease => 42
       end
 
       expect(one).to be_default
@@ -519,18 +519,18 @@ describe Puppet::Provider do
         end
 
         it "with the specification: %{spec}" % { spec: thisspec.join(', ') } do
-          allow(Facter).to receive(:value).with('os.family').and_return("redhat")
-          allow(Facter).to receive(:value).with('os.name').and_return("centos")
-          allow(Facter).to receive(:value).with('os.release.full').and_return("27")
+          allow(Facter).to receive(:value).with(:osfamily).and_return("redhat")
+          allow(Facter).to receive(:value).with(:operatingsystem).and_return("centos")
+          allow(Facter).to receive(:value).with(:operatingsystemrelease).and_return("27")
 
           one = type.provide(:one) do
             if defaultforspec[:one].key?(:defaultfor)
-              defaultfor    'os.family'       => "redhat" if  defaultforspec[:one][:defaultfor]
-              defaultfor    'os.family'       => "ubuntu" if !defaultforspec[:one][:defaultfor]
+              defaultfor    :osfamily               => "redhat" if  defaultforspec[:one][:defaultfor]
+              defaultfor    :osfamily               => "ubuntu" if !defaultforspec[:one][:defaultfor]
             end
             if defaultforspec[:one].key?(:notdefaultfor)
-              notdefaultfor 'os.name'         => "centos" if  defaultforspec[:one][:notdefaultfor]
-              notdefaultfor 'os.name'         => "ubuntu" if !defaultforspec[:one][:notdefaultfor]
+              notdefaultfor :operatingsystem        => "centos" if  defaultforspec[:one][:notdefaultfor]
+              notdefaultfor :operatingsystem        => "ubuntu" if !defaultforspec[:one][:notdefaultfor]
             end
           end
 
@@ -538,14 +538,14 @@ describe Puppet::Provider do
           provider_options[:parent] = one if defaultforspec[:two][:derived] # :two inherits from one, if spec'd
           two = type.provide(:two, provider_options) do
             if defaultforspec[:two].key?(:defaultfor) || defaultforspec[:two].key?(:extradefaultfor)
-              defaultfor    'os.family'       => "redhat" if  defaultforspec[:two][:defaultfor]
-              defaultfor    'os.family'       => "redhat",#   defaultforspec[:two][:extradefaultfor] has two parts
-                            'os.name'         => "centos" if  defaultforspec[:two][:extradefaultfor]
-              defaultfor    'os.family'       => "ubuntu" if !defaultforspec[:two][:defaultfor]
+              defaultfor    :osfamily               => "redhat" if  defaultforspec[:two][:defaultfor]
+              defaultfor    :osfamily               => "redhat",#   defaultforspec[:two][:extradefaultfor] has two parts
+                            :operatingsystem        => "centos" if  defaultforspec[:two][:extradefaultfor]
+              defaultfor    :osfamily               => "ubuntu" if !defaultforspec[:two][:defaultfor]
             end
             if defaultforspec[:two].key?(:notdefaultfor)
-              notdefaultfor 'os.release.full' => "27" if  defaultforspec[:two][:notdefaultfor]
-              notdefaultfor 'os.release.full' => "99" if !defaultforspec[:two][:notdefaultfor]
+              notdefaultfor :operatingsystemrelease => "27" if  defaultforspec[:two][:notdefaultfor]
+              notdefaultfor :operatingsystemrelease => "99" if !defaultforspec[:two][:notdefaultfor]
             end
           end
 

--- a/spec/unit/type/package_spec.rb
+++ b/spec/unit/type/package_spec.rb
@@ -370,9 +370,9 @@ describe Puppet::Type.type(:package) do
   it "should select dnf over yum for dnf supported fedora versions" do
     dnf = Puppet::Type.type(:package).provider(:dnf)
     yum = Puppet::Type.type(:package).provider(:yum)
-    allow(Facter).to receive(:value).with('os.family').and_return(:redhat)
-    allow(Facter).to receive(:value).with('os.name').and_return(:fedora)
-    allow(Facter).to receive(:value).with('os.release.major').and_return("22")
+    allow(Facter).to receive(:value).with(:osfamily).and_return(:redhat)
+    allow(Facter).to receive(:value).with(:operatingsystem).and_return(:fedora)
+    allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return("22")
 
     expect(dnf.specificity).to be > yum.specificity
   end

--- a/spec/unit/type/resources_spec.rb
+++ b/spec/unit/type/resources_spec.rb
@@ -124,8 +124,8 @@ describe resources do
       context "on #{os}" do
         before :each do
           allow(Facter).to receive(:value).with(:kernel).and_return(os)
-          allow(Facter).to receive(:value).with('os.name').and_return(os)
-          allow(Facter).to receive(:value).with('os.family').and_return(os)
+          allow(Facter).to receive(:value).with(:operatingsystem).and_return(os)
+          allow(Facter).to receive(:value).with(:osfamily).and_return(os)
           allow(Puppet::FileSystem).to receive(:exist?).with('/etc/login.defs').and_return(false)
           @res = Puppet::Type.type(:resources).new :name => :user, :purge => true, :unless_system_user => true
           @res.catalog = Puppet::Resource::Catalog.new

--- a/spec/unit/type_spec.rb
+++ b/spec/unit/type_spec.rb
@@ -1142,7 +1142,7 @@ describe Puppet::Type, :unless => Puppet::Util::Platform.windows? do
 
       before :each do
         type.provide(:default) do
-          defaultfor 'os.name' => Facter.value('os.name')
+          defaultfor :operatingsystem => Facter.value(:operatingsystem)
           mk_resource_methods
           class << self
             attr_accessor :params
@@ -1172,7 +1172,7 @@ describe Puppet::Type, :unless => Puppet::Util::Platform.windows? do
     context "with a default provider" do
       before :each do
         type.provide(:default) do
-          defaultfor 'os.name' => Facter.value('os.name')
+          defaultfor :operatingsystem => Facter.value(:operatingsystem)
           mk_resource_methods
           class << self
             attr_accessor :names

--- a/tasks/parallel.rake
+++ b/tasks/parallel.rake
@@ -401,7 +401,7 @@ else
       # Default group size in rspec examples
       DEFAULT_GROUP_SIZE = 1000
 
-      process_count = [(args[:process_count] || Facter.value('processors.count')).to_i, 1].max
+      process_count = [(args[:process_count] || Facter.value("processorcount")).to_i, 1].max
       group_size = [(args[:group_size] || DEFAULT_GROUP_SIZE).to_i, 1].max
 
       abort unless Parallel::RSpec::Parallelizer.new(process_count, group_size, color_output?, args.extras).run


### PR DESCRIPTION
…gacy-facts"

This reverts commit 8660b32739ada447e32722f1e92e7086ce28737c, reversing
changes made to c6412ea369aa1613ca166b10fb819fcf6130814b.

This also sneakily reverts e972610daa450d1ff083d159506c5c1275837636 by
switching back to using legacy facts.

When/If we decide to reintroduce this functionality, it should be enough
to revert this revert.