### PR TITLE
(maint) stub Facter requests to external services

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -162,10 +162,20 @@ RSpec.configure do |config|
   PUPPET_FACTER_2_GCE_URL = %r{^http://metadata/computeMetadata/v1(beta1)?}.freeze
   PUPPET_FACTER_3_GCE_URL = "http://metadata.google.internal/computeMetadata/v1/?recursive=true&alt=json".freeze
 
+  # Facter azure metadata endpoint
+  PUPPET_FACTER_AZ_URL = "http://169.254.169.254/metadata/instance?api-version=2020-09-01"
+
+  # Facter EC2 endpoint
+  PUPPET_FACTER_EC2_METADATA = 'http://169.254.169.254/latest/meta-data/'
+  PUPPET_FACTER_EC2_USERDATA = 'http://169.254.169.254/latest/user-data/'
+
   config.around :each do |example|
-    # Ignore requests from Facter GCE fact in Travis
+    # Ignore requests from Facter to external services
     stub_request(:get, PUPPET_FACTER_2_GCE_URL)
     stub_request(:get, PUPPET_FACTER_3_GCE_URL)
+    stub_request(:get, PUPPET_FACTER_AZ_URL)
+    stub_request(:get, PUPPET_FACTER_EC2_METADATA)
+    stub_request(:get, PUPPET_FACTER_EC2_USERDATA)
 
     # Enable VCR if the example is tagged with `:vcr` metadata.
     if example.metadata[:vcr]


### PR DESCRIPTION
 We added an Azure Metadata fact in Facter 4.0.52,
 and GH Actions VMs are running on Azure, so there's
 an additional http call being made which needs to
 be stubbed.