### PR TITLE
(PUP-10985) Output facts existing only in Facter 4 via `diff` action

### DIFF
--- a/lib/puppet/util/fact_dif.rb
+++ b/lib/puppet/util/fact_dif.rb
@@ -1,15 +1,24 @@
 require 'json'
 
 class FactDif
-  def initialize(old_output, new_output, exclude_list = [])
+  def initialize(old_output, new_output, exclude_list, save_structured)
     @c_facter = JSON.parse(old_output)
     @next_facter = JSON.parse(new_output)
     @exclude_list = exclude_list
+    @save_structured = save_structured
+    @flat_diff = []
     @diff = {}
   end
 
   def difs
-    search_hash(@c_facter, [])
+    search_hash(((@c_facter.to_a - @next_facter.to_a) | (@next_facter.to_a - @c_facter.to_a)).to_h)
+
+    @flat_diff.sort_by { |a| a[0] }.each do |pair|
+      fact_path = pair[0]
+      value = pair[1]
+      compare(fact_path, value, @c_facter)
+      compare(fact_path, value, @next_facter)
+    end
 
     @diff
   end
@@ -28,35 +37,45 @@ class FactDif
         path.pop
       end
     else
-      compare(path, sh)
+      @flat_diff.push([path.dup, sh])
     end
   end
 
-  def compare(fact_path, old_value)
-    new_value = @next_facter.dig(*fact_path)
-    if different?(new_value, old_value) && !excluded?(fact_path.join('.'))
-      @diff[fact_path.join('.')] = { new_value: new_value, old_value: old_value }
+  def compare(fact_path, given_value, compared_hash)
+    compared_value = compared_hash.dig(*fact_path)
+    if different?(compared_value, given_value) && !excluded?(fact_path.join('.'))
+      fact_path = fact_path.map{|f| f.to_s.include?('.') ? "\"#{f}\"" : f}.join('.') unless @save_structured
+      if compared_hash == @c_facter
+        bury(*fact_path, { :new_value => given_value, :old_value => compared_value }, @diff)
+      else
+        bury(*fact_path, { :new_value => compared_value, :old_value => given_value }, @diff)
+      end
+    end
+  end
+
+  def bury(*paths, value, hash)
+    if paths.count > 1
+      path = paths.shift
+      hash[path] = Hash.new unless hash.key?(path)
+      bury(*paths, value, hash[path])
+    else
+      hash[*paths] = value
     end
   end
 
   def different?(new, old)
-    if old.is_a?(String) && new.is_a?(String)
+    if old.is_a?(String) && new.is_a?(String) && (old.include?(',') || new.include?(','))
       old_values = old.split(',')
       new_values = new.split(',')
 
-      diff = old_values - new_values
-      # also add new entries only available in Facter 4
-      diff.concat(new_values - old_values)
-
-      return true if diff.any?
-
-      return false
+      diff = (old_values - new_values) | (new_values - old_values)
+      return diff.size.positive?
     end
 
     old != new
   end
 
   def excluded?(fact_name)
-    @exclude_list.any? {|excluded_fact| fact_name =~ /^#{excluded_fact}$/}
+    @exclude_list.any? {|excluded_fact| fact_name =~ /#{excluded_fact}/}
   end
 end

--- a/spec/unit/application/facts_spec.rb
+++ b/spec/unit/application/facts_spec.rb
@@ -117,18 +117,74 @@ describe Puppet::Application::Facts do
 
   context 'when diff action is called' do
     let(:facter3_facts) { <<~END }
-      {
-        "macaddress": "64:52:11:22:03:2e",
-        "filesystems": "apfs,autofs"
+{
+  "hypervisors": {
+    "vmware": {
+      "version": ""
+    }
+  },
+  "networking": {
+    "interfaces": {
+      "lo": {
+        "bindings6": [
+          {
+            "network": "::1"
+          }
+        ]
+      },
+      "em0.1": {
+        "ip": "0.0.0.0"
       }
-    END
+    }
+  },
+  "macaddress": "64:52:11:22:03:2e",
+  "obsolete_fact": "true",
+  "mountpoints": {
+    "/var": {
+      "options": [
+        "noatime",
+        "journaled",
+        "nobrowse"
+      ]
+    }
+  }
+}
+END
 
     let(:facter4_facts) { <<~END }
-      {
-        "macaddress": "64:52:11:22:03:2e",
-        "filesystems": "apfs,autofs,devfs"
+{
+  "hypervisors": {
+    "vmware": {
+      "version": "ESXi 6.7"
+    }
+  },
+  "networking": {
+    "interfaces": {
+      "lo": {
+        "bindings6": [
+          {
+            "network": "::1",
+            "scope6": "host"
+          }
+        ]
+      },
+      "em0.1": {
+        "ip": "127.0.0.1"
       }
-    END
+    }
+  },
+  "macaddress": "64:52:11:22:03:2e",
+  "mountpoints": {
+    "/var": {
+      "options": [
+        "noatime",
+        "nobrowse",
+        "journaled"
+      ]
+    }
+  }
+}
+END
 
     before :each do
       Puppet::Node::Facts.indirection.terminus_class = :facter
@@ -139,46 +195,322 @@ describe Puppet::Application::Facts do
       allow(Puppet::Util::Execution).to receive(:execute).with(/puppet facts show --facterng/).and_return(facter4_facts)
     end
 
+    # Workaround for YAML issue on Ubuntu where null values get space as key
+    let(:regex) { false }
     shared_examples_for 'correctly rendering output' do |render_format|
       it 'correctly displays output' do
+        app.command_line.args << '--structured' if structured
+        app.command_line.args << '--exclude' << exclude if exclude
         app.command_line.args << '--render-as' << render_format if render_format
         expect {
           app.run
         }.to exit_with(0)
-         .and output(expected_output).to_stdout
+         .and output(regex ? /#{expected_output}/ : expected_output).to_stdout
       end
     end
 
-    context 'when formatting is set to default' do
-      let(:expected_output) { <<~END }
-        {
-          "filesystems": {
-            "new_value": "apfs,autofs,devfs",
-            "old_value": "apfs,autofs"
+    context 'when no exclude regex is provided via CLI' do
+      let(:exclude) { nil }
+      context 'when structured is requested' do
+        let(:structured) { true }
+        context 'when rendering is set to default' do
+          let(:expected_output) { <<~END }
+{
+  "hypervisors": {
+    "vmware": {
+      "version": {
+        "new_value": "ESXi 6.7",
+        "old_value": ""
+      }
+    }
+  },
+  "mountpoints": {
+    "/var": {
+      "options": {
+        "1": {
+          "new_value": "nobrowse",
+          "old_value": "journaled"
+        },
+        "2": {
+          "new_value": "journaled",
+          "old_value": "nobrowse"
+        }
+      }
+    }
+  },
+  "networking": {
+    "interfaces": {
+      "em0.1": {
+        "ip": {
+          "new_value": "127.0.0.1",
+          "old_value": "0.0.0.0"
+        }
+      },
+      "lo": {
+        "bindings6": {
+          "0": {
+            "scope6": {
+              "new_value": "host",
+              "old_value": null
+            }
           }
         }
-      END
+      }
+    }
+  },
+  "obsolete_fact": {
+    "new_value": null,
+    "old_value": "true"
+  }
+}
+END
 
-      it_behaves_like 'correctly rendering output'
+          it_behaves_like 'correctly rendering output'
+        end
+
+        context 'when rendering is set to yaml' do
+          # Workaround for YAML issue on Ubuntu where null values get space as key
+          let(:regex) { true }
+          let(:expected_output) { <<~END }
+---
+hypervisors:
+  vmware:
+    version:
+      :new_value: ESXi 6\.7
+      :old_value: ''
+mountpoints:
+  "/var":
+    options:
+      1:
+        :new_value: nobrowse
+        :old_value: journaled
+      2:
+        :new_value: journaled
+        :old_value: nobrowse
+networking:
+  interfaces:
+    em0\.1:
+      ip:
+        :new_value: 127\.0\.0\.1
+        :old_value: 0\.0\.0\.0
+    lo:
+      bindings6:
+        0:
+          scope6:
+            :new_value: host
+            :old_value:\s?
+obsolete_fact:
+  :new_value:\s?
+  :old_value: 'true'
+END
+
+          it_behaves_like 'correctly rendering output', 'yaml'
+        end
+
+        context 'when rendering is set to json' do
+          let(:expected_output) { <<~END }
+{"hypervisors":{"vmware":{"version":{"new_value":"ESXi 6.7","old_value":""}}},\
+"mountpoints":{"/var":{"options":{"1":{"new_value":"nobrowse","old_value":"journaled"},\
+"2":{"new_value":"journaled","old_value":"nobrowse"}}}},"networking":{"interfaces":\
+{"em0.1":{"ip":{"new_value":"127.0.0.1","old_value":"0.0.0.0"}},"lo":{"bindings6":\
+{"0":{"scope6":{"new_value":"host","old_value":null}}}}}},"obsolete_fact":\
+{"new_value":null,"old_value":"true"}}
+END
+
+          it_behaves_like 'correctly rendering output', 'json'
+        end
+      end
+
+      context 'when structured is not requested' do
+        let(:structured) { false }
+        context 'when rendering is set to default' do
+          let(:expected_output) { <<~END }
+{
+  "hypervisors.vmware.version": {
+    "new_value": "ESXi 6.7",
+    "old_value": ""
+  },
+  "mountpoints./var.options.1": {
+    "new_value": "nobrowse",
+    "old_value": "journaled"
+  },
+  "mountpoints./var.options.2": {
+    "new_value": "journaled",
+    "old_value": "nobrowse"
+  },
+  "networking.interfaces.\\"em0.1\\".ip": {
+    "new_value": "127.0.0.1",
+    "old_value": "0.0.0.0"
+  },
+  "networking.interfaces.lo.bindings6.0.scope6": {
+    "new_value": "host",
+    "old_value": null
+  },
+  "obsolete_fact": {
+    "new_value": null,
+    "old_value": "true"
+  }
+}
+END
+
+          it_behaves_like 'correctly rendering output'
+        end
+
+        context 'when rendering is set to yaml' do
+          # Workaround for YAML issue on Ubuntu where null values get space as key
+          let(:regex) { true }
+          let(:expected_output) { <<~END }
+---
+hypervisors\.vmware\.version:
+  :new_value: ESXi 6\.7
+  :old_value: ''
+mountpoints\./var\.options\.1:
+  :new_value: nobrowse
+  :old_value: journaled
+mountpoints\./var\.options\.2:
+  :new_value: journaled
+  :old_value: nobrowse
+networking\.interfaces\."em0\.1"\.ip:
+  :new_value: 127\.0\.0\.1
+  :old_value: 0\.0\.0\.0
+networking\.interfaces\.lo\.bindings6\.0\.scope6:
+  :new_value: host
+  :old_value:\s?
+obsolete_fact:
+  :new_value:\s?
+  :old_value: 'true'
+END
+
+          it_behaves_like 'correctly rendering output', 'yaml'
+        end
+
+        context 'when rendering is set to json' do
+          let(:expected_output) { <<~END }
+{"hypervisors.vmware.version":{"new_value":"ESXi 6.7","old_value":""},\
+"mountpoints./var.options.1":{"new_value":"nobrowse","old_value":"journaled"},\
+"mountpoints./var.options.2":{"new_value":"journaled","old_value":"nobrowse"},\
+"networking.interfaces.\\"em0.1\\".ip":{"new_value":"127.0.0.1",\
+"old_value":"0.0.0.0"},"networking.interfaces.lo.bindings6.0.scope6":\
+{"new_value":"host","old_value":null},"obsolete_fact":{"new_value":null,\
+"old_value":"true"}}
+END
+
+          it_behaves_like 'correctly rendering output', 'json'
+        end
+      end
     end
 
-    context 'when formatting is set to yaml' do
-      let(:expected_output) { <<~END }
-        ---
-        filesystems:
-          :new_value: apfs,autofs,devfs
-          :old_value: apfs,autofs
-      END
+    context 'when unwanted facts are excluded from diff via CLI option' do
+      let(:exclude) { '^mountpoints\./var\.options.*$|^obsolete_fact$|^hypervisors' }
+      context 'when structured is requested' do
+        let(:structured) { true }
+        context 'when rendering is set to default' do
+          let(:expected_output) { <<~END }
+{
+  "networking": {
+    "interfaces": {
+      "em0.1": {
+        "ip": {
+          "new_value": "127.0.0.1",
+          "old_value": "0.0.0.0"
+        }
+      },
+      "lo": {
+        "bindings6": {
+          "0": {
+            "scope6": {
+              "new_value": "host",
+              "old_value": null
+            }
+          }
+        }
+      }
+    }
+  }
+}
+END
 
-      it_behaves_like 'correctly rendering output', 'yaml'
-    end
+          it_behaves_like 'correctly rendering output'
+        end
 
-    context 'when formatting is set to json' do
-      let(:expected_output) { <<~END }
-        {"filesystems":{"new_value":"apfs,autofs,devfs","old_value":"apfs,autofs"}}
-      END
+        context 'when rendering is set to yaml' do
+          # Workaround for YAML issue on Ubuntu where null values get space as key
+          let(:regex) { true }
+          let(:expected_output) { <<~END }
+---
+networking:
+  interfaces:
+    em0\.1:
+      ip:
+        :new_value: 127\.0\.0\.1
+        :old_value: 0\.0\.0\.0
+    lo:
+      bindings6:
+        0:
+          scope6:
+            :new_value: host
+            :old_value:\s?
+END
 
-      it_behaves_like 'correctly rendering output', 'json'
+          it_behaves_like 'correctly rendering output', 'yaml'
+        end
+
+        context 'when rendering is set to json' do
+          let(:expected_output) { <<~END }
+{"networking":{"interfaces":{"em0.1":{"ip":{"new_value":"127.0.0.1",\
+"old_value":"0.0.0.0"}},"lo":{"bindings6":{"0":{"scope6":{"new_value":\
+"host","old_value":null}}}}}}}
+END
+
+          it_behaves_like 'correctly rendering output', 'json'
+        end
+      end
+
+      context 'when structured is not requested' do
+        let(:structured) { false }
+        context 'when rendering is set to default' do
+          let(:expected_output) { <<~END }
+{
+  "networking.interfaces.\\"em0.1\\".ip": {
+    "new_value": "127.0.0.1",
+    "old_value": "0.0.0.0"
+  },
+  "networking.interfaces.lo.bindings6.0.scope6": {
+    "new_value": "host",
+    "old_value": null
+  }
+}
+END
+
+          it_behaves_like 'correctly rendering output'
+        end
+
+        context 'when rendering is set to yaml' do
+          # Workaround for YAML issue on Ubuntu where null values get space as key
+          let(:regex) { true }
+          let(:expected_output) { <<~END }
+---
+networking\.interfaces\."em0\.1"\.ip:
+  :new_value: 127\.0\.0\.1
+  :old_value: 0\.0\.0\.0
+networking\.interfaces\.lo\.bindings6\.0\.scope6:
+  :new_value: host
+  :old_value:\s?
+END
+
+          it_behaves_like 'correctly rendering output', 'yaml'
+        end
+
+        context 'when rendering is set to json' do
+          let(:expected_output) { <<~END }
+{"networking.interfaces.\\"em0.1\\".ip":{"new_value":"127.0.0.1",\
+"old_value":"0.0.0.0"},"networking.interfaces.lo.bindings6.0.scope6":\
+{"new_value":"host","old_value":null}}
+END
+
+          it_behaves_like 'correctly rendering output', 'json'
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This commit aims to improve the `puppet facts diff` CLI command by:
- showing all differences between Facter 3 and Facter 4 (including facts available only in Facter 4)
- sorting output results in alphabetical order for better human readability
- allowing users to remove certain facts from output (via the `--exclude <regex>` CLI option)
- including a CLI option to see results in a fully structured form
- adding various code improvements
---
Before:
```sh-session
➜ puppet facts diff
{
  "hypervisors.vmware.version": {
    "new_value": "ESXi 6.7",
    "old_value": ""
  }
}

➜ puppet facts diff --render-as yaml
---
hypervisors.vmware.version:
  :new_value: ESXi 6.7
  :old_value: ''

➜ puppet facts diff --render-as json
{"hypervisors.vmware.version":{"new_value":"ESXi 6.7","old_value":""}}
```
---
After:
```sh-session
➜ # # # # # # #
➜ # Example of facts available only using Facter 4 on a Ubuntu 20.04
➜ puppet facts diff
{
  "disks.sda.type": {
    "new_value": "hdd",
    "old_value": null
  },
  "disks.sr0.type": {
    "new_value": "hdd",
    "old_value": null
  },
  "disks.sr1.type": {
    "new_value": "hdd",
    "old_value": null
  },
  "hypervisors.vmware.version": {
    "new_value": "ESXi 6.7",
    "old_value": ""
  },
  "networking.interfaces.ens192.bindings6.0.scope6": {
    "new_value": "link",
    "old_value": null
  },
  "networking.interfaces.lo.bindings6.0.scope6": {
    "new_value": "host",
    "old_value": null
  }
}

➜ puppet facts diff --render-as yaml
---
disks.sda.type:
  :new_value: hdd
  :old_value:
disks.sr0.type:
  :new_value: hdd
  :old_value:
disks.sr1.type:
  :new_value: hdd
  :old_value:
hypervisors.vmware.version:
  :new_value: ESXi 6.7
  :old_value: ''
networking.interfaces.ens192.bindings6.0.scope6:
  :new_value: link
  :old_value:
networking.interfaces.lo.bindings6.0.scope6:
  :new_value: host
  :old_value:

➜ puppet facts diff --render-as json
{"disks.sda.type":{"new_value":"hdd","old_value":null},"disks.sr0.type":{"new_value":"hdd","old_value":null},"disks.sr1.type":{"new_value":"hdd","old_value":null},"hypervisors.vmware.version":{"new_value":"ESXi 6.7","old_value":""},"networking.interfaces.ens192.bindings6.0.scope6":{"new_value":"link","old_value":null},"networking.interfaces.lo.bindings6.0.scope6":{"new_value":"host","old_value":null}}


➜ # # # # # # #
➜ # --structured examples
➜ puppet facts diff --structured
{
  "disks": {
    "sda": {
      "type": {
        "new_value": "hdd",
        "old_value": null
      }
    },
    "sr0": {
      "type": {
        "new_value": "hdd",
        "old_value": null
      }
    },
    "sr1": {
      "type": {
        "new_value": "hdd",
        "old_value": null
      }
    }
  },
  "hypervisors": {
    "vmware": {
      "version": {
        "new_value": "ESXi 6.7",
        "old_value": ""
      }
    }
  },
  "networking": {
    "interfaces": {
      "ens192": {
        "bindings6": {
          "0": {
            "scope6": {
              "new_value": "link",
              "old_value": null
            }
          }
        }
      },
      "lo": {
        "bindings6": {
          "0": {
            "scope6": {
              "new_value": "host",
              "old_value": null
            }
          }
        }
      }
    }
  }
}

➜ puppet facts diff --render-as yaml --structured
---
disks:
  sda:
    type:
      :new_value: hdd
      :old_value:
  sr0:
    type:
      :new_value: hdd
      :old_value:
  sr1:
    type:
      :new_value: hdd
      :old_value:
hypervisors:
  vmware:
    version:
      :new_value: ESXi 6.7
      :old_value: ''
networking:
  interfaces:
    ens192:
      bindings6:
        0:
          scope6:
            :new_value: link
            :old_value:
    lo:
      bindings6:
        0:
          scope6:
            :new_value: host
            :old_value:

➜ puppet facts diff --render-as json --structured
{"disks":{"sda":{"type":{"new_value":"hdd","old_value":null}},"sr0":{"type":{"new_value":"hdd","old_value":null}},"sr1":{"type":{"new_value":"hdd","old_value":null}}},"hypervisors":{"vmware":{"version":{"new_value":"ESXi 6.7","old_value":""}}},"networking":{"interfaces":{"ens192":{"bindings6":{"0":{"scope6":{"new_value":"link","old_value":null}}}},"lo":{"bindings6":{"0":{"scope6":{"new_value":"host","old_value":null}}}}}}}


➜ # # # # # # #
➜ # --exclude examples
➜ puppet facts diff --exclude '^disks\..*\.type$|^hypervisors.vmware.version$'
{
  "networking.interfaces.ens192.bindings6.0.scope6": {
    "new_value": "link",
    "old_value": null
  },
  "networking.interfaces.lo.bindings6.0.scope6": {
    "new_value": "host",
    "old_value": null
  }
}

➜ puppet facts diff --structured --render-as yaml --exclude disks
---
hypervisors:
  vmware:
    version:
      :new_value: ESXi 6.7
      :old_value: ''
networking:
  interfaces:
    ens192:
      bindings6:
        0:
          scope6:
            :new_value: link
            :old_value:
    lo:
      bindings6:
        0:
          scope6:
            :new_value: host
            :old_value:

➜ puppet facts diff --structured --render-as json --exclude 'disks|networking'
{"hypervisors":{"vmware":{"version":{"new_value":"ESXi 6.7","old_value":""}}}}
```