### PR TITLE
(maint) Merge up 6.x into main 

### DIFF
--- a/acceptance/tests/resource/file/ticket_8740_should_not_enumerate_root_directory.rb
+++ b/acceptance/tests/resource/file/ticket_8740_should_not_enumerate_root_directory.rb
@@ -1,7 +1,7 @@
 test_name "#8740: should not enumerate root directory"
 
 confine :except, :platform => 'windows'
-confine :except, :platform => /osx-10.1[5-9]/
+confine :except, :platform => /(osx-10.1[5-9]|osx-11-)/
 
 tag 'audit:high',
     'audit:refactor',   # Use block style `test_name`

--- a/acceptance/tests/resource/user/should_allow_password_salt_iterations_osx.rb
+++ b/acceptance/tests/resource/user/should_allow_password_salt_iterations_osx.rb
@@ -1,6 +1,8 @@
 test_name "should allow password, salt, and iteration attributes in OSX"
 
 confine :to, :platform => /osx/
+#TODO Fix Big Sur password manager PUP-11026
+confine :except, :platform => /osx-11-/
 
 tag 'audit:high',
     'audit:refactor',  # Use block style `test_run`

--- a/acceptance/tests/resource/user/should_modify_home.rb
+++ b/acceptance/tests/resource/user/should_modify_home.rb
@@ -1,6 +1,6 @@
 test_name "should modify the home directory of an user on OS X < 10.14" do
   confine :to, :platform => /osx/
-  confine :except, :platform => /osx-10.1[4-9]/
+  confine :except, :platform => /(osx-10.1[4-9]|osx-11-)/
 
   tag 'audit:high',
       'audit:acceptance' # Could be done as integration tests, but would

--- a/acceptance/tests/resource/user/should_modify_uid.rb
+++ b/acceptance/tests/resource/user/should_modify_uid.rb
@@ -1,6 +1,6 @@
 test_name "should modify the uid of an user OS X < 10.14" do
   confine :to, :platform => /osx/
-  confine :except, :platform => /osx-10.1[4-9]/
+  confine :except, :platform => /(osx-10.1[4-9]|osx-11-)/
 
   tag 'audit:high',
       'audit:acceptance' # Could be done as integration tests, but would


### PR DESCRIPTION
  (PUP-11002) Expose v4 Catalog endpoint in compiler service
  (PUP-11025) Skip failing acceptance tests for Big Sur
  (packaging) Updating manpage file for 6.x
  (packaging) Bump to version '6.23.0' [no-promote]

 Conflicts:
	.gemspec
	lib/puppet/http/service/compiler.rb
	lib/puppet/version.rb
	man/man5/puppet.conf.5
	man/man8/puppet.8

Conflict diff:
```diff
diff --cc .gemspec
index 63fa8a9438,96c7e3ec63..0000000000
--- a/.gemspec
+++ b/.gemspec
@@@ -13,7 -13,7 +13,11 @@@

  Gem::Specification.new do |s|
    s.name = "puppet"
++<<<<<<< HEAD
 +  version = "7.7.0"
++=======
+   version = "6.23.0"
++>>>>>>> upstream/6.x
    mdata = version.match(/(\d+\.\d+\.\d+)/)
    s.version = mdata ? mdata[1] : version

diff --cc lib/puppet/http/service/compiler.rb
index 54e855859e,00149462f2..0000000000
--- a/lib/puppet/http/service/compiler.rb
+++ b/lib/puppet/http/service/compiler.rb
@@@ -119,7 -129,79 +119,83 @@@ class Puppet::HTTP::Service::Compiler
      [response, deserialize(response, Puppet::Resource::Catalog)]
    end

++<<<<<<< HEAD
 +  # Submit a GET request to retrieve the facts for the named node.
++=======
+   #
+   # @api private
+   #
+   # Submit a POST request to request a catalog to the server using v4 endpoint
+   #
+   # @param [String] certname The name of the node for which to compile the catalog.
+   # @param [Hash] persistent A hash containing two required keys, facts and catalog,
+   #   which when set to true will cause the facts and reports to be stored in
+   #   PuppetDB, or discarded if set to false.
+   # @param [String] environment The name of the environment for which to compile the catalog.
+   # @param [Hash] facts A hash with a required values key, containing a hash of all the
+   #    facts for the node. If not provided, Puppet will attempt to fetch facts for the node
+   #    from PuppetDB.
+   # @param [Hash] trusted_facts A hash with a required values key containing a hash of
+   #    the trusted facts for a node
+   # @param [String] transaction_uuid The id for tracking the catalog compilation and
+   #    report submission.
+   # @param [String] job_id The id of the orchestrator job that triggered this run.
+   # @param [Hash] options A hash of options beyond direct input to catalogs. Options:
+   #    - prefer_requested_environment Whether to always override a node's classified
+   #      environment with the one supplied in the request. If this is true and no environment
+   #      is supplied, fall back to the classified environment, or finally, 'production'.
+   #    - capture_logs Whether to return the errors and warnings that occurred during
+   #      compilation alongside the catalog in the response body.
+   #    - log_level The logging level to use during the compile when capture_logs is true.
+   #      Options are 'err', 'warning', 'info', and 'debug'.
+   #
+   # @return [Array<Puppet::HTTP::Response, Puppet::Resource::Catalog, Array<String>>] An array
+   #   containing the request response, the deserialized catalog returned by
+   #   the server and array containing logs (log array will be empty if capture_logs is false)
+   #
+   def post_catalog4(certname, persistence:, environment:, facts: nil, trusted_facts: nil, transaction_uuid: nil, job_id: nil, options: nil)
+     unless persistence.is_a?(Hash) && (missing = [:facts, :catalog] - persistence.keys.map(&:to_sym)).empty?
+       raise ArgumentError.new("The 'persistence' hash is missing the keys: #{missing.join(', ')}")
+     end
+     raise ArgumentError.new("Facts must be a Hash not a #{facts.class}") unless facts.nil? || facts.is_a?(Hash)
+     body = {
+       certname: certname,
+       persistence: persistence,
+       environment: environment,
+       transaction_uuid: transaction_uuid,
+       job_id: job_id,
+       options: options
+     }
+     body[:facts] = { values: facts } unless facts.nil?
+     body[:trusted_facts] = { values: trusted_facts } unless trusted_facts.nil?
+     headers = add_puppet_headers(
+       'Accept' => get_mime_types(Puppet::Resource::Catalog).join(', '),
+       'Content-Type' => 'application/json'
+     )
+
+     url = URI::HTTPS.build(host: @url.host, port: @url.port, path: Puppet::Util.uri_encode("/puppet/v4/catalog"))
+     response = @client.post(
+       url,
+       body.to_json,
+       headers: headers
+     )
+     process_response(response)
+     begin
+       response_body = JSON.parse(response.body)
+       catalog = Puppet::Resource::Catalog.from_data_hash(response_body['catalog'])
+     rescue => err
+       raise Puppet::HTTP::SerializationError.new("Failed to deserialize catalog from puppetserver response: #{err.message}", err)
+     end
+
+     logs = response_body['logs'] || []
+     [response, catalog, logs]
+   end
+
+   #
+   # @api private
+   #
+   # Submit a GET request to retrieve the facts for the named node
++>>>>>>> upstream/6.x
    #
    # @param [String] name Name of the node to retrieve facts for
    # @param [String] environment Name of the environment we are operating in
diff --cc lib/puppet/version.rb
index c3756ac371,0d6f61326c..0000000000
--- a/lib/puppet/version.rb
+++ b/lib/puppet/version.rb
@@@ -6,7 -6,7 +6,11 @@@
  # Raketasks and such to set the version based on the output of `git describe`

  module Puppet
++<<<<<<< HEAD
 +  PUPPETVERSION = '7.7.0'
++=======
+   PUPPETVERSION = '6.23.0'
++>>>>>>> upstream/6.x

    ##
    # version is a public API method intended to always provide a fast and
diff --cc man/man5/puppet.conf.5
index 0848abfbbc,c70f2438ff..0000000000
--- a/man/man5/puppet.conf.5
+++ b/man/man5/puppet.conf.5
@@@ -907,7 -939,7 +907,11 @@@ The time to wait for data to be read fr
  The HTTP User\-Agent string to send when making network requests\.
  .
  .IP "\(bu" 4
++<<<<<<< HEAD
 +\fIDefault\fR: Puppet/7\.7\.0 Ruby/2\.5\.1\-p57 (x86_64\-linux)
++=======
+ \fIDefault\fR: Puppet/6\.23\.0 Ruby/2\.5\.1\-p57 (x86_64\-linux)
++>>>>>>> upstream/6.x
  .
  .IP "" 0
  .
diff --cc man/man8/puppet.8
index f6240747f7,25d7d57885..0000000000
--- a/man/man8/puppet.8
+++ b/man/man8/puppet.8
@@@ -25,4 -25,4 +25,8 @@@ Specialized
  catalog Compile, save, view, and convert catalogs\. describe Display help about resource types device Manage remote network devices doc Generate Puppet references epp Interact directly with the EPP template parser/renderer\. facts Retrieve and store facts\. filebucket Store and retrieve files in a filebucket generate Generates Puppet code from Ruby definitions\. node View and manage node definitions\. parser Interact directly with the parser\. plugin Interact with the Puppet plugin system\. script Run a puppet manifests as a script without compiling a catalog ssl Manage SSL keys and certificates for puppet SSL clients
  .
  .P
++<<<<<<< HEAD
 +See \'puppet help \fIsubcommand\fR \fIaction\fR\' for help on a specific subcommand action\. See \'puppet help \fIsubcommand\fR\' for help on a specific subcommand\. Puppet v7\.7\.0
++=======
+ See \'puppet help \fIsubcommand\fR \fIaction\fR\' for help on a specific subcommand action\. See \'puppet help \fIsubcommand\fR\' for help on a specific subcommand\. Puppet v6\.23\.0
++>>>>>>> upstream/6.x
```

Kept main version in all cases except for `lib/puppet/http/service/compiler.rb` where we merged up the new method.