### PR TITLE
(PUP-10947) Modify the exclude list for `puppet facts diff`

### DIFF
--- a/lib/puppet/face/facts.rb
+++ b/lib/puppet/face/facts.rb
@@ -2,28 +2,20 @@ require 'puppet/indirector/face'
 require 'puppet/node/facts'
 require 'puppet/util/fact_dif'
 
-EXCLUDE_LIST = %w[facterversion
-  swapfree_mb swapsize_mb
-  load_averages\.*
-  memory\.swap\.available_bytes memory\.swap\.capacity memory\.swap\.total_bytes
-  memory\.swap\.used_bytes memory\.swap\.available
-  memory\.system\.available memory\.system\.available_bytes memory\.system\.capacity memory\.swap\.used
-  memory\.system\.total_bytes memory\.system\.used memory\.system\.used_bytes
-  memoryfree memoryfree_mb memorysize_mb
-  mountpoints\..* mtu_.* mountpoints\..*\.capacity
-  networking\.interfaces\..*\.mtu networking\.mtu partitions\..*\.filesystem
-  partitions\..*\.size_bytes partitions\..*\.mount partitions\..*\.uuid
-  disks\..*\.size_bytes
-  hypervisors\.lpar\.partition_number hypervisors\.xen\.privileged hypervisors\.zone\..* hypervisors\.ldom\..*
+EXCLUDE_LIST = %w[ facterversion
+  load_averages\..*
   processors\.speed
-  ldom_.*
-  boardassettag dmi\.board\.asset_tag
-  blockdevice_.*_vendor blockdevice_.*_size
-  system_uptime\.days system_uptime\.hours system_uptime\.seconds system_uptime\.uptime
-  uptime_days uptime_hours uptime_seconds
-  system_profiler\.uptime
-  sp_uptime
-  uptime]
+  swapfree swapfree_mb
+  memoryfree memoryfree_mb
+  memory\.swap\.available_bytes memory\.swap\.used_bytes
+  memory\.swap\.available memory\.swap\.capacity memory\.swap\.used
+  memory\.system\.available_bytes memory\.system\.used_bytes
+  memory\.system\.available memory\.system\.capacity memory\.system\.used
+  mountpoints\..*\.available* mountpoints\..*\.capacity mountpoints\..*\.used*
+  sp_uptime system_profiler\.uptime
+  uptime uptime_days uptime_hours uptime_seconds
+  system_uptime\.uptime system_uptime\.days system_uptime\.hours system_uptime\.seconds
+]
 
 Puppet::Indirector::Face.define(:facts, '0.0.1') do
   copyright "Puppet Inc.", 2011

--- a/lib/puppet/util/fact_dif.rb
+++ b/lib/puppet/util/fact_dif.rb
@@ -57,6 +57,6 @@ class FactDif
   end
 
   def excluded?(fact_name)
-    @exclude_list.any? {|excluded_fact| fact_name =~ /#{excluded_fact}/}
+    @exclude_list.any? {|excluded_fact| fact_name =~ /^#{excluded_fact}$/}
   end
 end


### PR DESCRIPTION
This commit updates the exclude list for `puppet facts diff` by removing non-volatile facts and adding missed ones that were discovered while running the command on all of our available platforms.

Results from above tests were taken and processed as follows:

- The initial exclude list was (49 in total): `facterversion`, `swapfree_mb`, `swapsize_mb`, `load_averages\.*`, `memory\.swap\.available_bytes`, `memory\.swap\.capacity`, `memory\.swap\.total_bytes`, `memory\.swap\.used_bytes`, `memory\.swap\.available`, `memory\.system\.available`, `memory\.system\.available_bytes`, `memory\.system\.capacity`, `memory\.swap\.used`, `memory\.system\.total_bytes`, `memory\.system\.used`, `memory\.system\.used_bytes`, `memoryfree`, `memoryfree_mb`, `memorysize_mb`, `mountpoints\..*`, `mtu_.*`, `mountpoints\..*\.capacity`, `networking\.interfaces\..*\.mtu`, `networking\.mtu`, `partitions\..*\.filesystem`, `partitions\..*\.size_bytes`, `partitions\..*\.mount`, `partitions\..*\.uuid`, `disks\..*\.size_bytes`, `hypervisors\.lpar\.partition_number`, `hypervisors\.xen\.privileged`, `hypervisors\.zone\..*`, `hypervisors\.ldom\..*`, `processors\.speed`, `ldom_.*`, `boardassettag`, `dmi\.board\.asset_tag`, `blockdevice_.*_vendor`, `blockdevice_.*_size`, `system_uptime\.days`, `system_uptime\.hours`, `system_uptime\.seconds`, `system_uptime\.uptime`, `uptime_days`, `uptime_hours`, `uptime_seconds`, `system_profiler\.uptime`, `sp_uptime`, `uptime`

- [1] Was caught being used with initial exclude list (24 in total): `facterversion`, `swapfree_mb`, `swapsize_mb`, `load_averages\..*`, `memory\.swap\.available_bytes`, `memory\.swap\.capacity`, `memory\.swap\.used_bytes`, `memory\.swap\.available`, `memory\.system\.available`, `memory\.system\.available_bytes`, `memory\.system\.capacity`, `memory\.swap\.used`, `memory\.system\.used`, `memory\.system\.used_bytes`, `memoryfree`, `memoryfree_mb`, `memorysize_mb`, `mountpoints\..*`, `mountpoints\..*\.capacity`, `processors\.speed`, `system_uptime\.seconds`, `system_uptime\.uptime`, `uptime_seconds`, `uptime`

- Was not caught being used with initial exclude list (25 in total): `memory\.swap\.total_bytes`, `memory\.system\.total_bytes`, `mtu_.*`, `networking\.interfaces\..*\.mtu`, `networking\.mtu`, `partitions\..*\.filesystem`, `partitions\..*\.size_bytes`, `partitions\..*\.mount`, `partitions\..*\.uuid`, `disks\..*\.size_bytes`, `hypervisors\.lpar\.partition_number`, `hypervisors\.xen\.privileged`, `hypervisors\.zone\..*`, `hypervisors\.ldom\..*`, `ldom_.*`, `boardassettag`, `dmi\.board\.asset_tag`, `blockdevice_.*_vendor`, `blockdevice_.*_size`, `system_uptime\.days`, `system_uptime\.hours`, `uptime_days`, `uptime_hours`, `system_profiler\.uptime`, `sp_uptime`

- [2] After selecting using the volatile facts containing the keywords `memory`, `bytes` and `uptime` from the list of unused above, we got (10 in total): `memory\.swap\.total_bytes`, `memory\.system\.total_bytes`, `partitions\..*\.size_bytes`, `disks\..*\.size_bytes`, `system_uptime\.days`, `system_uptime\.hours`, `uptime_days`, `uptime_hours`, `system_profiler\.uptime`, `sp_uptime`

- [3] Facts found with differences and not caught by current exclude list (7 in total):

```json
"network6_lo0":
{
  "new_value": "::1",
  "old_value": "::"
},
"networking.interfaces.lo0.bindings6.0.network":
{
  "new_value": "::1",
  "old_value": "::"
},
"networking.interfaces.lo0.network6":
{
  "new_value": "::1",
  "old_value": "::"
},
"swapfree":
{
  "new_value": "502.72 MiB",
  "old_value": "502.71 MiB"
},
"hypervisors.vmware.version":
{
  "new_value": "ESXi 6.7",
  "old_value": ""
}
```

- By combining [1], [2] and [3] (only volatile: `swapfree`) from above (35 in total):  

```
  facterversion
  load_averages\..*
  disks\..*\.size_bytes
  memorysize_mb
  swapfree swapfree_mb swapsize_mb
  memoryfree memoryfree_mb
  memory\.swap\.available memory\.swap\.capacity memory\.swap\.used
  memory\.swap\.available_bytes memory\.swap\.total_bytes memory\.swap\.used_bytes
  memory\.system\.available memory\.system\.capacity memory\.system\.used 
  memory\.system\.available_bytes memory\.system\.total_bytes memory\.system\.used_bytes
  mountpoints\..*
  processors\.speed
  partitions\..*\.size_bytes
  sp_uptime system_profiler\.uptime
  uptime uptime_days uptime_hours uptime_seconds
  system_uptime\.uptime system_uptime\.days system_uptime\.hours system_uptime\.seconds
```

- The proposed exclude list, with proposals from @joshcooper included,  we get to (30 in total):
```
  facterversion
  load_averages\..*
  processors\.speed
  swapfree swapfree_mb
  memoryfree memoryfree_mb
  memory\.swap\.available_bytes memory\.swap\.used_bytes
  memory\.swap\.available memory\.swap\.capacity memory\.swap\.used
  memory\.system\.available_bytes memory\.system\.used_bytes
  memory\.system\.available memory\.system\.capacity memory\.system\.used 
  mountpoints\..*\.available* mountpoints\..*\.capacity mountpoints\..*\.used* 
  sp_uptime system_profiler\.uptime
  uptime uptime_days uptime_hours uptime_seconds
  system_uptime\.uptime system_uptime\.days system_uptime\.hours system_uptime\.seconds
```

Also modified the `excluded?` method to match fact names from beginning to end. Otherwise, `uptime`, `memoryfree` and `swapfree` would make the specific patterns `sp_uptime`, `system_profiler\.uptime`, `system_uptime\.days`, `system_uptime\.hours`, `system_uptime\.seconds`, `system_uptime\.uptime`, `uptime_days`, `uptime_hours`, `uptime_seconds`, `memoryfree_mb` and `swapfree_mb` obsolete and could match unwanted facts in the future.