### PR TITLE
(maint) Retrieve only stdout for `puppet facts diff`

### DIFF
--- a/lib/puppet/face/facts.rb
+++ b/lib/puppet/face/facts.rb
@@ -141,8 +141,8 @@ Puppet::Indirector::Face.define(:facts, '0.0.1') do
           puppet_show_cmd = "ruby -S -- #{puppet_show_cmd}"
         end
 
-        facter_3_result = Puppet::Util::Execution.execute("#{puppet_show_cmd} --no-facterng #{cmd_flags}")
-        facter_ng_result = Puppet::Util::Execution.execute("#{puppet_show_cmd} --facterng #{cmd_flags}")
+        facter_3_result = Puppet::Util::Execution.execute("#{puppet_show_cmd} --no-facterng #{cmd_flags}", combine: false)
+        facter_ng_result = Puppet::Util::Execution.execute("#{puppet_show_cmd} --facterng #{cmd_flags}", combine: false)
 
         exclude_list = options[:exclude].nil? ? EXCLUDE_LIST : EXCLUDE_LIST + [ options[:exclude] ]
         fact_diff = FactDif.new(facter_3_result, facter_ng_result, exclude_list, options[:structured])

--- a/spec/unit/application/facts_spec.rb
+++ b/spec/unit/application/facts_spec.rb
@@ -191,8 +191,8 @@ END
       app.command_line.args = %w{diff}
 
       allow(Facter).to receive(:value).with('facterversion').and_return('3.99.0')
-      allow(Puppet::Util::Execution).to receive(:execute).with(/puppet facts show --no-facterng/).and_return(facter3_facts)
-      allow(Puppet::Util::Execution).to receive(:execute).with(/puppet facts show --facterng/).and_return(facter4_facts)
+      allow(Puppet::Util::Execution).to receive(:execute).with(/puppet facts show --no-facterng/, combine:false).and_return(facter3_facts)
+      allow(Puppet::Util::Execution).to receive(:execute).with(/puppet facts show --facterng/, combine:false).and_return(facter4_facts)
     end
 
     # Workaround for YAML issue on Ubuntu where null values get space as key


### PR DESCRIPTION
Previously, when executing `puppet facts show` for creating the result of `puppet facts diff`, we could end up with warnings besides the needed output  which was breaking our JSON parsing. This commit ensures that we retrieve stdout only and discard stderr.

Example of error:
```sh-session
➜  puppet facts diff
Error: 765: unexpected token at 'Warning: Facter: timeout option is not supported for custom facts and will be ignored.
{"aio_agent_version":"6.21.1.48", ...
```