### PR TITLE
(PUP-7559) Pass correct mode when lookup SELinux default context

### DIFF
--- a/lib/puppet/type/file/selcontext.rb
+++ b/lib/puppet/type/file/selcontext.rb
@@ -42,7 +42,7 @@ module Puppet
         return nil
       end
 
-      context = self.get_selinux_default_context(@resource[:path], @resource[:ensure].to_s)
+      context = self.get_selinux_default_context(@resource[:path], @resource[:ensure])
       unless context
         return nil
       end

--- a/lib/puppet/type/file/selcontext.rb
+++ b/lib/puppet/type/file/selcontext.rb
@@ -42,7 +42,7 @@ module Puppet
         return nil
       end
 
-      context = self.get_selinux_default_context(@resource[:path])
+      context = self.get_selinux_default_context(@resource[:path], @resource[:ensure].to_s)
       unless context
         return nil
       end

--- a/lib/puppet/util/selinux.rb
+++ b/lib/puppet/util/selinux.rb
@@ -213,14 +213,13 @@ module Puppet::Util::SELinux
   # what context a new resource being created should have.
   def get_create_mode(resource_ensure)
     mode = 0
-    return mode if resource_ensure == 'absent'
     case resource_ensure
-    when "present", "file"
-      mode = 0 | S_IFREG
-    when "directory"
-      mode = 0 | S_IFDIR
-    when "link"
-      mode = 0 | S_IFLNK
+    when :present, :file
+      mode |= S_IFREG
+    when :directory
+      mode |= S_IFDIR
+    when :link
+      mode |= S_IFLNK
     end
     mode
   end

--- a/spec/unit/type/file/selinux_spec.rb
+++ b/spec/unit/type/file/selinux_spec.rb
@@ -50,13 +50,13 @@ require 'spec_helper'
     end
 
     it "should handle no default gracefully" do
-      expect(@sel).to receive(:get_selinux_default_context).with(@path).and_return(nil)
+      expect(@sel).to receive(:get_selinux_default_context).with(@path, @resource[:ensure].to_s).and_return(nil)
       expect(@sel.default).to be_nil
     end
 
     it "should be able to detect matchpathcon defaults" do
       allow(@sel).to receive(:debug)
-      expect(@sel).to receive(:get_selinux_default_context).with(@path).and_return("user_u:role_r:type_t:s0")
+      expect(@sel).to receive(:get_selinux_default_context).with(@path, @resource[:ensure].to_s).and_return("user_u:role_r:type_t:s0")
       expectedresult = case param
         when :seluser; "user_u"
         when :selrole; "role_r"

--- a/spec/unit/type/file/selinux_spec.rb
+++ b/spec/unit/type/file/selinux_spec.rb
@@ -7,7 +7,7 @@ require 'spec_helper'
 
     before do
       @path = make_absolute("/my/file")
-      @resource = Puppet::Type.type(:file).new :path => @path
+      @resource = Puppet::Type.type(:file).new(:path => @path, :ensure => :file)
       @sel = property.new :resource => @resource
     end
 
@@ -50,13 +50,13 @@ require 'spec_helper'
     end
 
     it "should handle no default gracefully" do
-      expect(@sel).to receive(:get_selinux_default_context).with(@path, @resource[:ensure].to_s).and_return(nil)
+      expect(@sel).to receive(:get_selinux_default_context).with(@path, :file).and_return(nil)
       expect(@sel.default).to be_nil
     end
 
     it "should be able to detect matchpathcon defaults" do
       allow(@sel).to receive(:debug)
-      expect(@sel).to receive(:get_selinux_default_context).with(@path, @resource[:ensure].to_s).and_return("user_u:role_r:type_t:s0")
+      expect(@sel).to receive(:get_selinux_default_context).with(@path, :file).and_return("user_u:role_r:type_t:s0")
       expectedresult = case param
         when :seluser; "user_u"
         when :selrole; "role_r"

--- a/spec/unit/util/selinux_spec.rb
+++ b/spec/unit/util/selinux_spec.rb
@@ -177,8 +177,8 @@ describe Puppet::Util::SELinux do
         allow(Selinux).to receive(:matchpathcon).with("/root/chuj", 32768).and_return(-1)
         allow(self).to receive(:file_lstat).with("/root/chuj").and_raise(Errno::ENOENT, "/root/chuj")
 
-        expect(get_selinux_default_context("/root/chuj", "present")).to be_nil
-        expect(get_selinux_default_context("/root/chuj", "file")).to be_nil
+        expect(get_selinux_default_context("/root/chuj", :present)).to be_nil
+        expect(get_selinux_default_context("/root/chuj", :file)).to be_nil
       end
     end
 
@@ -189,7 +189,7 @@ describe Puppet::Util::SELinux do
         allow(Selinux).to receive(:matchpathcon).with("/root/chuj", 16384).and_return(-1)
         allow(self).to receive(:file_lstat).with("/root/chuj").and_raise(Errno::ENOENT, "/root/chuj")
 
-        expect(get_selinux_default_context("/root/chuj", "directory")).to be_nil
+        expect(get_selinux_default_context("/root/chuj", :directory)).to be_nil
       end
     end
 
@@ -200,7 +200,7 @@ describe Puppet::Util::SELinux do
         allow(Selinux).to receive(:matchpathcon).with("/root/chuj", 40960).and_return(-1)
         allow(self).to receive(:file_lstat).with("/root/chuj").and_raise(Errno::ENOENT, "/root/chuj")
 
-        expect(get_selinux_default_context("/root/chuj", "link")).to be_nil
+        expect(get_selinux_default_context("/root/chuj", :link)).to be_nil
       end
     end
 
@@ -394,20 +394,20 @@ describe Puppet::Util::SELinux do
 
   describe "get_create_mode" do
     it "should return 0 if the resource is absent" do
-      expect(get_create_mode("absent")).to eq(0)
+      expect(get_create_mode(:absent)).to eq(0)
     end
 
     it "should return mode with file type set to S_IFREG when resource is file" do
-      expect(get_create_mode("present")).to eq(32768)
-      expect(get_create_mode("file")).to eq(32768)
+      expect(get_create_mode(:present)).to eq(32768)
+      expect(get_create_mode(:file)).to eq(32768)
     end
 
     it "should return mode with file type set to S_IFDIR when resource is dir" do
-      expect(get_create_mode("directory")).to eq(16384)
+      expect(get_create_mode(:directory)).to eq(16384)
     end
 
     it "should return mode with file type set to S_IFLNK when resource is link" do
-      expect(get_create_mode("link")).to eq(40960)
+      expect(get_create_mode(:link)).to eq(40960)
     end
 
     it "should return 0 for everything else" do

--- a/spec/unit/util/selinux_spec.rb
+++ b/spec/unit/util/selinux_spec.rb
@@ -159,7 +159,7 @@ describe Puppet::Util::SELinux do
       end
     end
 
-    it "handles no such file or directory errors by issuing a warning" do
+    it "backward compatibly handles no such file or directory errors by issuing a warning when resource_ensure not set" do
       without_partial_double_verification do
         allow(self).to receive(:selinux_support?).and_return(true)
         allow(self).to receive(:selinux_label_support?).and_return(true)
@@ -167,6 +167,51 @@ describe Puppet::Util::SELinux do
         allow(self).to receive(:file_lstat).with("/root/chuj").and_raise(Errno::ENOENT, "/root/chuj")
 
         expect(get_selinux_default_context("/root/chuj")).to be_nil
+      end
+    end
+
+    it "should determine mode based on resource ensure when set to file" do
+      without_partial_double_verification do
+        allow(self).to receive(:selinux_support?).and_return(true)
+        allow(self).to receive(:selinux_label_support?).and_return(true)
+        allow(Selinux).to receive(:matchpathcon).with("/root/chuj", 32768).and_return(-1)
+        allow(self).to receive(:file_lstat).with("/root/chuj").and_raise(Errno::ENOENT, "/root/chuj")
+
+        expect(get_selinux_default_context("/root/chuj", "present")).to be_nil
+        expect(get_selinux_default_context("/root/chuj", "file")).to be_nil
+      end
+    end
+
+    it "should determine mode based on resource ensure when set to dir" do
+      without_partial_double_verification do
+        allow(self).to receive(:selinux_support?).and_return(true)
+        allow(self).to receive(:selinux_label_support?).and_return(true)
+        allow(Selinux).to receive(:matchpathcon).with("/root/chuj", 16384).and_return(-1)
+        allow(self).to receive(:file_lstat).with("/root/chuj").and_raise(Errno::ENOENT, "/root/chuj")
+
+        expect(get_selinux_default_context("/root/chuj", "directory")).to be_nil
+      end
+    end
+
+    it "should determine mode based on resource ensure when set to link" do
+      without_partial_double_verification do
+        allow(self).to receive(:selinux_support?).and_return(true)
+        allow(self).to receive(:selinux_label_support?).and_return(true)
+        allow(Selinux).to receive(:matchpathcon).with("/root/chuj", 40960).and_return(-1)
+        allow(self).to receive(:file_lstat).with("/root/chuj").and_raise(Errno::ENOENT, "/root/chuj")
+
+        expect(get_selinux_default_context("/root/chuj", "link")).to be_nil
+      end
+    end
+
+    it "should determine mode based on resource ensure when set to unknown" do
+      without_partial_double_verification do
+        allow(self).to receive(:selinux_support?).and_return(true)
+        allow(self).to receive(:selinux_label_support?).and_return(true)
+        allow(Selinux).to receive(:matchpathcon).with("/root/chuj", 0).and_return(-1)
+        allow(self).to receive(:file_lstat).with("/root/chuj").and_raise(Errno::ENOENT, "/root/chuj")
+
+        expect(get_selinux_default_context("/root/chuj", "unknown")).to be_nil
       end
     end
 
@@ -329,21 +374,44 @@ describe Puppet::Util::SELinux do
     end
 
     it "should return nil if no default context exists" do
-      expect(self).to receive(:get_selinux_default_context).with("/foo").and_return(nil)
+      expect(self).to receive(:get_selinux_default_context).with("/foo", nil).and_return(nil)
       expect(set_selinux_default_context("/foo")).to be_nil
     end
 
     it "should do nothing and return nil if the current context matches the default context" do
-      expect(self).to receive(:get_selinux_default_context).with("/foo").and_return("user_u:role_r:type_t")
+      expect(self).to receive(:get_selinux_default_context).with("/foo", nil).and_return("user_u:role_r:type_t")
       expect(self).to receive(:get_selinux_current_context).with("/foo").and_return("user_u:role_r:type_t")
       expect(set_selinux_default_context("/foo")).to be_nil
     end
 
     it "should set and return the default context if current and default do not match" do
-      expect(self).to receive(:get_selinux_default_context).with("/foo").and_return("user_u:role_r:type_t")
+      expect(self).to receive(:get_selinux_default_context).with("/foo", nil).and_return("user_u:role_r:type_t")
       expect(self).to receive(:get_selinux_current_context).with("/foo").and_return("olduser_u:role_r:type_t")
       expect(self).to receive(:set_selinux_context).with("/foo", "user_u:role_r:type_t").and_return(true)
       expect(set_selinux_default_context("/foo")).to eq("user_u:role_r:type_t")
+    end
+  end
+
+  describe "get_create_mode" do
+    it "should return 0 if the resource is absent" do
+      expect(get_create_mode("absent")).to eq(0)
+    end
+
+    it "should return mode with file type set to S_IFREG when resource is file" do
+      expect(get_create_mode("present")).to eq(32768)
+      expect(get_create_mode("file")).to eq(32768)
+    end
+
+    it "should return mode with file type set to S_IFDIR when resource is dir" do
+      expect(get_create_mode("directory")).to eq(16384)
+    end
+
+    it "should return mode with file type set to S_IFLNK when resource is link" do
+      expect(get_create_mode("link")).to eq(40960)
+    end
+
+    it "should return 0 for everything else" do
+      expect(get_create_mode("unknown")).to eq(0)
     end
   end
 end


### PR DESCRIPTION
See #8537 for details. This supersedes that PR and targets 6.x.

Note https://github.com/puppetlabs/puppet/blob/67ad21b64237eb4f808844bdaa3c2b0e4cdef95c/lib/puppet/util/filetype.rb#L131 is unchanged because in that case we've already written the file prior to retrieving its selinux context.