### PR TITLE
(PUP-10952) Respect `rich_data` setting without rereading env conf

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ require:
   rubocop-i18n
 
 AllCops:
+  TargetRubyVersion: 2.4
   Include:
     - 'lib/**/*.rb'
     - 'ext/**/*.rb'
@@ -541,6 +542,9 @@ Style/ParallelAssignment:
   Enabled: false
 
 Performance/RedundantBlockCall:
+  Enabled: false
+
+Performance/RegexpMatch:
   Enabled: false
 
 Style/IdenticalConditionalBranches:

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -2157,10 +2157,6 @@ EOT
     :rich_data => {
       :default  => true,
       :type     => :boolean,
-      :hook    => proc do |value|
-        envs = Puppet.lookup(:environments) { nil }
-        envs.clear_all unless envs.nil?
-      end,
       :desc     => <<-'EOT'
         Enables having extended data in the catalog by storing them as a hash with the special key
         `__ptype`. When enabled, resource containing values of the data types `Binary`, `Regexp`,

--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -214,15 +214,22 @@ class Puppet::Node::Environment
     errors
   end
 
+  def rich_data_from_env_conf
+    unless @checked_conf_for_rich_data
+      environment_conf = Puppet.lookup(:environments).get_conf(name)
+      @rich_data_from_conf = environment_conf&.rich_data
+      @checked_conf_for_rich_data = true
+    end
+    @rich_data_from_conf
+  end
+
   # Checks if this environment permits use of rich data types in the catalog
+  # Checks the environment conf for an override on first query, then going forward
+  # either uses that, or if unset, uses the current value of the `rich_data` setting.
   # @return [Boolean] `true` if rich data is permitted.
   # @api private
   def rich_data?
-    if @rich_data.nil?
-      environment_conf = Puppet.lookup(:environments).get_conf(name)
-      @rich_data = (environment_conf.nil? ? Puppet[:rich_data] : environment_conf.rich_data)
-    end
-    @rich_data
+    @rich_data = rich_data_from_env_conf.nil? ? Puppet[:rich_data] : rich_data_from_env_conf
   end
 
   # Return an environment-specific Puppet setting.


### PR DESCRIPTION
This commit removes the on-write hook from the rich data setting,
instead updating environments to read the current value from settings
directly when queried, if not overwritten in the environment conf. The
env conf is read once and its rich_data setting (or lack thereof) is
cached, so we don't read the file over and over.

------
Thanks for your contribution! Note that all community contributors will be required to sign our Contributor License Agreement, unless you fall under the [Trivial Patch Exemption Policy](https://puppet.com/community/trivial-patch-exemption-policy). If you believe it applies to your pull request, please comment explaining why you do not need to sign the CLA. Directions for signing will be attached to your pull request shortly.

Please note that all contributions may be publicly recognized in release notes.
