### PR TITLE
(PUP-10959) Lock loader hierarchy instead of individual loaders

### DIFF
--- a/lib/puppet/functions.rb
+++ b/lib/puppet/functions.rb
@@ -606,7 +606,7 @@ module Puppet::Functions
     attr_reader :local_types, :parser, :loader
 
     def initialize(loader, name)
-      @loader = Puppet::Pops::Loader::PredefinedLoader.new(loader, :"local_function_#{name}")
+      @loader = Puppet::Pops::Loader::PredefinedLoader.new(loader, :"local_function_#{name}", loader.environment)
       @local_types = []
       # get the shared parser used by puppet's compiler
       @parser = Puppet::Pops::Parser::EvaluatingParser.singleton()

--- a/lib/puppet/loaders.rb
+++ b/lib/puppet/loaders.rb
@@ -24,10 +24,6 @@ module Puppet
       require 'puppet/pops/loader/predefined_loader'
       require 'puppet/pops/loader/generic_plan_instantiator'
       require 'puppet/pops/loader/puppet_plan_instantiator'
-
-      # The implementation of synchronized applies it to all subclasses so we
-      # want to add it to be base class after any subclasses are created
-      Loader.include Puppet::Concurrent::Synchronized
     end
   end
 

--- a/lib/puppet/pops/loader/base_loader.rb
+++ b/lib/puppet/pops/loader/base_loader.rb
@@ -13,8 +13,8 @@ class BaseLoader < Loader
   # The parent loader
   attr_reader :parent
 
-  def initialize(parent_loader, loader_name)
-    super(loader_name)
+  def initialize(parent_loader, loader_name, environment)
+    super(loader_name, environment)
     @parent = parent_loader # the higher priority loader to consult
     @named_values = {}      # hash name => NamedEntry
     @last_result = nil      # the value of the last name (optimization)

--- a/lib/puppet/pops/loader/dependency_loader.rb
+++ b/lib/puppet/pops/loader/dependency_loader.rb
@@ -18,8 +18,8 @@ class Puppet::Pops::Loader::DependencyLoader < Puppet::Pops::Loader::BaseLoader
   # @param name [String] the name of the dependency-loader (used for debugging and tracing only)
   # @param dependency_loaders [Array<Puppet::Pops::Loader>] array of loaders for modules this module depends on
   #
-  def initialize(parent_loader, name, dependency_loaders)
-    super parent_loader, name
+  def initialize(parent_loader, name, dependency_loaders, environment)
+    super(parent_loader, name, environment)
     @dependency_loaders = dependency_loaders
   end
 

--- a/lib/puppet/pops/loader/loader.rb
+++ b/lib/puppet/pops/loader/loader.rb
@@ -70,9 +70,11 @@ class Loader
   # @api public
   #
   def load(type, name)
-    result = load_typed(TypedName.new(type, name.to_s))
-    if result
-      result.value
+    synchronize do
+      result = load_typed(TypedName.new(type, name.to_s))
+      if result
+        result.value
+      end
     end
   end
 
@@ -142,6 +144,13 @@ class Loader
   # @api private
   def private_loader
     self
+  end
+
+  # Lock around a block
+  # This exists so some subclasses that are set up statically and don't actually
+  # load can override it
+  def synchronize(&block)
+    @environment.lock.synchronize(&block)
   end
 
   # Binds a value to a name. The name should not start with '::', but may contain multiple segments.

--- a/lib/puppet/pops/loader/loader.rb
+++ b/lib/puppet/pops/loader/loader.rb
@@ -26,14 +26,15 @@ ENVIRONMENT = 'environment'.freeze
 ENVIRONMENT_PRIVATE = 'environment private'.freeze
 
 class Loader
-  attr_reader :loader_name
+  attr_reader :environment, :loader_name
 
   # Describes the kinds of things that loaders can load
   LOADABLE_KINDS = [:func_4x, :func_4xpp, :func_3x, :datatype, :type_pp, :resource_type_pp, :plan, :task].freeze
 
   # @param [String] name the name of the loader. Must be unique among all loaders maintained by a {Loader} instance
-  def initialize(loader_name)
+  def initialize(loader_name, environment)
     @loader_name = loader_name.freeze
+    @environment = environment
   end
 
   # Search all places where this loader would find values of a given type and return a list the

--- a/lib/puppet/pops/loader/module_loaders.rb
+++ b/lib/puppet/pops/loader/module_loaders.rb
@@ -45,17 +45,17 @@ module ModuleLoaders
     #
     puppet_lib = File.realpath(File.join(File.dirname(__FILE__), '../../..'))
     LibRootedFileBased.new(parent_loader,
-                                                       loaders,
-                                                       nil,
-                                                       puppet_lib,   # may or may not have a 'lib' above 'puppet'
-                                                       'puppet_system',
-                                                        [:func_4x, :func_3x, :datatype]   # only load ruby functions and types from "puppet"
-                                                       )
+                           loaders,
+                           nil,
+                           puppet_lib,   # may or may not have a 'lib' above 'puppet'
+                           'puppet_system',
+                           [:func_4x, :func_3x, :datatype]   # only load ruby functions and types from "puppet"
+                          )
   end
 
   def self.environment_loader_from(parent_loader, loaders, env_path)
     if env_path.nil? || env_path.empty?
-      EmptyLoader.new(parent_loader, ENVIRONMENT)
+      EmptyLoader.new(parent_loader, ENVIRONMENT, loaders.environment)
     else
       FileBased.new(parent_loader,
         loaders,
@@ -125,7 +125,7 @@ module ModuleLoaders
     # @param loader_name [String] a name that is used for human identification (useful when module_name is nil)
     #
     def initialize(parent_loader, loaders, module_name, path, loader_name, loadables)
-      super parent_loader, loader_name
+      super(parent_loader, loader_name, loaders.environment)
 
       raise ArgumentError, 'path based loader cannot be instantiated without a path' if path.nil? || path.empty?
 

--- a/lib/puppet/pops/loader/predefined_loader.rb
+++ b/lib/puppet/pops/loader/predefined_loader.rb
@@ -19,6 +19,10 @@ class PredefinedLoader < BaseLoader
   def allow_shadowing?
     true
   end
+
+  def synchronize(&block)
+    yield
+  end
 end
 
 end

--- a/lib/puppet/pops/loader/runtime3_type_loader.rb
+++ b/lib/puppet/pops/loader/runtime3_type_loader.rb
@@ -10,7 +10,7 @@ class Runtime3TypeLoader < BaseLoader
   attr_reader :resource_3x_loader
 
   def initialize(parent_loader, loaders, environment, resource_3x_loader)
-    super(parent_loader, environment.name)
+    super(parent_loader, environment.name, environment)
     @environment = environment
     @resource_3x_loader = resource_3x_loader
   end

--- a/lib/puppet/pops/loader/static_loader.rb
+++ b/lib/puppet/pops/loader/static_loader.rb
@@ -122,6 +122,10 @@ class StaticLoader < Loader
   def create_resource_type_reference(name)
     add_type(name, Types::TypeFactory.resource(name))
   end
+
+  def synchronize(&block)
+    yield
+  end
 end
 end
 end

--- a/lib/puppet/pops/loaders.rb
+++ b/lib/puppet/pops/loaders.rb
@@ -398,7 +398,7 @@ class Loaders
 
       if env_path.nil?
         # Not a real directory environment, cannot work as a module TODO: Drop when legacy env are dropped?
-        loader = add_loader_by_name(Loader::SimpleEnvironmentLoader.new(@runtime3_type_loader, Loader::ENVIRONMENT))
+        loader = add_loader_by_name(Loader::SimpleEnvironmentLoader.new(@runtime3_type_loader, Loader::ENVIRONMENT, environment))
       else
         # View the environment as a module to allow loading from it - this module is always called 'environment'
         loader = Loader::ModuleLoaders.environment_loader_from(@runtime3_type_loader, self, env_path)
@@ -413,7 +413,7 @@ class Loaders
     # Code in the environment gets to see all modules (since there is no metadata for the environment)
     # but since this is not given to the module loaders, they can not load global code (since they can not
     # have prior knowledge about this
-    loader = add_loader_by_name(Loader::DependencyLoader.new(loader, Loader::ENVIRONMENT_PRIVATE, @module_resolver.all_module_loaders()))
+    loader = add_loader_by_name(Loader::DependencyLoader.new(loader, Loader::ENVIRONMENT_PRIVATE, @module_resolver.all_module_loaders(), environment))
 
     # The module loader gets the private loader via a lazy operation to look up the module's private loader.
     # This does not work for an environment since it is not resolved the same way.
@@ -529,13 +529,13 @@ class Loaders
     private
 
     def create_loader_with_all_modules_visible(from_module_data)
-      @loaders.add_loader_by_name(Loader::DependencyLoader.new(from_module_data.public_loader, "#{from_module_data.name} private", all_module_loaders()))
+      @loaders.add_loader_by_name(Loader::DependencyLoader.new(from_module_data.public_loader, "#{from_module_data.name} private", all_module_loaders(), @loaders.environment))
     end
 
     def create_loader_with_dependencies_first(from_module_data)
       dependency_loaders = from_module_data.dependency_names.collect { |name| @index[name].public_loader }
       visible_loaders = dependency_loaders + (all_module_loaders() - dependency_loaders)
-      @loaders.add_loader_by_name(Loader::DependencyLoader.new(from_module_data.public_loader, "#{from_module_data.name} private", visible_loaders))
+      @loaders.add_loader_by_name(Loader::DependencyLoader.new(from_module_data.public_loader, "#{from_module_data.name} private", visible_loaders, @loaders.environment))
     end
   end
 end

--- a/lib/puppet/pops/types/p_type_set_type.rb
+++ b/lib/puppet/pops/types/p_type_set_type.rb
@@ -15,7 +15,7 @@ class PTypeSetType < PMetaType
   # @api private
   class TypeSetLoader < Loader::BaseLoader
     def initialize(type_set, parent)
-      super(parent, "(TypeSetFirstLoader '#{type_set.name}')")
+      super(parent, "(TypeSetFirstLoader '#{type_set.name}')", parent.environment)
       @type_set = type_set
     end
 

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -4,6 +4,7 @@ require 'puppet/util/watched_file'
 require 'puppet/util/command_line/puppet_option_parser'
 require 'forwardable'
 require 'fileutils'
+require 'concurrent'
 
 # The class for handling configuration files.
 class Puppet::Settings
@@ -146,8 +147,8 @@ class Puppet::Settings
     @configuration_file = nil
 
     # And keep a per-environment cache
-    @cache = Hash.new { |hash, key| hash[key] = {} }
-    @values = Hash.new { |hash, key| hash[key] = {} }
+    @cache = Concurrent::Hash.new { |hash, key| hash[key] = Concurrent::Hash.new }
+    @values = Concurrent::Hash.new { |hash, key| hash[key] = Concurrent::Hash.new }
 
     # The list of sections we've used.
     @used = []

--- a/spec/unit/pops/loaders/dependency_loader_spec.rb
+++ b/spec/unit/pops/loaders/dependency_loader_spec.rb
@@ -122,7 +122,7 @@ Puppet::Functions.create_function('testmodule::foo') {
 
   def loader_for(name, dir)
       module_loader = Puppet::Pops::Loader::ModuleLoaders.module_loader_from(static_loader, loaders, name, dir)
-      Puppet::Pops::Loader::DependencyLoader.new(static_loader, 'test-dep', [module_loader])
+      Puppet::Pops::Loader::DependencyLoader.new(static_loader, 'test-dep', [module_loader], loaders.environment)
   end
 
   def typed_name(type, name)

--- a/spec/unit/pops/types/type_parser_spec.rb
+++ b/spec/unit/pops/types/type_parser_spec.rb
@@ -210,7 +210,8 @@ describe TypeParser do
   end
 
   context 'with loader context' do
-    let(:loader) { Puppet::Pops::Loader::BaseLoader.new(nil, "type_parser_unit_test_loader") }
+    let(:environment) { Puppet::Node::Environment.create(:testing, []) }
+    let(:loader) { Puppet::Pops::Loader::BaseLoader.new(nil, "type_parser_unit_test_loader", environment) }
 
     it 'interprets anything that is not found by the loader to be a type reference' do
       expect(loader).to receive(:load).with(:type, 'nonesuch').and_return(nil)


### PR DESCRIPTION
This makes loaders aware of the environment they are loading for and then attempts to lock with the environment instead of synchronizing each loader instance on itself.