### PR TITLE
(maint) merge 6.x to main

### DIFF
--- a/acceptance/tests/agent/agent_disable_lockfile.rb
+++ b/acceptance/tests/agent/agent_disable_lockfile.rb
@@ -2,7 +2,7 @@ test_name "C4553 - agent --disable/--enable functionality should manage the agen
 tag 'audit:integration', # lockfile uses the standard `vardir` location to store/query lockfile.
                          # The validation of the `vardir` at the OS level
                          # should be accomplished in another test.
-    'audit:medium',
+    'audit:high',
     'audit:refactor'     # This test should not require a master. Remove the use of `with_puppet_running_on`.
 
 #

--- a/acceptance/tests/agent/agent_parses_json_catalog.rb
+++ b/acceptance/tests/agent/agent_parses_json_catalog.rb
@@ -1,6 +1,6 @@
 test_name "C99978: Agent parses a JSON catalog"
 
-tag 'risk:medium',
+tag 'risk:high',
     'audit:high',        # tests defined catalog format
     'audit:integration', # There is no OS specific risk here.
     'server',

--- a/acceptance/tests/agent/fallback_to_cached_catalog.rb
+++ b/acceptance/tests/agent/fallback_to_cached_catalog.rb
@@ -1,6 +1,6 @@
 test_name "fallback to the cached catalog"
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:integration', # This test is not OS sensitive.
     'audit:refactor'     # A catalog fixture can be used for this test. Remove the usage of `with_puppet_running_on`.
 

--- a/acceptance/tests/aix/aix_package_provider.rb
+++ b/acceptance/tests/aix/aix_package_provider.rb
@@ -1,6 +1,6 @@
 test_name "aix package provider should work correctly" do
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:acceptance'  # OS specific by definition.
 
   confine :to, :platform => /aix/
@@ -38,8 +38,8 @@ test_name "aix package provider should work correctly" do
 
   step "download packages to use for test" do
     on hosts, "mkdir -p #{dir}"
-    on hosts, "curl neptune.puppetlabs.lan/misc/sudo.#{version1}.aix51.lam.bff > #{dir}/sudo.#{version1}.aix51.lam.bff"
-    on hosts, "curl neptune.puppetlabs.lan/misc/sudo.#{version2}.aix51.lam.bff > #{dir}/sudo.#{version2}.aix51.lam.bff"
+    on hosts, "curl https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/misc/sudo.#{version1}.aix51.lam.bff > #{dir}/sudo.#{version1}.aix51.lam.bff"
+    on hosts, "curl https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/misc/sudo.#{version2}.aix51.lam.bff > #{dir}/sudo.#{version2}.aix51.lam.bff"
   end
 
   step "install the older version of package" do

--- a/acceptance/tests/aix/nim_package_provider.rb
+++ b/acceptance/tests/aix/nim_package_provider.rb
@@ -1,6 +1,6 @@
 test_name "NIM package provider should work correctly"
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:acceptance'  # OS specific by definition
 
 # nim test is slow, confine to only aix 7.2 and recent puppet versions

--- a/acceptance/tests/allow_arbitrary_node_name_fact_for_agent.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_fact_for_agent.rb
@@ -1,6 +1,6 @@
 test_name "node_name_fact should be used to determine the node name for puppet agent"
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:integration',  # Tests that the server properly overrides certname with node_name fact.
                           # Testing of passenger master is no longer needed.
     'server'

--- a/acceptance/tests/allow_arbitrary_node_name_for_agent.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_for_agent.rb
@@ -1,6 +1,6 @@
 test_name "node_name_value should be used as the node name for puppet agent"
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:integration',  # Tests that the server properly overrides certname with node_name fact.
                           # Testing of passenger master is no longer needed.
     'server'

--- a/acceptance/tests/catalog_with_binary_data.rb
+++ b/acceptance/tests/catalog_with_binary_data.rb
@@ -6,7 +6,7 @@ test_name "C100300: Catalog containing binary data is applied correctly" do
   require 'puppet/acceptance/agent_fqdn_utils'
   extend Puppet::Acceptance::AgentFqdnUtils
 
-  tag 'risk:medium',
+  tag 'risk:high',
       'server'
 
   test_num        = 'c100300'

--- a/acceptance/tests/direct_puppet/cached_catalog_remediate_local_drift.rb
+++ b/acceptance/tests/direct_puppet/cached_catalog_remediate_local_drift.rb
@@ -3,7 +3,7 @@ extend Puppet::Acceptance::StaticCatalogUtils
 
 test_name "PUP-5122: Puppet remediates local drift using code_id and content_uri" do
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:acceptance',
       'audit:refactor',  # use mk_tmp_environment_with_teardown helper for environment construction
       'server'

--- a/acceptance/tests/direct_puppet/catalog_uuid_correlates_catalogs_with_reports.rb
+++ b/acceptance/tests/direct_puppet/catalog_uuid_correlates_catalogs_with_reports.rb
@@ -1,6 +1,6 @@
 test_name "PUP-5872: catalog_uuid correlates catalogs with reports" do
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:acceptance',
       'audit:refactor'    # remove dependence on server by adding a
                           # catalog and report fixture to validate against.

--- a/acceptance/tests/direct_puppet/supports_utf8.rb
+++ b/acceptance/tests/direct_puppet/supports_utf8.rb
@@ -6,7 +6,7 @@ test_name "C97172: static catalogs support utf8" do
   require 'puppet/acceptance/agent_fqdn_utils'
   extend Puppet::Acceptance::AgentFqdnUtils
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:acceptance',
       'audit:refactor'  # Review for agent side UTF validation.
 

--- a/acceptance/tests/environment/broken_unassigned_environment_handled_gracefully.rb
+++ b/acceptance/tests/environment/broken_unassigned_environment_handled_gracefully.rb
@@ -1,6 +1,6 @@
 test_name 'PUP-3755 Test an un-assigned broken environment'
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:integration',
     'audit:refactor',     # Use mk_temp_environment_with_teardown helper
     'server'

--- a/acceptance/tests/environment/custom_type_provider_from_same_environment.rb
+++ b/acceptance/tests/environment/custom_type_provider_from_same_environment.rb
@@ -2,7 +2,7 @@ test_name 'C59122: ensure provider from same env as custom type' do
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:integration',  # This behavior is specific to the master to 'do the right thing'
     'server'
 

--- a/acceptance/tests/environment/directory_environment_production_created_master.rb
+++ b/acceptance/tests/environment/directory_environment_production_created_master.rb
@@ -1,6 +1,6 @@
 test_name 'ensure production environment created by master if missing'
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:integration',
     'server'
 

--- a/acceptance/tests/environment/enc_nonexistent_directory_environment.rb
+++ b/acceptance/tests/environment/enc_nonexistent_directory_environment.rb
@@ -2,7 +2,7 @@ test_name "Master should produce error if enc specifies a nonexistent environmen
   require 'puppet/acceptance/classifier_utils.rb'
   extend Puppet::Acceptance::ClassifierUtils
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:unit',
       'server'
 

--- a/acceptance/tests/environment/environment_scenario-bad.rb
+++ b/acceptance/tests/environment/environment_scenario-bad.rb
@@ -4,7 +4,7 @@ test_name 'Test behavior of directory environments when environmentpath is set t
   require 'puppet/acceptance/classifier_utils'
   extend Puppet::Acceptance::ClassifierUtils
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:unit', # The error responses for the agent should be covered by Ruby unit tests.
       # The server 404/400 response should be covered by server integration tests.
       'server'

--- a/acceptance/tests/environment/negative/agent_run_should_fail_if_env_unreadable.rb
+++ b/acceptance/tests/environment/negative/agent_run_should_fail_if_env_unreadable.rb
@@ -1,6 +1,6 @@
 test_name "C97899 - Agent run should fail if environment is unreadable" do
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:integration',
       'audit:refactor', # use mk_temp_environment_with_teardown
       'server'

--- a/acceptance/tests/environment/negative/agent_run_should_fail_if_site_pp_unreadable.rb
+++ b/acceptance/tests/environment/negative/agent_run_should_fail_if_site_pp_unreadable.rb
@@ -1,6 +1,6 @@
 test_name "C98160 - Agent run should fail if an environment's site.pp is unreadable" do
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:integration',
       'audit:refactor', # use mk_temp_environment_with_teardown
       'server'

--- a/acceptance/tests/environment/use_agent_environment_when_enc_doesnt_specify.rb
+++ b/acceptance/tests/environment/use_agent_environment_when_enc_doesnt_specify.rb
@@ -2,7 +2,7 @@ test_name "Agent should use agent environment if there is an enc that does not s
   require 'puppet/acceptance/classifier_utils'
   extend Puppet::Acceptance::ClassifierUtils
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:integration',
       'server'
 

--- a/acceptance/tests/environment/use_agent_environment_when_no_enc.rb
+++ b/acceptance/tests/environment/use_agent_environment_when_no_enc.rb
@@ -1,6 +1,6 @@
 test_name "Agent should use agent environment if there is no enc-specified environment" do
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:integration',
       'audit:refactor', # This can be combined with use_agent_environment_when_enc_doesnt_specify test
       'server'

--- a/acceptance/tests/environment/use_enc_environment.rb
+++ b/acceptance/tests/environment/use_enc_environment.rb
@@ -2,7 +2,7 @@ test_name 'Agent should use environment given by ENC and only compile a catalog 
   require 'puppet/acceptance/classifier_utils.rb'
   extend Puppet::Acceptance::ClassifierUtils
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:integration',
       'server'
 

--- a/acceptance/tests/environment/use_enc_environment_for_pluginsync.rb
+++ b/acceptance/tests/environment/use_enc_environment_for_pluginsync.rb
@@ -1,6 +1,6 @@
 test_name "Agent should use environment given by ENC for pluginsync" do
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:integration',
       'audit:refactor', # This test should be rolled into use_enc_environment
       'server'

--- a/acceptance/tests/environment/use_environment_from_environmentpath.rb
+++ b/acceptance/tests/environment/use_environment_from_environmentpath.rb
@@ -2,7 +2,7 @@ test_name "Use environments from the environmentpath" do
   require 'puppet/acceptance/classifier_utils'
   extend Puppet::Acceptance::ClassifierUtils
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:integration',
       'server'
 

--- a/acceptance/tests/face/4654_facts_face.rb
+++ b/acceptance/tests/face/4654_facts_face.rb
@@ -1,6 +1,6 @@
 test_name "Puppet facts face should resolve custom and external facts"
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:integration'   # The facter acceptance tests should be acceptance.
                           # However, the puppet face merely needs to interact with libfacter.
                           # So, this should be an integration test.

--- a/acceptance/tests/face/loadable_from_modules.rb
+++ b/acceptance/tests/face/loadable_from_modules.rb
@@ -3,7 +3,7 @@ test_name "Exercise loading a face from a module"
 # Because the module tool does not work on windows, we can't run this test there
 confine :except, :platform => 'windows'
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:acceptance',    # This has been OS sensitive.
     'audit:refactor'       # Remove the confine against windows and refactor to
                            # accommodate the Windows platform.

--- a/acceptance/tests/face/parser_validate.rb
+++ b/acceptance/tests/face/parser_validate.rb
@@ -1,6 +1,6 @@
 test_name 'parser validate' do
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:unit'   # Parser validation should be core to ruby
                    # and platform agnostic.
 

--- a/acceptance/tests/language/exported_resources.rb
+++ b/acceptance/tests/language/exported_resources.rb
@@ -2,7 +2,7 @@ test_name "C94788: exported resources using a yaml terminus for storeconfigs" do
 require 'puppet/acceptance/environment_utils'
 extend Puppet::Acceptance::EnvironmentUtils
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:integration',
     'audit:refactor',     # This could be a component of a larger workflow scenario.
     'server'

--- a/acceptance/tests/language/pcore_generate_env_isolation.rb
+++ b/acceptance/tests/language/pcore_generate_env_isolation.rb
@@ -2,7 +2,7 @@ test_name 'C98345: ensure puppet generate assures env. isolation' do
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:integration',
     'server'
 

--- a/acceptance/tests/language/pcore_resource_types_should_have_precedence_over_ruby.rb
+++ b/acceptance/tests/language/pcore_resource_types_should_have_precedence_over_ruby.rb
@@ -1,6 +1,6 @@
 test_name 'C98097 - generated pcore resource types should be loaded instead of ruby for custom types' do
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:integration',
     'audit:refactor',    # use `mk_temp_environment_with_teardown` helper to build environment
     'server'

--- a/acceptance/tests/language/return.rb
+++ b/acceptance/tests/language/return.rb
@@ -1,6 +1,6 @@
 test_name 'C98162 - Validate `return` immediately returns from a block of code' do
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:unit'
 
   agents.each do |agent|

--- a/acceptance/tests/language/server_set_facts.rb
+++ b/acceptance/tests/language/server_set_facts.rb
@@ -2,7 +2,7 @@ test_name 'C64667: ensure server_facts is set and error if any value is overwrit
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:acceptance', # Validating server/client interaction
     'server'
 

--- a/acceptance/tests/loader/autoload_from_resource_type_decl.rb
+++ b/acceptance/tests/loader/autoload_from_resource_type_decl.rb
@@ -1,5 +1,5 @@
 test_name 'C100303: Resource type statement triggered auto-loading works both with and without generated types' do
-  tag 'risk:medium'
+  tag 'risk:high'
 
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils

--- a/acceptance/tests/loader/func4x_loadable_from_modules.rb
+++ b/acceptance/tests/loader/func4x_loadable_from_modules.rb
@@ -20,7 +20,7 @@ test_name "Exercise a module with 4x function and 4x system function"
 require 'puppet/acceptance/temp_file_utils'
 extend Puppet::Acceptance::TempFileUtils
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:unit'    # This should be covered adequately by unit tests
 
 initialize_temp_dirs

--- a/acceptance/tests/loader/resource_triggers_autoload.rb
+++ b/acceptance/tests/loader/resource_triggers_autoload.rb
@@ -1,5 +1,5 @@
 test_name 'C100296: can auto-load defined types using a Resource statement' do
-  tag 'risk:medium'
+  tag 'risk:high'
 
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils

--- a/acceptance/tests/lookup/config3_interpolation.rb
+++ b/acceptance/tests/lookup/config3_interpolation.rb
@@ -2,7 +2,7 @@ test_name 'C99578: lookup should allow interpolation in hiera3 configs' do
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:integration',
     'audit:refactor',  # This test specifically tests interpolation on the master.
                        # Recommend adding an additonal test that validates

--- a/acceptance/tests/lookup/config5_interpolation.rb
+++ b/acceptance/tests/lookup/config5_interpolation.rb
@@ -2,7 +2,7 @@ test_name 'C99578: hiera5 lookup config with interpolated scoped nested variable
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:integration',
     'audit:refactor',  # This test specifically tests interpolation on the master.
                        # Recommend adding an additonal test that validates

--- a/acceptance/tests/lookup/hiera3_custom_backend.rb
+++ b/acceptance/tests/lookup/hiera3_custom_backend.rb
@@ -4,7 +4,7 @@ test_name 'C99630: hiera v3 custom backend' do
   require 'puppet/acceptance/temp_file_utils.rb'
   extend Puppet::Acceptance::TempFileUtils
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:acceptance',
     'audit:refactor',  # Master is not needed for this test. Refactor
                        # to use puppet apply with a local module tree.

--- a/acceptance/tests/lookup/lookup_rich_values.rb
+++ b/acceptance/tests/lookup/lookup_rich_values.rb
@@ -2,7 +2,7 @@ test_name 'C99044: lookup should allow rich data as values' do
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:acceptance',
     'audit:refactor',  # Master is not needed for this test. Refactor
                        # to use puppet apply with a local environment.

--- a/acceptance/tests/lookup/merge_strategies.rb
+++ b/acceptance/tests/lookup/merge_strategies.rb
@@ -2,7 +2,7 @@ test_name 'C99903: merge strategies' do
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:acceptance',
     'audit:refactor',  # Master is not needed for this test. Refactor
                        # to use puppet apply with a local module tree.

--- a/acceptance/tests/lookup/v3_config_and_data.rb
+++ b/acceptance/tests/lookup/v3_config_and_data.rb
@@ -2,7 +2,7 @@ test_name 'C99629: hiera v5 can use v3 config and data' do
   require 'puppet/acceptance/environment_utils.rb'
   extend Puppet::Acceptance::EnvironmentUtils
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:acceptance',
     'audit:refactor',  # Master is not needed for this test. Refactor
                        # to use puppet apply with a local module tree.

--- a/acceptance/tests/lookup/v4_hieradata_with_v5_configs.rb
+++ b/acceptance/tests/lookup/v4_hieradata_with_v5_configs.rb
@@ -2,7 +2,7 @@ test_name 'C99572: v4 hieradata with v5 configs' do
   require 'puppet/acceptance/puppet_type_test_tools.rb'
   extend Puppet::Acceptance::PuppetTypeTestTools
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:acceptance',
     'audit:refactor',  # Master is not needed for this test. Refactor
                        # to use puppet apply with a local module tree.

--- a/acceptance/tests/modulepath.rb
+++ b/acceptance/tests/modulepath.rb
@@ -1,5 +1,5 @@
 test_name 'Supports vendored modules' do
-  tag 'risk:medium'
+  tag 'risk:high'
 
   # beacon custom type emits a message so we can tell where the
   # type was loaded from, e.g. vendored, global, and whether the

--- a/acceptance/tests/modules/changes/invalid_module_install_path.rb
+++ b/acceptance/tests/modules/changes/invalid_module_install_path.rb
@@ -1,6 +1,6 @@
 test_name 'puppet module changes (on an invalid module install path)'
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:acceptance',
     'audit:refactor'   # Master is not requiered for this test. Replace with agents.each
                        # Wrap steps in blocks in accordance with Beaker style guide

--- a/acceptance/tests/modules/changes/missing_checksums_json.rb
+++ b/acceptance/tests/modules/changes/missing_checksums_json.rb
@@ -1,6 +1,6 @@
 test_name 'puppet module changes (on a module which is missing checksums.json)'
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:acceptance',
     'audit:refactor'   # Master is not required for this test. Replace with agents.each
                        # Wrap steps in blocks in accordance with Beaker style guide

--- a/acceptance/tests/modules/changes/missing_metadata_json.rb
+++ b/acceptance/tests/modules/changes/missing_metadata_json.rb
@@ -1,6 +1,6 @@
 test_name 'puppet module changes (on a module which is missing metadata.json)'
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:acceptance',
     'audit:refactor'   # Master is not required for this test. Replace with agents.each
                        # Wrap steps in blocks in accordance with Beaker style guide

--- a/acceptance/tests/modules/changes/module_with_modified_file.rb
+++ b/acceptance/tests/modules/changes/module_with_modified_file.rb
@@ -1,6 +1,6 @@
 test_name 'puppet module changes (on a module with a modified file)'
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:acceptance',
     'audit:refactor'   # Master is not required for this test. Replace with agents.each
                        # Wrap steps in blocks in accordance with Beaker style guide

--- a/acceptance/tests/modules/changes/module_with_removed_file.rb
+++ b/acceptance/tests/modules/changes/module_with_removed_file.rb
@@ -1,6 +1,6 @@
 test_name 'puppet module changes (on a module with a removed file)'
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:acceptance',
     'audit:refactor'   # Master is not required for this test. Replace with agents.each
                        # Wrap steps in blocks in accordance with Beaker style guide

--- a/acceptance/tests/modules/changes/unmodified_module.rb
+++ b/acceptance/tests/modules/changes/unmodified_module.rb
@@ -1,6 +1,6 @@
 test_name 'puppet module changes (on an unmodified module)'
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:acceptance',
     'audit:refactor'   # Master is not required for this test. Replace with agents.each
                        # Wrap steps in blocks in accordance with Beaker style guide

--- a/acceptance/tests/modules/list/with_environment.rb
+++ b/acceptance/tests/modules/list/with_environment.rb
@@ -1,7 +1,7 @@
 test_name 'puppet module list (with environment)'
 
 tag 'server',
-    'audit:medium',
+    'audit:high',
     'audit:acceptance',
     'audit:refactor'   # Master is not required for this test. Replace with agents.each
                        # Wrap steps in blocks in accordance with Beaker style guide

--- a/acceptance/tests/ordering/master_agent_application.rb
+++ b/acceptance/tests/ordering/master_agent_application.rb
@@ -1,6 +1,6 @@
 test_name "Puppet applies resources without dependencies in file order over the network"
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:integration',
     'server'
 

--- a/acceptance/tests/parser_functions/calling_all_functions.rb
+++ b/acceptance/tests/parser_functions/calling_all_functions.rb
@@ -1,6 +1,6 @@
 test_name 'Calling all functions.. test in progress!'
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:acceptance'
 
 # create single manifest calling all functions

--- a/acceptance/tests/parser_functions/hiera/lookup_data.rb
+++ b/acceptance/tests/parser_functions/hiera/lookup_data.rb
@@ -1,6 +1,6 @@
 test_name "Lookup data using the hiera parser function"
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:acceptance',
     'audit:refactor'    # Master is not required for this test. Replace with agents.each
 

--- a/acceptance/tests/parser_functions/hiera_array/lookup_data.rb
+++ b/acceptance/tests/parser_functions/hiera_array/lookup_data.rb
@@ -1,6 +1,6 @@
 test_name "Lookup data using the hiera_array parser function"
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:acceptance',
     'audit:refactor'    # Master is not required for this test. Replace with agents.each
 

--- a/acceptance/tests/parser_functions/hiera_hash/lookup_data.rb
+++ b/acceptance/tests/parser_functions/hiera_hash/lookup_data.rb
@@ -1,6 +1,6 @@
 test_name "Lookup data using the hiera_hash parser function"
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:acceptance',
     'audit:refactor'    # Master is not required for this test. Replace with agents.each
 

--- a/acceptance/tests/parser_functions/hiera_in_templates.rb
+++ b/acceptance/tests/parser_functions/hiera_in_templates.rb
@@ -1,6 +1,6 @@
 test_name "Calling Hiera function from inside templates"
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:integration',
     'audit:refactor'    # Master is not required for this test. Replace with agents.each
 

--- a/acceptance/tests/parser_functions/no_exception_in_reduce_with_bignum.rb
+++ b/acceptance/tests/parser_functions/no_exception_in_reduce_with_bignum.rb
@@ -2,7 +2,7 @@ test_name 'C97760: Integer in reduce() should not cause exception' do
   require 'puppet/acceptance/environment_utils'
   extend Puppet::Acceptance::EnvironmentUtils
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:unit'
 
   app_type = File.basename(__FILE__, '.*')

--- a/acceptance/tests/parser_functions/puppet_lookup_cmd.rb
+++ b/acceptance/tests/parser_functions/puppet_lookup_cmd.rb
@@ -1,6 +1,6 @@
 test_name "Puppet Lookup Command"
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:acceptance',
     'audit:refactor'   # Master is not required for this test. Replace with agents.each
                        # Wrap steps in blocks in accordance with Beaker style guide

--- a/acceptance/tests/pluginsync/3935_pluginsync_should_follow_symlinks.rb
+++ b/acceptance/tests/pluginsync/3935_pluginsync_should_follow_symlinks.rb
@@ -1,6 +1,6 @@
 test_name "pluginsync should not error when modulepath is a symlink and no modules have plugin directories"
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:integration',
     'server'
 

--- a/acceptance/tests/pluginsync/4420_pluginfacts_should_be_resolvable_on_agent.rb
+++ b/acceptance/tests/pluginsync/4420_pluginfacts_should_be_resolvable_on_agent.rb
@@ -1,5 +1,5 @@
 test_name "Pluginsync'ed external facts should be resolvable on the agent" do
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:integration'
 
 #

--- a/acceptance/tests/pluginsync/4847_pluginfacts_should_be_resolvable_from_applications.rb
+++ b/acceptance/tests/pluginsync/4847_pluginfacts_should_be_resolvable_from_applications.rb
@@ -1,6 +1,6 @@
 test_name "Pluginsync'ed custom facts should be resolvable during application runs" do
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:integration'
 
   #

--- a/acceptance/tests/pluginsync/7316_apps_should_be_available_via_pluginsync.rb
+++ b/acceptance/tests/pluginsync/7316_apps_should_be_available_via_pluginsync.rb
@@ -1,6 +1,6 @@
 test_name 'the pluginsync functionality should sync app definitions, and they should be runnable afterwards' do
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:integration'
 
   #

--- a/acceptance/tests/pluginsync/7316_faces_with_app_stubs_should_be_available_via_pluginsync.rb
+++ b/acceptance/tests/pluginsync/7316_faces_with_app_stubs_should_be_available_via_pluginsync.rb
@@ -1,6 +1,6 @@
 test_name "the pluginsync functionality should sync app definitions, and they should be runnable afterwards"
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:integration',
     'server'
 

--- a/acceptance/tests/pluginsync/feature/pluginsync_should_sync_features.rb
+++ b/acceptance/tests/pluginsync/feature/pluginsync_should_sync_features.rb
@@ -1,6 +1,6 @@
 test_name "the pluginsync functionality should sync feature and function definitions" do
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:integration'
 
   #

--- a/acceptance/tests/pluginsync/files_earlier_in_modulepath_take_precendence.rb
+++ b/acceptance/tests/pluginsync/files_earlier_in_modulepath_take_precendence.rb
@@ -1,6 +1,6 @@
 test_name "earlier modules take precendence over later modules in the modulepath"
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:integration',
     'server'
 

--- a/acceptance/tests/puppet_apply_basics.rb
+++ b/acceptance/tests/puppet_apply_basics.rb
@@ -4,7 +4,7 @@
 
 test_name "Trivial puppet tests"
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:unit'
 
 step "check that puppet apply displays notices"

--- a/acceptance/tests/reports/agent_sends_json_report_for_cached_catalog.rb
+++ b/acceptance/tests/reports/agent_sends_json_report_for_cached_catalog.rb
@@ -1,7 +1,7 @@
 test_name "C100533: Agent sends json report for cached catalog" do
 
-  tag 'risk:medium',
-      'audit:medium',
+  tag 'risk:high',
+      'audit:high',
       'audit:integration',
       'server'
 

--- a/acceptance/tests/reports/cached_catalog_status_in_report.rb
+++ b/acceptance/tests/reports/cached_catalog_status_in_report.rb
@@ -1,5 +1,5 @@
 test_name "PUP-5867: The report specifies whether a cached catalog was used, and if so, why" do
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:integration',
       'server'
 

--- a/acceptance/tests/reports/corrective_change_new_resource.rb
+++ b/acceptance/tests/reports/corrective_change_new_resource.rb
@@ -7,7 +7,7 @@ test_name "C98092 - a new resource should not be reported as a corrective change
   require 'puppet/acceptance/agent_fqdn_utils'
   extend Puppet::Acceptance::AgentFqdnUtils
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:integration',
       'audit:refactor',    # Uses a server currently but is testing agent report
       'broken:images'

--- a/acceptance/tests/reports/corrective_change_outside_puppet.rb
+++ b/acceptance/tests/reports/corrective_change_outside_puppet.rb
@@ -7,7 +7,7 @@ test_name "C98093 - a resource changed outside of Puppet will be reported as a c
   require 'puppet/acceptance/agent_fqdn_utils'
   extend Puppet::Acceptance::AgentFqdnUtils
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:integration',
       'audit:refactor',    # Uses a server currently, but is testing agent report
       'broken:images'

--- a/acceptance/tests/reports/corrective_change_via_puppet.rb
+++ b/acceptance/tests/reports/corrective_change_via_puppet.rb
@@ -7,7 +7,7 @@ test_name "C98094 - a resource changed via Puppet manifest will not be reported 
   require 'puppet/acceptance/agent_fqdn_utils'
   extend Puppet::Acceptance::AgentFqdnUtils
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:integration',
       'audit:refactor',    # Uses a server currently, but is testing agent report
       'broken:images',

--- a/acceptance/tests/reports/submission.rb
+++ b/acceptance/tests/reports/submission.rb
@@ -1,6 +1,6 @@
 test_name "Report submission"
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:integration'
 
 if master.is_pe?

--- a/acceptance/tests/resource/group/should_manage_attributes_aix.rb
+++ b/acceptance/tests/resource/group/should_manage_attributes_aix.rb
@@ -1,7 +1,7 @@
 test_name "should correctly manage the attributes property for the Group (AIX only)" do
   confine :to, :platform => /aix/
   
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:acceptance' # Could be done as integration tests, but would
                          # require changing the system running the test
                          # in ways that might require special permissions

--- a/acceptance/tests/resource/group/should_manage_members.rb
+++ b/acceptance/tests/resource/group/should_manage_members.rb
@@ -3,7 +3,7 @@ test_name "should correctly manage the members property for the Group resource" 
   # property
   confine :to, :platform => /windows|osx|aix|^el-|fedora/
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:acceptance' # Could be done as integration tests, but would
                          # require changing the system running the test
                          # in ways that might require special permissions

--- a/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
+++ b/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
@@ -6,7 +6,7 @@ test_name "ticket 1073: common package name in two different providers should be
     skip_test('Skipping EC2 Hosts') if fact_on(agent, 'ec2_metadata')
   end
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:acceptance' # Uses a provider that depends on AIO packaging
 
   require 'puppet/acceptance/rpm_util'

--- a/acceptance/tests/resource/package/does_not_exist.rb
+++ b/acceptance/tests/resource/package/does_not_exist.rb
@@ -1,7 +1,7 @@
 # Redmine (#22529)
 test_name "Puppet returns only resource package declaration when querying an uninstalled package" do
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:acceptance' # Could be done at the integration (or unit) layer though
                          # actual changing of resources could irreparably damage a
                          # host running this, or require special permissions.

--- a/acceptance/tests/resource/package/windows.rb
+++ b/acceptance/tests/resource/package/windows.rb
@@ -1,7 +1,7 @@
 test_name "Windows Package Provider" do
   confine :to, :platform => 'windows'
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:acceptance'
 
   require 'puppet/acceptance/windows_utils'

--- a/acceptance/tests/resource/package/yum.rb
+++ b/acceptance/tests/resource/package/yum.rb
@@ -6,7 +6,7 @@ test_name "test the yum package provider" do
     skip_test('Skipping EC2 Hosts') if fact_on(agent, 'ec2_metadata')
   end
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:acceptance' # Could be done at the integration (or unit) layer though
                          # actual changing of resources could irreparably damage a
                          # host running this, or require special permissions.

--- a/acceptance/tests/resource/service/AIX_service_provider.rb
+++ b/acceptance/tests/resource/service/AIX_service_provider.rb
@@ -1,6 +1,6 @@
 test_name 'AIX Service Provider Testing'
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
                        # actual changing of resources could irreparably damage a

--- a/acceptance/tests/resource/service/init_on_systemd.rb
+++ b/acceptance/tests/resource/service/init_on_systemd.rb
@@ -5,7 +5,7 @@ test_name 'SysV on default Systemd Service Provider Validation' do
     stdout =~ /systemctl/
   end
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:acceptance' # Could be done at the integration (or unit) layer though
                          # actual changing of resources could irreparably damage a
                          # host running this, or require special permissions.

--- a/acceptance/tests/resource/service/launchd_provider.rb
+++ b/acceptance/tests/resource/service/launchd_provider.rb
@@ -1,6 +1,6 @@
 test_name 'Mac OS X launchd Provider Testing'
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
                        # actual changing of resources could irreparably damage a
@@ -81,19 +81,16 @@ SCRIPT
   end
 
   # switching from stopped to running should output the correct status of the service and not 'absent'
-  step "Start the service on #{agent} when service is stopped, and check outoput" do
+  step "Start the service on #{agent} when service is stopped, and check output" do
     on agent, puppet_resource('service', svc, 'ensure=stopped')
-    on agent, puppet_resource('service', svc, 'ensure=running') do |result|
-      assert_match(/service { '#{svc}':\n  ensure.+=> 'running',\n}$/, stdout, 'Service status change failed')
-    end
-  end
-
-   # switching from running to stopped should output the correct status of the service and not 'absent'
-  step "Start the service on #{agent} when service is running, and check outoput" do
     on agent, puppet_resource('service', svc, 'ensure=running')
-    on agent, puppet_resource('service', svc, 'ensure=stopped') do |result|
-      assert_match(/service { '#{svc}':\n  ensure.+=> 'stopped',\n}$/, stdout, 'Service status change failed')
-    end
+    assert_service_status_on_host(agent, svc, {:ensure => 'running'})
   end
 
+  # switching from running to stopped should output the correct status of the service and not 'absent'
+  step "Stop the service on #{agent} when service is running, and check output" do
+    on agent, puppet_resource('service', svc, 'ensure=running')
+    on agent, puppet_resource('service', svc, 'ensure=stopped')
+    assert_service_status_on_host(agent, svc, {:ensure => 'stopped'})
+  end
 end

--- a/acceptance/tests/resource/service/puppet_service_management.rb
+++ b/acceptance/tests/resource/service/puppet_service_management.rb
@@ -1,6 +1,6 @@
 test_name "The Puppet service should be manageable with Puppet"
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:refactor',  # Use block style `test_name`
     'audit:acceptance' # uses services from a running puppet-agent install
 #

--- a/acceptance/tests/resource/service/service_enable_linux.rb
+++ b/acceptance/tests/resource/service/service_enable_linux.rb
@@ -1,6 +1,6 @@
 test_name 'SysV and Systemd Service Provider Validation'
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:refactor',  # Investigate merging with init_on_systemd.rb
                        # Use block style `test_name`
     'audit:acceptance' # Could be done at the integration (or unit) layer though

--- a/acceptance/tests/resource/service/should_not_change_the_system.rb
+++ b/acceptance/tests/resource/service/should_not_change_the_system.rb
@@ -1,6 +1,6 @@
 test_name "`puppet resource service` should list running services without calling dangerous init scripts"
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:refactor',   # Use block style `test_name`
     'audit:integration' # Doesn't change the system it runs on
 

--- a/acceptance/tests/resource/service/should_query_all.rb
+++ b/acceptance/tests/resource/service/should_query_all.rb
@@ -1,6 +1,6 @@
 test_name "should query all services"
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:refactor',   # Investigate combining with should_not_change_the_system.rb
                         # Use block style `test_name`
     'audit:integration' # Doesn't change the system it runs on

--- a/acceptance/tests/resource/service/smf_basic_tests.rb
+++ b/acceptance/tests/resource/service/smf_basic_tests.rb
@@ -1,7 +1,7 @@
 test_name "SMF: basic tests" do
   confine :to, :platform => 'solaris'
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:acceptance' # Could be done at the integration (or unit) layer though
                          # actual changing of resources could irreparably damage a
                          # host running this, or require special permissions.

--- a/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
+++ b/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
@@ -3,7 +3,7 @@ extend Puppet::Acceptance::ServiceUtils
 
 test_name 'Systemd masked services are unmasked before attempting to start'
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:refactor',  # Use block style `test_run`
     'audit:acceptance' # Could be done at the integration (or unit) layer though
                        # actual changing of resources could irreparably damage a

--- a/acceptance/tests/resource/service/windows_mixed_utf8.rb
+++ b/acceptance/tests/resource/service/windows_mixed_utf8.rb
@@ -2,7 +2,7 @@
 test_name "Windows Service Provider With Mixed UTF-8 Service Names" do
   confine :to, :platform => 'windows'
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:acceptance'
 
   require 'puppet/acceptance/windows_utils'

--- a/acceptance/tests/resource/tidy/resources_should_be_non_isomorphic.rb
+++ b/acceptance/tests/resource/tidy/resources_should_be_non_isomorphic.rb
@@ -1,7 +1,7 @@
 # This test is to verify multi tidy resources with same path but
 # different matches should not cause error as found in the bug PUP-6508
 test_name "PUP-6655 - C98145 tidy resources should be non-isomorphic" do
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:integration'
 
   agents. each do |agent|

--- a/acceptance/tests/resource/tidy/should_remove_old_files.rb
+++ b/acceptance/tests/resource/tidy/should_remove_old_files.rb
@@ -1,6 +1,6 @@
 test_name "Tidying files by date"
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:refactor',  # Use block style `test_run`
     'audit:integration'
 

--- a/acceptance/tests/resource/user/osx_10.4_should_fail_when_modify_home.rb
+++ b/acceptance/tests/resource/user/osx_10.4_should_fail_when_modify_home.rb
@@ -1,7 +1,7 @@
 test_name "should not modify the home directory of an user on OS X >= 10.14" do
   confine :to, :platform => /osx-10.1[4-9]/
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:acceptance' # Could be done as integration tests, but would
                          # require changing the system running the test
                        # in ways that might require special permissions

--- a/acceptance/tests/resource/user/osx_10.4_should_fail_when_modify_uid.rb
+++ b/acceptance/tests/resource/user/osx_10.4_should_fail_when_modify_uid.rb
@@ -1,7 +1,7 @@
 test_name "should not modify the uid of an user on OS X >= 10.14" do
   confine :to, :platform => /osx-10.1[4-9]/
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:acceptance' # Could be done as integration tests, but would
                          # require changing the system running the test
                        # in ways that might require special permissions

--- a/acceptance/tests/resource/user/should_allow_password_salt_iterations_osx.rb
+++ b/acceptance/tests/resource/user/should_allow_password_salt_iterations_osx.rb
@@ -2,7 +2,7 @@ test_name "should allow password, salt, and iteration attributes in OSX"
 
 confine :to, :platform => /osx/
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:refactor',  # Use block style `test_run`
     'audit:acceptance' # Could be done as integration tests, but would
                        # require changing the system running the test

--- a/acceptance/tests/resource/user/should_create.rb
+++ b/acceptance/tests/resource/user/should_create.rb
@@ -1,6 +1,6 @@
 test_name "should create a user"
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:refactor',  # Use block style `test_run`
     'audit:acceptance' # Could be done as integration tests, but would
                        # require changing the system running the test

--- a/acceptance/tests/resource/user/should_create_with_expiry_absent.rb
+++ b/acceptance/tests/resource/user/should_create_with_expiry_absent.rb
@@ -1,7 +1,7 @@
 test_name "verifies that puppet resource creates a user and assigns the correct expiry date when absent" do
   confine :except, :platform => 'windows'
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:acceptance' # Could be done as integration tests, but would
                          # require changing the system running the test
                          # in ways that might require special permissions

--- a/acceptance/tests/resource/user/should_create_with_gid.rb
+++ b/acceptance/tests/resource/user/should_create_with_gid.rb
@@ -1,7 +1,7 @@
 test_name "verifies that puppet resource creates a user and assigns the correct group"
 confine :except, :platform => 'windows'
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:refactor',  # Use block style `test_run`
     'audit:acceptance' # Could be done as integration tests, but would
                        # require changing the system running the test

--- a/acceptance/tests/resource/user/should_destroy.rb
+++ b/acceptance/tests/resource/user/should_destroy.rb
@@ -1,6 +1,6 @@
 test_name "should delete a user"
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:refactor',  # Use block style `test_run`
     'audit:acceptance' # Could be done as integration tests, but would
                        # require changing the system running the test

--- a/acceptance/tests/resource/user/should_destroy_with_managehome.rb
+++ b/acceptance/tests/resource/user/should_destroy_with_managehome.rb
@@ -1,6 +1,6 @@
 test_name "should delete a user with managehome=true"
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:refactor',  # Use block style `test_run`
     'audit:acceptance' # Could be done as integration tests, but would
                        # require changing the system running the test

--- a/acceptance/tests/resource/user/should_manage_attributes_aix.rb
+++ b/acceptance/tests/resource/user/should_manage_attributes_aix.rb
@@ -1,7 +1,7 @@
 test_name "should correctly manage the attributes property for the User resource (AIX only)" do
   confine :to, :platform => /aix/
   
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:acceptance' # Could be done as integration tests, but would
                          # require changing the system running the test
                          # in ways that might require special permissions

--- a/acceptance/tests/resource/user/should_manage_shell.rb
+++ b/acceptance/tests/resource/user/should_manage_shell.rb
@@ -1,6 +1,6 @@
 test_name "should manage user shell"
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:refactor',  # Use block style `test_run`
     'audit:acceptance' # Could be done as integration tests, but would
                        # require changing the system running the test

--- a/acceptance/tests/resource/user/should_modify.rb
+++ b/acceptance/tests/resource/user/should_modify.rb
@@ -1,5 +1,5 @@
 test_name "should modify a user"
-tag 'audit:medium',
+tag 'audit:high',
     'audit:refactor',  # Use block style `test_run`
     'audit:acceptance' # Could be done as integration tests, but would
                        # require changing the system running the test

--- a/acceptance/tests/resource/user/should_modify_home.rb
+++ b/acceptance/tests/resource/user/should_modify_home.rb
@@ -2,7 +2,7 @@ test_name "should modify the home directory of an user on OS X < 10.14" do
   confine :to, :platform => /osx/
   confine :except, :platform => /osx-10.1[4-9]/
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:acceptance' # Could be done as integration tests, but would
                          # require changing the system running the test
                        # in ways that might require special permissions

--- a/acceptance/tests/resource/user/should_modify_uid.rb
+++ b/acceptance/tests/resource/user/should_modify_uid.rb
@@ -2,7 +2,7 @@ test_name "should modify the uid of an user OS X < 10.14" do
   confine :to, :platform => /osx/
   confine :except, :platform => /osx-10.1[4-9]/
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:acceptance' # Could be done as integration tests, but would
                          # require changing the system running the test
                        # in ways that might require special permissions

--- a/acceptance/tests/resource/user/should_modify_when_not_managing_home.rb
+++ b/acceptance/tests/resource/user/should_modify_when_not_managing_home.rb
@@ -1,6 +1,6 @@
 test_name "should modify a user when no longer managing home (#20726)"
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:refactor',  # Use block style `test_run`
     'audit:acceptance' # Could be done as integration tests, but would
                        # require changing the system running the test

--- a/acceptance/tests/resource/user/should_modify_while_managing_home.rb
+++ b/acceptance/tests/resource/user/should_modify_while_managing_home.rb
@@ -1,6 +1,6 @@
 test_name "should modify a user without changing home directory (pending #19542)"
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:refactor',  # Use block style `test_run`
     'audit:acceptance' # Could be done as integration tests, but would
                        # require changing the system running the test

--- a/acceptance/tests/resource/user/should_not_create_existing.rb
+++ b/acceptance/tests/resource/user/should_not_create_existing.rb
@@ -1,6 +1,6 @@
 test_name "tests that user resource will not add users that already exist." do
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:acceptance' # Could be done as integration tests, but would
                          # require changing the system running the test
                          # in ways that might require special permissions

--- a/acceptance/tests/resource/user/should_not_destroy_unexisting.rb
+++ b/acceptance/tests/resource/user/should_not_destroy_unexisting.rb
@@ -1,6 +1,6 @@
 test_name "ensure that puppet does not report removing a user that does not exist"
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:refactor',  # Use block style `test_run`
     'audit:acceptance' # Could be done as integration tests, but would
                        # require changing the system running the test

--- a/acceptance/tests/resource/user/should_not_modify_disabled.rb
+++ b/acceptance/tests/resource/user/should_not_modify_disabled.rb
@@ -2,7 +2,7 @@ test_name 'PUP-6586 Ensure puppet does not continually reset password for disabl
 
   confine :to, :platform => 'windows'
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:acceptance' # Could be done as integration tests, but would
                          # require changing the system running the test
                          # in ways that might require special permissions

--- a/acceptance/tests/resource/user/should_purge.rb
+++ b/acceptance/tests/resource/user/should_purge.rb
@@ -3,7 +3,7 @@ test_name "should purge a user" do
   confine :except, :platform => /^aix/
   confine :except, :platform => /^solaris/
   confine :except, :platform => /^osx/
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:acceptance'
 
   agents.each do |agent|

--- a/acceptance/tests/resource/user/should_query.rb
+++ b/acceptance/tests/resource/user/should_query.rb
@@ -1,6 +1,6 @@
 test_name "test that we can query and find a user that exists."
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:refactor',  # Use block style `test_run`
     'audit:acceptance' # Could be done as integration tests, but would
                        # require changing the system running the test

--- a/acceptance/tests/resource/user/should_query_all.rb
+++ b/acceptance/tests/resource/user/should_query_all.rb
@@ -1,6 +1,6 @@
 test_name "should query all users"
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:refactor',  # Use block style `test_run`
     'audit:integration'
 

--- a/acceptance/tests/resource/user/utf8_user_comments.rb
+++ b/acceptance/tests/resource/user/utf8_user_comments.rb
@@ -9,7 +9,7 @@
 # Where applicable, we should be able to do this in different locales
 test_name 'PUP-6777 Manage users with UTF-8 comments' do
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:acceptance' # Could be done as integration tests, but would
                          # require changing the system running the test
                          # in ways that might require special permissions

--- a/acceptance/tests/server_returns_pson_when_preferred_serialization_set.rb
+++ b/acceptance/tests/server_returns_pson_when_preferred_serialization_set.rb
@@ -1,7 +1,7 @@
 test_name "C100532: Server returns expected format when --preferred_serialization_format is set" do
 
-  tag 'risk:medium',
-      'audit:medium',
+  tag 'risk:high',
+      'audit:high',
       'audit:integration',
       'server'
 

--- a/acceptance/tests/ticket_1334_clientbucket_corrupted.rb
+++ b/acceptance/tests/ticket_1334_clientbucket_corrupted.rb
@@ -1,6 +1,6 @@
 test_name 'C99977 corrupted clientbucket' do
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:integration'
 
   agents.each do |agent|

--- a/acceptance/tests/ticket_13948_lib_dir_hook_should_be_called_on_initialization.rb
+++ b/acceptance/tests/ticket_13948_lib_dir_hook_should_be_called_on_initialization.rb
@@ -4,7 +4,7 @@ require 'puppet/acceptance/temp_file_utils'
 
 extend Puppet::Acceptance::TempFileUtils
 
-tag 'audit:medium',      # tests basic custom module/pluginsync handling?
+tag 'audit:high',      # tests basic custom module/pluginsync handling?
     'audit:refactor',    # Use block style `test_namme`
     'audit:integration',
     'server'

--- a/acceptance/tests/ticket_15560_managehome.rb
+++ b/acceptance/tests/ticket_15560_managehome.rb
@@ -1,6 +1,6 @@
 test_name "#15560: Manage home directories"
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:refactor',  # Use block style `test_namme`
                        # refactor to be OS agnostic and added to the resource/user
                        # tests. managehome is currently not covered there.

--- a/acceptance/tests/ticket_2280_refresh_fail_should_fail_run.rb
+++ b/acceptance/tests/ticket_2280_refresh_fail_should_fail_run.rb
@@ -1,6 +1,6 @@
 test_name 'C100297 - A resource triggered by a refresh that fails should be reported as a failure when using --detailed-exitcodes' do
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:integration' # Service type interaction with --detailed-exitcodes
 
   manifest =<<EOS

--- a/acceptance/tests/ticket_2455_on_solaris_init_provider_should_start_service_in_own_smf_contract.rb
+++ b/acceptance/tests/ticket_2455_on_solaris_init_provider_should_start_service_in_own_smf_contract.rb
@@ -1,6 +1,6 @@
 test_name "(PUP-2455) Service provider should start Solaris init service in its own SMF contract"
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:refactor',  # Use block style `test_name`
                        # Use mk_temp_environment_with_teardown
                        # Combine with Service resource tests

--- a/acceptance/tests/ticket_5477_master_not_dectect_sitepp.rb
+++ b/acceptance/tests/ticket_5477_master_not_dectect_sitepp.rb
@@ -5,7 +5,7 @@
 #
 test_name "Ticket 5477, Puppet Master does not detect newly created site.pp file"
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:integration',
     'audit:refactor',     # Use block style `test_name`
     'server'

--- a/acceptance/tests/ticket_5592_hiera_lookup_when_param_undef.rb
+++ b/acceptance/tests/ticket_5592_hiera_lookup_when_param_undef.rb
@@ -1,6 +1,6 @@
 test_name 'Ensure hiera lookup occurs if class param is undef' do
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:unit'    # basic auto lookup functionality
 
   agents.each do |agent|

--- a/acceptance/tests/ticket_6541_invalid_filebucket_files.rb
+++ b/acceptance/tests/ticket_6541_invalid_filebucket_files.rb
@@ -1,6 +1,6 @@
 test_name "#6541: file type truncates target when filebucket cannot retrieve hash"
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:integration', # file type and file bucket interop
     'audit:refactor'     # look into combining with ticket_4622_filebucket_diff_test.rb
                          # Use block style `test_run`

--- a/acceptance/tests/ticket_6857_password-disclosure-when-changing-a-users-password.rb
+++ b/acceptance/tests/ticket_6857_password-disclosure-when-changing-a-users-password.rb
@@ -1,6 +1,6 @@
 test_name "#6857: redact password hashes when applying in noop mode"
 
-tag 'audit:medium',
+tag 'audit:high',
     'audit:refactor',    # Use block style `test_name`
     'audit:integration'
 

--- a/acceptance/tests/ticket_9862_puppet_runs_without_service_user_or_group_present.rb
+++ b/acceptance/tests/ticket_9862_puppet_runs_without_service_user_or_group_present.rb
@@ -1,6 +1,6 @@
 test_name "#9862: puppet runs without service user or group present"
 
-tag 'audit:medium',     # startup/configuration, high impact, low risk
+tag 'audit:high',     # startup/configuration, high impact, low risk
     'audit:refactor',    # Use block style `test_name`
     'audit:integration' # could easily be acceptance, not package dependant,
                         # but changing a person running the tests users and

--- a/acceptance/tests/utf8/utf8-in-function-args.rb
+++ b/acceptance/tests/utf8/utf8-in-function-args.rb
@@ -1,6 +1,6 @@
 test_name 'utf-8 characters in function parameters' do
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:integration', # not package dependent but may want to vary platform by LOCALE/encoding
       'audit:refactor'     # if keeping, use mk_temp_environment_with_teardown
 

--- a/acceptance/tests/utf8/utf8-in-puppet-describe.rb
+++ b/acceptance/tests/utf8/utf8-in-puppet-describe.rb
@@ -1,6 +1,6 @@
 test_name 'utf-8 characters in module doc string, puppet describe' do
 
-  tag 'audit:medium',      # utf-8 is high impact in general, puppet describe low risk?
+  tag 'audit:high',      # utf-8 is high impact in general, puppet describe low risk?
       'audit:integration', # not package dependent but may want to vary platform by LOCALE/encoding
       'audit:refactor'     # if keeping, use mk_temp_environment_with_teardown
                            # remove with_puppet_running_on unless pluginsync is absolutely necessary

--- a/acceptance/tests/windows/PA-2191_windows_nocodepage_utf8_fallback.rb
+++ b/acceptance/tests/windows/PA-2191_windows_nocodepage_utf8_fallback.rb
@@ -1,7 +1,7 @@
 test_name 'PA-2191 - winruby fallsback to UTF8 for invalid CodePage' do
   confine :to, platform: 'windows'
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:acceptance'
 
   agents.each do |host|

--- a/acceptance/tests/windows/PUP-9719_windows_system_first_pa_run.rb
+++ b/acceptance/tests/windows/PUP-9719_windows_system_first_pa_run.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 test_name 'PUP-9719 Windows First Agent run as SYSTEM sets cache file permissions correctly' do
-  tag 'audit:high',
+  tag 'risk:high',
+      'audit:high',
       'audit:integration'
 
   confine :to, platform: 'windows'

--- a/acceptance/tests/windows/QA-506_windows_exit_codes_test.rb
+++ b/acceptance/tests/windows/QA-506_windows_exit_codes_test.rb
@@ -1,7 +1,7 @@
 test_name "Windows Exec `exit_code` Parameter Acceptance Test"
 
-tag 'risk:medium',
-    'audit:medium',
+tag 'risk:high',
+    'audit:high',
     'audit:refactor',   # Use block style `test_name`
     'audit:integration' # exec resource succeeds when the `exit_code` parameter
                         # is given a windows specific exit code and a exec

--- a/acceptance/tests/windows/QA-760_win_dash_dot_file_test.rb
+++ b/acceptance/tests/windows/QA-760_win_dash_dot_file_test.rb
@@ -1,7 +1,7 @@
 test_name "QA-760 - Windows Files Containing '-' and '.'"
 
-tag 'risk:medium',
-    'audit:medium',
+tag 'risk:high',
+    'audit:high',
     'audit:refactor',   # Use block style `test_name`
     'audit:integration'
 

--- a/acceptance/tests/windows/enable_password_changes_special_users.rb
+++ b/acceptance/tests/windows/enable_password_changes_special_users.rb
@@ -1,6 +1,6 @@
 test_name 'Puppet should change passwords for disabled, expired, or locked out Windows user accounts' do
 
-  tag 'audit:medium',
+  tag 'audit:high',
       'audit:acceptance'
 
   require 'date'

--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -30,7 +30,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   def self.instances
     i = []
     output = systemctl('list-unit-files', '--type', 'service', '--full', '--all',  '--no-pager')
-    output.scan(/^(\S+)\s+(disabled|enabled|masked|indirect|bad|static)\s*$/i).each do |m|
+    output.scan(/^(\S+)\s+(disabled|enabled|masked|indirect|bad|static)\s*([^-]\S+)?\s*$/i).each do |m|
       Puppet.debug("#{m[0]} marked as bad by `systemctl`. It is recommended to be further checked.") if m[1] == "bad"
       i << new(:name => m[0])
     end

--- a/spec/fixtures/unit/provider/service/systemd/list_unit_files_services_vendor_preset
+++ b/spec/fixtures/unit/provider/service/systemd/list_unit_files_services_vendor_preset
@@ -1,0 +1,9 @@
+UNIT FILE                                  STATE           VENDOR PRESET
+arp-ethers.service                         disabled        disabled     
+auditd.service                             enabled         enabled      
+dbus.service                               enabled         disabled     
+udev.service                               enabled-runtime disabled
+umountfs.service                           linked-runtime  disabled
+umountnfs.service                          masked          disabled
+umountroot.service                         masked-runtime  disabled
+urandom.service                            indirect        enabled

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -200,6 +200,17 @@ describe 'Puppet::Type::Service::Provider::Systemd',
       })
     end
 
+    it "correctly parses services when list-unit-files has an additional column" do
+      expect(provider_class).to receive(:systemctl).with('list-unit-files', '--type', 'service', '--full', '--all', '--no-pager').and_return(File.read(my_fixture('list_unit_files_services_vendor_preset')))
+      expect(provider_class.instances.map(&:name)).to match_array(%w{
+        arp-ethers.service
+        auditd.service
+        dbus.service
+        umountnfs.service
+        urandom.service
+      })
+    end
+
     it "should print a debug message when a service with the state `bad` is found" do
       expect(provider_class).to receive(:systemctl).with('list-unit-files', '--type', 'service', '--full', '--all', '--no-pager').and_return(File.read(my_fixture('list_unit_files_services')))
       expect(Puppet).to receive(:debug).with("apparmor.service marked as bad by `systemctl`. It is recommended to be further checked.")


### PR DESCRIPTION
Merge remote-tracking branch 'pl/6.x' into main

    * pl/6.x:
      (PUP-10923) Keep Solaris IPS and i18n tests on `medium`
      (PUP-10923) Change all acceptance back to audit/risk high
      (PUP-10949) Fix systemctl list-unit-files parsing
      (PUP-10923) Fix launchd provider test
      (PUP-10923) Fix AIX acceptance test
      (PUP-10947) Modify the exclude list for `puppet facts diff`
```
CONFLICT (modify/delete): lib/puppet/util/fact_dif.rb deleted in HEAD and modified in pl/6.x. Version pl/6.x of lib/puppet/util/fact_dif.rb left in tree.
CONFLICT (content): Merge conflict in lib/puppet/face/facts.rb
CONFLICT (content): Merge conflict in acceptance/tests/windows/PUP-9719_windows_system_first_pa_run.rb
CONFLICT (content): Merge conflict in acceptance/tests/resource/user/should_query_all.rb
CONFLICT (content): Merge conflict in acceptance/tests/resource/user/should_query.rb
CONFLICT (content): Merge conflict in acceptance/tests/resource/user/should_not_destroy_unexisting.rb
CONFLICT (content): Merge conflict in acceptance/tests/resource/user/should_not_create_existing.rb
CONFLICT (content): Merge conflict in acceptance/tests/resource/user/should_modify_while_managing_home.rb
CONFLICT (content): Merge conflict in acceptance/tests/resource/user/should_modify_when_not_managing_home.rb
CONFLICT (content): Merge conflict in acceptance/tests/resource/user/should_modify.rb
CONFLICT (content): Merge conflict in acceptance/tests/resource/user/should_destroy_with_managehome.rb
CONFLICT (content): Merge conflict in acceptance/tests/resource/user/should_destroy.rb
CONFLICT (modify/delete): acceptance/tests/resource/service/ticket_4124_should_list_all_disabled.rb deleted in HEAD and modified in pl/6.x. Version pl/6.x of acceptance/tests/resource/service/ticket_4124_should_list_all_disabled.rb left in tree.
CONFLICT (modify/delete): acceptance/tests/resource/service/ticket_4123_should_list_all_running_redhat.rb deleted in HEAD and modified in pl/6.x. Version pl/6.x of acceptance/tests/resource/service/ticket_4123_should_list_all_running_redhat.rb left in tree.
CONFLICT (modify/delete): acceptance/tests/puppet_apply_a_file_should_create_a_file_and_report_the_md5.rb deleted in HEAD and modified in pl/6.x. Version pl/6.x of acceptance/tests/puppet_apply_a_file_should_create_a_file_and_report_the_md5.rb left in tree.
CONFLICT (content): Merge conflict in acceptance/tests/pluginsync/4420_pluginfacts_should_be_resolvable_on_agent.rb
```