### PR TITLE
(PUP-11024) enable dnfmodule with no default profile on newer dnf(main)

### DIFF
--- a/lib/puppet/provider/package/dnfmodule.rb
+++ b/lib/puppet/provider/package/dnfmodule.rb
@@ -93,7 +93,7 @@ Puppet::Type.type(:package).provide :dnfmodule, :parent => :dnf do
         # module has no default profile and no profile was requested, so just enable the stream
         # DNF versions prior to 4.2.8 do not need this workaround
         # see https://bugzilla.redhat.com/show_bug.cgi?id=1669527
-        if @resource[:flavor] == nil && e.message =~ /^missing groups or modules: #{Regexp.quote(@resource[:name])}$/
+        if @resource[:flavor] == nil && e.message =~ /^(?:missing|broken) groups or modules: #{Regexp.quote(@resource[:name])}$/
           enable(args)
         else
           raise

--- a/spec/unit/provider/package/dnfmodule_spec.rb
+++ b/spec/unit/provider/package/dnfmodule_spec.rb
@@ -123,8 +123,17 @@ describe Puppet::Type.type(:package).provider(:dnfmodule) do
         provider.install
       end
 
-      it "should just enable the module if it has no default profile" do
+      it "should just enable the module if it has no default profile(missing groups or modules)" do
         dnf_exception = Puppet::ExecutionFailure.new("Error: Problems in request:\nmissing groups or modules: #{resource[:name]}")
+        allow(provider).to receive(:execute).with(array_including('install')).and_raise(dnf_exception)
+        resource[:ensure] = :present
+        expect(provider).to receive(:execute).with(array_including('install')).ordered
+        expect(provider).to receive(:execute).with(array_including('enable')).ordered
+        provider.install
+      end
+
+      it "should just enable the module if it has no default profile(broken groups or modules)" do
+        dnf_exception = Puppet::ExecutionFailure.new("Error: Problems in request:\nbroken groups or modules: #{resource[:name]}")
         allow(provider).to receive(:execute).with(array_including('install')).and_raise(dnf_exception)
         resource[:ensure] = :present
         expect(provider).to receive(:execute).with(array_including('install')).ordered


### PR DESCRIPTION
When trying to install a module without default profile, newer
`dnf` versions (eg. 4.2.23) show a different error message.

This commit adapts the `dnf` error message expected in dnfmodule provider.