### PR TITLE
(PUP-11022) Resolve order dependent test failures

### DIFF
--- a/spec/unit/gettext/config_spec.rb
+++ b/spec/unit/gettext/config_spec.rb
@@ -27,6 +27,18 @@ describe Puppet::GettextConfig do
     Puppet::GettextConfig.delete_all_text_domains
   end
 
+  # These tests assume gettext is enabled, but it will be disabled when the
+  # first time the `Puppet[:disable_i18n]` setting is resolved
+  around(:each) do |example|
+    disabled = Puppet::GettextConfig.instance_variable_get(:@gettext_disabled)
+    Puppet::GettextConfig.instance_variable_set(:@gettext_disabled, false)
+    begin
+      example.run
+    ensure
+      Puppet::GettextConfig.instance_variable_set(:@gettext_disabled, disabled)
+    end
+  end
+
   describe 'setting and getting the locale' do
     it 'should return "en" when gettext is unavailable' do
       allow(Puppet::GettextConfig).to receive(:gettext_loaded?).and_return(false)

--- a/spec/unit/provider/service/init_spec.rb
+++ b/spec/unit/provider/service/init_spec.rb
@@ -83,6 +83,7 @@ describe 'Puppet::Type::Service::Provider::Init',
       allow(provider_class).to receive(:defpath).and_return('tmp')
 
       @services = ['one', 'two', 'three', 'four', 'umountfs']
+      allow(Dir).to receive(:entries).and_call_original
       allow(Dir).to receive(:entries).with('tmp').and_return(@services)
       expect(FileTest).to receive(:directory?).with('tmp').and_return(true)
       allow(FileTest).to receive(:executable?).and_return(true)

--- a/spec/unit/provider/service/openwrt_spec.rb
+++ b/spec/unit/provider/service/openwrt_spec.rb
@@ -32,6 +32,7 @@ describe 'Puppet::Type::Service::Provider::Openwrt',
     allow(File).to receive(:directory?).with('/etc/init.d').and_return(true)
 
     allow(Puppet::FileSystem).to receive(:exist?).with('/etc/init.d/myservice').and_return(true)
+    allow(FileTest).to receive(:file?).and_call_original
     allow(FileTest).to receive(:file?).with('/etc/init.d/myservice').and_return(true)
     allow(FileTest).to receive(:executable?).with('/etc/init.d/myservice').and_return(true)
   end
@@ -47,7 +48,8 @@ describe 'Puppet::Type::Service::Provider::Openwrt',
     let(:services) {['dnsmasq', 'dropbear', 'firewall', 'led', 'puppet', 'uhttpd' ]}
 
     before :each do
-      allow(Dir).to receive(:entries).and_return(services)
+      allow(Dir).to receive(:entries).and_call_original
+      allow(Dir).to receive(:entries).with('/etc/init.d').and_return(services)
       allow(FileTest).to receive(:directory?).and_return(true)
       allow(FileTest).to receive(:executable?).and_return(true)
     end

--- a/spec/unit/transaction/additional_resource_generator_spec.rb
+++ b/spec/unit/transaction/additional_resource_generator_spec.rb
@@ -93,8 +93,6 @@ describe Puppet::Transaction::AdditionalResourceGenerator do
     end
   end
 
-
-
   after(:each) do
     Puppet::Type.rmtype(:gen_empty)
     Puppet::Type.rmtype(:eval_after)

--- a/spec/unit/transaction_spec.rb
+++ b/spec/unit/transaction_spec.rb
@@ -793,16 +793,8 @@ describe Puppet::Transaction do
     end
 
     it "should call Selinux.matchpathcon_fini in case Selinux is enabled ", :if => Puppet.features.posix? do
-      unless defined?(Selinux)
-        module Selinux
-          def self.is_selinux_enabled
-            true
-          end
-
-          def self.matchpathcon_fini
-          end
-        end
-      end
+      selinux = double('selinux', is_selinux_enabled: true, matchpathcon_fini: nil)
+      stub_const('Selinux', selinux)
 
       resource = Puppet::Type.type(:file).new(:path => make_absolute("/tmp/foo"))
       transaction = transaction_with_resource(resource)

--- a/spec/unit/transaction_spec.rb
+++ b/spec/unit/transaction_spec.rb
@@ -5,13 +5,6 @@ require 'puppet_spec/compiler'
 require 'puppet/transaction'
 require 'fileutils'
 
-Puppet::Type.newtype(:generator) do
-  newparam(:name) { isnamevar }
-
-  def generate
-  end
-end
-
 describe Puppet::Transaction do
   include PuppetSpec::Files
   include PuppetSpec::Compiler
@@ -25,6 +18,19 @@ describe Puppet::Transaction do
   def transaction_with_resource(resource)
     transaction = Puppet::Transaction.new(catalog_with_resource(resource), nil, Puppet::Graph::SequentialPrioritizer.new)
     transaction
+  end
+
+  before(:all) do
+    Puppet::Type.newtype(:transaction_generator) do
+      newparam(:name) { isnamevar }
+
+      def generate
+      end
+    end
+  end
+
+  after(:all) do
+    Puppet::Type.rmtype(:transaction_generator)
   end
 
   before do
@@ -330,9 +336,9 @@ describe Puppet::Transaction do
   describe "when generating resources before traversal" do
     let(:catalog) { Puppet::Resource::Catalog.new }
     let(:transaction) { Puppet::Transaction.new(catalog, nil, Puppet::Graph::SequentialPrioritizer.new) }
-    let(:generator) { Puppet::Type.type(:generator).new :title => "generator" }
+    let(:generator) { Puppet::Type.type(:transaction_generator).new :title => "generator" }
     let(:generated) do
-      %w[a b c].map { |name| Puppet::Type.type(:generator).new(:name => name) }
+      %w[a b c].map { |name| Puppet::Type.type(:transaction_generator).new(:name => name) }
     end
 
     before :each do
@@ -673,7 +679,7 @@ describe Puppet::Transaction do
         end
 
         describe "and new resources are generated" do
-          let(:generator) { Puppet::Type.type(:generator).new :title => "generator" }
+          let(:generator) { Puppet::Type.type(:transaction_generator).new :title => "generator" }
           let(:generated) do
             %w[a b c].map { |name| Puppet::Type.type(:package).new :title => "foo", :name => name, :provider => :apt }
           end

--- a/spec/unit/util/selinux_spec.rb
+++ b/spec/unit/util/selinux_spec.rb
@@ -3,26 +3,29 @@ require 'spec_helper'
 require 'pathname'
 require 'puppet/util/selinux'
 
-unless defined?(Selinux)
-  module Selinux
-    def self.is_selinux_enabled
-      false
-    end
-  end
-end
-
 describe Puppet::Util::SELinux do
   include Puppet::Util::SELinux
 
+  let(:selinux) { double('selinux', is_selinux_enabled: false) }
+
+  before :each do
+    stub_const('Selinux', selinux)
+  end
+
   describe "selinux_support?" do
-    it "should return :true if this system has SELinux enabled" do
+    it "should return true if this system has SELinux enabled" do
       expect(Selinux).to receive(:is_selinux_enabled).and_return(1)
-      expect(selinux_support?).to be_truthy
+      expect(selinux_support?).to eq(true)
     end
 
-    it "should return :false if this system lacks SELinux" do
+    it "should return false if this system has SELinux disabled" do
       expect(Selinux).to receive(:is_selinux_enabled).and_return(0)
-      expect(selinux_support?).to be_falsey
+      expect(selinux_support?).to eq(false)
+    end
+
+    it "should return false if this system lacks SELinux" do
+      hide_const('Selinux')
+      expect(selinux_support?).to eq(false)
     end
 
     it "should return nil if /proc/mounts does not exist" do


### PR DESCRIPTION
This resolves order dependent test failures seen when running:

```shell
$ bundle exec rspec spec/integration/application/plugin_spec.rb spec/unit/gettext/config_spec.rb
$ bundle exec rspec spec/integration/application/plugin_spec.rb spec/unit/provider/service/init_spec.rb
$ bundle exec rspec spec/unit/util/selinux_spec.rb spec/unit/transaction_spec.rb
$ bundle exec rspec spec/unit/transaction/additional_resource_generator_spec.rb spec/unit/transaction_spec.rb
```

There will be merge conflicts when merging to main, I'll take care of that after this passes CI