### PR TITLE
(docs) mark documentation examples in lib/puppet/functions.rb as source code

### DIFF
--- a/lib/puppet/functions/partition.rb
+++ b/lib/puppet/functions/partition.rb
@@ -5,13 +5,21 @@
 Puppet::Functions.create_function(:partition) do
   # @param collection A collection of things to partition.
   # @example Partition array of empty strings, results in e.g. [[''], [b, c]]
+  #   ```puppet
   #   ['', b, c].partition |$s| { $s.empty }
+  #   ```
   # @example Partition array of strings using index, results in e.g. [['', 'ab'], ['b']]
+  #   ```puppet
   #   ['', b, ab].partition |$i, $s| { $i == 2 or $s.empty }
+  #   ```
   # @example Partition hash of strings by key-value pair, results in e.g. [[['b', []]], [['a', [1, 2]]]]
+  #   ```puppet
   #   { a => [1, 2], b => [] }.partition |$kv| { $kv[1].empty }
+  #   ```
   # @example Partition hash of strings by key and value, results in e.g. [[['b', []]], [['a', [1, 2]]]]
+  #   ```puppet
   #   { a => [1, 2], b => [] }.partition |$k, $v| { $v.empty }
+  #   ```
   dispatch :partition_1 do
     required_param 'Collection', :collection
     block_param 'Callable[1,1]', :block


### PR DESCRIPTION
The `|` (pipe character) in the examples given in `lib/puppet/functions.rb` are currently rendered in https://puppet.com/docs/puppet/latest/function.html#partition as _table_ _cell_ _dividers_, but it’s supposed to be Puppet source code.