### PR TITLE
(PUP-11004) Return new CA location as default if it exists

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -58,6 +58,18 @@ module Puppet
     end
   end
 
+  def self.default_cadir
+    return "" if Puppet::Util::Platform.windows?
+    old_ca_dir = "#{Puppet[:ssldir]}/ca"
+    new_ca_dir = '/etc/puppetlabs/puppetserver/ca'
+
+    if File.exist?("#{new_ca_dir}/ca_crt.pem")
+      new_ca_dir
+    else
+      old_ca_dir
+    end
+  end
+
   ############################################################################################
   # NOTE: For information about the available values for the ":type" property of settings,
   #   see the docs for Settings.define_settings
@@ -1150,7 +1162,7 @@ EOT
       :desc    => "The name to use the Certificate Authority certificate.",
     },
     :cadir => {
-      :default => "$ssldir/ca",
+      :default => lambda { default_cadir },
       :type => :directory,
       :desc => "The root directory for the certificate authority.",
     },

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -234,4 +234,20 @@ describe "Defaults" do
       Puppet.initialize_settings
     end
   end
+
+  describe "the default cadir", :unless => Puppet::Util::Platform.windows?  do
+    it 'defaults to inside the ssldir if not migrated' do
+      expect(File).to receive(:exist?).with('/etc/puppetlabs/puppetserver/ca/ca_crt.pem').and_return(false)
+      expect(Puppet.default_cadir).to eq("#{Puppet[:ssldir]}/ca")
+    end
+
+    it 'returns the new location if there is CA content there' do
+      expect(File).to receive(:exist?).with('/etc/puppetlabs/puppetserver/ca/ca_crt.pem').and_return(true)
+      expect(Puppet.default_cadir).to eq('/etc/puppetlabs/puppetserver/ca')
+    end
+
+    it 'returns an empty string for Windows platforms', :if => Puppet::Util::Platform.windows? do
+      expect(Puppet.default_cadir).to eq("")
+    end
+  end
 end


### PR DESCRIPTION
This commit adds logic to the default CA dir calculation to make it
return the new CA dir location `/etc/puppetlabs/puppetserver/ca` if the
new location has CA content, since in this case, we understand that
the CA has been migrated, and we want to be using the new location. When
the new location does not exist, we return the old default, since we
want to use the old location for new installs.