### PR TITLE
(PUP-10973) Default `puppet facts diff` output to pretty JSON

### DIFF
--- a/lib/puppet/face/facts.rb
+++ b/lib/puppet/face/facts.rb
@@ -117,8 +117,6 @@ Puppet::Indirector::Face.define(:facts, '0.0.1') do
     $ puppet facts diff
     EOT
 
-    render_as :json
-
     when_invoked do |*args|
       Puppet.settings.preferred_run_mode = :agent
       Puppet::Node::Facts.indirection.terminus_class = :facter
@@ -140,6 +138,15 @@ Puppet::Indirector::Face.define(:facts, '0.0.1') do
       else
         Puppet.warning _("Already using Facter 4. To use `puppet facts diff` remove facterng from the .conf file or run `puppet config set facterng false`.")
         exit 0
+      end
+    end
+
+    when_rendering :console do |result|
+      case result
+      when Array, Hash
+        Puppet::Util::Json.dump(result, :pretty => true)
+      else
+        result
       end
     end
   end


### PR DESCRIPTION
This commit allows the `diff` action (from `face/facts.rb`) to output results in a friendly and human readable format by default. The previous one-liner output can still be achieved by using the `--render-as json` option.

Output from Ubuntu 20.04 ARM (without fix):
```sh-session
➜ puppet facts diff
{"mountpoints./.device":{"new_value":"/dev/nvme0n1p1","old_value":"PARTUUID=4ef7520f-474e-4d3e-a298-fe71ee0e99c5"}}

➜ puppet facts diff --render-as yaml
---
mountpoints./.device:
  :new_value: "/dev/nvme0n1p1"
  :old_value: PARTUUID=4ef7520f-474e-4d3e-a298-fe71ee0e99c5

➜ puppet facts diff --render-as json
{"mountpoints./.device":{"new_value":"/dev/nvme0n1p1","old_value":"PARTUUID=4ef7520f-474e-4d3e-a298-fe71ee0e99c5"}}
```

Output from Ubuntu 20.04 ARM (with fix applied):
```sh-session
➜ puppet facts diff
{
  "mountpoints./.device": {
    "new_value": "/dev/nvme0n1p1",
    "old_value": "PARTUUID=4ef7520f-474e-4d3e-a298-fe71ee0e99c5"
  }
}

➜ puppet facts diff --render-as yaml
---
mountpoints./.device:
  :new_value: "/dev/nvme0n1p1"
  :old_value: PARTUUID=4ef7520f-474e-4d3e-a298-fe71ee0e99c5

➜ puppet facts diff --render-as json
{"mountpoints./.device":{"new_value":"/dev/nvme0n1p1","old_value":"PARTUUID=4ef7520f-474e-4d3e-a298-fe71ee0e99c5"}}
```