### PR TITLE
(PUP-11002) Expose v4 Catalog endpoint in compiler service

### DIFF
--- a/lib/puppet/http/service/compiler.rb
+++ b/lib/puppet/http/service/compiler.rb
@@ -132,6 +132,75 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
   #
   # @api private
   #
+  # Submit a POST request to request a catalog to the server using v4 endpoint
+  #
+  # @param [String] certname The name of the node for which to compile the catalog.
+  # @param [Hash] persistent A hash containing two required keys, facts and catalog,
+  #   which when set to true will cause the facts and reports to be stored in
+  #   PuppetDB, or discarded if set to false.
+  # @param [String] environment The name of the environment for which to compile the catalog.
+  # @param [Hash] facts A hash with a required values key, containing a hash of all the
+  #    facts for the node. If not provided, Puppet will attempt to fetch facts for the node
+  #    from PuppetDB.
+  # @param [Hash] trusted_facts A hash with a required values key containing a hash of
+  #    the trusted facts for a node
+  # @param [String] transaction_uuid The id for tracking the catalog compilation and
+  #    report submission.
+  # @param [String] job_id The id of the orchestrator job that triggered this run.
+  # @param [Hash] options A hash of options beyond direct input to catalogs. Options:
+  #    - prefer_requested_environment Whether to always override a node's classified 
+  #      environment with the one supplied in the request. If this is true and no environment
+  #      is supplied, fall back to the classified environment, or finally, 'production'.
+  #    - capture_logs Whether to return the errors and warnings that occurred during
+  #      compilation alongside the catalog in the response body.
+  #    - log_level The logging level to use during the compile when capture_logs is true.
+  #      Options are 'err', 'warning', 'info', and 'debug'.
+  #
+  # @return [Array<Puppet::HTTP::Response, Puppet::Resource::Catalog, Array<String>>] An array
+  #   containing the request response, the deserialized catalog returned by
+  #   the server and array containing logs (log array will be empty if capture_logs is false)
+  #
+  def post_catalog4(certname, persistence:, environment:, facts: nil, trusted_facts: nil, transaction_uuid: nil, job_id: nil, options: nil)
+    unless persistence.is_a?(Hash) && (missing = [:facts, :catalog] - persistence.keys.map(&:to_sym)).empty?
+      raise ArgumentError.new("The 'persistence' hash is missing the keys: #{missing.join(', ')}")
+    end
+    raise ArgumentError.new("Facts must be a Hash not a #{facts.class}") unless facts.nil? || facts.is_a?(Hash)
+    body = {
+      certname: certname,
+      persistence: persistence,
+      environment: environment,
+      transaction_uuid: transaction_uuid,
+      job_id: job_id,
+      options: options
+    }
+    body[:facts] = { values: facts } unless facts.nil?
+    body[:trusted_facts] = { values: trusted_facts } unless trusted_facts.nil?
+    headers = add_puppet_headers(
+      'Accept' => get_mime_types(Puppet::Resource::Catalog).join(', '),
+      'Content-Type' => 'application/json'
+    )
+
+    url = URI::HTTPS.build(host: @url.host, port: @url.port, path: Puppet::Util.uri_encode("/puppet/v4/catalog"))
+    response = @client.post(
+      url,
+      body.to_json,
+      headers: headers
+    )
+    process_response(response)
+    begin
+      response_body = JSON.parse(response.body)
+      catalog = Puppet::Resource::Catalog.from_data_hash(response_body['catalog'])
+    rescue => err
+      raise Puppet::HTTP::SerializationError.new("Failed to deserialize catalog from puppetserver response: #{err.message}", err)
+    end
+    
+    logs = response_body['logs'] || []
+    [response, catalog, logs]
+  end
+
+  #
+  # @api private
+  #
   # Submit a GET request to retrieve the facts for the named node
   #
   # @param [String] name Name of the node to retrieve facts for

--- a/spec/unit/http/service/compiler_spec.rb
+++ b/spec/unit/http/service/compiler_spec.rb
@@ -1,3 +1,4 @@
+
 # coding: utf-8
 require 'spec_helper'
 require 'puppet/http'
@@ -254,6 +255,128 @@ describe Puppet::HTTP::Service::Compiler do
 
           subject.post_catalog(certname, environment: environment, facts: facts)
         end
+      end
+    end
+  end
+
+  context 'when posting for a v4 catalog' do
+    let(:uri) {"https://compiler.example.com:8140/puppet/v4/catalog"}
+    let(:persistence) {{ facts: true, catalog: true }}
+    let(:facts) {{ 'foo' => 'bar' }}
+    let(:trusted_facts) {{}}
+    let(:uuid) { "ec3d2844-b236-4287-b0ad-632fbb4d1ff0" }
+    let(:job_id) { "1" }
+    let(:payload) {{
+      environment: environment,
+      persistence: persistence,
+      facts: facts,
+      trusted_facts: trusted_facts,
+      transaction_uuid: uuid,
+      job_id: job_id,
+      options: {
+        prefer_requested_environment: false,
+        capture_logs: false
+      }
+    }}
+    let(:serialized_catalog) {{ 'catalog' => catalog.to_data_hash }.to_json}
+    let(:catalog_response) {{ body: serialized_catalog, headers: {'Content-Type' => formatter.mime }}}
+
+    it 'includes default HTTP headers' do
+      stub_request(:post, uri).with do |request|
+        expect(request.headers).to include({'X-Puppet-Version' => /./, 'User-Agent' => /./})
+        expect(request.headers).to_not include('X-Puppet-Profiling')
+      end.to_return(**catalog_response)
+
+      subject.post_catalog4(certname, payload)
+    end
+
+    it 'defaults the server and port based on settings' do
+      Puppet[:server] = 'compiler2.example.com'
+      Puppet[:serverport] = 8141
+
+      stub_request(:post, "https://compiler2.example.com:8141/puppet/v4/catalog")
+        .to_return(**catalog_response)
+
+      subject.post_catalog4(certname, payload)
+    end
+
+    it 'includes puppet headers set via the :http_extra_headers and :profile settings' do
+      stub_request(:post, uri).with(headers: {'Example-Header' => 'real-thing', 'another' => 'thing', 'X-Puppet-Profiling' => 'true'}).
+        to_return(**catalog_response)
+
+      Puppet[:http_extra_headers] = 'Example-Header:real-thing,another:thing'
+      Puppet[:profile] = true
+
+      subject.post_catalog4(certname, payload)
+    end
+
+    it 'returns a deserialized catalog' do
+      stub_request(:post, uri)
+        .to_return(**catalog_response)
+
+      _, cat, _ = subject.post_catalog4(certname, payload)
+      expect(cat).to be_a(Puppet::Resource::Catalog)
+      expect(cat.name).to eq(certname)
+    end
+
+    it 'returns the request response' do
+      stub_request(:post, uri)
+        .to_return(**catalog_response)
+
+      resp, _, _ = subject.post_catalog4(certname, payload)
+      expect(resp).to be_a(Puppet::HTTP::Response)
+    end
+
+    it 'raises a response error if unsuccessful' do
+      stub_request(:post, uri)
+        .to_return(status: [500, "Server Error"])
+
+      expect {
+        subject.post_catalog4(certname, payload)
+      }.to raise_error do |err|
+        expect(err).to be_an_instance_of(Puppet::HTTP::ResponseError)
+        expect(err.message).to eq('Server Error')
+        expect(err.response.code).to eq(500)
+      end
+    end
+
+    it 'raises a response error when server response is not JSON' do
+      stub_request(:post, uri)
+        .to_return(body: "this isn't valid JSON", headers: {'Content-Type' => 'application/json'})
+
+      expect {
+        subject.post_catalog4(certname, payload)
+      }.to raise_error do |err|
+        expect(err).to be_an_instance_of(Puppet::HTTP::SerializationError)
+        expect(err.message).to match(/Failed to deserialize catalog from puppetserver response/)
+      end
+    end
+
+    it 'raises a response error when server response a JSON serialized catalog' do
+      stub_request(:post, uri)
+        .to_return(body: {oops: 'bad response data'}.to_json, headers: {'Content-Type' => 'application/json'})
+
+      expect {
+        subject.post_catalog4(certname, payload)
+      }.to raise_error do |err|
+        expect(err).to be_an_instance_of(Puppet::HTTP::SerializationError)
+        expect(err.message).to match(/Failed to deserialize catalog from puppetserver response/)
+      end
+    end
+
+    it 'raises ArgumentError when the `persistence` hash does not contain required keys' do
+      payload[:persistence].delete(:facts)
+      expect { subject.post_catalog4(certname, payload) }.to raise_error do |err|
+        expect(err).to be_an_instance_of(ArgumentError)
+        expect(err.message).to match(/The 'persistence' hash is missing the keys: facts/)
+      end
+    end
+
+    it 'raises ArgumentError when `facts` are not a Hash' do
+      payload[:facts] = Puppet::Node::Facts.new(certname)
+      expect { subject.post_catalog4(certname, payload) }.to raise_error do |err|
+        expect(err).to be_an_instance_of(ArgumentError)
+        expect(err.message).to match(/Facts must be a Hash not a Puppet::Node::Facts/)
       end
     end
   end


### PR DESCRIPTION
This commit adds a method to the `Puppet::HTTP::Service::Compiler` class to expose the v4 catalog enpoint in puppetserver.