### PR TITLE
(PUP-10946) add max-files for file and tidy resources

### DIFF
--- a/lib/puppet/http/service/file_server.rb
+++ b/lib/puppet/http/service/file_server.rb
@@ -106,7 +106,7 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
   #   An array with the request response and an array of the deserialized
   #   metadata for each file returned from the server
   #
-  def get_file_metadatas(path: nil, environment:, recurse: :false, recurselimit: nil, ignore: nil, links: :manage, checksum_type: Puppet[:digest_algorithm], source_permissions: :ignore)
+  def get_file_metadatas(path: nil, environment:, recurse: :false, recurselimit: nil, max_files: nil, ignore: nil, links: :manage, checksum_type: Puppet[:digest_algorithm], source_permissions: :ignore)
     validate_path(path)
 
     headers = add_puppet_headers('Accept' => get_mime_types(Puppet::FileServing::Metadata).join(', '))
@@ -117,6 +117,7 @@ class Puppet::HTTP::Service::FileServer < Puppet::HTTP::Service
       params: {
         recurse: recurse,
         recurselimit: recurselimit,
+        max_files: max_files,
         ignore: ignore,
         links: links,
         checksum_type: checksum_type,

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -194,6 +194,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
           :source_permissions => resource[:source_permissions] ? resource[:source_permissions].to_sym : :ignore,
           :recurse            => true,
           :recurselimit       => resource[:recurselimit],
+          :max_files          => resource[:max_files],
           :ignore             => resource[:ignore],
         }
 

--- a/lib/puppet/indirector/file_metadata/rest.rb
+++ b/lib/puppet/indirector/file_metadata/rest.rb
@@ -46,6 +46,7 @@ class Puppet::Indirector::FileMetadata::Rest < Puppet::Indirector::REST
       environment: request.environment.to_s,
       recurse: request.options[:recurse],
       recurselimit: request.options[:recurselimit],
+      max_files: request.options[:max_files],
       ignore: request.options[:ignore],
       links: request.options[:links],
       checksum_type: request.options[:checksum_type],

--- a/lib/puppet/type/tidy.rb
+++ b/lib/puppet/type/tidy.rb
@@ -50,6 +50,22 @@ Puppet::Type.newtype(:tidy) do
     end
   end
 
+  newparam(:max_files) do
+    desc "In case the resource is a directory and the recursion is enabled, puppet will
+      generate a new resource for each file file found, possible leading to
+      an excessive number of resources generated without any control.
+
+      Setting `max_files` will check the number of file resources that
+      will eventually be created and will raise a resource argument error if the
+      limit will be exceeded.
+
+      Use value `0` to disable the check. In this case, a warning is logged if
+      the number of files exceeds 1000."
+
+    defaultto 0
+    newvalues(/^[0-9]+$/)
+  end
+
   newparam(:matches) do
     desc <<-'EOT'
       One or more (shell type) file glob patterns, which restrict
@@ -256,9 +272,12 @@ Puppet::Type.newtype(:tidy) do
 
     case self[:recurse]
     when Integer, /^\d+$/
-      parameter = { :recurse => true, :recurselimit => self[:recurse] }
+      parameter = { :max_files => self[:max_files],
+                    :recurse => true,
+                    :recurselimit => self[:recurse] }
     when true, :true, :inf
-      parameter = { :recurse => true }
+      parameter = { :max_files => self[:max_files],
+                    :recurse => true }
     end
 
     if parameter

--- a/spec/unit/indirector/catalog/compiler_spec.rb
+++ b/spec/unit/indirector/catalog/compiler_spec.rb
@@ -909,9 +909,10 @@ describe Puppet::Resource::Catalog::Compiler do
         it "inlines child metadata" do
           catalog = compile_to_catalog(<<-MANIFEST, node)
             file { '#{path}':
-              ensure  => directory,
-              recurse => true,
-              source  => '#{source_dir}'
+              ensure    => directory,
+              recurse   => true,
+              source    => '#{source_dir}',
+              max_files => 1234,
             }
           MANIFEST
 
@@ -925,6 +926,7 @@ describe Puppet::Resource::Catalog::Compiler do
             :source_permissions => :ignore,
             :recurse            => true,
             :recurselimit       => nil,
+            :max_files          => 1234,
             :ignore             => nil,
           }
           expect(Puppet::FileServing::Metadata.indirection).to receive(:search).with(source_dir, options).and_return([metadata, child_metadata])
@@ -938,14 +940,15 @@ describe Puppet::Resource::Catalog::Compiler do
         it "uses resource parameters when inlining metadata" do
           catalog = compile_to_catalog(<<-MANIFEST, node)
             file { '#{path}':
-              ensure  => directory,
-              recurse => true,
-              source  => '#{source_dir}',
-              checksum => sha256,
+              ensure             => directory,
+              recurse            => true,
+              source             => '#{source_dir}',
+              checksum           => sha256,
               source_permissions => use_when_creating,
-              recurselimit => 2,
-              ignore => 'foo.+',
-              links => follow,
+              recurselimit       => 2,
+              max_files          => 4321,
+              ignore             => 'foo.+',
+              links              => follow,
             }
           MANIFEST
 
@@ -956,6 +959,7 @@ describe Puppet::Resource::Catalog::Compiler do
             :source_permissions => :use_when_creating,
             :recurse            => true,
             :recurselimit       => 2,
+            :max_files          => 4321,
             :ignore             => 'foo.+',
           }
           expect(Puppet::FileServing::Metadata.indirection).to receive(:search).with(source_dir, options).and_return([metadata, child_metadata])

--- a/spec/unit/type/tidy_spec.rb
+++ b/spec/unit/type/tidy_spec.rb
@@ -195,17 +195,27 @@ describe tidy do
         allow(Puppet::FileServing::Fileset).to receive(:new).and_return(@fileset)
       end
 
-      it "should use a Fileset for infinite recursion" do
-        expect(Puppet::FileServing::Fileset).to receive(:new).with(@basepath, :recurse => true).and_return(@fileset)
+      it "should use a Fileset with default max_files for infinite recursion" do
+        expect(Puppet::FileServing::Fileset).to receive(:new).with(@basepath, :recurse => true, :max_files=>0).and_return(@fileset)
         expect(@fileset).to receive(:files).and_return(%w{. one two})
         allow(@tidy).to receive(:tidy?).and_return(false)
 
         @tidy.generate
       end
 
-      it "should use a Fileset for limited recursion" do
+      it "should use a Fileset with default max_files for limited recursion" do
         @tidy[:recurse] = 42
-        expect(Puppet::FileServing::Fileset).to receive(:new).with(@basepath, :recurse => true, :recurselimit => 42).and_return(@fileset)
+        expect(Puppet::FileServing::Fileset).to receive(:new).with(@basepath, :recurse => true, :recurselimit => 42, :max_files=>0).and_return(@fileset)
+        expect(@fileset).to receive(:files).and_return(%w{. one two})
+        allow(@tidy).to receive(:tidy?).and_return(false)
+
+        @tidy.generate
+      end
+
+      it "should use a Fileset with max_files for limited recursion" do
+        @tidy[:recurse] = 42
+        @tidy[:max_files] = 9876
+        expect(Puppet::FileServing::Fileset).to receive(:new).with(@basepath, :recurse => true, :recurselimit => 42, :max_files=>9876).and_return(@fileset)
         expect(@fileset).to receive(:files).and_return(%w{. one two})
         allow(@tidy).to receive(:tidy?).and_return(false)
 
@@ -411,7 +421,7 @@ describe tidy do
       @tidy[:recurse] = true
       @tidy[:rmdirs] = true
       fileset = double('fileset')
-      expect(Puppet::FileServing::Fileset).to receive(:new).with(@basepath, :recurse => true).and_return(fileset)
+      expect(Puppet::FileServing::Fileset).to receive(:new).with(@basepath, :recurse => true, :max_files=>0).and_return(fileset)
       expect(fileset).to receive(:files).and_return(%w{. one two one/subone two/subtwo one/subone/ssone})
       allow(@tidy).to receive(:tidy?).and_return(true)
 
@@ -433,7 +443,7 @@ describe tidy do
       @tidy[:recurse] = true
       @tidy[:rmdirs] = true
       fileset = double('fileset')
-      expect(Puppet::FileServing::Fileset).to receive(:new).with(@basepath, :recurse => true).and_return(fileset)
+      expect(Puppet::FileServing::Fileset).to receive(:new).with(@basepath, :recurse => true, :max_files=>0).and_return(fileset)
       expect(fileset).to receive(:files).and_return(%w{. a a/2 a/1 a/3})
       allow(@tidy).to receive(:tidy?).and_return(true)
 
@@ -446,7 +456,7 @@ describe tidy do
       @tidy[:noop] = true
 
       fileset = double('fileset')
-      expect(Puppet::FileServing::Fileset).to receive(:new).with(@basepath, :recurse => true).and_return(fileset)
+      expect(Puppet::FileServing::Fileset).to receive(:new).with(@basepath, :recurse => true, :max_files=>0).and_return(fileset)
       expect(fileset).to receive(:files).and_return(%w{. a a/2 a/1 a/3})
       allow(@tidy).to receive(:tidy?).and_return(true)
 


### PR DESCRIPTION
Adds a new parameter, `max-files`, to limit the number of resources
that may be created by types supporting recursion(file, tidy).

In case the number of resources is greater than `max-files`, an
ArgumentError is raised.