### PR TITLE
(PUP-10997) ignore empty lines in /etc/group

### DIFF
--- a/lib/puppet/provider/user/useradd.rb
+++ b/lib/puppet/provider/user/useradd.rb
@@ -135,7 +135,7 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
 
     Puppet::FileSystem.each_line(group_file) do |line|
       data = line.chomp.split(':')
-      if data.last.split(',').include?(user)
+      if !data.empty? && data.last.split(',').include?(user)
         @groups_of[user] << data.first
       end
     end


### PR DESCRIPTION
This is to update useradd provider to ignore empty lines in /etc/group

```
# egrep -n '^$|testuser' /etc/passwd /etc/group
/etc/passwd:24:testuser:x:1001:1001:testuser:/home/testuser:/bin/bash
/etc/group:41:centos:x:1000:testuser
/etc/group:42:testuser:x:1001:
/etc/group:43:
# bundle exec puppet apply -e "user { 'testuser': groups => ['centos'], forcelocal => true}"
Notice: Compiled catalog for [redacted] in environment production in 0.02 seconds
Notice: Applied catalog in 0.02 seconds
```

Confirmed no changes/still working as expected if /etc/group does not contain empty lines, and if adding user:

```
# egrep -n '^$|testuser' /etc/passwd /etc/group
/etc/passwd:24:testuser:x:1001:1001:testuser:/home/testuser:/bin/bash
/etc/group:41:centos:x:1000:testuser
/etc/group:42:testuser:x:1001:
# bundle exec puppet apply -e "user { 'testuser': groups => ['centos'], forcelocal => true}"
Notice: Compiled catalog for [redacted] in environment production in 0.02 seconds
Notice: Applied catalog in 0.02 seconds
# userdel testuser
# egrep -n '^$|testuser' /etc/passwd /etc/group
# bundle exec puppet apply -e "user { 'testuser': groups => ['centos'], forcelocal => true}"
Notice: Compiled catalog for [redacted] in environment production in 0.02 seconds
Notice: /Stage[main]/Main/User[testuser]/ensure: created
Notice: Applied catalog in 0.36 seconds
# egrep -n '^$|testuser' /etc/passwd /etc/group
/etc/passwd:24:testuser:x:1001:1001:testuser:/home/testuser:/bin/bash
/etc/group:41:centos:x:1000:testuser
/etc/group:42:testuser:x:1001:
```