### PR TITLE
(PUP-10964) fix puppet_gem command on Windows

### DIFF
--- a/lib/puppet/provider/package/puppet_gem.rb
+++ b/lib/puppet/provider/package/puppet_gem.rb
@@ -4,8 +4,19 @@ Puppet::Type.type(:package).provide :puppet_gem, :parent => :gem do
 
   has_feature :versionable, :install_options, :uninstall_options
 
+  confine :true => Facter.value(:aio_agent_version)
+
+  def self.windows_gemcmd
+    puppet_dir = Puppet::Util.get_env('PUPPET_DIR')
+    if puppet_dir
+      File.join(Puppet::Util.get_env('PUPPET_DIR').to_s, 'bin', 'gem.bat')
+    else
+      File.join(Gem.default_bindir, 'gem.bat')
+    end
+  end
+
   if Puppet::Util::Platform.windows?
-    commands :gemcmd => File.join(Puppet::Util.get_env('PUPPET_DIR').to_s, 'bin', 'gem.bat')
+    commands :gemcmd => windows_gemcmd
   else
     commands :gemcmd => "/opt/puppetlabs/puppet/bin/gem"
   end

--- a/spec/unit/provider/package/puppet_gem_spec.rb
+++ b/spec/unit/provider/package/puppet_gem_spec.rb
@@ -31,6 +31,34 @@ describe Puppet::Type.type(:package).provider(:puppet_gem) do
     allow(Puppet::Util::Platform).to receive(:windows?).and_return(false)
   end
 
+
+  describe '.windows_gemcmd' do
+    context 'when PUPPET_DIR is not set' do
+      before do
+        allow(Puppet::Util).to receive(:get_env).and_call_original
+        allow(Puppet::Util).to receive(:get_env).with('PUPPET_DIR').and_return(nil)
+        allow(Gem).to receive(:default_bindir).and_return('default_gem_bin')
+      end
+
+      it 'uses Gem.default_bindir' do
+        expected_path = File.join('default_gem_bin', 'gem.bat')
+        expect(described_class.windows_gemcmd).to eql(expected_path)
+      end
+    end
+
+    context 'when PUPPET_DIR is set' do
+      before do
+        allow(Puppet::Util).to receive(:get_env).and_call_original
+        allow(Puppet::Util).to receive(:get_env).with('PUPPET_DIR').and_return('puppet_dir')
+      end
+
+      it 'uses Gem.default_bindir' do
+        expected_path = File.join('puppet_dir', 'bin', 'gem.bat')
+        expect(described_class.windows_gemcmd).to eql(expected_path)
+      end
+    end
+  end
+
   context "when installing" do
     before :each do
       allow(provider).to receive(:rubygem_version).and_return('1.9.9')


### PR DESCRIPTION
When puppet is used as a library, environment.bat
is not sourced and this leads to `PUPPET_DIR` to
not be set. Because `puppet_gem` is relying on that
to build the `gem.bat` path, it will end-up using
a non-existing path, making this provider not suitable.
This has been noticed when using the `puppet_gem`
with the package task in PE.

This commit updates the `puppet_gem` provider to
use `Gem.default_bindir` to determine the location
of the execatables. To avoid accidental usage of
`puppet_gem` provider with system ruby, a confine to
the existence of `aio_agent_version` facts has been added.

Manually tested that `package` task works in PE.
If `puppet_gem` is run from puppet as a gem, it will report that the provider is not functional.