### PR TITLE
(PUP-11000) Change agent_disabled_lockfile setting type to string

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1768,7 +1768,7 @@ EOT
     },
     :agent_disabled_lockfile => {
         :default    => "$statedir/agent_disabled.lock",
-        :type       => :file,
+        :type       => :string,
         :desc       => "A lock file to indicate that puppet agent runs have been administratively
           disabled.  File contains a JSON object with state information.",
     },


### PR DESCRIPTION
There is a race condition that can cause parallel or rapid puppet agent runs to truncate the `agent_disabled_lockfile` this is similiar to a very old issue with the puppetdlockfile #1158.

This changes the `agent_disabled_lockfile` setting type to string to ensure that a file resource is not added to the catalog.