### PR TITLE
(maint) Fix exclude_list for `puppet facts diff`

### DIFF
--- a/lib/puppet/face/facts.rb
+++ b/lib/puppet/face/facts.rb
@@ -11,7 +11,7 @@ EXCLUDE_LIST = %w[ facterversion
   memory\.swap\.available memory\.swap\.capacity memory\.swap\.used
   memory\.system\.available_bytes memory\.system\.used_bytes
   memory\.system\.available memory\.system\.capacity memory\.system\.used
-  mountpoints\..*\.available* mountpoints\..*\.capacity mountpoints\..*\.used*
+  mountpoints\..*\.available.* mountpoints\..*\.capacity mountpoints\..*\.used.*
   sp_uptime system_profiler\.uptime
   uptime uptime_days uptime_hours uptime_seconds
   system_uptime\.uptime system_uptime\.days system_uptime\.hours system_uptime\.seconds

--- a/spec/integration/http/client_spec.rb
+++ b/spec/integration/http/client_spec.rb
@@ -153,7 +153,7 @@ describe Puppet::HTTP::Client, unless: Puppet::Util::Platform.jruby? do
   end
 
   context 'ciphersuites' do
-    it "does not connect when using an SSLv3 ciphersuite" do
+    it "does not connect when using an SSLv3 ciphersuite", :if => Puppet::Util::Package.versioncmp(OpenSSL::OPENSSL_LIBRARY_VERSION.split[1], '1.1.1e') > 0 do
       Puppet[:ciphers] = "DES-CBC3-SHA"
 
       https_server.start_server do |port|


### PR DESCRIPTION
This commit adds missing characters from the `EXCLUDE_LIST` array of regular expressions used for filtering the `puppet facts diff` output of volatile facts.