### PR TITLE
(PUP-10923) Fix aix acceptance test

### DIFF
--- a/acceptance/tests/resource/service/AIX_service_provider.rb
+++ b/acceptance/tests/resource/service/AIX_service_provider.rb
@@ -60,12 +60,7 @@ end
 
 agents.each do |agent|
 
-  ## Setup
-  run_nonexistent_service_tests(
-    'sloth_daemon',
-    /The sloth_daemon Subsystem is not on file/,
-    { 'starting' => 'ensure => running' }
-  )
+  run_nonexistent_service_tests('nonexistent_service')
 
   step "Setup on #{agent}"
   sloth_daemon_path = agent.tmpfile("sloth_daemon.sh")

--- a/acceptance/tests/resource/service/puppet_service_runs_puppet.rb
+++ b/acceptance/tests/resource/service/puppet_service_runs_puppet.rb
@@ -30,7 +30,7 @@ test_name 'Starting the puppet service should successfully run puppet' do
       assert_service_status_on_host(agent, 'puppet', {'ensure' => 'running'})
     end
 
-    retry_params = {:max_retries => 15,
+    retry_params = {:max_retries => 30,
                     :retry_interval => 2}
 
     step 'Ensure last_run_report.yaml is created' do


### PR DESCRIPTION
An unwanted change from the following commit https://github.com/puppetlabs/puppet/commit/2dd43150b3596b872e82141a6b1be515dd805809#diff-8605333114f5da06990288c0de42387d8b1e0e694eb670498efa0fa5fc0597e3R63-R68 got in main, which breaks the AIX service tests as the call to `run_nonexistent_service_tests` was changed, but the method signature was not changed.

To fix this, revert to the 6.x version of the AIX test.