### PR TITLE
(maint) Increase test private key length to 2048

### DIFF
--- a/spec/fixtures/ssl/127.0.0.1-key.pem
+++ b/spec/fixtures/ssl/127.0.0.1-key.pem
@@ -1,67 +1,117 @@
-Private-Key: (1024 bit)
+RSA Private-Key: (2048 bit, 2 primes)
 modulus:
-    00:98:34:bb:6c:44:52:00:23:29:ae:bb:7c:c9:91:
-    ec:6b:1c:83:b1:db:6c:b6:1b:12:fb:e3:f4:e4:20:
-    27:6c:c7:50:f9:ac:ef:f8:7a:de:00:4a:01:cb:ba:
-    9b:be:35:3c:e5:33:ef:32:79:61:1c:a6:70:23:19:
-    16:19:ae:33:e5:96:0a:70:3d:81:2f:b3:59:64:89:
-    45:ef:86:97:4d:00:9b:1d:68:9e:8d:5e:75:fb:69:
-    c0:1b:b2:06:1d:97:1a:27:30:38:3e:4f:11:04:70:
-    70:98:c1:6a:fc:93:a5:17:0f:fb:fe:42:31:af:f3:
-    6a:bc:51:dc:33:86:be:5f:c9
+    00:ac:e5:d9:12:cd:61:69:66:ca:b9:6d:cf:b7:b5:
+    be:b9:21:de:d5:7d:dd:35:bc:c7:2a:23:a3:46:11:
+    ad:a7:23:02:f9:d1:71:ec:8c:34:c2:9b:bb:dd:6b:
+    b4:1f:4c:01:e9:c3:55:f4:ad:aa:17:24:ce:03:59:
+    54:fc:ce:f0:c0:c0:df:1e:89:b2:99:45:8d:49:cd:
+    68:7e:77:00:65:c2:ed:4a:90:fc:18:d7:50:3c:21:
+    28:a8:93:a1:47:ee:58:da:09:47:7d:67:70:a7:a8:
+    83:ea:38:d8:97:96:fd:f0:b7:17:3b:ab:fc:db:2b:
+    80:cf:e4:eb:4a:0f:0c:80:b0:18:d0:44:9a:6e:74:
+    70:a3:26:35:98:ad:f5:0c:b1:47:43:57:8a:ac:08:
+    30:b7:a0:9a:77:60:07:70:69:ef:50:9d:06:85:90:
+    20:71:67:2e:f5:c8:b0:1b:b2:fd:ff:57:4b:b6:0e:
+    18:d9:7b:95:e1:12:6b:fa:d2:8b:70:f8:1a:d3:36:
+    8d:c8:91:e0:d1:75:5a:21:17:f7:fe:70:e8:46:14:
+    d8:e1:f2:77:7d:21:76:0c:3b:e4:02:b9:d7:18:ac:
+    86:a3:1e:33:fc:34:72:c6:ea:7f:20:fe:39:74:cf:
+    ff:89:47:47:45:e1:71:13:46:7e:84:8c:23:2e:41:
+    1d:87
 publicExponent: 65537 (0x10001)
 privateExponent:
-    6a:b3:cd:10:c1:74:9b:14:0b:8c:ab:73:77:fc:0c:
-    b9:aa:6b:c8:ac:03:32:47:18:af:ed:c7:28:86:42:
-    1d:48:3d:c4:4b:30:90:09:d2:c8:71:19:81:31:79:
-    2d:87:35:01:99:be:fe:ab:89:21:04:ad:68:6d:95:
-    c8:bb:0f:35:b7:84:83:ce:32:fe:9e:98:b5:71:a0:
-    67:30:e5:17:1d:d9:c3:48:9b:a7:c1:f4:17:f8:4a:
-    bb:88:1b:94:2c:cc:5d:90:92:f8:6e:93:36:eb:42:
-    63:d0:c9:6f:04:e5:c1:2f:dc:a8:1f:19:ed:e5:b0:
-    45:23:ab:82:d4:0b:69:81
+    00:87:54:8d:59:63:3a:89:06:b5:4c:f8:bf:ea:7a:
+    ae:63:38:38:b4:00:85:82:47:55:d9:0c:f6:02:a5:
+    59:b8:05:f6:91:55:b8:07:40:23:17:e4:4f:e2:db:
+    27:ac:8b:90:bf:c9:6e:61:4b:01:64:86:21:5e:8b:
+    b0:b3:04:c3:7b:0c:3c:58:29:cd:8a:9c:df:1f:52:
+    51:25:13:be:52:e8:85:55:a5:30:3d:bd:62:86:fe:
+    29:55:f1:df:fe:6e:78:4b:89:91:d4:7d:7f:b7:2b:
+    76:bd:81:6b:3f:14:27:86:1f:b9:66:b2:93:03:76:
+    04:a8:34:f5:5a:0d:77:6a:cd:a1:6a:34:43:1b:e8:
+    2f:d6:81:ca:68:fc:93:53:9d:16:30:22:e4:80:44:
+    6b:ec:dc:ec:f6:d0:48:69:5d:89:af:a3:02:09:40:
+    25:9a:23:48:ad:58:c1:8d:25:af:74:6e:38:ec:dc:
+    ee:b8:79:e1:94:36:62:64:93:94:9b:29:0c:44:8c:
+    40:ef:40:d3:4b:89:96:5d:9f:84:8a:f7:f6:9a:6a:
+    d4:19:ea:f6:90:07:3f:b8:b3:4e:33:dc:7f:e9:32:
+    00:58:1c:52:1e:80:3b:94:50:4e:f4:56:c4:77:97:
+    d4:66:9e:03:be:5a:be:b1:8f:73:3f:ea:e4:5e:d4:
+    5c:79
 prime1:
-    00:c8:90:0e:0f:a2:ab:82:a7:e5:3a:69:dd:3a:e7:
-    a2:80:ef:b2:12:c5:fb:4b:a2:cf:b6:9a:41:8c:d8:
-    b5:76:05:c5:d3:c6:0e:1d:c6:1e:14:9f:14:21:53:
-    15:08:42:70:12:12:36:1e:0d:be:b8:5d:ce:46:66:
-    0b:fc:1a:dd:95
+    00:de:cf:6e:40:b7:15:fc:7d:11:6d:bf:78:12:9e:
+    75:28:de:92:99:3f:70:e0:98:2f:2b:8b:a8:32:3a:
+    b5:c6:5b:da:7d:25:e2:c7:ff:bf:79:74:28:26:1f:
+    cd:75:84:2c:c0:99:9f:aa:dc:e0:8d:ec:0b:d8:f0:
+    89:11:d7:24:26:53:8a:62:77:ba:5b:07:c8:2a:62:
+    99:25:28:fc:00:9d:03:c0:d6:c3:28:2e:46:9d:5b:
+    71:8e:d0:1a:2f:3d:19:93:29:f4:89:a3:cd:41:d2:
+    8a:64:a2:cd:19:11:f9:6e:59:e4:35:9d:7f:d1:31:
+    74:5b:48:f4:7b:e8:1a:20:73
 prime2:
-    00:c2:46:ec:9d:fc:0b:1c:e7:c4:b3:2a:eb:ff:64:
-    8e:2d:32:f7:f5:9c:bf:60:46:ca:46:db:91:33:fb:
-    47:8a:c4:2c:c7:4a:b0:34:cb:34:1b:93:bd:aa:3a:
-    3a:a4:b8:f6:4e:4b:b7:23:03:bb:07:43:6e:39:31:
-    61:ce:0c:24:65
+    00:c6:a7:12:f0:68:f2:30:a9:c3:78:59:a6:f7:fb:
+    dc:05:93:14:c7:54:00:c6:f7:5c:1a:c4:3a:07:b2:
+    25:f2:fb:83:7e:20:f5:c4:dd:fc:46:54:2e:58:89:
+    c2:fc:4e:5c:d8:a8:a1:a7:98:76:59:ad:45:94:fc:
+    97:d4:a5:0b:1e:51:07:3e:86:e0:2e:f7:29:32:71:
+    65:a5:3b:97:33:bc:00:f4:f7:66:e6:ee:49:ec:19:
+    5c:b3:74:0e:61:ce:94:3e:f4:69:32:ea:df:b3:d8:
+    08:df:56:36:ca:af:c7:e8:f1:0d:91:b4:0b:fb:47:
+    05:fd:87:02:41:48:9d:2d:9d
 exponent1:
-    14:08:5f:7f:2c:4e:59:44:8f:de:df:c8:1b:24:1b:
-    d5:29:1b:ee:48:1c:2b:97:dd:8b:6d:a8:f2:7a:8a:
-    d5:79:0a:23:76:fa:dd:fa:75:f2:b5:58:fb:63:23:
-    0c:aa:26:2b:87:ea:23:e2:57:94:6e:ba:35:c9:e7:
-    94:8c:d2:69
+    56:77:57:49:04:04:23:45:01:f3:7e:3f:81:b2:3e:
+    b3:4a:94:c7:a6:08:0f:10:e0:15:5d:10:3b:d5:ee:
+    de:f8:9c:74:be:b4:20:7b:4e:7a:3a:aa:ae:08:df:
+    7a:00:7e:41:8c:1c:9b:79:36:27:bd:77:e7:8b:89:
+    16:04:50:c2:12:df:7c:51:0c:5f:f1:48:2b:b2:b1:
+    cd:ea:f6:c8:e2:26:27:ba:f0:67:72:75:f2:f1:1e:
+    c3:96:5c:e3:02:2a:1f:a3:43:83:fa:ae:58:21:f5:
+    95:12:5c:d7:a2:d3:12:91:0d:f0:04:9c:2a:b9:af:
+    77:11:7b:d7:6d:fe:5d:a3
 exponent2:
-    50:c3:c5:68:64:38:86:7a:bf:a6:30:68:cd:d2:92:
-    dc:ad:7c:b1:c9:c9:31:90:1c:55:5a:c0:41:98:ec:
-    03:ff:4c:12:49:b5:79:2d:24:eb:75:fe:fa:3e:9c:
-    d4:8f:e4:2d:66:82:aa:f6:c9:10:da:f2:7e:aa:4d:
-    db:a7:e6:95
+    43:20:be:13:a3:43:04:12:b9:cc:f7:6e:a6:a9:e3:
+    25:b7:17:f4:6b:7c:7f:bf:a2:ce:20:b5:03:58:bd:
+    de:28:03:bd:21:62:2b:8e:5f:eb:5c:12:f5:34:48:
+    41:7e:31:7d:bd:2e:33:36:1f:f8:19:c7:43:9b:3f:
+    ab:49:c2:42:12:5b:82:53:8d:7a:11:67:48:76:6d:
+    44:b2:a8:5b:81:12:49:b5:38:7e:9c:d3:3a:07:2f:
+    fe:2c:1f:98:09:78:aa:f5:68:7f:1e:43:4d:c0:98:
+    ee:ef:71:40:78:b9:f3:0b:51:ec:84:8c:ef:f2:86:
+    21:af:f7:a1:1b:ea:91:39
 coefficient:
-    45:11:a8:a2:ab:92:a6:f2:42:b3:7f:09:8d:ae:45:
-    25:e5:c6:24:9e:80:ea:58:b5:d7:44:7f:84:47:6b:
-    4d:da:f0:f3:4c:60:5b:9d:18:64:b2:89:2c:1e:b2:
-    60:35:58:ef:90:6f:b5:12:d7:0e:d7:7b:4a:62:ac:
-    38:b4:12:80
+    37:50:c3:b7:3b:85:e4:0d:db:82:ac:12:23:ca:6c:
+    84:45:ed:16:c0:bb:9c:0d:58:1d:52:b0:c3:a8:8a:
+    4e:f6:b4:ac:6d:b5:d5:18:0c:bc:80:fe:53:55:13:
+    c7:92:e5:71:95:bc:93:e8:24:93:94:ef:f0:10:00:
+    db:00:20:c1:f4:50:6d:9d:53:e7:58:e8:7e:04:34:
+    2e:fd:b9:b0:51:ff:22:b0:d6:ad:84:9e:c0:22:6f:
+    f8:40:a7:22:b8:46:3a:92:47:76:16:de:af:8d:a2:
+    5e:02:1d:21:32:be:88:b3:83:f8:6d:b9:9c:ce:19:
+    55:38:7d:98:65:8a:4d:25
 -----BEGIN RSA PRIVATE KEY-----
-MIICWwIBAAKBgQCYNLtsRFIAIymuu3zJkexrHIOx22y2GxL74/TkICdsx1D5rO/4
-et4ASgHLupu+NTzlM+8yeWEcpnAjGRYZrjPllgpwPYEvs1lkiUXvhpdNAJsdaJ6N
-XnX7acAbsgYdlxonMDg+TxEEcHCYwWr8k6UXD/v+QjGv82q8Udwzhr5fyQIDAQAB
-AoGAarPNEMF0mxQLjKtzd/wMuapryKwDMkcYr+3HKIZCHUg9xEswkAnSyHEZgTF5
-LYc1AZm+/quJIQStaG2VyLsPNbeEg84y/p6YtXGgZzDlFx3Zw0ibp8H0F/hKu4gb
-lCzMXZCS+G6TNutCY9DJbwTlwS/cqB8Z7eWwRSOrgtQLaYECQQDIkA4PoquCp+U6
-ad0656KA77ISxftLos+2mkGM2LV2BcXTxg4dxh4UnxQhUxUIQnASEjYeDb64Xc5G
-Zgv8Gt2VAkEAwkbsnfwLHOfEsyrr/2SOLTL39Zy/YEbKRtuRM/tHisQsx0qwNMs0
-G5O9qjo6pLj2Tku3IwO7B0NuOTFhzgwkZQJAFAhffyxOWUSP3t/IGyQb1Skb7kgc
-K5fdi22o8nqK1XkKI3b63fp18rVY+2MjDKomK4fqI+JXlG66NcnnlIzSaQJAUMPF
-aGQ4hnq/pjBozdKS3K18scnJMZAcVVrAQZjsA/9MEkm1eS0k63X++j6c1I/kLWaC
-qvbJENryfqpN26fmlQJARRGooquSpvJCs38Jja5FJeXGJJ6A6li110R/hEdrTdrw
-80xgW50YZLKJLB6yYDVY75BvtRLXDtd7SmKsOLQSgA==
+MIIEowIBAAKCAQEArOXZEs1haWbKuW3Pt7W+uSHe1X3dNbzHKiOjRhGtpyMC+dFx
+7Iw0wpu73Wu0H0wB6cNV9K2qFyTOA1lU/M7wwMDfHomymUWNSc1ofncAZcLtSpD8
+GNdQPCEoqJOhR+5Y2glHfWdwp6iD6jjYl5b98LcXO6v82yuAz+TrSg8MgLAY0ESa
+bnRwoyY1mK31DLFHQ1eKrAgwt6Cad2AHcGnvUJ0GhZAgcWcu9ciwG7L9/1dLtg4Y
+2XuV4RJr+tKLcPga0zaNyJHg0XVaIRf3/nDoRhTY4fJ3fSF2DDvkArnXGKyGox4z
+/DRyxup/IP45dM//iUdHReFxE0Z+hIwjLkEdhwIDAQABAoIBAQCHVI1ZYzqJBrVM
++L/qeq5jODi0AIWCR1XZDPYCpVm4BfaRVbgHQCMX5E/i2yesi5C/yW5hSwFkhiFe
+i7CzBMN7DDxYKc2KnN8fUlElE75S6IVVpTA9vWKG/ilV8d/+bnhLiZHUfX+3K3a9
+gWs/FCeGH7lmspMDdgSoNPVaDXdqzaFqNEMb6C/Wgcpo/JNTnRYwIuSARGvs3Oz2
+0EhpXYmvowIJQCWaI0itWMGNJa90bjjs3O64eeGUNmJkk5SbKQxEjEDvQNNLiZZd
+n4SK9/aaatQZ6vaQBz+4s04z3H/pMgBYHFIegDuUUE70VsR3l9RmngO+Wr6xj3M/
+6uRe1Fx5AoGBAN7PbkC3Ffx9EW2/eBKedSjekpk/cOCYLyuLqDI6tcZb2n0l4sf/
+v3l0KCYfzXWELMCZn6rc4I3sC9jwiRHXJCZTimJ3ulsHyCpimSUo/ACdA8DWwygu
+Rp1bcY7QGi89GZMp9ImjzUHSimSizRkR+W5Z5DWdf9ExdFtI9HvoGiBzAoGBAMan
+EvBo8jCpw3hZpvf73AWTFMdUAMb3XBrEOgeyJfL7g34g9cTd/EZULliJwvxOXNio
+oaeYdlmtRZT8l9SlCx5RBz6G4C73KTJxZaU7lzO8APT3ZubuSewZXLN0DmHOlD70
+aTLq37PYCN9WNsqvx+jxDZG0C/tHBf2HAkFInS2dAoGAVndXSQQEI0UB834/gbI+
+s0qUx6YIDxDgFV0QO9Xu3vicdL60IHtOejqqrgjfegB+QYwcm3k2J71354uJFgRQ
+whLffFEMX/FIK7Kxzer2yOImJ7rwZ3J18vEew5Zc4wIqH6NDg/quWCH1lRJc16LT
+EpEN8AScKrmvdxF7123+XaMCgYBDIL4To0MEErnM926mqeMltxf0a3x/v6LOILUD
+WL3eKAO9IWIrjl/rXBL1NEhBfjF9vS4zNh/4GcdDmz+rScJCEluCU416EWdIdm1E
+sqhbgRJJtTh+nNM6By/+LB+YCXiq9Wh/HkNNwJju73FAeLnzC1HshIzv8oYhr/eh
+G+qROQKBgDdQw7c7heQN24KsEiPKbIRF7RbAu5wNWB1SsMOoik72tKxttdUYDLyA
+/lNVE8eS5XGVvJPoJJOU7/AQANsAIMH0UG2dU+dY6H4ENC79ubBR/yKw1q2EnsAi
+b/hApyK4RjqSR3YW3q+Nol4CHSEyvoizg/htuZzOGVU4fZhlik0l
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/127.0.0.1.pem
+++ b/spec/fixtures/ssl/127.0.0.1.pem
@@ -1,48 +1,69 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 3 (0x3)
-    Signature Algorithm: sha256WithRSAEncryption
+        Serial Number: 5 (0x5)
+        Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Apr 19 22:31:22 2029 GMT
+            Not After : Apr 18 18:46:23 2031 GMT
         Subject: CN=127.0.0.1
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                Public-Key: (1024 bit)
+                RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:98:34:bb:6c:44:52:00:23:29:ae:bb:7c:c9:91:
-                    ec:6b:1c:83:b1:db:6c:b6:1b:12:fb:e3:f4:e4:20:
-                    27:6c:c7:50:f9:ac:ef:f8:7a:de:00:4a:01:cb:ba:
-                    9b:be:35:3c:e5:33:ef:32:79:61:1c:a6:70:23:19:
-                    16:19:ae:33:e5:96:0a:70:3d:81:2f:b3:59:64:89:
-                    45:ef:86:97:4d:00:9b:1d:68:9e:8d:5e:75:fb:69:
-                    c0:1b:b2:06:1d:97:1a:27:30:38:3e:4f:11:04:70:
-                    70:98:c1:6a:fc:93:a5:17:0f:fb:fe:42:31:af:f3:
-                    6a:bc:51:dc:33:86:be:5f:c9
+                    00:ac:e5:d9:12:cd:61:69:66:ca:b9:6d:cf:b7:b5:
+                    be:b9:21:de:d5:7d:dd:35:bc:c7:2a:23:a3:46:11:
+                    ad:a7:23:02:f9:d1:71:ec:8c:34:c2:9b:bb:dd:6b:
+                    b4:1f:4c:01:e9:c3:55:f4:ad:aa:17:24:ce:03:59:
+                    54:fc:ce:f0:c0:c0:df:1e:89:b2:99:45:8d:49:cd:
+                    68:7e:77:00:65:c2:ed:4a:90:fc:18:d7:50:3c:21:
+                    28:a8:93:a1:47:ee:58:da:09:47:7d:67:70:a7:a8:
+                    83:ea:38:d8:97:96:fd:f0:b7:17:3b:ab:fc:db:2b:
+                    80:cf:e4:eb:4a:0f:0c:80:b0:18:d0:44:9a:6e:74:
+                    70:a3:26:35:98:ad:f5:0c:b1:47:43:57:8a:ac:08:
+                    30:b7:a0:9a:77:60:07:70:69:ef:50:9d:06:85:90:
+                    20:71:67:2e:f5:c8:b0:1b:b2:fd:ff:57:4b:b6:0e:
+                    18:d9:7b:95:e1:12:6b:fa:d2:8b:70:f8:1a:d3:36:
+                    8d:c8:91:e0:d1:75:5a:21:17:f7:fe:70:e8:46:14:
+                    d8:e1:f2:77:7d:21:76:0c:3b:e4:02:b9:d7:18:ac:
+                    86:a3:1e:33:fc:34:72:c6:ea:7f:20:fe:39:74:cf:
+                    ff:89:47:47:45:e1:71:13:46:7e:84:8c:23:2e:41:
+                    1d:87
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Subject Alternative Name: 
                 DNS:127.0.0.1, DNS:127.0.0.2
     Signature Algorithm: sha256WithRSAEncryption
-         a0:40:1e:cc:ed:75:47:4b:3a:a6:05:fb:a6:29:22:cd:f9:28:
-         4c:f3:3d:0c:e2:df:6c:91:68:52:1b:df:d4:9d:88:36:e9:db:
-         ca:94:a4:14:d9:2a:bb:b6:f7:a9:4a:70:f7:db:d7:86:e4:82:
-         e4:dd:08:77:03:7b:fb:99:24:fd:15:44:b5:05:dd:b3:ff:dc:
-         e0:b4:e8:92:7f:58:b3:2f:48:ba:80:c9:a6:1c:c8:8e:99:e1:
-         52:f4:52:90:ad:44:8b:89:39:a1:51:67:15:99:a2:f5:76:75:
-         b4:12:f5:5e:99:e7:8b:7b:b1:9d:04:63:31:33:36:0d:a8:67:
-         00:42
+         7f:f0:00:00:e5:c3:8d:d1:bf:5a:6c:d5:36:86:8a:08:b6:dc:
+         26:b8:4e:af:25:5a:6b:e2:04:50:fe:b1:9a:4b:03:c2:d7:9b:
+         7b:6d:3c:51:a9:2b:d2:b1:53:ae:02:df:de:65:a5:95:38:a7:
+         72:ac:86:5d:af:fb:67:9a:5f:48:7b:ab:05:54:ea:4d:bf:be:
+         d0:45:2b:84:26:4c:c5:62:a8:62:bb:46:5d:6b:e4:b9:aa:1f:
+         b7:3d:44:32:ea:c5:b4:d1:3b:e3:ca:7f:47:46:f0:47:10:a5:
+         7a:93:65:23:e7:6b:42:2e:52:7f:4e:9d:89:b8:8c:26:de:8e:
+         b4:63:be:28:83:2e:06:6a:e6:fc:80:24:de:8a:3f:ab:2d:b6:
+         98:2e:60:d0:36:40:cc:52:1b:c9:1b:12:14:ee:2e:29:3f:5d:
+         57:6b:17:b0:23:57:e5:f0:64:03:ab:86:3c:1b:4f:d8:3a:27:
+         18:b2:82:4e:dc:ca:47:cf:d0:30:a2:d2:48:5a:89:f5:a2:93:
+         29:df:fb:dc:c4:a2:ee:40:2b:14:30:cb:ff:ff:a7:df:34:6a:
+         54:ae:47:0a:5b:e0:c4:9d:7c:0a:14:16:96:b3:8c:5c:d8:22:
+         50:2b:b4:59:01:6a:de:90:14:ea:5a:4d:eb:69:ee:bd:35:e3:
+         e6:5a:8b:68
 -----BEGIN CERTIFICATE-----
-MIIBvzCCASigAwIBAgIBAzANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
-IENBMB4XDTcwMDEwMTAwMDAwMFoXDTI5MDQxOTIyMzEyMlowFDESMBAGA1UEAwwJ
-MTI3LjAuMC4xMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCYNLtsRFIAIymu
-u3zJkexrHIOx22y2GxL74/TkICdsx1D5rO/4et4ASgHLupu+NTzlM+8yeWEcpnAj
-GRYZrjPllgpwPYEvs1lkiUXvhpdNAJsdaJ6NXnX7acAbsgYdlxonMDg+TxEEcHCY
-wWr8k6UXD/v+QjGv82q8Udwzhr5fyQIDAQABoyMwITAfBgNVHREEGDAWggkxMjcu
-MC4wLjGCCTEyNy4wLjAuMjANBgkqhkiG9w0BAQsFAAOBgQCgQB7M7XVHSzqmBfum
-KSLN+ShM8z0M4t9skWhSG9/UnYg26dvKlKQU2Sq7tvepSnD329eG5ILk3Qh3A3v7
-mST9FUS1Bd2z/9zgtOiSf1izL0i6gMmmHMiOmeFS9FKQrUSLiTmhUWcVmaL1dnW0
-EvVemeeLe7GdBGMxMzYNqGcAQg==
+MIICxDCCAaygAwIBAgIBBTANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMxMDQxODE4NDYyM1owFDESMBAGA1UEAwwJ
+MTI3LjAuMC4xMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArOXZEs1h
+aWbKuW3Pt7W+uSHe1X3dNbzHKiOjRhGtpyMC+dFx7Iw0wpu73Wu0H0wB6cNV9K2q
+FyTOA1lU/M7wwMDfHomymUWNSc1ofncAZcLtSpD8GNdQPCEoqJOhR+5Y2glHfWdw
+p6iD6jjYl5b98LcXO6v82yuAz+TrSg8MgLAY0ESabnRwoyY1mK31DLFHQ1eKrAgw
+t6Cad2AHcGnvUJ0GhZAgcWcu9ciwG7L9/1dLtg4Y2XuV4RJr+tKLcPga0zaNyJHg
+0XVaIRf3/nDoRhTY4fJ3fSF2DDvkArnXGKyGox4z/DRyxup/IP45dM//iUdHReFx
+E0Z+hIwjLkEdhwIDAQABoyMwITAfBgNVHREEGDAWggkxMjcuMC4wLjGCCTEyNy4w
+LjAuMjANBgkqhkiG9w0BAQsFAAOCAQEAf/AAAOXDjdG/WmzVNoaKCLbcJrhOryVa
+a+IEUP6xmksDwtebe208Uakr0rFTrgLf3mWllTincqyGXa/7Z5pfSHurBVTqTb++
+0EUrhCZMxWKoYrtGXWvkuaoftz1EMurFtNE748p/R0bwRxClepNlI+drQi5Sf06d
+ibiMJt6OtGO+KIMuBmrm/IAk3oo/qy22mC5g0DZAzFIbyRsSFO4uKT9dV2sXsCNX
+5fBkA6uGPBtP2DonGLKCTtzKR8/QMKLSSFqJ9aKTKd/73MSi7kArFDDL//+n3zRq
+VK5HClvgxJ18ChQWlrOMXNgiUCu0WQFq3pAU6lpN62nuvTXj5lqLaA==
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/bad-basic-constraints.pem
+++ b/spec/fixtures/ssl/bad-basic-constraints.pem
@@ -1,26 +1,35 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 8 (0x8)
-    Signature Algorithm: sha256WithRSAEncryption
+        Serial Number: 10 (0xa)
+        Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Apr 19 22:31:22 2029 GMT
+            Not After : Apr 18 18:46:23 2031 GMT
         Subject: CN=Test CA
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                Public-Key: (1024 bit)
+                RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:d0:b3:d8:3f:2b:c0:45:8c:f0:3d:96:58:2c:5e:
-                    0e:6a:46:81:ab:10:2f:22:9c:7c:69:f0:61:b7:2d:
-                    f2:2f:46:97:d5:d9:1b:08:c8:c9:e8:18:a5:d8:89:
-                    27:a7:80:cb:0a:8e:ee:26:32:89:70:37:2b:bf:6f:
-                    7e:ee:12:7d:49:c7:0c:19:46:7c:65:99:dc:1f:1a:
-                    31:af:ab:87:01:b3:68:8a:5b:51:a7:78:ca:cc:1d:
-                    7c:26:b4:27:5f:67:75:99:7e:9f:16:ed:88:b3:8f:
-                    77:0f:b3:e8:b3:97:bc:70:8b:ec:62:b9:a2:47:4b:
-                    ef:dc:af:d4:9f:3d:17:cd:03
+                    00:dd:a5:83:44:db:51:be:98:ef:b1:63:a7:04:b9:
+                    ff:cd:71:d3:06:76:c4:25:68:e8:ea:ef:c5:b4:f9:
+                    c2:76:aa:c0:1b:1b:0f:44:13:da:db:cf:d4:f4:88:
+                    5c:cc:ac:f2:76:fb:9e:b6:2e:40:da:b8:c1:c8:cd:
+                    24:90:63:10:6c:99:ee:0c:10:74:cc:38:b8:f3:b4:
+                    d9:ed:1e:ac:07:29:b4:fe:f1:16:c2:18:7c:34:fd:
+                    50:25:0f:f7:45:84:e0:4b:21:41:a4:5b:19:42:85:
+                    a3:a8:d3:6a:ea:0f:80:f3:1a:06:f8:aa:31:4b:e5:
+                    44:a8:37:80:d1:1b:01:ae:f3:b8:35:c6:3f:10:82:
+                    84:fc:59:d9:47:d6:a9:e3:5e:f3:9f:89:23:6a:ed:
+                    bc:92:6a:a1:49:2c:99:c3:89:b3:ab:3a:9f:6b:2d:
+                    e6:39:95:15:e0:71:5f:6b:6a:23:2e:bc:cd:40:b2:
+                    47:42:13:f4:f5:e7:43:76:5c:db:9d:10:3b:91:10:
+                    cc:c7:27:db:a8:18:53:c9:50:eb:83:39:80:98:bf:
+                    c0:cf:75:a8:31:56:2c:0f:32:44:b0:b8:2d:22:f9:
+                    f6:a2:d6:0b:cf:5f:a2:89:7c:15:97:a9:01:5c:97:
+                    6a:b9:9c:c2:aa:fd:a3:d9:aa:61:04:65:e4:13:7e:
+                    58:7d
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Basic Constraints: critical
@@ -28,32 +37,45 @@ Certificate:
             X509v3 Key Usage: critical
                 Certificate Sign, CRL Sign
             X509v3 Subject Key Identifier: 
-                2C:25:19:A1:6C:B3:F7:69:FD:76:9B:3A:22:CB:0C:56:01:01:F1:31
+                61:DF:EE:CE:DA:49:6B:5E:F3:EF:94:FE:F9:DC:C7:C0:5A:74:FE:DB
             Netscape Comment: 
                 Puppet Server Internal Certificate
             X509v3 Authority Key Identifier: 
-                keyid:2C:25:19:A1:6C:B3:F7:69:FD:76:9B:3A:22:CB:0C:56:01:01:F1:31
+                keyid:61:DF:EE:CE:DA:49:6B:5E:F3:EF:94:FE:F9:DC:C7:C0:5A:74:FE:DB
 
     Signature Algorithm: sha256WithRSAEncryption
-         12:60:01:ec:ea:6c:bc:d6:4e:e7:40:b6:9f:cd:8c:6e:6d:42:
-         4f:d8:db:42:f8:8d:04:09:48:ad:22:50:e5:de:7f:ec:d5:19:
-         21:3f:6b:d0:85:d4:75:20:18:a7:cc:a0:7c:b2:08:6f:d6:7b:
-         a7:63:22:25:1b:f8:20:66:ea:b7:40:09:25:05:7b:61:6d:a1:
-         4f:af:72:51:c9:c8:42:87:04:ab:6e:b6:98:ed:f9:9c:98:64:
-         dc:78:e0:f1:21:16:46:93:67:89:af:a7:da:b4:8d:b7:11:a8:
-         9a:9b:66:be:a4:7f:71:84:57:b4:2b:3c:56:e0:37:f9:6a:29:
-         cd:4a
+         86:10:78:cb:49:09:83:84:9c:7f:33:c8:fc:08:d6:db:02:b7:
+         d3:e7:6b:62:3a:fd:37:d6:b8:a7:5c:8c:42:fb:b0:d6:de:5c:
+         5b:47:2c:22:05:e3:9b:05:2d:96:23:96:2f:40:c7:22:aa:32:
+         5d:b9:73:31:44:c2:60:f1:e5:d8:a3:c1:38:68:ec:37:4e:b0:
+         da:5e:88:b6:64:6b:8d:c3:fc:bd:08:df:81:f9:16:5a:27:1b:
+         3e:7d:8c:ac:7c:59:52:b9:cd:f3:77:1a:dc:fe:4e:92:cd:2b:
+         29:1e:0b:ea:1a:90:a4:da:39:06:52:6f:15:db:58:58:b1:9f:
+         7a:3f:e2:a1:b2:8e:ce:32:e2:5c:f4:55:0d:21:0a:53:35:ce:
+         50:fd:98:6a:c1:1f:72:83:69:a3:43:0b:3b:f5:36:76:5e:c3:
+         cb:1d:47:51:a0:e4:1f:1f:2a:ce:8e:8c:da:41:ce:4b:ea:47:
+         2d:36:d5:2d:d5:e0:44:39:4d:07:1e:79:65:5c:69:46:1a:9a:
+         12:ba:ce:55:9c:73:ed:75:51:30:db:71:f9:34:87:08:ec:a0:
+         23:6e:c3:8e:da:81:4f:3d:3b:70:42:a6:f8:16:82:03:17:ca:
+         ba:73:4a:8d:34:36:c1:b6:2a:ef:85:89:26:2a:a2:34:db:fc:
+         c9:b8:1b:0b
 -----BEGIN CERTIFICATE-----
-MIICLzCCAZigAwIBAgIBCDANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
-IENBMB4XDTcwMDEwMTAwMDAwMFoXDTI5MDQxOTIyMzEyMlowEjEQMA4GA1UEAwwH
-VGVzdCBDQTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA0LPYPyvARYzwPZZY
-LF4OakaBqxAvIpx8afBhty3yL0aX1dkbCMjJ6Bil2Iknp4DLCo7uJjKJcDcrv29+
-7hJ9SccMGUZ8ZZncHxoxr6uHAbNoiltRp3jKzB18JrQnX2d1mX6fFu2Is493D7Po
-s5e8cIvsYrmiR0vv3K/Unz0XzQMCAwEAAaOBlDCBkTAMBgNVHRMBAf8EAjAAMA4G
-A1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQULCUZoWyz92n9dps6IssMVgEB8TEwMQYJ
-YIZIAYb4QgENBCQWIlB1cHBldCBTZXJ2ZXIgSW50ZXJuYWwgQ2VydGlmaWNhdGUw
-HwYDVR0jBBgwFoAULCUZoWyz92n9dps6IssMVgEB8TEwDQYJKoZIhvcNAQELBQAD
-gYEAEmAB7OpsvNZO50C2n82Mbm1CT9jbQviNBAlIrSJQ5d5/7NUZIT9r0IXUdSAY
-p8ygfLIIb9Z7p2MiJRv4IGbqt0AJJQV7YW2hT69yUcnIQocEq262mO35nJhk3Hjg
-8SEWRpNnia+n2rSNtxGomptmvqR/cYRXtCs8VuA3+WopzUo=
+MIIDNDCCAhygAwIBAgIBCjANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMxMDQxODE4NDYyM1owEjEQMA4GA1UEAwwH
+VGVzdCBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAN2lg0TbUb6Y
+77FjpwS5/81x0wZ2xCVo6OrvxbT5wnaqwBsbD0QT2tvP1PSIXMys8nb7nrYuQNq4
+wcjNJJBjEGyZ7gwQdMw4uPO02e0erAcptP7xFsIYfDT9UCUP90WE4EshQaRbGUKF
+o6jTauoPgPMaBviqMUvlRKg3gNEbAa7zuDXGPxCChPxZ2UfWqeNe85+JI2rtvJJq
+oUksmcOJs6s6n2st5jmVFeBxX2tqIy68zUCyR0IT9PXnQ3Zc250QO5EQzMcn26gY
+U8lQ64M5gJi/wM91qDFWLA8yRLC4LSL59qLWC89fool8FZepAVyXarmcwqr9o9mq
+YQRl5BN+WH0CAwEAAaOBlDCBkTAMBgNVHRMBAf8EAjAAMA4GA1UdDwEB/wQEAwIB
+BjAdBgNVHQ4EFgQUYd/uztpJa17z75T++dzHwFp0/tswMQYJYIZIAYb4QgENBCQW
+IlB1cHBldCBTZXJ2ZXIgSW50ZXJuYWwgQ2VydGlmaWNhdGUwHwYDVR0jBBgwFoAU
+Yd/uztpJa17z75T++dzHwFp0/tswDQYJKoZIhvcNAQELBQADggEBAIYQeMtJCYOE
+nH8zyPwI1tsCt9Pna2I6/TfWuKdcjEL7sNbeXFtHLCIF45sFLZYjli9AxyKqMl25
+czFEwmDx5dijwTho7DdOsNpeiLZka43D/L0I34H5FlonGz59jKx8WVK5zfN3Gtz+
+TpLNKykeC+oakKTaOQZSbxXbWFixn3o/4qGyjs4y4lz0VQ0hClM1zlD9mGrBH3KD
+aaNDCzv1NnZew8sdR1Gg5B8fKs6OjNpBzkvqRy021S3V4EQ5TQceeWVcaUYamhK6
+zlWcc+11UTDbcfk0hwjsoCNuw47agU89O3BCpvgWggMXyrpzSo00NsG2Ku+FiSYq
+ojTb/Mm4Gws=
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/bad-int-basic-constraints.pem
+++ b/spec/fixtures/ssl/bad-int-basic-constraints.pem
@@ -1,26 +1,35 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 1 (0x1)
-    Signature Algorithm: sha256WithRSAEncryption
+        Serial Number: 3 (0x3)
+        Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Apr 19 22:31:22 2029 GMT
+            Not After : Apr 18 18:46:23 2031 GMT
         Subject: CN=Test CA Subauthority
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                Public-Key: (1024 bit)
+                RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:c2:4a:6e:07:c6:1c:8b:2f:bf:91:3e:25:dc:54:
-                    2c:02:0f:1b:6f:5b:0e:5a:69:1d:dd:52:3f:8b:f4:
-                    c8:56:c6:f3:c5:56:2c:b8:82:67:81:09:7b:0d:6f:
-                    01:26:4a:ae:42:53:95:b1:32:ba:07:d4:64:bc:79:
-                    1f:16:0a:92:07:e5:af:5d:d6:b3:4d:09:58:b1:8a:
-                    ba:2c:c0:d3:9b:95:cc:a1:0d:e5:4d:40:1a:50:2d:
-                    a4:45:ff:05:63:62:84:35:73:2c:0f:b3:f6:69:fd:
-                    9b:d3:5e:a8:12:f0:c4:a0:77:25:59:e7:81:3d:ee:
-                    c5:22:10:75:ac:ad:cc:a4:1f
+                    00:cd:ef:ef:31:c5:33:69:3b:ee:25:06:b9:73:a7:
+                    09:e5:c9:9c:0b:39:48:26:fb:88:26:50:2d:8a:52:
+                    29:86:df:7a:12:f0:08:ea:61:52:80:98:9f:a5:45:
+                    26:ad:6d:05:e6:b5:81:e5:91:b3:6b:98:53:09:0a:
+                    e9:05:4b:29:de:3c:64:44:a7:d2:5d:3f:fc:5f:f8:
+                    29:1f:b0:40:e2:74:8a:26:fd:e8:d7:74:a5:78:de:
+                    bf:23:10:73:74:8d:1b:0c:4b:d7:1d:a9:ae:86:14:
+                    05:63:7c:2a:00:38:d6:57:8a:b7:a8:45:80:27:f5:
+                    71:0b:fa:e2:bd:a2:d1:08:8d:fa:cd:9c:f6:ad:89:
+                    76:ea:ab:1c:78:f9:26:5b:a3:18:2a:f7:90:15:ed:
+                    a7:db:50:e9:7d:55:99:7e:05:10:ca:56:11:51:5e:
+                    de:8c:e2:be:2a:8a:34:41:1d:1d:23:92:04:50:05:
+                    c5:5b:b8:7a:45:90:ee:0d:7f:01:b1:ed:d4:dd:c5:
+                    28:ed:7d:4d:6a:70:21:3b:95:5e:e2:31:d7:17:bd:
+                    5b:af:e4:ce:ad:6b:9f:5f:9e:e1:1e:86:ff:83:c1:
+                    88:ec:87:bb:bf:a1:26:22:75:b9:57:31:10:fd:a5:
+                    ca:82:70:6d:c8:a1:a3:f6:3e:76:3d:2e:cd:07:f9:
+                    7b:3f
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Basic Constraints: critical
@@ -28,32 +37,45 @@ Certificate:
             X509v3 Key Usage: critical
                 Certificate Sign, CRL Sign
             X509v3 Subject Key Identifier: 
-                23:78:2F:09:81:B0:7B:C6:79:1F:30:FE:FC:5E:37:14:FF:20:A0:20
+                9A:15:19:07:A0:54:8D:C3:9D:4F:07:C4:05:A1:85:AC:92:D8:B1:E5
             Netscape Comment: 
                 Puppet Server Internal Certificate
             X509v3 Authority Key Identifier: 
-                keyid:2C:25:19:A1:6C:B3:F7:69:FD:76:9B:3A:22:CB:0C:56:01:01:F1:31
+                keyid:61:DF:EE:CE:DA:49:6B:5E:F3:EF:94:FE:F9:DC:C7:C0:5A:74:FE:DB
 
     Signature Algorithm: sha256WithRSAEncryption
-         7a:8a:07:aa:d1:4d:7b:5b:01:cf:d3:9f:b0:3f:03:2e:ac:4b:
-         31:e8:86:4d:ca:c0:fb:cb:c2:80:73:60:ea:1e:0c:2f:7c:01:
-         fc:78:4e:3d:9b:be:16:85:bf:bc:c9:7b:41:9d:de:74:69:82:
-         97:b6:e1:e2:37:40:4b:36:ba:ad:fa:bd:c6:73:21:d9:c4:e5:
-         96:d6:6a:bf:c9:dc:0a:0e:9e:0b:44:5c:2f:b3:5a:54:75:14:
-         2b:53:a8:27:6f:8b:94:c9:27:cc:ed:8b:82:5b:09:b1:db:6d:
-         90:78:0a:e8:e2:ac:30:f6:1a:9f:77:4f:70:aa:4f:b7:61:fe:
-         49:41
+         d7:3a:0b:c1:06:57:c2:6c:f8:4e:79:c6:f9:0e:9c:a6:64:cc:
+         7b:c8:a5:7a:93:aa:d6:f5:e7:51:9a:26:6f:6c:b5:48:37:39:
+         ba:4b:6c:f8:d6:95:2d:db:e0:44:bd:f6:c9:a1:36:7a:12:0a:
+         b2:77:7b:84:c8:14:68:1e:c2:04:29:b5:83:3b:cf:29:dc:6b:
+         27:b3:ae:a3:24:aa:3b:0c:4c:4b:c0:7d:52:6d:5c:2c:d0:5d:
+         06:af:89:9a:0c:0f:2e:df:53:ae:82:23:36:e3:1a:cb:49:46:
+         e2:77:a1:3e:55:1c:81:f5:8e:c8:f2:da:8c:22:14:e6:84:47:
+         e9:56:8e:7a:c7:c4:54:e0:f1:f5:2f:00:c4:ad:e1:ff:ba:cb:
+         5e:66:22:f2:71:db:0e:31:22:5b:5e:ad:63:6e:bf:52:c9:4d:
+         91:cc:29:5d:b8:b3:d4:b0:a7:17:9b:bd:87:9b:09:ef:a2:68:
+         24:b2:1d:62:0a:f3:d6:15:7b:ba:26:7e:ca:e2:df:ac:4c:f9:
+         70:76:fc:fb:39:bf:d3:a8:21:19:2d:6d:a6:71:6f:e5:0f:c8:
+         9c:97:b0:5f:2c:85:d2:1f:b4:27:28:54:6f:30:f4:66:8a:bf:
+         cc:09:5c:0d:19:85:b6:04:8c:7c:03:a4:fc:a3:80:dc:1c:5b:
+         61:6d:12:0a
 -----BEGIN CERTIFICATE-----
-MIICPDCCAaWgAwIBAgIBATANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
-IENBMB4XDTcwMDEwMTAwMDAwMFoXDTI5MDQxOTIyMzEyMlowHzEdMBsGA1UEAwwU
-VGVzdCBDQSBTdWJhdXRob3JpdHkwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGB
-AMJKbgfGHIsvv5E+JdxULAIPG29bDlppHd1SP4v0yFbG88VWLLiCZ4EJew1vASZK
-rkJTlbEyugfUZLx5HxYKkgflr13Ws00JWLGKuizA05uVzKEN5U1AGlAtpEX/BWNi
-hDVzLA+z9mn9m9NeqBLwxKB3JVnngT3uxSIQdaytzKQfAgMBAAGjgZQwgZEwDAYD
-VR0TAQH/BAIwADAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFCN4LwmBsHvGeR8w
-/vxeNxT/IKAgMDEGCWCGSAGG+EIBDQQkFiJQdXBwZXQgU2VydmVyIEludGVybmFs
-IENlcnRpZmljYXRlMB8GA1UdIwQYMBaAFCwlGaFss/dp/XabOiLLDFYBAfExMA0G
-CSqGSIb3DQEBCwUAA4GBAHqKB6rRTXtbAc/Tn7A/Ay6sSzHohk3KwPvLwoBzYOoe
-DC98Afx4Tj2bvhaFv7zJe0Gd3nRpgpe24eI3QEs2uq36vcZzIdnE5ZbWar/J3AoO
-ngtEXC+zWlR1FCtTqCdvi5TJJ8zti4JbCbHbbZB4CujirDD2Gp93T3CqT7dh/klB
+MIIDQTCCAimgAwIBAgIBAzANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMxMDQxODE4NDYyM1owHzEdMBsGA1UEAwwU
+VGVzdCBDQSBTdWJhdXRob3JpdHkwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
+AoIBAQDN7+8xxTNpO+4lBrlzpwnlyZwLOUgm+4gmUC2KUimG33oS8AjqYVKAmJ+l
+RSatbQXmtYHlkbNrmFMJCukFSynePGREp9JdP/xf+CkfsEDidIom/ejXdKV43r8j
+EHN0jRsMS9cdqa6GFAVjfCoAONZXireoRYAn9XEL+uK9otEIjfrNnPatiXbqqxx4
++SZboxgq95AV7afbUOl9VZl+BRDKVhFRXt6M4r4qijRBHR0jkgRQBcVbuHpFkO4N
+fwGx7dTdxSjtfU1qcCE7lV7iMdcXvVuv5M6ta59fnuEehv+DwYjsh7u/oSYidblX
+MRD9pcqCcG3IoaP2PnY9Ls0H+Xs/AgMBAAGjgZQwgZEwDAYDVR0TAQH/BAIwADAO
+BgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFJoVGQegVI3DnU8HxAWhhayS2LHlMDEG
+CWCGSAGG+EIBDQQkFiJQdXBwZXQgU2VydmVyIEludGVybmFsIENlcnRpZmljYXRl
+MB8GA1UdIwQYMBaAFGHf7s7aSWte8++U/vncx8BadP7bMA0GCSqGSIb3DQEBCwUA
+A4IBAQDXOgvBBlfCbPhOecb5DpymZMx7yKV6k6rW9edRmiZvbLVINzm6S2z41pUt
+2+BEvfbJoTZ6Egqyd3uEyBRoHsIEKbWDO88p3Gsns66jJKo7DExLwH1SbVws0F0G
+r4maDA8u31OugiM24xrLSUbid6E+VRyB9Y7I8tqMIhTmhEfpVo56x8RU4PH1LwDE
+reH/usteZiLycdsOMSJbXq1jbr9SyU2RzClduLPUsKcXm72Hmwnvomgksh1iCvPW
+FXu6Jn7K4t+sTPlwdvz7Ob/TqCEZLW2mcW/lD8icl7BfLIXSH7QnKFRvMPRmir/M
+CVwNGYW2BIx8A6T8o4DcHFthbRIK
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/ca.pem
+++ b/spec/fixtures/ssl/ca.pem
@@ -1,26 +1,35 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 0 (0x0)
-    Signature Algorithm: sha256WithRSAEncryption
+        Serial Number: 2 (0x2)
+        Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Apr 19 22:31:22 2029 GMT
+            Not After : Apr 18 18:46:23 2031 GMT
         Subject: CN=Test CA
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                Public-Key: (1024 bit)
+                RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:d0:b3:d8:3f:2b:c0:45:8c:f0:3d:96:58:2c:5e:
-                    0e:6a:46:81:ab:10:2f:22:9c:7c:69:f0:61:b7:2d:
-                    f2:2f:46:97:d5:d9:1b:08:c8:c9:e8:18:a5:d8:89:
-                    27:a7:80:cb:0a:8e:ee:26:32:89:70:37:2b:bf:6f:
-                    7e:ee:12:7d:49:c7:0c:19:46:7c:65:99:dc:1f:1a:
-                    31:af:ab:87:01:b3:68:8a:5b:51:a7:78:ca:cc:1d:
-                    7c:26:b4:27:5f:67:75:99:7e:9f:16:ed:88:b3:8f:
-                    77:0f:b3:e8:b3:97:bc:70:8b:ec:62:b9:a2:47:4b:
-                    ef:dc:af:d4:9f:3d:17:cd:03
+                    00:dd:a5:83:44:db:51:be:98:ef:b1:63:a7:04:b9:
+                    ff:cd:71:d3:06:76:c4:25:68:e8:ea:ef:c5:b4:f9:
+                    c2:76:aa:c0:1b:1b:0f:44:13:da:db:cf:d4:f4:88:
+                    5c:cc:ac:f2:76:fb:9e:b6:2e:40:da:b8:c1:c8:cd:
+                    24:90:63:10:6c:99:ee:0c:10:74:cc:38:b8:f3:b4:
+                    d9:ed:1e:ac:07:29:b4:fe:f1:16:c2:18:7c:34:fd:
+                    50:25:0f:f7:45:84:e0:4b:21:41:a4:5b:19:42:85:
+                    a3:a8:d3:6a:ea:0f:80:f3:1a:06:f8:aa:31:4b:e5:
+                    44:a8:37:80:d1:1b:01:ae:f3:b8:35:c6:3f:10:82:
+                    84:fc:59:d9:47:d6:a9:e3:5e:f3:9f:89:23:6a:ed:
+                    bc:92:6a:a1:49:2c:99:c3:89:b3:ab:3a:9f:6b:2d:
+                    e6:39:95:15:e0:71:5f:6b:6a:23:2e:bc:cd:40:b2:
+                    47:42:13:f4:f5:e7:43:76:5c:db:9d:10:3b:91:10:
+                    cc:c7:27:db:a8:18:53:c9:50:eb:83:39:80:98:bf:
+                    c0:cf:75:a8:31:56:2c:0f:32:44:b0:b8:2d:22:f9:
+                    f6:a2:d6:0b:cf:5f:a2:89:7c:15:97:a9:01:5c:97:
+                    6a:b9:9c:c2:aa:fd:a3:d9:aa:61:04:65:e4:13:7e:
+                    58:7d
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Basic Constraints: critical
@@ -28,32 +37,45 @@ Certificate:
             X509v3 Key Usage: critical
                 Certificate Sign, CRL Sign
             X509v3 Subject Key Identifier: 
-                2C:25:19:A1:6C:B3:F7:69:FD:76:9B:3A:22:CB:0C:56:01:01:F1:31
+                61:DF:EE:CE:DA:49:6B:5E:F3:EF:94:FE:F9:DC:C7:C0:5A:74:FE:DB
             Netscape Comment: 
                 Puppet Server Internal Certificate
             X509v3 Authority Key Identifier: 
-                keyid:2C:25:19:A1:6C:B3:F7:69:FD:76:9B:3A:22:CB:0C:56:01:01:F1:31
+                keyid:61:DF:EE:CE:DA:49:6B:5E:F3:EF:94:FE:F9:DC:C7:C0:5A:74:FE:DB
 
     Signature Algorithm: sha256WithRSAEncryption
-         1c:a2:87:ce:19:24:db:66:41:6b:42:a9:19:85:76:5d:0f:9d:
-         30:18:6f:b7:90:7f:6a:c5:00:ce:21:73:4d:3e:c0:75:93:6d:
-         c6:d9:3b:ad:4c:4a:46:75:f3:51:96:f2:ad:c2:13:53:f0:e3:
-         f1:a6:49:0f:e7:4f:73:b6:60:9c:9d:52:c9:b6:61:4d:31:3f:
-         94:12:7f:ef:8c:f5:81:ea:7a:13:8e:11:8b:7c:83:80:65:50:
-         d2:3d:21:34:07:0a:58:25:43:8f:e6:c6:c9:30:7d:d8:8d:3d:
-         17:8b:43:78:43:0d:6b:43:ea:72:d7:84:2a:ac:f9:02:be:d1:
-         10:a0
+         28:6c:ca:8a:1f:b2:01:4b:35:d1:55:07:c8:7c:79:5f:fb:a2:
+         e0:09:e9:25:d5:db:9f:d6:91:a8:cc:66:b1:63:bd:ad:f8:80:
+         80:32:43:eb:77:ee:d7:fd:48:27:26:bb:e1:48:67:83:7c:91:
+         4d:62:96:d6:6c:ce:37:5d:ff:f8:6a:f4:8d:31:3b:4c:f4:0d:
+         4f:75:61:08:01:99:f0:92:d2:d0:50:08:6e:c3:0d:25:3b:5b:
+         53:60:da:fa:90:02:2b:29:90:3f:f8:23:bb:9c:4c:0f:ad:d0:
+         cc:1b:21:56:26:40:97:7c:86:33:31:7d:fd:a9:5f:53:14:3e:
+         80:5f:91:09:f7:76:e4:ad:30:17:d0:aa:52:ef:e8:f6:6e:b7:
+         8e:68:47:9b:f8:63:3e:50:52:ba:eb:4a:9e:40:c5:84:aa:94:
+         49:0a:8a:ff:17:57:18:bd:fc:4d:71:6d:83:ee:4d:7e:40:6c:
+         08:c5:ee:6e:0d:c6:97:ba:6d:35:80:89:c5:c5:95:7b:f0:d0:
+         0a:39:2f:8e:70:03:bf:da:56:1d:59:6c:2c:c9:04:9b:d6:b2:
+         f3:1b:cf:4f:f3:12:47:eb:05:ea:42:70:4f:02:33:d1:5e:27:
+         a0:e3:66:d6:b0:d5:ab:e2:32:ad:e8:50:e1:f2:eb:17:ad:87:
+         31:22:fe:22
 -----BEGIN CERTIFICATE-----
-MIICMjCCAZugAwIBAgIBADANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
-IENBMB4XDTcwMDEwMTAwMDAwMFoXDTI5MDQxOTIyMzEyMlowEjEQMA4GA1UEAwwH
-VGVzdCBDQTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA0LPYPyvARYzwPZZY
-LF4OakaBqxAvIpx8afBhty3yL0aX1dkbCMjJ6Bil2Iknp4DLCo7uJjKJcDcrv29+
-7hJ9SccMGUZ8ZZncHxoxr6uHAbNoiltRp3jKzB18JrQnX2d1mX6fFu2Is493D7Po
-s5e8cIvsYrmiR0vv3K/Unz0XzQMCAwEAAaOBlzCBlDAPBgNVHRMBAf8EBTADAQH/
-MA4GA1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQULCUZoWyz92n9dps6IssMVgEB8TEw
-MQYJYIZIAYb4QgENBCQWIlB1cHBldCBTZXJ2ZXIgSW50ZXJuYWwgQ2VydGlmaWNh
-dGUwHwYDVR0jBBgwFoAULCUZoWyz92n9dps6IssMVgEB8TEwDQYJKoZIhvcNAQEL
-BQADgYEAHKKHzhkk22ZBa0KpGYV2XQ+dMBhvt5B/asUAziFzTT7AdZNtxtk7rUxK
-RnXzUZbyrcITU/Dj8aZJD+dPc7ZgnJ1SybZhTTE/lBJ/74z1gep6E44Ri3yDgGVQ
-0j0hNAcKWCVDj+bGyTB92I09F4tDeEMNa0PqcteEKqz5Ar7REKA=
+MIIDNzCCAh+gAwIBAgIBAjANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMxMDQxODE4NDYyM1owEjEQMA4GA1UEAwwH
+VGVzdCBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAN2lg0TbUb6Y
+77FjpwS5/81x0wZ2xCVo6OrvxbT5wnaqwBsbD0QT2tvP1PSIXMys8nb7nrYuQNq4
+wcjNJJBjEGyZ7gwQdMw4uPO02e0erAcptP7xFsIYfDT9UCUP90WE4EshQaRbGUKF
+o6jTauoPgPMaBviqMUvlRKg3gNEbAa7zuDXGPxCChPxZ2UfWqeNe85+JI2rtvJJq
+oUksmcOJs6s6n2st5jmVFeBxX2tqIy68zUCyR0IT9PXnQ3Zc250QO5EQzMcn26gY
+U8lQ64M5gJi/wM91qDFWLA8yRLC4LSL59qLWC89fool8FZepAVyXarmcwqr9o9mq
+YQRl5BN+WH0CAwEAAaOBlzCBlDAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQE
+AwIBBjAdBgNVHQ4EFgQUYd/uztpJa17z75T++dzHwFp0/tswMQYJYIZIAYb4QgEN
+BCQWIlB1cHBldCBTZXJ2ZXIgSW50ZXJuYWwgQ2VydGlmaWNhdGUwHwYDVR0jBBgw
+FoAUYd/uztpJa17z75T++dzHwFp0/tswDQYJKoZIhvcNAQELBQADggEBAChsyoof
+sgFLNdFVB8h8eV/7ouAJ6SXV25/WkajMZrFjva34gIAyQ+t37tf9SCcmu+FIZ4N8
+kU1iltZszjdd//hq9I0xO0z0DU91YQgBmfCS0tBQCG7DDSU7W1Ng2vqQAispkD/4
+I7ucTA+t0MwbIVYmQJd8hjMxff2pX1MUPoBfkQn3duStMBfQqlLv6PZut45oR5v4
+Yz5QUrrrSp5AxYSqlEkKiv8XVxi9/E1xbYPuTX5AbAjF7m4Nxpe6bTWAicXFlXvw
+0Ao5L45wA7/aVh1ZbCzJBJvWsvMbz0/zEkfrBepCcE8CM9FeJ6DjZtaw1aviMq3o
+UOHy6xethzEi/iI=
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/crl.pem
+++ b/spec/fixtures/ssl/crl.pem
@@ -1,30 +1,40 @@
 Certificate Revocation List (CRL):
         Version 2 (0x1)
-    Signature Algorithm: sha256WithRSAEncryption
-        Issuer: /CN=Test CA
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=Test CA
         Last Update: Jan  1 00:00:00 1970 GMT
-        Next Update: Apr 19 22:31:22 2029 GMT
+        Next Update: Apr 18 18:46:23 2031 GMT
         CRL extensions:
             X509v3 Authority Key Identifier: 
-                keyid:2C:25:19:A1:6C:B3:F7:69:FD:76:9B:3A:22:CB:0C:56:01:01:F1:31
+                keyid:61:DF:EE:CE:DA:49:6B:5E:F3:EF:94:FE:F9:DC:C7:C0:5A:74:FE:DB
 
             X509v3 CRL Number: 
                 0
 No Revoked Certificates.
     Signature Algorithm: sha256WithRSAEncryption
-         48:c8:b3:f8:53:4c:79:92:ea:3e:19:c4:96:14:93:90:c4:e0:
-         6f:77:26:cb:6b:12:58:35:44:e7:5e:fb:b2:13:dc:5b:be:41:
-         09:1a:08:ab:15:38:73:a7:17:48:68:d0:64:d4:77:b6:5b:b1:
-         9c:1c:f6:2c:dd:ab:d7:83:97:ac:0d:5f:af:b2:81:90:2b:5f:
-         fa:2d:cf:f3:ee:1a:76:b5:3d:d2:9e:49:8c:71:dc:fc:cc:82:
-         2a:4a:81:80:35:2c:9f:8e:df:7e:83:89:f9:62:c1:e7:5a:7f:
-         34:cd:fa:da:83:bf:c9:4b:61:fd:c0:f5:16:e5:e1:b4:b9:70:
-         af:9a
+         6e:b5:9c:17:8b:61:3c:41:07:ac:de:27:18:ba:92:56:51:50:
+         23:d8:f9:1f:70:b8:a6:eb:ae:6c:2c:67:c1:0e:ae:96:0f:f4:
+         bc:0a:f3:bc:23:15:67:b0:32:a2:e0:4f:2c:7f:f9:c2:9d:91:
+         2e:32:01:60:3b:e4:ad:05:b6:60:f1:90:9d:cd:63:a5:62:c1:
+         4d:04:d6:90:30:f8:43:97:e6:88:0a:2a:65:8f:49:12:d6:41:
+         5e:11:62:00:a5:ff:0f:c3:3e:97:e0:93:31:de:64:7c:11:a5:
+         7b:f1:77:0a:8e:00:23:4c:9d:b1:c5:b5:41:bf:96:da:b7:c7:
+         e7:8c:44:1b:c2:de:15:0f:da:32:52:45:65:54:dc:1b:a7:5b:
+         d3:a2:b5:6e:85:3b:97:d9:09:52:c6:4d:6c:18:a4:22:58:11:
+         bf:12:27:2f:64:00:a5:9a:7d:b8:10:0c:6d:eb:b8:70:ee:e2:
+         58:86:eb:31:48:c0:af:92:92:fc:2e:1f:0f:61:77:7c:5c:a8:
+         ca:bc:52:94:e4:f2:bc:c2:f1:fa:aa:16:63:9d:16:51:92:7b:
+         ad:da:fd:94:ed:3d:e9:8c:ad:ba:95:34:98:6a:ea:e6:9c:8e:
+         38:a3:20:34:19:63:1e:7f:f3:26:07:7f:46:27:01:85:91:46:
+         44:66:c7:03
 -----BEGIN X509 CRL-----
-MIIBCjB1AgEBMA0GCSqGSIb3DQEBCwUAMBIxEDAOBgNVBAMMB1Rlc3QgQ0EXDTcw
-MDEwMTAwMDAwMFoXDTI5MDQxOTIyMzEyMlqgLzAtMB8GA1UdIwQYMBaAFCwlGaFs
-s/dp/XabOiLLDFYBAfExMAoGA1UdFAQDAgEAMA0GCSqGSIb3DQEBCwUAA4GBAEjI
-s/hTTHmS6j4ZxJYUk5DE4G93JstrElg1ROde+7IT3Fu+QQkaCKsVOHOnF0ho0GTU
-d7ZbsZwc9izdq9eDl6wNX6+ygZArX/otz/PuGna1PdKeSYxx3PzMgipKgYA1LJ+O
-336DifliwedafzTN+tqDv8lLYf3A9Rbl4bS5cK+a
+MIIBizB1AgEBMA0GCSqGSIb3DQEBCwUAMBIxEDAOBgNVBAMMB1Rlc3QgQ0EXDTcw
+MDEwMTAwMDAwMFoXDTMxMDQxODE4NDYyM1qgLzAtMB8GA1UdIwQYMBaAFGHf7s7a
+SWte8++U/vncx8BadP7bMAoGA1UdFAQDAgEAMA0GCSqGSIb3DQEBCwUAA4IBAQBu
+tZwXi2E8QQes3icYupJWUVAj2PkfcLim665sLGfBDq6WD/S8CvO8IxVnsDKi4E8s
+f/nCnZEuMgFgO+StBbZg8ZCdzWOlYsFNBNaQMPhDl+aICiplj0kS1kFeEWIApf8P
+wz6X4JMx3mR8EaV78XcKjgAjTJ2xxbVBv5bat8fnjEQbwt4VD9oyUkVlVNwbp1vT
+orVuhTuX2QlSxk1sGKQiWBG/EicvZAClmn24EAxt67hw7uJYhusxSMCvkpL8Lh8P
+YXd8XKjKvFKU5PK8wvH6qhZjnRZRknut2v2U7T3pjK26lTSYaurmnI44oyA0GWMe
+f/MmB39GJwGFkUZEZscD
 -----END X509 CRL-----

--- a/spec/fixtures/ssl/ec-key.pem
+++ b/spec/fixtures/ssl/ec-key.pem
@@ -1,18 +1,18 @@
 Private-Key: (256 bit)
 priv:
-    7e:cc:3d:2f:ed:f2:aa:9b:a4:9d:ad:13:f1:ef:5c:
-    e3:4f:3a:81:24:63:f3:cd:07:1c:74:6a:ec:c8:97:
-    47:83
+    f6:29:ef:a1:4b:33:2a:e1:ed:f9:25:c3:d1:53:81:
+    26:8d:65:e7:be:33:ea:b4:0e:7b:fa:d8:f5:58:53:
+    a6:a3
 pub:
-    04:b0:b9:7e:1e:25:44:42:3d:40:24:bb:e7:e5:34:
-    e6:16:05:b8:f0:ee:bf:0f:10:23:40:ff:af:40:7e:
-    1b:1c:3a:4b:e7:35:e4:06:98:97:ac:94:da:16:1f:
-    46:4f:72:0c:4b:08:b7:86:c0:a7:57:17:aa:57:a3:
-    1a:ba:b8:93:4e
+    04:c4:23:3b:de:c0:ca:4f:ea:d4:e9:b2:de:9f:df:
+    22:97:5b:89:48:de:a6:6c:82:f6:b6:fc:a9:e5:cb:
+    14:f9:e6:2c:ce:08:5c:e2:99:55:ff:55:c2:03:33:
+    90:49:13:9a:3f:25:29:70:19:2c:20:5e:8a:09:ad:
+    cd:9e:86:0a:e6
 ASN1 OID: prime256v1
 NIST CURVE: P-256
 -----BEGIN EC PRIVATE KEY-----
-MHcCAQEEIH7MPS/t8qqbpJ2tE/HvXONPOoEkY/PNBxx0auzIl0eDoAoGCCqGSM49
-AwEHoUQDQgAEsLl+HiVEQj1AJLvn5TTmFgW48O6/DxAjQP+vQH4bHDpL5zXkBpiX
-rJTaFh9GT3IMSwi3hsCnVxeqV6MauriTTg==
+MHcCAQEEIPYp76FLMyrh7fklw9FTgSaNZee+M+q0Dnv62PVYU6ajoAoGCCqGSM49
+AwEHoUQDQgAExCM73sDKT+rU6bLen98il1uJSN6mbIL2tvyp5csU+eYszghc4plV
+/1XCAzOQSROaPyUpcBksIF6KCa3NnoYK5g==
 -----END EC PRIVATE KEY-----

--- a/spec/fixtures/ssl/ec.pem
+++ b/spec/fixtures/ssl/ec.pem
@@ -1,40 +1,49 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 5 (0x5)
-    Signature Algorithm: sha256WithRSAEncryption
+        Serial Number: 7 (0x7)
+        Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA Subauthority
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Apr 19 22:31:22 2029 GMT
+            Not After : Apr 18 18:46:23 2031 GMT
         Subject: CN=ec
         Subject Public Key Info:
             Public Key Algorithm: id-ecPublicKey
                 Public-Key: (256 bit)
                 pub:
-                    04:b0:b9:7e:1e:25:44:42:3d:40:24:bb:e7:e5:34:
-                    e6:16:05:b8:f0:ee:bf:0f:10:23:40:ff:af:40:7e:
-                    1b:1c:3a:4b:e7:35:e4:06:98:97:ac:94:da:16:1f:
-                    46:4f:72:0c:4b:08:b7:86:c0:a7:57:17:aa:57:a3:
-                    1a:ba:b8:93:4e
+                    04:c4:23:3b:de:c0:ca:4f:ea:d4:e9:b2:de:9f:df:
+                    22:97:5b:89:48:de:a6:6c:82:f6:b6:fc:a9:e5:cb:
+                    14:f9:e6:2c:ce:08:5c:e2:99:55:ff:55:c2:03:33:
+                    90:49:13:9a:3f:25:29:70:19:2c:20:5e:8a:09:ad:
+                    cd:9e:86:0a:e6
                 ASN1 OID: prime256v1
                 NIST CURVE: P-256
     Signature Algorithm: sha256WithRSAEncryption
-         02:89:4d:ca:b0:89:38:e7:c3:ee:d8:55:76:7a:b6:b6:8c:8a:
-         a7:38:ef:62:97:3d:c6:83:5f:08:3d:39:d1:ea:50:12:32:37:
-         6d:c6:aa:42:21:8b:39:46:e7:a9:a0:16:6f:80:c0:8a:08:19:
-         4b:21:cb:14:59:49:d3:e7:f7:5b:ac:0f:ed:67:c3:b6:fa:c7:
-         7d:60:38:70:c5:6c:df:a0:3f:e5:c0:79:ce:2d:21:a5:4b:48:
-         50:a7:22:b3:71:d7:1a:44:47:8a:96:eb:e9:d3:fa:8d:dc:18:
-         7f:1e:45:86:a0:05:6e:61:8f:33:6a:ae:4e:21:60:5d:49:ee:
-         17:28
+         27:2e:2b:92:93:5d:39:da:ea:0e:ae:02:eb:aa:30:a5:bb:1a:
+         d5:e0:41:41:b5:6c:12:49:4d:61:39:1a:49:fc:5e:6a:22:ec:
+         7a:b0:4d:3e:ee:aa:f4:e9:c8:62:fd:c1:72:6d:c0:ee:21:0c:
+         eb:fb:5b:b1:81:ff:4e:bf:a7:c9:e8:37:02:2d:e3:f4:5c:49:
+         5f:e1:6f:96:9f:02:46:a6:8c:1d:d1:e8:50:f8:40:b2:db:a8:
+         c9:2d:5d:40:39:e7:31:c8:8f:9c:5a:bc:f8:a2:97:70:8d:fc:
+         0c:f1:ce:a2:66:7b:14:c8:ae:30:c7:90:8e:cb:ce:e3:b9:69:
+         9c:b8:6e:9e:61:a9:1b:90:28:2d:10:b3:5a:a1:b5:49:5a:48:
+         2f:7b:80:ef:db:e3:41:c6:c4:a1:46:87:0c:d9:b2:fc:16:fb:
+         ff:b6:93:ca:5e:67:73:1c:14:8a:a4:33:44:13:be:75:7c:6b:
+         61:3a:42:79:fc:a2:20:1a:cc:90:a4:63:3c:a2:b2:e2:52:0a:
+         03:21:6b:94:57:0e:4b:ab:30:b4:49:21:2f:bf:ae:aa:fc:62:
+         62:f9:f7:03:ba:5f:99:6d:50:5c:03:61:7f:9e:96:1d:07:dd:
+         32:f0:b7:80:22:4c:4c:00:50:59:2b:c8:76:1e:c3:b8:e5:0f:
+         ad:f0:1c:d8
 -----BEGIN CERTIFICATE-----
-MIIBWDCBwqADAgECAgEFMA0GCSqGSIb3DQEBCwUAMB8xHTAbBgNVBAMMFFRlc3Qg
-Q0EgU3ViYXV0aG9yaXR5MB4XDTcwMDEwMTAwMDAwMFoXDTI5MDQxOTIyMzEyMlow
-DTELMAkGA1UEAwwCZWMwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASwuX4eJURC
-PUAku+flNOYWBbjw7r8PECNA/69AfhscOkvnNeQGmJeslNoWH0ZPcgxLCLeGwKdX
-F6pXoxq6uJNOMA0GCSqGSIb3DQEBCwUAA4GBAAKJTcqwiTjnw+7YVXZ6traMiqc4
-72KXPcaDXwg9OdHqUBIyN23GqkIhizlG56mgFm+AwIoIGUshyxRZSdPn91usD+1n
-w7b6x31gOHDFbN+gP+XAec4tIaVLSFCnIrNx1xpER4qW6+nT+o3cGH8eRYagBW5h
-jzNqrk4hYF1J7hco
+MIIB2TCBwqADAgECAgEHMA0GCSqGSIb3DQEBCwUAMB8xHTAbBgNVBAMMFFRlc3Qg
+Q0EgU3ViYXV0aG9yaXR5MB4XDTcwMDEwMTAwMDAwMFoXDTMxMDQxODE4NDYyM1ow
+DTELMAkGA1UEAwwCZWMwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATEIzvewMpP
+6tTpst6f3yKXW4lI3qZsgva2/KnlyxT55izOCFzimVX/VcIDM5BJE5o/JSlwGSwg
+XooJrc2ehgrmMA0GCSqGSIb3DQEBCwUAA4IBAQAnLiuSk1052uoOrgLrqjCluxrV
+4EFBtWwSSU1hORpJ/F5qIux6sE0+7qr06chi/cFybcDuIQzr+1uxgf9Ov6fJ6DcC
+LeP0XElf4W+WnwJGpowd0ehQ+ECy26jJLV1AOecxyI+cWrz4opdwjfwM8c6iZnsU
+yK4wx5COy87juWmcuG6eYakbkCgtELNaobVJWkgve4Dv2+NBxsShRocM2bL8Fvv/
+tpPKXmdzHBSKpDNEE751fGthOkJ5/KIgGsyQpGM8orLiUgoDIWuUVw5LqzC0SSEv
+v66q/GJi+fcDul+ZbVBcA2F/npYdB90y8LeAIkxMAFBZK8h2HsO45Q+t8BzY
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/encrypted-ec-key.pem
+++ b/spec/fixtures/ssl/encrypted-ec-key.pem
@@ -1,21 +1,21 @@
 Private-Key: (256 bit)
 priv:
-    7e:cc:3d:2f:ed:f2:aa:9b:a4:9d:ad:13:f1:ef:5c:
-    e3:4f:3a:81:24:63:f3:cd:07:1c:74:6a:ec:c8:97:
-    47:83
+    f6:29:ef:a1:4b:33:2a:e1:ed:f9:25:c3:d1:53:81:
+    26:8d:65:e7:be:33:ea:b4:0e:7b:fa:d8:f5:58:53:
+    a6:a3
 pub:
-    04:b0:b9:7e:1e:25:44:42:3d:40:24:bb:e7:e5:34:
-    e6:16:05:b8:f0:ee:bf:0f:10:23:40:ff:af:40:7e:
-    1b:1c:3a:4b:e7:35:e4:06:98:97:ac:94:da:16:1f:
-    46:4f:72:0c:4b:08:b7:86:c0:a7:57:17:aa:57:a3:
-    1a:ba:b8:93:4e
+    04:c4:23:3b:de:c0:ca:4f:ea:d4:e9:b2:de:9f:df:
+    22:97:5b:89:48:de:a6:6c:82:f6:b6:fc:a9:e5:cb:
+    14:f9:e6:2c:ce:08:5c:e2:99:55:ff:55:c2:03:33:
+    90:49:13:9a:3f:25:29:70:19:2c:20:5e:8a:09:ad:
+    cd:9e:86:0a:e6
 ASN1 OID: prime256v1
 NIST CURVE: P-256
 -----BEGIN EC PRIVATE KEY-----
 Proc-Type: 4,ENCRYPTED
-DEK-Info: AES-128-CBC,0868B9423657113886CFF18689853E85
+DEK-Info: AES-128-CBC,7F75DD5C09F3396E0DE1F15482350FA4
 
-5PsfXd1EI/wHzw3qbXRnXgmbBmmtIvevJsAfC34P1sHAWRTcQnbj1R0TOiPYj65m
-GCkjLnAMNWxyHpjOtD7irdGINBEre+Puo68pmnXEOAFYIjOhjr1kQn3oQ7SQ35dV
-M8jBxhogriHr0Q7D7ab2KXJL6yBf4HrFYsg5lL97jlY=
+r576IEa+i0nLaChOpNHlM+krdE2sgt9INqxYZdL0bcUEHKC44QlPU3Wrq56jLj4n
+A9KtNG64NZTdVubOHqp41W2GSkehycFhdnItWfDCnK8Ru2/YDkDA+nIfMEgHS/uL
+Gsu2AAiBKIQsSX+CDDGwiBm5ayae30+o1nIdI/Y7fxU=
 -----END EC PRIVATE KEY-----

--- a/spec/fixtures/ssl/encrypted-key.pem
+++ b/spec/fixtures/ssl/encrypted-key.pem
@@ -1,70 +1,120 @@
-Private-Key: (1024 bit)
+RSA Private-Key: (2048 bit, 2 primes)
 modulus:
-    00:ef:bc:2c:47:fa:12:2d:09:ef:16:96:90:8b:84:
-    45:c7:86:f1:5e:8f:58:59:23:87:df:a1:e3:be:8c:
-    2f:ad:70:96:1a:f5:67:7f:5c:9c:54:5e:82:de:05:
-    7f:8f:9d:c9:f3:24:72:39:4f:1c:b4:a6:e0:d0:19:
-    af:bd:e4:29:65:bb:d7:43:3e:66:d3:4f:74:05:0b:
-    8a:e4:d5:52:08:af:9b:f4:f4:7d:6c:92:5f:cc:bb:
-    c2:2d:ca:d0:12:28:e5:c8:fd:f6:09:90:dd:85:f9:
-    85:d9:37:a6:fe:83:c7:24:e4:af:28:e3:ff:5a:1b:
-    72:5f:29:c6:39:88:5b:48:19
+    00:db:90:d7:cf:fe:81:bc:51:d1:a1:d2:d9:0f:c2:
+    21:16:06:3d:12:87:7c:e9:45:97:28:f4:33:12:51:
+    d2:b3:31:be:13:5d:28:a8:b5:fb:8f:0e:ce:3e:bb:
+    42:7a:3f:ba:35:e9:58:2a:fb:61:38:c0:6b:37:9f:
+    3f:de:b9:64:5b:c3:08:21:64:d7:c2:af:0a:ac:21:
+    0b:ed:c1:8a:71:fe:05:27:eb:4b:31:ba:79:62:e5:
+    41:ef:dd:66:85:76:28:bb:03:08:c7:35:26:85:c2:
+    f8:3b:1f:67:45:39:73:ce:d8:5d:df:4a:0b:4e:8c:
+    85:29:02:98:04:95:e9:d3:f6:d1:9f:6c:25:ce:a3:
+    81:4c:c7:4d:b5:ce:43:12:d9:b2:f1:68:c8:fd:a3:
+    57:16:f5:7a:42:85:fe:19:b5:ee:e8:3f:da:27:85:
+    82:c9:ec:d6:63:bf:cd:4b:75:1e:a0:c5:8f:ce:90:
+    b8:ca:25:ba:45:52:6d:e4:ea:6d:e5:1d:41:8e:4f:
+    33:4a:97:23:8e:c1:98:d4:60:a7:1e:1c:28:31:0d:
+    05:c8:a2:d2:d7:7a:d9:c3:46:26:a1:e7:ef:67:e7:
+    6b:ce:97:8a:37:0b:d7:e2:28:b0:33:85:b0:89:6b:
+    38:83:ae:a3:02:a7:d2:1a:87:f0:88:a6:a3:1a:db:
+    97:53
 publicExponent: 65537 (0x10001)
 privateExponent:
-    75:11:3b:c2:6e:30:60:04:00:d7:d3:f0:83:e0:b4:
-    be:89:7b:e6:84:33:4d:5c:17:66:b2:44:67:71:47:
-    7a:f7:86:a5:65:7f:03:e7:b2:83:54:9f:ad:51:9c:
-    08:02:b2:72:64:32:cf:1f:7d:d2:0d:c7:ac:77:4e:
-    a5:78:fc:69:3a:88:12:5b:81:81:19:c9:1f:9d:aa:
-    fa:35:2e:cd:df:71:ee:50:f9:59:53:99:52:22:f7:
-    48:ba:17:4f:47:b5:72:16:47:d1:1d:31:29:47:80:
-    b1:e1:3c:e0:a0:4b:ef:05:c5:ea:0a:b2:c7:4a:b9:
-    d3:06:c0:b7:7b:0a:2e:81
+    00:9d:74:93:af:8f:1e:4e:84:86:46:fc:43:b9:2f:
+    48:36:d9:26:76:e1:3e:cc:b2:a1:22:37:6d:60:97:
+    d8:f7:b4:96:50:a0:a0:05:cc:eb:a7:bd:c0:5d:f0:
+    40:4e:16:e1:5c:c4:07:fc:5a:e5:6f:a3:5d:c0:37:
+    ad:bf:f5:47:69:1e:c5:f7:dc:af:75:e7:bd:49:8f:
+    31:54:c1:54:9d:46:c3:3f:cb:56:d3:44:9c:c4:35:
+    10:42:09:8d:f9:eb:b0:6d:dc:51:31:3a:86:73:aa:
+    4c:05:6a:11:ce:ec:d2:85:e5:57:fc:46:c7:30:ff:
+    48:87:0e:5b:21:fe:b7:fe:ce:4f:8c:2c:cf:ea:d1:
+    0c:59:83:7e:d4:3f:db:0c:09:8d:8d:af:c5:38:8d:
+    96:44:37:7c:a3:4f:79:09:fe:11:cb:cf:20:40:6c:
+    fd:a3:cc:d9:f2:f4:35:79:63:c3:f8:1c:c1:6e:d4:
+    76:2b:67:84:4d:d3:af:81:72:17:ba:9d:98:0c:58:
+    0a:c8:4d:8f:28:95:2b:fa:d9:31:1d:31:ad:c5:87:
+    90:1b:2c:69:42:22:b1:1b:73:4a:22:82:af:b7:5b:
+    82:b4:38:39:3b:f2:47:ef:3d:7d:09:9b:e8:5b:b5:
+    d8:56:1c:16:e7:3a:6e:7d:85:3f:1c:1d:3f:ee:dd:
+    f1:d1
 prime1:
-    00:fa:cc:b0:ba:9e:06:c5:f7:63:09:37:e7:9f:aa:
-    4d:f8:f1:b4:7f:aa:c6:8a:04:16:93:73:af:ba:1f:
-    e3:97:76:11:a9:4d:fb:42:8b:f0:51:0a:7d:6c:69:
-    fa:2f:d8:7b:ad:20:79:de:71:ea:e2:e0:a3:69:1b:
-    1e:e3:6c:9b:e9
+    00:f2:0c:fe:99:b5:ed:bb:24:f6:79:61:75:f5:a8:
+    9b:56:f9:f3:ee:5b:84:1c:31:00:5e:01:02:b4:50:
+    ea:fb:a8:13:22:73:c2:12:1b:c2:53:55:14:f3:2e:
+    a3:62:f8:82:04:4c:23:09:50:98:c1:ab:45:18:96:
+    c7:a4:e8:29:84:04:ab:24:37:17:45:0b:b3:02:7f:
+    c3:4a:30:3f:ad:69:49:0b:49:c5:89:e0:07:b7:b3:
+    d7:50:19:85:c0:f1:73:60:b4:76:f8:c2:c5:01:7c:
+    09:23:49:57:2a:cc:d7:e1:d6:d9:b4:6b:54:20:61:
+    7f:3a:70:9b:9d:01:12:fa:e7
 prime2:
-    00:f4:b4:bf:cf:56:a0:fa:94:15:5c:24:9c:45:fd:
-    54:31:72:75:7b:ef:d5:de:5b:64:c9:6a:88:42:e0:
-    0d:f0:63:c2:46:9e:59:81:be:60:ee:05:01:b0:dd:
-    e4:12:d0:5b:77:76:c0:5b:f2:21:0c:5b:42:af:f5:
-    c2:5b:c6:1c:b1
+    00:e8:38:1f:fb:1b:f6:4d:e1:be:f0:80:c1:a1:55:
+    2b:d1:db:09:98:cc:70:eb:99:f0:9e:0b:2c:2d:60:
+    20:96:f7:b3:c5:6b:98:22:c5:bf:c3:20:5e:91:be:
+    d1:81:fc:14:36:70:9b:37:9e:6d:c8:6e:84:f6:fa:
+    65:30:64:0e:b0:50:05:85:a8:07:0b:be:4e:de:c1:
+    17:71:39:03:e3:9e:4e:69:5c:51:02:af:97:b8:30:
+    da:95:2e:24:b4:78:76:46:bc:db:a2:27:66:5a:ce:
+    e5:0f:01:82:fe:cb:31:bc:fe:19:6a:e5:73:b6:a5:
+    ad:3a:f3:61:ec:f7:a9:fe:b5
 exponent1:
-    15:d0:1f:be:db:67:b3:68:24:d0:f4:6f:cc:cf:3f:
-    20:db:c4:db:25:bb:46:dd:bc:28:ee:f2:e5:b9:48:
-    4e:30:12:b1:2a:fb:23:7a:90:58:3c:15:54:8c:93:
-    19:fe:36:23:84:a3:94:d9:4b:98:97:f9:1e:77:21:
-    64:9e:59:a1
+    04:5d:93:a1:f6:14:09:92:0b:17:f9:58:05:4c:3b:
+    31:00:65:13:e1:76:aa:83:7f:bc:32:4c:78:30:15:
+    6c:e0:85:27:d3:ea:a6:24:f6:06:46:bc:8f:fe:41:
+    58:21:9f:46:b0:90:d9:34:28:ed:25:47:a3:bf:e4:
+    6d:e6:fa:08:b5:84:d8:ac:5d:b1:13:1a:f1:6a:98:
+    7d:18:0d:ad:f4:fe:2a:43:f4:5a:1e:3e:45:63:ea:
+    f8:38:dd:9e:b3:3c:1f:7c:61:c0:ee:d2:5a:ca:7f:
+    e7:b1:04:ef:72:ae:5a:16:63:ea:cb:1c:c3:50:be:
+    d8:b0:fb:3d:83:ad:71:f5
 exponent2:
-    00:81:96:5e:a5:5c:48:ef:aa:10:0d:b5:cd:94:3a:
-    ed:a5:29:ea:11:72:17:1e:23:e4:21:cd:ea:cf:0f:
-    7c:12:3b:a2:1c:67:ab:1a:cc:48:e4:83:7e:3b:bd:
-    a6:14:58:86:b7:a3:09:87:27:98:5c:c4:cf:72:03:
-    81:a3:bc:2c:61
+    69:f2:f9:7c:6b:44:94:42:14:08:cc:e6:0b:42:bd:
+    cc:70:80:4f:6b:af:75:7e:f5:ce:55:d0:a1:1f:43:
+    9f:3d:82:92:e7:45:31:50:41:ee:b7:fd:0d:c8:1e:
+    f4:8c:5b:78:7f:26:02:59:51:43:6a:51:56:11:e6:
+    4b:0e:cb:b8:db:b9:b9:42:71:7c:85:26:9c:f1:42:
+    4d:d1:32:9a:0e:67:3e:20:f5:81:21:36:3a:be:67:
+    6c:3a:f2:5a:38:bf:d6:04:62:bc:f7:f6:f6:25:81:
+    52:b8:60:d8:f9:42:47:35:33:c9:96:c8:95:a3:bf:
+    86:ae:f6:95:d4:65:86:25
 coefficient:
-    7d:b4:b6:78:c7:d3:0c:44:6f:a2:aa:83:8a:79:65:
-    69:24:b2:31:ac:59:ed:6c:bf:4c:1a:1a:27:f0:c8:
-    e9:38:ff:84:50:df:b5:10:c2:6e:4b:5c:c2:4c:c9:
-    82:2a:db:0a:6f:59:dd:12:93:8c:c1:9d:57:f3:dd:
-    66:41:9a:e0
+    28:91:92:b0:3c:bb:1c:58:e9:95:6c:70:fb:66:1d:
+    19:b5:eb:ca:17:83:b9:b6:90:83:9f:18:e4:f2:69:
+    72:e8:20:17:30:0f:dc:9c:4b:8a:9a:38:53:e1:c6:
+    01:ff:bc:1b:2b:22:84:95:48:6f:9e:01:8e:6b:b6:
+    50:f8:42:9d:76:67:e8:34:86:2d:b8:66:32:9d:01:
+    8e:3a:a4:1d:3c:9a:02:85:a5:1d:74:ef:8d:6a:d2:
+    2f:61:2c:e9:17:02:d7:22:9c:ee:8e:4c:cb:de:76:
+    6d:c2:1c:17:af:a3:3c:6a:f2:6a:6a:9c:b5:fb:9b:
+    2f:1e:c9:15:29:97:d2:3d
 -----BEGIN RSA PRIVATE KEY-----
 Proc-Type: 4,ENCRYPTED
-DEK-Info: AES-128-CBC,7D9CB780A5571FAC184E44E1D736A163
+DEK-Info: AES-128-CBC,8F1EB474F99CE22E5ABC5EFE44FF0E3E
 
-Qm1/dU9pVgWJvFbAsoTpvKsID72hLSQt9Krsoi1qzoCkCjY/9zuYcZs5IAx9rzZj
-ykULBjY9ZIBaNplQtpH1VRHl7YvrZ72oYXeTyQL0+fYyjqjC3X6SSATyOFR2yycs
-cXGE/jFvVnFdU/vmuv26laHCINhJ9KGJXLQRXoobMNxCR7uE4CVI8AKmKLxNq7jL
-GrkKUE4T9gkoWZOnck7TfYxSplc8ttSPRuaxV0eEAohkmOZBdL6vi7TXVhaEf7ym
-ZeUi5yUTByBqMBFgk6Az4Pr6U/etY0JbYRYwB0Opg+vjvAxqkmtgDKqZQkobZ7w2
-61l9a01u2fXxN1CahJKgoke1vw4FQdDtFoIbtKPxZSGFOi8G7fSFk9+L8yeombXH
-3omxcUJqtsteWFJbqHkMZYY9uK3NpZ+RifC1tmNV0h99oFpUxOkqP52T6TIJaav7
-YQaxJXqjBp8d07o+mtKLu4oggcFfXCYNdepG9L/U5TrTFeLmhf7Ep2zzr5NF1cbG
-DF1k0X4g9obOKbSVLMDD+umWmvj8FNXcKZ1joRcGfY2WZbjJtofdOhLbCD8/M4lE
-h2KyrhMbRalg0A82IFPoavGeTSmvK1iNcwSf04JYKNx2wpzjF+eTzMHpyPPv9RyV
-2fRtSXZmfQA33BmTo0QImST22WqL76auJEQTKlH4Ka6Q7OQLC+xYzyhm7CZCFBzU
-T46HRAwxjptK89yWIvawDdAUcxZ/H/TjVOGG+q/DRQYI/Gyf4IOZqKTfIVg/JlvD
-njF3wo6kRV0JLrifTnev5mQwl3y9MXW5KUsAedLcWl7tv33pkbXFy7B/7Pn1wH67
++NQ5qz3FIKH4rcFo1QA0I+hwzIo1POBhLvGBiIK6nhGNneQnCTSq3CgKXtG5gOKI
+t5Ts9gNscN8rxx3iyUk1ldp4eDGf1VxMj1K1Fu8WDclssSqBwSM1QgUBuze41Ei/
+BmLd9wK0u+fGs5mTkcC/VyhOeO2N/4qWpQdsoI5iUf85xfljB330uMeiNJ+hO6mO
+x1NcVuqdKVhgEg+UZ1l6sPZPtiybPrTxVZebWolYp/aKWa2ZF2p9DeI/pSze5tFW
+a64RnKOWopKyDKU2xAprNXd6qG1zuFAYFGwo1bfCeSwDfV928bw3kx6xXJ12BIW8
+GilMF7aKgSc6zlo+vBQt6K5AIkz2Xez3K8KfgQJ1LwNRgWVCA9pL5aQ+wHJJq21A
++lG/8OYsWPcUhcWgiF8Ydw0nhfSj7+lnCM4PlKfleBkHIXMI4i+s8JDO+3NCvOQE
+ntpYSrzCN1RkdMSmq8OBw1L40PfsEFVQLV1sYQMGa/8Xt/P+QywqivQ4RmGD/7yk
+uuMoazjI7i6Ig1lwTItRR7Wwwx806a722BniTZ1LPtRlRzf0pOQ8Iw2FQgGUcNRO
+b4Y+W1g0f+KdM8DwmIzGx9jmWy9KaFpNF2Zc/rGS8a76h/B2HJEfQxONT+2LOLzs
+FjgfFQhyJGdr43xoum3wnFzKWzCb52kVfoGhXwCJMIXBE1xo6FHBFgXYMFKxTC0N
+eTj7fJ506YJ+924H6jSNC4JsysyFJ7zPOWMKcnBr5bkV7ct9ipozuAlfKdGeS6Ag
+S9l6Y2H+USe99nwptwEhFGk9hjh2tn61UoenwiqZkiMJufBOHn9BmmvfRRB3778s
+/PgltXzDxEu78Wi+0q1XSr1DvvKTH1Co2kdw+9ddliJ4GlAdubZyAIcEDqIHWdgv
+VvNqgd38ckTMWUT6Kc11Of+c3iwuxSRV3GI9kyHRb6zoTKmEfAFGKyUfUuMG1w0c
+v0H42JOulvODObP82dxjDcj8Givm9VhBD9F5K9WaffOAsLKDyGLD9tN8nqjuI2sB
+476Wf0ZvYNpLZlQXUUeHBs6lniq08Kp8eC/FA1VFq5PenPfot/QgarcJEAsM74Kb
+eqMirO3IRJ9wWs49Ti/l2XdzdGjD06LiOo2QBSSNi0UHKZZ1o/GRZN0wvNZIT/ya
+Xea50ONfAoJCUTnvXn7sykONDyPpUb6BpC9P3dE6V6V8vAyGn2koL7QWwQrUK7II
+o+ZDLaaK11XhGYjVUW0RPf2FEjfBq9rLaBhAjHzODx+ZEIhGd78/c1wZ9Fs/XG8q
+9A8rp4Bf8bq5LTlMQ0Bedaq1DFyyD2d1f2ssSpfTwxe07nKms4tFP0nGtvSUjPwf
+zExeYXvpx6q0uShuYbX0PTruM0M73EsXza/RbgxpoUQRP8uC5+Yoxk/3xll021cd
+F6fxfg8qKaGRFAVwP7wJWronZnCdNKmMhzMNvZeVDxrOITqsMmCM53iWJAJKIFFj
+tXXSMqAarWhvjZ41+0/kz4afVjcNFgxfADxrT7sZ4tmLqchsVhfqx7gtU+szQNM8
+sUOPmzOP915hrFplU06/blzJIMYQEHrsKS1MgN6EtiRfw5qiVx8LxFScMs9wca4G
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/intermediate-agent-crl.pem
+++ b/spec/fixtures/ssl/intermediate-agent-crl.pem
@@ -1,31 +1,40 @@
 Certificate Revocation List (CRL):
         Version 2 (0x1)
-    Signature Algorithm: sha256WithRSAEncryption
-        Issuer: /CN=Test CA Agent Subauthority
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=Test CA Agent Subauthority
         Last Update: Jan  1 00:00:00 1970 GMT
-        Next Update: Apr 19 22:31:22 2029 GMT
+        Next Update: Apr 18 18:46:23 2031 GMT
         CRL extensions:
             X509v3 Authority Key Identifier: 
-                keyid:71:55:03:0F:DF:BC:E6:CE:3E:DE:05:DE:06:0F:E1:4F:BA:00:16:8D
+                keyid:30:5C:E0:85:AC:BF:77:41:18:C8:05:24:E3:0A:3E:71:66:1A:95:82
 
             X509v3 CRL Number: 
                 0
 No Revoked Certificates.
     Signature Algorithm: sha256WithRSAEncryption
-         07:24:a1:9d:d9:ec:57:1c:0b:68:ee:fb:59:c5:98:65:77:59:
-         49:a5:c5:51:69:9e:4c:20:94:d8:7b:f1:cb:e3:c8:4d:5e:a2:
-         58:3d:a6:6c:e1:7d:52:a3:d5:44:d5:be:95:95:c5:b8:10:86:
-         12:5a:4d:03:f2:73:d2:c9:94:a5:f5:c9:bb:78:bf:8e:7d:cf:
-         8e:5c:77:51:3b:4f:0f:bb:3b:f7:f3:00:45:00:9a:4b:4e:db:
-         3b:95:d3:cf:d5:dd:d0:78:28:b0:3a:9c:b1:2b:75:88:91:5b:
-         6e:b8:39:25:59:67:73:c1:21:6c:2b:b1:a9:da:e8:da:04:ca:
-         64:aa
+         14:7d:d2:53:6f:ce:63:c4:c7:ea:0a:50:9a:31:68:5d:04:9e:
+         d6:57:07:67:54:0c:c7:8a:a3:64:1f:81:eb:71:3f:6e:7d:6b:
+         db:15:38:0d:57:a7:ac:1e:73:93:f5:e2:ff:0e:d1:ed:a2:9f:
+         1c:40:7d:6e:2e:29:7f:aa:e1:8e:46:d1:03:be:6a:3f:c8:b1:
+         dd:3d:a3:0d:f5:6b:b3:ef:23:5d:f6:1c:2a:a7:b7:31:b2:0e:
+         90:79:03:7f:03:24:9e:ad:9e:bf:18:63:b4:87:81:cf:8b:7f:
+         88:e1:6c:fd:c4:3d:46:c3:85:30:74:ca:89:f6:37:e3:dc:c5:
+         4c:50:ee:62:2d:71:e8:dd:ac:46:f8:3f:23:6c:80:3c:e7:be:
+         00:93:a6:6f:e6:0d:86:4e:15:d8:46:cf:0d:cd:61:b2:74:ac:
+         57:9f:79:db:ab:46:de:a7:30:b3:13:a0:44:04:7d:d6:02:a6:
+         94:1a:1e:7e:20:43:2a:69:27:4b:7e:7a:00:8d:ab:39:74:19:
+         f3:b6:b1:89:c8:2d:38:26:92:c4:fd:5c:9a:68:f5:9a:b0:65:
+         7f:e7:a9:04:96:f7:e1:f8:90:79:e4:26:1b:db:cc:93:10:97:
+         ad:23:a4:74:56:31:0a:90:5e:d2:cb:cf:ff:cd:9b:fe:8f:35:
+         96:d0:3a:9a
 -----BEGIN X509 CRL-----
-MIIBHjCBiAIBATANBgkqhkiG9w0BAQsFADAlMSMwIQYDVQQDDBpUZXN0IENBIEFn
-ZW50IFN1YmF1dGhvcml0eRcNNzAwMTAxMDAwMDAwWhcNMjkwNDE5MjIzMTIyWqAv
-MC0wHwYDVR0jBBgwFoAUcVUDD9+85s4+3gXeBg/hT7oAFo0wCgYDVR0UBAMCAQAw
-DQYJKoZIhvcNAQELBQADgYEAByShndnsVxwLaO77WcWYZXdZSaXFUWmeTCCU2Hvx
-y+PITV6iWD2mbOF9UqPVRNW+lZXFuBCGElpNA/Jz0smUpfXJu3i/jn3Pjlx3UTtP
-D7s79/MARQCaS07bO5XTz9Xd0HgosDqcsSt1iJFbbrg5JVlnc8EhbCuxqdro2gTK
-ZKo=
+MIIBnzCBiAIBATANBgkqhkiG9w0BAQsFADAlMSMwIQYDVQQDDBpUZXN0IENBIEFn
+ZW50IFN1YmF1dGhvcml0eRcNNzAwMTAxMDAwMDAwWhcNMzEwNDE4MTg0NjIzWqAv
+MC0wHwYDVR0jBBgwFoAUMFzghay/d0EYyAUk4wo+cWYalYIwCgYDVR0UBAMCAQAw
+DQYJKoZIhvcNAQELBQADggEBABR90lNvzmPEx+oKUJoxaF0EntZXB2dUDMeKo2Qf
+getxP259a9sVOA1Xp6wec5P14v8O0e2inxxAfW4uKX+q4Y5G0QO+aj/Isd09ow31
+a7PvI132HCqntzGyDpB5A38DJJ6tnr8YY7SHgc+Lf4jhbP3EPUbDhTB0yon2N+Pc
+xUxQ7mItcejdrEb4PyNsgDznvgCTpm/mDYZOFdhGzw3NYbJ0rFefedurRt6nMLMT
+oEQEfdYCppQaHn4gQyppJ0t+egCNqzl0GfO2sYnILTgmksT9XJpo9ZqwZX/nqQSW
+9+H4kHnkJhvbzJMQl60jpHRWMQqQXtLLz//Nm/6PNZbQOpo=
 -----END X509 CRL-----

--- a/spec/fixtures/ssl/intermediate-agent.pem
+++ b/spec/fixtures/ssl/intermediate-agent.pem
@@ -1,26 +1,35 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 6 (0x6)
-    Signature Algorithm: sha256WithRSAEncryption
+        Serial Number: 8 (0x8)
+        Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Apr 19 22:31:22 2029 GMT
+            Not After : Apr 18 18:46:23 2031 GMT
         Subject: CN=Test CA Agent Subauthority
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                Public-Key: (1024 bit)
+                RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:e7:30:19:5b:4d:c2:77:b0:2d:8f:54:19:8d:f5:
-                    cf:91:57:48:ae:0d:59:c0:a2:75:d0:d5:11:5b:72:
-                    97:c9:8b:45:8e:7b:91:03:1c:57:c5:08:f0:ae:00:
-                    da:b0:1b:9a:bd:c3:ee:fd:f6:c2:1d:05:9d:f5:5e:
-                    e3:91:bd:c1:80:cd:0a:45:f7:89:32:91:19:31:11:
-                    95:a9:14:d3:6b:02:a3:2d:df:68:b8:c4:0e:a3:27:
-                    18:e9:22:f1:fa:d4:e8:5a:bc:f1:11:c5:fd:e1:b6:
-                    d8:00:e4:82:60:00:37:f9:54:cb:a9:ad:fe:ea:e3:
-                    8b:c3:67:07:04:e6:70:b0:45
+                    00:c8:76:0f:6b:12:72:bc:6a:03:90:71:fa:b3:01:
+                    69:bd:d5:d0:64:74:b9:6b:a0:3e:9e:fc:ea:25:c7:
+                    5f:da:c9:95:1e:f8:dc:63:74:f9:3d:ee:28:fe:70:
+                    e9:e8:62:d2:1b:ac:3e:ab:42:a7:2a:95:2b:b4:22:
+                    43:7d:68:1a:c0:39:4f:7a:0c:45:2b:41:4c:de:14:
+                    d2:9e:1f:e5:ce:85:2d:db:d6:7f:25:b0:9b:94:f8:
+                    e4:ed:11:2e:cd:9c:c8:5d:15:bb:11:96:ec:e0:3e:
+                    9a:af:b3:26:50:5d:9c:5f:29:6b:3a:cc:ff:21:07:
+                    e5:13:99:e5:c0:f7:34:ca:7b:49:f4:ba:dc:41:29:
+                    65:db:65:e9:61:7a:f4:17:18:fc:ab:70:a5:de:22:
+                    32:ab:24:63:5c:14:25:48:88:ee:36:33:0b:36:81:
+                    77:d7:ac:1d:75:d6:09:95:54:ef:f2:52:a2:52:15:
+                    58:ce:4e:9e:aa:6f:46:a2:fb:58:30:62:97:4e:80:
+                    87:82:89:f9:22:ab:95:8e:17:bf:64:b5:6f:0e:5f:
+                    54:c3:b0:4a:fa:d3:99:38:00:f7:b1:f6:a9:2c:b1:
+                    c9:ba:3c:07:b7:5c:91:1a:0f:3d:34:74:3f:58:e2:
+                    fa:8d:66:38:a7:a6:af:f2:a7:f2:f1:95:7a:a0:49:
+                    18:19
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Basic Constraints: critical
@@ -28,33 +37,45 @@ Certificate:
             X509v3 Key Usage: critical
                 Certificate Sign, CRL Sign
             X509v3 Subject Key Identifier: 
-                71:55:03:0F:DF:BC:E6:CE:3E:DE:05:DE:06:0F:E1:4F:BA:00:16:8D
+                30:5C:E0:85:AC:BF:77:41:18:C8:05:24:E3:0A:3E:71:66:1A:95:82
             Netscape Comment: 
                 Puppet Server Internal Certificate
             X509v3 Authority Key Identifier: 
-                keyid:2C:25:19:A1:6C:B3:F7:69:FD:76:9B:3A:22:CB:0C:56:01:01:F1:31
+                keyid:61:DF:EE:CE:DA:49:6B:5E:F3:EF:94:FE:F9:DC:C7:C0:5A:74:FE:DB
 
     Signature Algorithm: sha256WithRSAEncryption
-         96:88:36:03:b3:7f:ae:df:a6:58:7d:4e:3d:71:22:ab:88:95:
-         98:e2:58:45:ab:b3:c7:a6:53:91:43:61:a6:b6:07:0b:65:84:
-         3f:41:53:2f:fb:d9:07:06:7a:fe:19:52:11:e8:f0:5e:dd:04:
-         62:24:9a:a4:23:4d:58:5c:47:81:3e:e9:ab:5b:ee:92:3e:74:
-         6d:21:78:6e:2d:a8:d9:83:0d:91:b8:43:0f:94:3c:c2:47:e9:
-         04:55:cc:52:7f:95:2f:5a:21:08:56:a0:f2:88:7d:a0:82:3b:
-         6a:96:34:4d:bb:0d:7c:31:16:0f:9b:84:71:34:ee:ec:fe:bf:
-         8c:cb
+         af:6b:69:42:d0:c9:88:83:80:46:fe:d7:0c:dc:cc:81:8a:f9:
+         f0:21:15:53:fa:fa:f2:95:dd:53:17:d6:b5:cc:2d:f8:64:b6:
+         19:62:c7:3e:7e:75:4f:89:b5:00:c2:3d:b2:3c:51:29:31:5b:
+         a0:32:9f:76:5a:1f:36:06:64:47:9b:9a:dd:93:3c:c4:32:7e:
+         3e:f8:19:32:72:ac:ac:e7:fe:a5:06:4a:ee:72:9c:c0:d9:36:
+         72:5a:5f:af:41:c5:9a:4f:0c:ed:22:db:1f:86:b1:f4:ae:54:
+         a1:93:ba:26:b5:93:15:31:ec:a9:d9:2f:94:61:e3:fc:67:69:
+         6b:01:54:02:36:93:d0:73:ae:64:5d:b4:ec:87:65:99:f6:04:
+         7b:b1:d0:51:fc:b3:9e:b1:63:53:c4:cf:38:2c:19:42:69:bd:
+         10:08:a2:92:87:f8:58:7a:9b:cc:cd:f7:41:a2:2f:6a:a1:45:
+         48:70:6e:7a:39:a3:8d:96:ae:ea:65:ea:ab:b6:06:72:0b:f7:
+         76:c0:6e:a0:ad:48:f1:73:7c:22:91:11:eb:88:24:f6:5e:ec:
+         84:5f:65:51:57:43:a6:c6:38:65:d5:c3:7a:f1:4e:b3:54:62:
+         1b:f3:16:30:c3:b3:c6:cf:f1:a6:f8:f2:d8:c6:d0:f7:2a:18:
+         06:f5:a3:ed
 -----BEGIN CERTIFICATE-----
-MIICRTCCAa6gAwIBAgIBBjANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
-IENBMB4XDTcwMDEwMTAwMDAwMFoXDTI5MDQxOTIyMzEyMlowJTEjMCEGA1UEAwwa
-VGVzdCBDQSBBZ2VudCBTdWJhdXRob3JpdHkwgZ8wDQYJKoZIhvcNAQEBBQADgY0A
-MIGJAoGBAOcwGVtNwnewLY9UGY31z5FXSK4NWcCiddDVEVtyl8mLRY57kQMcV8UI
-8K4A2rAbmr3D7v32wh0FnfVe45G9wYDNCkX3iTKRGTERlakU02sCoy3faLjEDqMn
-GOki8frU6Fq88RHF/eG22ADkgmAAN/lUy6mt/urji8NnBwTmcLBFAgMBAAGjgZcw
-gZQwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFHFV
-Aw/fvObOPt4F3gYP4U+6ABaNMDEGCWCGSAGG+EIBDQQkFiJQdXBwZXQgU2VydmVy
-IEludGVybmFsIENlcnRpZmljYXRlMB8GA1UdIwQYMBaAFCwlGaFss/dp/XabOiLL
-DFYBAfExMA0GCSqGSIb3DQEBCwUAA4GBAJaINgOzf67fplh9Tj1xIquIlZjiWEWr
-s8emU5FDYaa2BwtlhD9BUy/72QcGev4ZUhHo8F7dBGIkmqQjTVhcR4E+6atb7pI+
-dG0heG4tqNmDDZG4Qw+UPMJH6QRVzFJ/lS9aIQhWoPKIfaCCO2qWNE27DXwxFg+b
-hHE07uz+v4zL
+MIIDSjCCAjKgAwIBAgIBCDANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMxMDQxODE4NDYyM1owJTEjMCEGA1UEAwwa
+VGVzdCBDQSBBZ2VudCBTdWJhdXRob3JpdHkwggEiMA0GCSqGSIb3DQEBAQUAA4IB
+DwAwggEKAoIBAQDIdg9rEnK8agOQcfqzAWm91dBkdLlroD6e/Oolx1/ayZUe+Nxj
+dPk97ij+cOnoYtIbrD6rQqcqlSu0IkN9aBrAOU96DEUrQUzeFNKeH+XOhS3b1n8l
+sJuU+OTtES7NnMhdFbsRluzgPpqvsyZQXZxfKWs6zP8hB+UTmeXA9zTKe0n0utxB
+KWXbZelhevQXGPyrcKXeIjKrJGNcFCVIiO42Mws2gXfXrB111gmVVO/yUqJSFVjO
+Tp6qb0ai+1gwYpdOgIeCifkiq5WOF79ktW8OX1TDsEr605k4APex9qksscm6PAe3
+XJEaDz00dD9Y4vqNZjinpq/yp/LxlXqgSRgZAgMBAAGjgZcwgZQwDwYDVR0TAQH/
+BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFDBc4IWsv3dBGMgFJOMK
+PnFmGpWCMDEGCWCGSAGG+EIBDQQkFiJQdXBwZXQgU2VydmVyIEludGVybmFsIENl
+cnRpZmljYXRlMB8GA1UdIwQYMBaAFGHf7s7aSWte8++U/vncx8BadP7bMA0GCSqG
+SIb3DQEBCwUAA4IBAQCva2lC0MmIg4BG/tcM3MyBivnwIRVT+vryld1TF9a1zC34
+ZLYZYsc+fnVPibUAwj2yPFEpMVugMp92Wh82BmRHm5rdkzzEMn4++Bkycqys5/6l
+BkrucpzA2TZyWl+vQcWaTwztItsfhrH0rlShk7omtZMVMeyp2S+UYeP8Z2lrAVQC
+NpPQc65kXbTsh2WZ9gR7sdBR/LOesWNTxM84LBlCab0QCKKSh/hYepvMzfdBoi9q
+oUVIcG56OaONlq7qZeqrtgZyC/d2wG6grUjxc3wikRHriCT2XuyEX2VRV0Omxjhl
+1cN68U6zVGIb8xYww7PGz/Gm+PLYxtD3KhgG9aPt
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/intermediate-crl.pem
+++ b/spec/fixtures/ssl/intermediate-crl.pem
@@ -1,36 +1,46 @@
 Certificate Revocation List (CRL):
         Version 2 (0x1)
-    Signature Algorithm: sha256WithRSAEncryption
-        Issuer: /CN=Test CA Subauthority
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=Test CA Subauthority
         Last Update: Jan  1 00:00:00 1970 GMT
-        Next Update: Apr 19 22:31:22 2029 GMT
+        Next Update: Apr 18 18:46:23 2031 GMT
         CRL extensions:
             X509v3 Authority Key Identifier: 
-                keyid:23:78:2F:09:81:B0:7B:C6:79:1F:30:FE:FC:5E:37:14:FF:20:A0:20
+                keyid:9A:15:19:07:A0:54:8D:C3:9D:4F:07:C4:05:A1:85:AC:92:D8:B1:E5
 
             X509v3 CRL Number: 
                 0
 Revoked Certificates:
-    Serial Number: 04
-        Revocation Date: Apr 22 22:31:22 2019 GMT
+    Serial Number: 06
+        Revocation Date: Apr 20 18:46:23 2021 GMT
         CRL entry extensions:
             X509v3 CRL Reason Code: 
                 Key Compromise
     Signature Algorithm: sha256WithRSAEncryption
-         75:08:37:d8:e9:75:be:6b:8f:3e:f4:03:43:03:63:b8:26:02:
-         b3:a8:eb:fc:61:f5:0a:ab:8d:4f:59:ba:79:e4:d2:45:be:9a:
-         60:ee:ba:85:a3:0e:2e:2b:e0:6f:ac:18:0e:94:c8:76:b6:17:
-         c3:fb:55:ab:26:9c:a4:26:8b:9f:74:51:e8:33:8e:83:50:e6:
-         6e:38:04:7b:35:db:75:55:88:1b:8d:19:f3:ed:9c:18:1e:3c:
-         40:31:73:5e:4d:a7:a2:ef:55:b1:0c:70:ef:85:60:d8:d5:39:
-         32:d0:84:8d:b3:96:e6:35:93:8a:da:e6:ec:1f:37:98:9a:5c:
-         37:40
+         42:21:b1:27:84:31:dd:f0:bd:13:1f:70:b4:6e:e3:f5:9e:ec:
+         c4:fd:64:a9:b3:78:c1:8f:26:76:b0:3d:4b:60:5f:be:6d:e7:
+         c1:47:e0:f5:c2:f3:3f:6e:fc:4c:19:f8:41:82:52:9a:f4:02:
+         d6:3a:23:91:21:92:5c:8c:fa:84:79:dc:10:3f:e3:42:45:5a:
+         e6:26:12:67:42:45:c3:76:30:00:05:66:5e:79:cc:0f:d3:90:
+         04:33:72:6c:d5:ae:5e:b4:d1:b1:91:4f:69:f9:b1:7e:c2:33:
+         ae:b6:bb:2e:28:66:b5:0d:03:54:3f:93:40:ac:17:58:e6:d6:
+         c9:7d:3b:96:ec:47:6f:09:a3:a0:ff:b9:77:f9:64:bf:10:30:
+         df:20:d0:95:36:f4:88:d8:c4:c3:da:3e:86:07:e4:1e:11:c2:
+         da:e5:1f:0f:82:3b:40:2e:cf:f8:14:a5:38:2b:b2:c3:80:18:
+         84:e9:d5:90:85:36:00:9d:96:5e:03:ed:ee:2d:d9:5b:57:7f:
+         9e:0d:7d:5b:4e:f9:89:3d:e2:d9:91:db:ae:6e:b0:34:59:30:
+         9c:2e:0a:c8:74:57:10:db:6c:2f:60:70:d6:bb:c7:18:7b:0a:
+         96:3d:77:71:51:11:3f:a3:16:fc:bd:7d:cd:12:a3:98:07:4c:
+         a3:2c:7e:37
 -----BEGIN X509 CRL-----
-MIIBPDCBpgIBATANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0IENBIFN1
-YmF1dGhvcml0eRcNNzAwMTAxMDAwMDAwWhcNMjkwNDE5MjIzMTIyWjAiMCACAQQX
-DTE5MDQyMjIyMzEyMlowDDAKBgNVHRUEAwoBAaAvMC0wHwYDVR0jBBgwFoAUI3gv
-CYGwe8Z5HzD+/F43FP8goCAwCgYDVR0UBAMCAQAwDQYJKoZIhvcNAQELBQADgYEA
-dQg32Ol1vmuPPvQDQwNjuCYCs6jr/GH1CquNT1m6eeTSRb6aYO66haMOLivgb6wY
-DpTIdrYXw/tVqyacpCaLn3RR6DOOg1DmbjgEezXbdVWIG40Z8+2cGB48QDFzXk2n
-ou9VsQxw74Vg2NU5MtCEjbOW5jWTitrm7B83mJpcN0A=
+MIIBvTCBpgIBATANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0IENBIFN1
+YmF1dGhvcml0eRcNNzAwMTAxMDAwMDAwWhcNMzEwNDE4MTg0NjIzWjAiMCACAQYX
+DTIxMDQyMDE4NDYyM1owDDAKBgNVHRUEAwoBAaAvMC0wHwYDVR0jBBgwFoAUmhUZ
+B6BUjcOdTwfEBaGFrJLYseUwCgYDVR0UBAMCAQAwDQYJKoZIhvcNAQELBQADggEB
+AEIhsSeEMd3wvRMfcLRu4/We7MT9ZKmzeMGPJnawPUtgX75t58FH4PXC8z9u/EwZ
++EGCUpr0AtY6I5EhklyM+oR53BA/40JFWuYmEmdCRcN2MAAFZl55zA/TkAQzcmzV
+rl600bGRT2n5sX7CM662uy4oZrUNA1Q/k0CsF1jm1sl9O5bsR28Jo6D/uXf5ZL8Q
+MN8g0JU29IjYxMPaPoYH5B4RwtrlHw+CO0Auz/gUpTgrssOAGITp1ZCFNgCdll4D
+7e4t2VtXf54NfVtO+Yk94tmR265usDRZMJwuCsh0VxDbbC9gcNa7xxh7CpY9d3FR
+ET+jFvy9fc0So5gHTKMsfjc=
 -----END X509 CRL-----

--- a/spec/fixtures/ssl/intermediate.pem
+++ b/spec/fixtures/ssl/intermediate.pem
@@ -1,26 +1,35 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 1 (0x1)
-    Signature Algorithm: sha256WithRSAEncryption
+        Serial Number: 3 (0x3)
+        Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Apr 19 22:31:22 2029 GMT
+            Not After : Apr 18 18:46:23 2031 GMT
         Subject: CN=Test CA Subauthority
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                Public-Key: (1024 bit)
+                RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:c2:4a:6e:07:c6:1c:8b:2f:bf:91:3e:25:dc:54:
-                    2c:02:0f:1b:6f:5b:0e:5a:69:1d:dd:52:3f:8b:f4:
-                    c8:56:c6:f3:c5:56:2c:b8:82:67:81:09:7b:0d:6f:
-                    01:26:4a:ae:42:53:95:b1:32:ba:07:d4:64:bc:79:
-                    1f:16:0a:92:07:e5:af:5d:d6:b3:4d:09:58:b1:8a:
-                    ba:2c:c0:d3:9b:95:cc:a1:0d:e5:4d:40:1a:50:2d:
-                    a4:45:ff:05:63:62:84:35:73:2c:0f:b3:f6:69:fd:
-                    9b:d3:5e:a8:12:f0:c4:a0:77:25:59:e7:81:3d:ee:
-                    c5:22:10:75:ac:ad:cc:a4:1f
+                    00:cd:ef:ef:31:c5:33:69:3b:ee:25:06:b9:73:a7:
+                    09:e5:c9:9c:0b:39:48:26:fb:88:26:50:2d:8a:52:
+                    29:86:df:7a:12:f0:08:ea:61:52:80:98:9f:a5:45:
+                    26:ad:6d:05:e6:b5:81:e5:91:b3:6b:98:53:09:0a:
+                    e9:05:4b:29:de:3c:64:44:a7:d2:5d:3f:fc:5f:f8:
+                    29:1f:b0:40:e2:74:8a:26:fd:e8:d7:74:a5:78:de:
+                    bf:23:10:73:74:8d:1b:0c:4b:d7:1d:a9:ae:86:14:
+                    05:63:7c:2a:00:38:d6:57:8a:b7:a8:45:80:27:f5:
+                    71:0b:fa:e2:bd:a2:d1:08:8d:fa:cd:9c:f6:ad:89:
+                    76:ea:ab:1c:78:f9:26:5b:a3:18:2a:f7:90:15:ed:
+                    a7:db:50:e9:7d:55:99:7e:05:10:ca:56:11:51:5e:
+                    de:8c:e2:be:2a:8a:34:41:1d:1d:23:92:04:50:05:
+                    c5:5b:b8:7a:45:90:ee:0d:7f:01:b1:ed:d4:dd:c5:
+                    28:ed:7d:4d:6a:70:21:3b:95:5e:e2:31:d7:17:bd:
+                    5b:af:e4:ce:ad:6b:9f:5f:9e:e1:1e:86:ff:83:c1:
+                    88:ec:87:bb:bf:a1:26:22:75:b9:57:31:10:fd:a5:
+                    ca:82:70:6d:c8:a1:a3:f6:3e:76:3d:2e:cd:07:f9:
+                    7b:3f
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Basic Constraints: critical
@@ -28,33 +37,45 @@ Certificate:
             X509v3 Key Usage: critical
                 Certificate Sign, CRL Sign
             X509v3 Subject Key Identifier: 
-                23:78:2F:09:81:B0:7B:C6:79:1F:30:FE:FC:5E:37:14:FF:20:A0:20
+                9A:15:19:07:A0:54:8D:C3:9D:4F:07:C4:05:A1:85:AC:92:D8:B1:E5
             Netscape Comment: 
                 Puppet Server Internal Certificate
             X509v3 Authority Key Identifier: 
-                keyid:2C:25:19:A1:6C:B3:F7:69:FD:76:9B:3A:22:CB:0C:56:01:01:F1:31
+                keyid:61:DF:EE:CE:DA:49:6B:5E:F3:EF:94:FE:F9:DC:C7:C0:5A:74:FE:DB
 
     Signature Algorithm: sha256WithRSAEncryption
-         82:ba:d5:8d:f2:d3:98:79:1a:02:15:a2:3d:b3:53:e7:79:28:
-         05:39:aa:be:2d:7c:6a:4f:c2:66:60:86:62:41:ba:eb:d5:de:
-         6e:3a:81:4a:22:33:5b:22:31:35:61:9e:d9:9c:f8:59:fa:93:
-         e7:7e:9c:f9:e7:15:60:34:f2:2a:3a:13:96:94:c8:de:24:b6:
-         bf:0d:20:aa:4a:9b:eb:c1:9c:49:be:2f:69:69:01:53:0a:06:
-         2a:1d:e7:02:6b:a8:d8:e7:95:32:7e:b5:79:e6:40:0e:72:02:
-         74:24:75:eb:3d:17:8d:75:87:2b:2a:dd:5e:98:d8:67:e3:5c:
-         2a:9d
+         80:38:84:87:30:76:98:4d:35:d8:99:c1:26:f9:4b:bc:aa:e4:
+         e0:6f:b8:b2:0b:ad:22:82:b5:74:98:f2:98:7b:34:92:5e:d8:
+         fa:0f:4f:73:43:b1:5d:d8:69:35:7d:41:1f:ab:bc:6a:14:3f:
+         ff:78:5d:8e:c4:7d:38:5a:14:99:d2:fc:08:08:69:5c:78:9b:
+         5b:a8:bc:bb:92:27:4e:1f:15:48:1c:da:71:f9:ce:ec:3f:55:
+         1b:e5:5d:54:2e:10:b8:b6:57:c7:af:f7:de:7c:c0:76:50:4e:
+         37:a9:3d:26:b8:50:61:89:36:1e:82:92:9d:f5:fd:96:a9:fc:
+         c2:1e:ae:1c:b0:96:03:21:75:7b:9f:56:fa:96:e0:0e:de:df:
+         98:74:65:b8:8d:52:eb:30:7f:aa:4d:d8:38:c2:0b:47:5d:64:
+         c6:52:a2:26:10:f3:5a:d6:04:22:cc:39:8a:30:33:61:6d:6d:
+         67:f2:dd:e6:1f:a0:45:36:ce:db:80:8c:5f:2a:ef:6e:c8:ee:
+         64:20:7f:b1:eb:b1:71:1e:ff:31:00:91:3d:6d:fe:b6:e2:9a:
+         de:7a:fe:e5:59:fc:b5:b7:3f:70:d2:b8:17:99:1a:5b:73:01:
+         c4:17:cc:41:ed:d3:6d:20:56:0b:d7:8f:78:41:10:95:e2:66:
+         ab:f2:2b:4b
 -----BEGIN CERTIFICATE-----
-MIICPzCCAaigAwIBAgIBATANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
-IENBMB4XDTcwMDEwMTAwMDAwMFoXDTI5MDQxOTIyMzEyMlowHzEdMBsGA1UEAwwU
-VGVzdCBDQSBTdWJhdXRob3JpdHkwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGB
-AMJKbgfGHIsvv5E+JdxULAIPG29bDlppHd1SP4v0yFbG88VWLLiCZ4EJew1vASZK
-rkJTlbEyugfUZLx5HxYKkgflr13Ws00JWLGKuizA05uVzKEN5U1AGlAtpEX/BWNi
-hDVzLA+z9mn9m9NeqBLwxKB3JVnngT3uxSIQdaytzKQfAgMBAAGjgZcwgZQwDwYD
-VR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFCN4LwmBsHvG
-eR8w/vxeNxT/IKAgMDEGCWCGSAGG+EIBDQQkFiJQdXBwZXQgU2VydmVyIEludGVy
-bmFsIENlcnRpZmljYXRlMB8GA1UdIwQYMBaAFCwlGaFss/dp/XabOiLLDFYBAfEx
-MA0GCSqGSIb3DQEBCwUAA4GBAIK61Y3y05h5GgIVoj2zU+d5KAU5qr4tfGpPwmZg
-hmJBuuvV3m46gUoiM1siMTVhntmc+Fn6k+d+nPnnFWA08io6E5aUyN4ktr8NIKpK
-m+vBnEm+L2lpAVMKBiod5wJrqNjnlTJ+tXnmQA5yAnQkdes9F411hysq3V6Y2Gfj
-XCqd
+MIIDRDCCAiygAwIBAgIBAzANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMxMDQxODE4NDYyM1owHzEdMBsGA1UEAwwU
+VGVzdCBDQSBTdWJhdXRob3JpdHkwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
+AoIBAQDN7+8xxTNpO+4lBrlzpwnlyZwLOUgm+4gmUC2KUimG33oS8AjqYVKAmJ+l
+RSatbQXmtYHlkbNrmFMJCukFSynePGREp9JdP/xf+CkfsEDidIom/ejXdKV43r8j
+EHN0jRsMS9cdqa6GFAVjfCoAONZXireoRYAn9XEL+uK9otEIjfrNnPatiXbqqxx4
++SZboxgq95AV7afbUOl9VZl+BRDKVhFRXt6M4r4qijRBHR0jkgRQBcVbuHpFkO4N
+fwGx7dTdxSjtfU1qcCE7lV7iMdcXvVuv5M6ta59fnuEehv+DwYjsh7u/oSYidblX
+MRD9pcqCcG3IoaP2PnY9Ls0H+Xs/AgMBAAGjgZcwgZQwDwYDVR0TAQH/BAUwAwEB
+/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFJoVGQegVI3DnU8HxAWhhayS2LHl
+MDEGCWCGSAGG+EIBDQQkFiJQdXBwZXQgU2VydmVyIEludGVybmFsIENlcnRpZmlj
+YXRlMB8GA1UdIwQYMBaAFGHf7s7aSWte8++U/vncx8BadP7bMA0GCSqGSIb3DQEB
+CwUAA4IBAQCAOISHMHaYTTXYmcEm+Uu8quTgb7iyC60igrV0mPKYezSSXtj6D09z
+Q7Fd2Gk1fUEfq7xqFD//eF2OxH04WhSZ0vwICGlceJtbqLy7kidOHxVIHNpx+c7s
+P1Ub5V1ULhC4tlfHr/fefMB2UE43qT0muFBhiTYegpKd9f2WqfzCHq4csJYDIXV7
+n1b6luAO3t+YdGW4jVLrMH+qTdg4wgtHXWTGUqImEPNa1gQizDmKMDNhbW1n8t3m
+H6BFNs7bgIxfKu9uyO5kIH+x67FxHv8xAJE9bf624preev7lWfy1tz9w0rgXmRpb
+cwHEF8xB7dNtIFYL1494QRCV4mar8itL
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/pluto-key.pem
+++ b/spec/fixtures/ssl/pluto-key.pem
@@ -1,67 +1,117 @@
-Private-Key: (1024 bit)
+RSA Private-Key: (2048 bit, 2 primes)
 modulus:
-    00:96:dd:38:6c:f5:6a:d5:c1:69:6b:81:97:91:a0:
-    05:be:53:2b:96:b5:cb:25:4c:f8:35:81:0e:aa:81:
-    66:49:10:58:cf:0c:8e:d1:01:2a:0a:38:ae:a2:e0:
-    8c:8a:7d:cf:d0:44:09:90:59:d7:02:6e:aa:fa:72:
-    6e:34:31:d8:ff:c5:69:90:f5:d9:17:b1:8d:0e:df:
-    8b:b1:2b:f8:7d:0d:7e:0b:6e:ba:05:b7:5f:da:d8:
-    2f:e5:66:11:37:f9:20:af:8e:f1:42:c3:6d:f0:00:
-    bb:72:90:08:c7:26:84:04:b1:48:dd:8e:72:20:20:
-    30:04:31:b4:71:7b:92:b7:17
+    00:af:60:0e:10:6c:0e:f7:88:5c:38:9b:66:d3:4e:
+    69:ed:ad:d0:d4:31:8f:22:81:e0:94:53:0a:32:74:
+    06:92:ab:48:ad:af:e9:e6:60:d5:83:f2:c3:a5:29:
+    1e:48:d8:91:9c:fd:5e:f6:e9:ea:a3:89:02:45:2c:
+    d8:63:d1:18:ff:67:10:11:6d:0f:32:a6:8a:43:02:
+    f1:5f:0a:95:ef:31:90:0d:af:84:46:4c:3b:7a:dd:
+    aa:07:aa:4d:b0:56:0e:dc:4d:1d:d0:be:d5:13:fd:
+    af:40:69:01:1a:4d:d5:e5:d7:78:65:f9:b4:ca:00:
+    91:e5:45:a0:cb:e8:c0:20:5b:80:fb:db:00:9c:a5:
+    1f:59:8f:e8:9c:21:56:90:a9:30:11:4d:65:84:82:
+    28:de:6e:54:20:79:4a:ec:00:b0:26:08:60:47:ef:
+    3a:bb:24:62:53:bb:e1:28:57:d3:77:2c:56:48:dd:
+    dc:40:dc:7d:b2:1f:1f:c5:0a:d5:0a:9e:73:de:0f:
+    57:9e:e3:d5:cf:2f:58:2a:aa:a8:8f:8b:ad:e9:78:
+    c4:b8:69:0c:c6:8f:5a:9c:f5:24:c3:76:20:e8:cd:
+    98:98:6b:06:89:e1:ad:5e:c0:8e:c5:1e:cf:d5:c5:
+    b1:f2:96:fc:a2:90:1e:4c:c8:7f:7b:f8:8e:dd:9e:
+    aa:17
 publicExponent: 65537 (0x10001)
 privateExponent:
-    0d:3e:44:2a:c4:6c:69:71:3e:08:d2:ea:74:3d:20:
-    e3:f1:37:1d:56:be:0b:7b:33:3a:b7:26:8b:6f:2a:
-    84:75:6b:e6:59:0a:dc:6c:06:bd:b8:f6:13:94:34:
-    a2:1f:a3:33:7c:15:7e:d7:74:19:61:8f:9e:c6:96:
-    c7:fc:2c:39:3d:21:58:1d:72:09:97:5e:07:73:39:
-    8f:e5:23:62:76:5f:16:60:be:13:1a:c2:aa:5e:da:
-    90:b2:6a:c7:55:1b:15:ba:06:47:88:6e:e4:f3:2f:
-    76:1a:0a:72:9e:f2:2f:48:e3:58:05:ee:9f:56:f0:
-    42:bd:8e:96:1f:2d:de:59
+    00:9a:91:1d:34:2a:18:f2:df:92:f0:2d:3e:ee:23:
+    e1:46:a2:f8:37:dc:ca:1b:8e:be:81:db:c2:53:ff:
+    60:bf:aa:08:ef:53:e8:e1:ac:1c:e3:23:76:7d:bd:
+    84:bc:8d:6b:a1:22:ca:ac:f2:33:64:18:e0:10:59:
+    db:09:f6:83:82:ae:b2:41:b9:8e:38:85:01:bc:d7:
+    fe:26:56:ed:18:98:e5:2e:ba:af:e9:49:4c:ef:18:
+    28:c0:82:bf:e0:17:a9:17:4f:3c:64:fb:9c:4e:f7:
+    3a:9b:99:30:68:9f:8b:52:fc:9a:57:be:42:31:fb:
+    58:9a:ea:c8:32:8f:9b:ad:a7:a2:73:8c:14:d2:1a:
+    4a:cc:1c:25:60:97:ba:bf:c1:37:8c:ff:8d:6b:fd:
+    4d:41:a1:f4:36:03:14:11:39:f1:bb:48:a5:80:35:
+    ca:97:13:af:09:9e:41:e1:65:b2:0a:67:c4:06:ed:
+    96:50:ed:67:17:ae:83:f6:bb:a3:97:cb:2a:c5:16:
+    0b:89:3b:01:a0:93:82:fe:16:c3:c1:88:47:5f:e6:
+    ab:a6:ed:ee:6f:ae:0b:bb:d3:6e:16:d7:d9:43:f3:
+    1d:a6:b0:5e:99:d1:40:30:fc:e6:06:c2:22:8c:6c:
+    f3:be:5d:12:6d:63:50:2e:cd:2e:d8:16:f9:8d:f9:
+    87:59
 prime1:
-    00:c4:ea:3f:6c:c8:0a:dc:98:c6:73:7e:fc:c4:73:
-    9f:53:3a:c2:2c:7e:cc:58:26:60:49:f6:38:85:fa:
-    6b:2a:17:ec:f2:7f:a6:ee:71:1c:ae:c6:0f:82:f1:
-    11:f2:13:43:c1:23:e1:d4:3f:b2:bc:66:0b:32:85:
-    20:2d:c2:fb:53
+    00:dc:a8:a5:35:2f:54:5f:9f:32:6a:47:83:5b:f2:
+    22:b6:63:2a:89:09:3e:49:7b:ed:f7:11:c2:3b:45:
+    2e:ae:b9:1c:24:12:8b:7c:a0:3b:91:8a:fc:60:8c:
+    a4:6f:5a:80:1d:74:ab:4f:3c:ff:83:73:10:3d:db:
+    23:ca:a3:e5:77:5f:76:44:06:92:35:a8:b4:ef:c1:
+    74:02:b0:a1:87:75:7f:a3:9b:f0:76:ac:c9:44:23:
+    df:4d:e9:35:2d:7c:07:64:2b:ae:26:b0:4f:f0:67:
+    23:5c:a5:d3:cd:cf:d8:31:b1:9f:b5:13:3e:07:22:
+    b7:70:b0:b0:d0:a0:12:a6:0d
 prime2:
-    00:c4:21:a3:60:a7:b8:71:d4:12:f7:d1:a6:5b:2e:
-    33:65:e9:e6:58:98:0e:09:aa:02:79:b6:de:a0:1f:
-    9f:33:f0:34:58:2e:ca:a8:3f:60:d2:68:50:56:e4:
-    26:2b:48:4b:53:42:5b:35:79:41:c1:9c:10:80:09:
-    bb:0a:f9:a0:ad
+    00:cb:76:b6:85:a6:ff:85:e8:f7:f1:ad:0b:86:4c:
+    3b:24:6d:bc:e9:c9:df:90:b1:a3:a8:1b:0b:35:32:
+    dc:26:96:56:b3:f7:c0:70:9f:de:b2:59:10:38:a0:
+    f3:3f:06:2c:0b:85:76:b4:b7:15:60:17:15:2d:74:
+    fc:93:15:7e:31:4d:25:59:2e:76:12:2e:1a:e8:66:
+    d4:81:52:9d:02:bb:f9:e4:c5:42:46:38:11:b5:ca:
+    ed:4b:91:cd:9c:4e:0b:8b:cb:74:86:34:ce:e9:ed:
+    ec:d8:1e:18:7b:29:7d:03:c0:61:27:46:53:6a:e6:
+    0e:1b:8c:5e:35:f6:ba:0b:b3
 exponent1:
-    03:9f:a3:e7:26:8f:3c:9b:fb:1a:e8:fd:51:c8:26:
-    e8:6b:2e:63:8f:39:c7:6d:7d:5c:1f:11:cf:35:5a:
-    7f:7d:cd:38:71:2c:eb:3a:5d:a2:c1:b6:4b:5c:90:
-    4d:fa:18:c7:17:17:f2:c5:f1:4e:12:3a:a6:85:58:
-    a0:3e:f4:4d
+    46:52:60:c4:40:5f:2d:52:38:e8:f1:fd:85:11:f7:
+    ca:14:74:7b:d3:bc:4c:02:f8:e5:a2:7d:3a:12:64:
+    3c:3e:b6:1f:30:e1:cf:47:e9:74:0a:cd:3f:9f:d2:
+    cf:c2:11:ce:51:5e:3f:14:7b:81:d2:eb:bc:2a:d8:
+    8f:3e:08:65:30:c1:2a:10:c6:0b:df:c6:3a:1a:76:
+    f4:5c:82:3d:ff:4e:3c:3f:f8:34:7a:00:72:7c:d4:
+    2f:aa:40:ce:4c:16:b6:ef:cc:c2:7b:b2:1e:35:60:
+    69:a8:57:85:e1:d5:4e:91:03:0a:dc:25:0a:75:1f:
+    ed:04:02:75:9a:6e:17:09
 exponent2:
-    00:96:6b:0d:f7:d4:e9:ba:32:e1:91:3a:32:91:7f:
-    6f:5f:db:f1:13:45:1a:8f:02:d9:ff:2a:e6:b6:7b:
-    4a:07:f5:52:cf:c6:a3:1a:41:f1:29:ad:62:e0:20:
-    fd:bc:f8:26:fc:e5:c9:39:cb:93:48:bf:3e:50:54:
-    26:25:16:a9:c9
+    66:df:6f:09:c4:96:0d:ae:ed:2e:54:c0:2e:f6:fc:
+    30:3f:0b:f5:69:0c:90:ac:40:83:0e:a9:6c:0c:7b:
+    23:47:80:2f:1e:65:3e:8c:96:9c:b6:4b:6d:56:73:
+    a6:ba:08:2b:0b:20:29:df:27:ff:9d:ac:27:7f:ae:
+    f4:ef:39:0e:d4:62:bd:e4:af:ee:21:41:99:9f:e4:
+    72:3e:c3:04:4e:e6:da:b4:a1:fd:be:fb:b5:5f:14:
+    fb:d0:8c:95:2b:20:cb:5d:e3:5c:b7:f6:a6:70:95:
+    ff:ef:b7:91:0e:39:17:5c:7d:c2:cd:db:ff:80:b2:
+    41:5b:87:86:e1:68:cf:e1
 coefficient:
-    03:ff:60:b9:86:8a:d9:ee:79:fc:2b:01:a5:f7:7c:
-    56:f6:57:32:8e:21:18:17:37:c3:34:dc:d5:8b:ed:
-    56:fa:9f:10:34:92:fb:06:b8:87:c2:36:ce:6a:7a:
-    9f:ae:56:e0:02:e3:0c:87:57:4c:9f:5a:fe:c3:0a:
-    b0:7b:cd:e4
+    00:8c:38:5e:33:4c:b2:94:37:37:37:69:4a:84:f5:
+    29:01:d5:e1:88:0b:4b:88:a1:d6:af:ca:f0:77:1e:
+    ba:20:70:83:30:b6:d8:ad:fd:f5:28:e9:49:6c:8c:
+    28:75:bc:c4:e1:64:2e:65:43:ec:50:00:fa:03:5f:
+    c6:93:99:b6:32:c8:c7:b3:06:23:8b:0c:5c:91:68:
+    6e:dc:75:94:e1:57:fb:f0:f4:47:8a:52:53:1b:a9:
+    b4:44:a7:7f:aa:df:6d:30:85:35:da:7a:ab:3f:1a:
+    97:6b:31:7f:2e:00:c4:92:4a:eb:5f:39:25:8a:a7:
+    9b:f4:1b:0b:86:cb:da:b3:e1
 -----BEGIN RSA PRIVATE KEY-----
-MIICXAIBAAKBgQCW3Ths9WrVwWlrgZeRoAW+UyuWtcslTPg1gQ6qgWZJEFjPDI7R
-ASoKOK6i4IyKfc/QRAmQWdcCbqr6cm40Mdj/xWmQ9dkXsY0O34uxK/h9DX4LbroF
-t1/a2C/lZhE3+SCvjvFCw23wALtykAjHJoQEsUjdjnIgIDAEMbRxe5K3FwIDAQAB
-AoGADT5EKsRsaXE+CNLqdD0g4/E3HVa+C3szOrcmi28qhHVr5lkK3GwGvbj2E5Q0
-oh+jM3wVftd0GWGPnsaWx/wsOT0hWB1yCZdeB3M5j+UjYnZfFmC+ExrCql7akLJq
-x1UbFboGR4hu5PMvdhoKcp7yL0jjWAXun1bwQr2Olh8t3lkCQQDE6j9syArcmMZz
-fvzEc59TOsIsfsxYJmBJ9jiF+msqF+zyf6bucRyuxg+C8RHyE0PBI+HUP7K8Zgsy
-hSAtwvtTAkEAxCGjYKe4cdQS99GmWy4zZenmWJgOCaoCebbeoB+fM/A0WC7KqD9g
-0mhQVuQmK0hLU0JbNXlBwZwQgAm7CvmgrQJAA5+j5yaPPJv7Guj9Ucgm6GsuY485
-x219XB8RzzVaf33NOHEs6zpdosG2S1yQTfoYxxcX8sXxThI6poVYoD70TQJBAJZr
-DffU6boy4ZE6MpF/b1/b8RNFGo8C2f8q5rZ7Sgf1Us/GoxpB8SmtYuAg/bz4Jvzl
-yTnLk0i/PlBUJiUWqckCQAP/YLmGitnuefwrAaX3fFb2VzKOIRgXN8M03NWL7Vb6
-nxA0kvsGuIfCNs5qep+uVuAC4wyHV0yfWv7DCrB7zeQ=
+MIIEpAIBAAKCAQEAr2AOEGwO94hcOJtm005p7a3Q1DGPIoHglFMKMnQGkqtIra/p
+5mDVg/LDpSkeSNiRnP1e9unqo4kCRSzYY9EY/2cQEW0PMqaKQwLxXwqV7zGQDa+E
+Rkw7et2qB6pNsFYO3E0d0L7VE/2vQGkBGk3V5dd4Zfm0ygCR5UWgy+jAIFuA+9sA
+nKUfWY/onCFWkKkwEU1lhIIo3m5UIHlK7ACwJghgR+86uyRiU7vhKFfTdyxWSN3c
+QNx9sh8fxQrVCp5z3g9XnuPVzy9YKqqoj4ut6XjEuGkMxo9anPUkw3Yg6M2YmGsG
+ieGtXsCOxR7P1cWx8pb8opAeTMh/e/iO3Z6qFwIDAQABAoIBAQCakR00Khjy35Lw
+LT7uI+FGovg33Mobjr6B28JT/2C/qgjvU+jhrBzjI3Z9vYS8jWuhIsqs8jNkGOAQ
+WdsJ9oOCrrJBuY44hQG81/4mVu0YmOUuuq/pSUzvGCjAgr/gF6kXTzxk+5xO9zqb
+mTBon4tS/JpXvkIx+1ia6sgyj5utp6JzjBTSGkrMHCVgl7q/wTeM/41r/U1BofQ2
+AxQROfG7SKWANcqXE68JnkHhZbIKZ8QG7ZZQ7WcXroP2u6OXyyrFFguJOwGgk4L+
+FsPBiEdf5qum7e5vrgu7024W19lD8x2msF6Z0UAw/OYGwiKMbPO+XRJtY1AuzS7Y
+FvmN+YdZAoGBANyopTUvVF+fMmpHg1vyIrZjKokJPkl77fcRwjtFLq65HCQSi3yg
+O5GK/GCMpG9agB10q088/4NzED3bI8qj5XdfdkQGkjWotO/BdAKwoYd1f6Ob8Has
+yUQj303pNS18B2QrriawT/BnI1yl083P2DGxn7UTPgcit3CwsNCgEqYNAoGBAMt2
+toWm/4Xo9/GtC4ZMOyRtvOnJ35Cxo6gbCzUy3CaWVrP3wHCf3rJZEDig8z8GLAuF
+drS3FWAXFS10/JMVfjFNJVkudhIuGuhm1IFSnQK7+eTFQkY4EbXK7UuRzZxOC4vL
+dIY0zunt7NgeGHspfQPAYSdGU2rmDhuMXjX2uguzAoGARlJgxEBfLVI46PH9hRH3
+yhR0e9O8TAL45aJ9OhJkPD62HzDhz0fpdArNP5/Sz8IRzlFePxR7gdLrvCrYjz4I
+ZTDBKhDGC9/GOhp29FyCPf9OPD/4NHoAcnzUL6pAzkwWtu/MwnuyHjVgaahXheHV
+TpEDCtwlCnUf7QQCdZpuFwkCgYBm328JxJYNru0uVMAu9vwwPwv1aQyQrECDDqls
+DHsjR4AvHmU+jJactkttVnOmuggrCyAp3yf/nawnf6707zkO1GK95K/uIUGZn+Ry
+PsMETubatKH9vvu1XxT70IyVKyDLXeNct/amcJX/77eRDjkXXH3Czdv/gLJBW4eG
+4WjP4QKBgQCMOF4zTLKUNzc3aUqE9SkB1eGIC0uIodavyvB3HrogcIMwttit/fUo
+6UlsjCh1vMThZC5lQ+xQAPoDX8aTmbYyyMezBiOLDFyRaG7cdZThV/vw9EeKUlMb
+qbREp3+q320whTXaeqs/GpdrMX8uAMSSSutfOSWKp5v0GwuGy9qz4Q==
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/pluto.pem
+++ b/spec/fixtures/ssl/pluto.pem
@@ -1,44 +1,66 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 7 (0x7)
-    Signature Algorithm: sha256WithRSAEncryption
+        Serial Number: 9 (0x9)
+        Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA Agent Subauthority
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Apr 19 22:31:22 2029 GMT
+            Not After : Apr 18 18:46:23 2031 GMT
         Subject: CN=pluto
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                Public-Key: (1024 bit)
+                RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:96:dd:38:6c:f5:6a:d5:c1:69:6b:81:97:91:a0:
-                    05:be:53:2b:96:b5:cb:25:4c:f8:35:81:0e:aa:81:
-                    66:49:10:58:cf:0c:8e:d1:01:2a:0a:38:ae:a2:e0:
-                    8c:8a:7d:cf:d0:44:09:90:59:d7:02:6e:aa:fa:72:
-                    6e:34:31:d8:ff:c5:69:90:f5:d9:17:b1:8d:0e:df:
-                    8b:b1:2b:f8:7d:0d:7e:0b:6e:ba:05:b7:5f:da:d8:
-                    2f:e5:66:11:37:f9:20:af:8e:f1:42:c3:6d:f0:00:
-                    bb:72:90:08:c7:26:84:04:b1:48:dd:8e:72:20:20:
-                    30:04:31:b4:71:7b:92:b7:17
+                    00:af:60:0e:10:6c:0e:f7:88:5c:38:9b:66:d3:4e:
+                    69:ed:ad:d0:d4:31:8f:22:81:e0:94:53:0a:32:74:
+                    06:92:ab:48:ad:af:e9:e6:60:d5:83:f2:c3:a5:29:
+                    1e:48:d8:91:9c:fd:5e:f6:e9:ea:a3:89:02:45:2c:
+                    d8:63:d1:18:ff:67:10:11:6d:0f:32:a6:8a:43:02:
+                    f1:5f:0a:95:ef:31:90:0d:af:84:46:4c:3b:7a:dd:
+                    aa:07:aa:4d:b0:56:0e:dc:4d:1d:d0:be:d5:13:fd:
+                    af:40:69:01:1a:4d:d5:e5:d7:78:65:f9:b4:ca:00:
+                    91:e5:45:a0:cb:e8:c0:20:5b:80:fb:db:00:9c:a5:
+                    1f:59:8f:e8:9c:21:56:90:a9:30:11:4d:65:84:82:
+                    28:de:6e:54:20:79:4a:ec:00:b0:26:08:60:47:ef:
+                    3a:bb:24:62:53:bb:e1:28:57:d3:77:2c:56:48:dd:
+                    dc:40:dc:7d:b2:1f:1f:c5:0a:d5:0a:9e:73:de:0f:
+                    57:9e:e3:d5:cf:2f:58:2a:aa:a8:8f:8b:ad:e9:78:
+                    c4:b8:69:0c:c6:8f:5a:9c:f5:24:c3:76:20:e8:cd:
+                    98:98:6b:06:89:e1:ad:5e:c0:8e:c5:1e:cf:d5:c5:
+                    b1:f2:96:fc:a2:90:1e:4c:c8:7f:7b:f8:8e:dd:9e:
+                    aa:17
                 Exponent: 65537 (0x10001)
     Signature Algorithm: sha256WithRSAEncryption
-         57:cd:20:5c:a5:26:46:6d:88:4d:ae:5b:4d:a2:d2:37:09:0e:
-         81:6f:ed:01:9a:45:a0:ef:ac:51:33:f3:70:b6:f7:bf:1d:1e:
-         a6:e6:c3:15:bd:80:f8:01:d5:ed:a3:78:f5:56:4e:00:1f:47:
-         d9:e7:04:81:a8:bc:f0:b9:30:fa:67:02:75:0c:5c:e8:ea:71:
-         3f:36:4a:1b:39:62:eb:ab:ad:46:2d:93:74:6d:5b:b7:87:fc:
-         b3:0b:bd:d7:11:4e:2b:59:87:bc:29:31:da:a5:74:07:e2:46:
-         dc:1c:a6:cb:20:fc:4b:f0:c3:31:01:1d:f9:1a:76:c9:f2:68:
-         dd:c2
+         0a:2a:22:ca:3c:6e:fb:29:47:7f:f3:28:ff:2f:7f:4e:ce:66:
+         43:a2:ef:40:eb:22:9e:95:d0:06:31:0f:a6:cb:20:bf:e5:e5:
+         5b:7f:32:d3:6d:d4:b5:0b:b0:69:eb:f5:73:ea:64:8e:8f:9d:
+         84:56:a5:dd:f7:ea:6e:20:ae:3a:9d:9c:1e:0e:ca:52:14:8b:
+         a2:60:99:24:10:72:33:40:57:16:ee:c5:19:40:31:9e:07:88:
+         06:24:45:07:b1:19:9f:b7:88:c6:64:04:83:b4:8e:a3:b6:70:
+         ee:46:10:d8:42:0d:ad:50:41:0f:2b:89:0b:c7:98:e9:9a:59:
+         21:2b:a1:0d:d0:24:a0:e1:56:1e:c7:83:be:0e:bd:64:dc:5d:
+         19:c3:92:5a:f6:57:70:a5:7d:b9:0a:5f:d6:18:90:d0:3e:6d:
+         e1:ae:8f:bb:e8:f7:c7:16:cd:31:89:5a:9f:93:0b:9e:03:8b:
+         66:7f:b5:06:72:a3:86:24:25:33:8a:08:64:15:45:91:ef:a6:
+         53:1d:5a:0a:b6:03:b8:3d:73:b5:ad:dc:69:6f:24:d0:ec:b6:
+         5e:1a:f0:0f:b1:69:47:1a:71:e3:43:1e:e4:c2:8f:54:61:e1:
+         17:ce:44:a9:3f:6a:55:a1:db:5e:d8:4d:c8:36:22:22:f8:ca:
+         67:b8:85:42
 -----BEGIN CERTIFICATE-----
-MIIBqTCCARKgAwIBAgIBBzANBgkqhkiG9w0BAQsFADAlMSMwIQYDVQQDDBpUZXN0
-IENBIEFnZW50IFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0yOTA0MTky
-MjMxMjJaMBAxDjAMBgNVBAMMBXBsdXRvMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCB
-iQKBgQCW3Ths9WrVwWlrgZeRoAW+UyuWtcslTPg1gQ6qgWZJEFjPDI7RASoKOK6i
-4IyKfc/QRAmQWdcCbqr6cm40Mdj/xWmQ9dkXsY0O34uxK/h9DX4LbroFt1/a2C/l
-ZhE3+SCvjvFCw23wALtykAjHJoQEsUjdjnIgIDAEMbRxe5K3FwIDAQABMA0GCSqG
-SIb3DQEBCwUAA4GBAFfNIFylJkZtiE2uW02i0jcJDoFv7QGaRaDvrFEz83C2978d
-HqbmwxW9gPgB1e2jePVWTgAfR9nnBIGovPC5MPpnAnUMXOjqcT82Shs5YuurrUYt
-k3RtW7eH/LMLvdcRTitZh7wpMdqldAfiRtwcpssg/EvwwzEBHfkadsnyaN3C
+MIICrjCCAZagAwIBAgIBCTANBgkqhkiG9w0BAQsFADAlMSMwIQYDVQQDDBpUZXN0
+IENBIEFnZW50IFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zMTA0MTgx
+ODQ2MjNaMBAxDjAMBgNVBAMMBXBsdXRvMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+MIIBCgKCAQEAr2AOEGwO94hcOJtm005p7a3Q1DGPIoHglFMKMnQGkqtIra/p5mDV
+g/LDpSkeSNiRnP1e9unqo4kCRSzYY9EY/2cQEW0PMqaKQwLxXwqV7zGQDa+ERkw7
+et2qB6pNsFYO3E0d0L7VE/2vQGkBGk3V5dd4Zfm0ygCR5UWgy+jAIFuA+9sAnKUf
+WY/onCFWkKkwEU1lhIIo3m5UIHlK7ACwJghgR+86uyRiU7vhKFfTdyxWSN3cQNx9
+sh8fxQrVCp5z3g9XnuPVzy9YKqqoj4ut6XjEuGkMxo9anPUkw3Yg6M2YmGsGieGt
+XsCOxR7P1cWx8pb8opAeTMh/e/iO3Z6qFwIDAQABMA0GCSqGSIb3DQEBCwUAA4IB
+AQAKKiLKPG77KUd/8yj/L39OzmZDou9A6yKeldAGMQ+myyC/5eVbfzLTbdS1C7Bp
+6/Vz6mSOj52EVqXd9+puIK46nZweDspSFIuiYJkkEHIzQFcW7sUZQDGeB4gGJEUH
+sRmft4jGZASDtI6jtnDuRhDYQg2tUEEPK4kLx5jpmlkhK6EN0CSg4VYex4O+Dr1k
+3F0Zw5Ja9ldwpX25Cl/WGJDQPm3hro+76PfHFs0xiVqfkwueA4tmf7UGcqOGJCUz
+ighkFUWR76ZTHVoKtgO4PXO1rdxpbyTQ7LZeGvAPsWlHGnHjQx7kwo9UYeEXzkSp
+P2pVodte2E3INiIi+MpnuIVC
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/request-key.pem
+++ b/spec/fixtures/ssl/request-key.pem
@@ -1,67 +1,117 @@
-Private-Key: (1024 bit)
+RSA Private-Key: (2048 bit, 2 primes)
 modulus:
-    00:9a:61:a1:62:58:9d:04:2e:8a:53:d0:68:7a:00:
-    96:1b:2c:9b:ba:b6:d5:78:69:9f:63:51:2e:65:20:
-    bb:de:34:32:03:83:81:63:3e:5f:54:14:c1:64:66:
-    73:22:13:e0:6c:c7:4c:07:df:46:7a:cd:71:d6:4a:
-    1d:28:97:72:10:00:42:d9:3a:5e:73:ab:92:d6:e4:
-    30:59:14:89:4b:8a:58:8c:0d:ba:1e:7a:b5:fd:c5:
-    31:b2:2f:c8:37:e6:47:05:23:7a:71:db:f0:66:7f:
-    cc:0a:a8:1e:26:ca:80:2d:8c:a1:e3:af:4a:49:61:
-    8f:94:99:70:48:9b:06:26:bd
+    00:c2:a5:41:96:ca:af:a4:6e:84:61:33:30:0c:87:
+    17:ae:a9:35:16:d0:4a:db:c1:23:e0:33:1d:2d:d6:
+    76:d0:f6:79:d3:69:6e:2c:5a:c0:04:c8:27:e0:75:
+    86:03:43:61:61:71:33:1a:9f:30:c5:77:78:10:2c:
+    93:95:dc:4b:b0:14:19:78:63:f0:de:cd:5a:20:fe:
+    7f:8e:96:60:ab:94:5a:df:26:fb:d2:34:d4:73:7a:
+    ca:bf:73:bb:e4:60:ac:15:dc:f7:37:40:cb:4c:ad:
+    d2:4c:f7:5f:ee:dd:b4:c4:cb:91:6d:5d:7d:18:ca:
+    99:85:4e:bd:55:6f:f4:de:61:d1:ee:45:63:21:22:
+    00:7e:8b:85:18:35:09:02:f0:61:58:af:e0:cc:21:
+    0f:cd:c8:10:df:e9:2f:b7:f1:b9:2b:88:da:9a:90:
+    91:ea:bc:55:cd:d6:42:90:fe:06:9a:0d:c2:44:d1:
+    7c:0a:86:72:3e:d0:f4:05:62:e6:fa:e0:74:51:2b:
+    36:3e:c9:98:fa:0a:be:5f:ac:c7:fd:bf:4b:81:de:
+    f1:b7:c5:43:73:02:66:98:1f:89:60:48:f9:53:a4:
+    75:c9:68:ab:00:3d:e9:4d:2c:84:9f:a7:a5:71:14:
+    89:fb:f5:d9:fa:0a:7e:9e:c8:b4:32:65:a1:05:52:
+    18:39
 publicExponent: 65537 (0x10001)
 privateExponent:
-    1f:0f:1f:49:ca:ec:24:08:3c:fa:29:c6:ab:2c:ed:
-    06:20:8e:60:1d:22:8b:6c:2c:8d:ed:aa:38:dc:42:
-    0f:ad:4e:96:98:61:72:96:fc:d4:cc:ac:2f:c7:d0:
-    c7:fd:59:bc:68:c8:2a:19:48:73:b2:5b:81:b2:3d:
-    75:8a:2a:7f:2f:9e:ae:32:e7:4a:45:fb:b1:f4:45:
-    d1:57:77:c5:a2:4e:16:30:c9:9b:a0:73:6d:64:39:
-    87:83:f1:df:0a:6c:21:5e:3f:5a:df:c6:44:9f:73:
-    8d:69:89:9a:04:70:e2:58:af:be:93:a6:ba:7e:1e:
-    5a:89:35:23:87:c3:c3:fd
+    7e:21:60:53:3a:9c:7e:cd:2e:f3:5d:9c:31:42:09:
+    52:a1:4b:49:b1:48:11:07:23:1c:51:83:03:05:0a:
+    91:76:66:93:5c:aa:8c:0b:72:8a:a6:b9:50:76:57:
+    95:1d:c0:a8:c8:15:f9:96:56:a0:5f:3e:6a:1c:b8:
+    b6:4f:be:ac:27:1a:2a:2d:79:14:a7:b5:53:d4:17:
+    0c:6a:dd:d1:d1:9c:e1:25:fd:e0:c5:63:36:41:c7:
+    c8:30:52:fd:36:b7:cc:a3:17:7f:b2:79:0b:03:48:
+    57:9f:a5:86:c0:1c:37:ba:42:4e:c0:5a:24:0a:85:
+    59:21:21:07:90:38:f9:30:ff:ff:b9:30:c7:e3:27:
+    df:a9:51:39:df:6a:a7:7a:c1:45:fe:36:09:bb:36:
+    f4:88:db:4e:ae:80:b0:89:3a:3a:d6:5c:72:02:61:
+    93:63:0a:9f:49:f9:6b:dd:70:7e:ae:16:ba:12:63:
+    7c:a4:94:25:9d:7b:54:cd:b3:2d:7d:f9:91:89:98:
+    66:5b:e6:1d:f7:95:56:cd:94:be:a8:72:ed:26:f6:
+    6c:23:6d:5e:10:7c:99:55:8f:a5:b8:2f:1e:81:d8:
+    53:2e:92:5b:24:2b:58:62:db:fd:f3:d0:c7:66:70:
+    f0:4a:cc:67:1d:ff:9b:82:17:81:eb:69:a9:bc:c0:
+    01
 prime1:
-    00:c9:49:17:ab:19:b4:7a:ba:98:1a:71:a0:95:de:
-    b1:f5:75:f1:43:27:51:db:36:85:aa:c4:a8:78:8c:
-    ea:aa:35:16:d4:d8:48:52:20:5e:e1:97:c4:ad:de:
-    58:b6:cf:f8:16:a2:74:3c:37:1c:92:f8:f5:f3:93:
-    8a:f9:6c:95:df
+    00:f1:e5:23:22:8d:ab:e3:30:c5:59:14:b9:72:c6:
+    7a:7f:66:f8:22:92:af:83:18:3f:39:4d:ac:16:77:
+    b0:35:fb:a6:e3:22:6e:fe:60:a4:02:7f:8c:94:98:
+    5b:e7:f6:31:ad:90:ce:40:81:a5:b5:a3:5c:3a:e9:
+    e4:c1:44:87:4f:dd:b1:fa:f4:42:40:11:df:01:80:
+    72:ab:a9:26:ad:5d:3f:8b:ba:42:f9:31:61:93:3f:
+    7d:f3:e9:c6:61:52:f2:8b:05:c5:9b:ca:3a:f1:f3:
+    fb:02:c6:83:6c:f0:86:25:2a:ee:e2:45:8c:90:b8:
+    a8:a5:a1:b3:d8:41:0b:32:01
 prime2:
-    00:c4:58:9b:56:6d:ac:1e:75:57:63:86:30:53:27:
-    26:cf:e5:55:2a:ff:49:b3:25:57:d7:30:99:d9:d7:
-    c6:8a:46:3d:dd:d9:ec:33:5e:ab:e2:00:60:84:78:
-    b3:d8:55:e3:c4:48:06:d4:12:42:7a:6c:47:b6:28:
-    9a:aa:36:fe:e3
+    00:cd:fe:ce:7b:b1:5c:69:87:a2:ea:18:74:e1:66:
+    99:a9:21:95:6e:5d:69:58:ea:df:3c:bf:c6:9d:5e:
+    31:19:74:4f:4b:c9:a3:41:2f:74:09:50:b8:34:b9:
+    3f:bd:4c:51:0a:80:b1:ea:a4:d2:d7:e3:9d:39:da:
+    68:53:68:f0:dc:ca:d6:5d:9a:69:2e:12:80:72:c8:
+    e1:a5:3d:0e:2d:fc:ba:c4:b5:6d:1c:43:e8:5f:ef:
+    14:28:d1:3e:e1:a6:44:a5:b3:51:d0:de:d4:9b:80:
+    5c:cf:82:4a:4d:38:26:da:8a:4e:b8:b6:55:86:5a:
+    0b:fa:30:b5:c3:e9:c7:f6:39
 exponent1:
-    12:9e:4e:30:27:6a:88:47:a6:36:1b:f8:8c:a4:52:
-    b5:af:b9:27:4b:05:c9:4f:1b:c2:15:fa:b7:5b:e1:
-    80:e8:f4:39:af:df:d0:a8:e9:dd:d8:19:fb:33:2b:
-    e5:8d:0b:17:9c:e3:3f:86:a1:7f:fe:c3:51:4a:7e:
-    7a:5f:ce:e5
+    0f:ad:e2:91:22:cd:b9:74:37:d6:86:59:5e:ef:2e:
+    91:83:83:21:fa:90:15:d7:44:81:da:5f:05:35:cc:
+    de:32:e9:a6:5f:5d:02:70:11:31:78:43:0c:7e:b3:
+    b6:5d:66:ea:f1:2f:ed:4e:7a:07:44:07:7e:6a:1a:
+    c1:cc:47:59:0d:ed:b3:6e:91:bc:c5:6b:c7:15:24:
+    59:ac:25:2d:a7:95:ae:e0:eb:e6:6b:24:ff:fe:65:
+    93:a1:db:92:03:66:65:4c:82:7a:8e:a9:33:75:b5:
+    17:80:f6:93:e1:23:50:d5:6f:96:8b:1b:89:65:ee:
+    c8:8d:aa:b2:a1:c4:b0:01
 exponent2:
-    00:87:17:3b:d1:6c:65:e7:12:ef:0c:6f:d0:21:f6:
-    27:13:15:03:d3:30:90:61:ac:c8:d2:2b:03:3f:c9:
-    e1:35:53:fc:ce:fe:58:30:43:eb:d8:f4:4f:73:f5:
-    a4:2f:ad:70:a7:a4:b2:e6:08:a6:2a:9b:03:80:06:
-    51:db:d9:38:e7
+    00:8c:35:55:d7:8d:25:e8:52:40:c9:f3:71:82:85:
+    b2:2b:13:47:c1:81:e5:15:77:70:10:ca:3b:66:9b:
+    58:f2:09:5f:7b:a7:37:ee:43:5d:48:85:df:8b:4b:
+    57:9e:01:d6:db:3e:33:5b:11:6a:cd:35:08:ab:fb:
+    03:ad:5a:2d:2f:2b:04:73:5b:89:21:a9:c8:31:d8:
+    96:f5:40:34:69:8a:ae:98:fb:1f:d3:f0:48:b7:1b:
+    64:6e:4f:d5:ec:02:9e:90:e6:17:d7:02:04:55:ff:
+    2d:ac:b3:f2:dc:d2:4e:67:cb:61:bf:89:a3:76:b9:
+    cd:93:32:1a:55:c9:c6:a7:c9
 coefficient:
-    52:f7:43:0b:33:a8:23:c9:fa:58:72:b1:a4:5f:f4:
-    7f:c3:6e:f5:01:69:61:e1:97:c3:99:d5:e8:3c:45:
-    51:c0:0d:41:68:0c:bf:c6:39:9c:8a:f2:19:37:8f:
-    46:90:6e:35:7a:0c:eb:eb:02:8d:e2:bd:58:43:01:
-    51:76:70:62
+    00:a0:ae:da:e7:29:9d:f3:04:c0:53:97:42:96:bb:
+    74:11:5b:8c:4f:7d:7d:08:16:06:a0:61:cc:34:ca:
+    c4:97:43:eb:1d:c3:8e:29:b6:33:5e:8a:ea:5c:32:
+    b9:b5:3c:fe:11:9d:6e:b3:87:0f:ae:02:66:cc:7a:
+    0c:f3:96:6b:59:9a:bd:fd:bd:6b:dc:aa:ca:a7:ef:
+    ec:b9:91:5f:be:19:82:80:db:34:d3:56:67:b0:ec:
+    be:81:0c:01:4e:53:23:b7:af:86:1f:eb:9d:35:6f:
+    58:a4:34:f1:df:14:e7:f3:a1:3b:6a:7d:5c:d6:a3:
+    b8:9f:5f:f3:51:95:eb:11:6b
 -----BEGIN RSA PRIVATE KEY-----
-MIICXAIBAAKBgQCaYaFiWJ0ELopT0Gh6AJYbLJu6ttV4aZ9jUS5lILveNDIDg4Fj
-Pl9UFMFkZnMiE+Bsx0wH30Z6zXHWSh0ol3IQAELZOl5zq5LW5DBZFIlLiliMDboe
-erX9xTGyL8g35kcFI3px2/Bmf8wKqB4myoAtjKHjr0pJYY+UmXBImwYmvQIDAQAB
-AoGAHw8fScrsJAg8+inGqyztBiCOYB0ii2wsje2qONxCD61Olphhcpb81MysL8fQ
-x/1ZvGjIKhlIc7JbgbI9dYoqfy+erjLnSkX7sfRF0Vd3xaJOFjDJm6BzbWQ5h4Px
-3wpsIV4/Wt/GRJ9zjWmJmgRw4livvpOmun4eWok1I4fDw/0CQQDJSRerGbR6upga
-caCV3rH1dfFDJ1HbNoWqxKh4jOqqNRbU2EhSIF7hl8St3li2z/gWonQ8NxyS+PXz
-k4r5bJXfAkEAxFibVm2sHnVXY4YwUycmz+VVKv9JsyVX1zCZ2dfGikY93dnsM16r
-4gBghHiz2FXjxEgG1BJCemxHtiiaqjb+4wJAEp5OMCdqiEemNhv4jKRSta+5J0sF
-yU8bwhX6t1vhgOj0Oa/f0Kjp3dgZ+zMr5Y0LF5zjP4ahf/7DUUp+el/O5QJBAIcX
-O9FsZecS7wxv0CH2JxMVA9MwkGGsyNIrAz/J4TVT/M7+WDBD69j0T3P1pC+tcKek
-suYIpiqbA4AGUdvZOOcCQFL3QwszqCPJ+lhysaRf9H/DbvUBaWHhl8OZ1eg8RVHA
-DUFoDL/GOZyK8hk3j0aQbjV6DOvrAo3ivVhDAVF2cGI=
+MIIEpAIBAAKCAQEAwqVBlsqvpG6EYTMwDIcXrqk1FtBK28Ej4DMdLdZ20PZ502lu
+LFrABMgn4HWGA0NhYXEzGp8wxXd4ECyTldxLsBQZeGPw3s1aIP5/jpZgq5Ra3yb7
+0jTUc3rKv3O75GCsFdz3N0DLTK3STPdf7t20xMuRbV19GMqZhU69VW/03mHR7kVj
+ISIAfouFGDUJAvBhWK/gzCEPzcgQ3+kvt/G5K4jampCR6rxVzdZCkP4Gmg3CRNF8
+CoZyPtD0BWLm+uB0USs2PsmY+gq+X6zH/b9Lgd7xt8VDcwJmmB+JYEj5U6R1yWir
+AD3pTSyEn6elcRSJ+/XZ+gp+nsi0MmWhBVIYOQIDAQABAoIBAH4hYFM6nH7NLvNd
+nDFCCVKhS0mxSBEHIxxRgwMFCpF2ZpNcqowLcoqmuVB2V5UdwKjIFfmWVqBfPmoc
+uLZPvqwnGioteRSntVPUFwxq3dHRnOEl/eDFYzZBx8gwUv02t8yjF3+yeQsDSFef
+pYbAHDe6Qk7AWiQKhVkhIQeQOPkw//+5MMfjJ9+pUTnfaqd6wUX+Ngm7NvSI206u
+gLCJOjrWXHICYZNjCp9J+WvdcH6uFroSY3yklCWde1TNsy19+ZGJmGZb5h33lVbN
+lL6ocu0m9mwjbV4QfJlVj6W4Lx6B2FMuklskK1hi2/3z0MdmcPBKzGcd/5uCF4Hr
+aam8wAECgYEA8eUjIo2r4zDFWRS5csZ6f2b4IpKvgxg/OU2sFnewNfum4yJu/mCk
+An+MlJhb5/YxrZDOQIGltaNcOunkwUSHT92x+vRCQBHfAYByq6kmrV0/i7pC+TFh
+kz998+nGYVLyiwXFm8o68fP7AsaDbPCGJSru4kWMkLiopaGz2EELMgECgYEAzf7O
+e7FcaYei6hh04WaZqSGVbl1pWOrfPL/GnV4xGXRPS8mjQS90CVC4NLk/vUxRCoCx
+6qTS1+OdOdpoU2jw3MrWXZppLhKAcsjhpT0OLfy6xLVtHEPoX+8UKNE+4aZEpbNR
+0N7Um4Bcz4JKTTgm2opOuLZVhloL+jC1w+nH9jkCgYAPreKRIs25dDfWhlle7y6R
+g4Mh+pAV10SB2l8FNczeMummX10CcBExeEMMfrO2XWbq8S/tTnoHRAd+ahrBzEdZ
+De2zbpG8xWvHFSRZrCUtp5Wu4OvmayT//mWToduSA2ZlTIJ6jqkzdbUXgPaT4SNQ
+1W+WixuJZe7IjaqyocSwAQKBgQCMNVXXjSXoUkDJ83GChbIrE0fBgeUVd3AQyjtm
+m1jyCV97pzfuQ11Ihd+LS1eeAdbbPjNbEWrNNQir+wOtWi0vKwRzW4khqcgx2Jb1
+QDRpiq6Y+x/T8Ei3G2RuT9XsAp6Q5hfXAgRV/y2ss/Lc0k5ny2G/iaN2uc2TMhpV
+ycanyQKBgQCgrtrnKZ3zBMBTl0KWu3QRW4xPfX0IFgagYcw0ysSXQ+sdw44ptjNe
+iupcMrm1PP4RnW6zhw+uAmbMegzzlmtZmr39vWvcqsqn7+y5kV++GYKA2zTTVmew
+7L6BDAFOUyO3r4Yf6501b1ikNPHfFOfzoTtqfVzWo7ifX/NRlesRaw==
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/request.pem
+++ b/spec/fixtures/ssl/request.pem
@@ -4,36 +4,57 @@ Certificate Request:
         Subject: CN=pending
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                Public-Key: (1024 bit)
+                RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:9a:61:a1:62:58:9d:04:2e:8a:53:d0:68:7a:00:
-                    96:1b:2c:9b:ba:b6:d5:78:69:9f:63:51:2e:65:20:
-                    bb:de:34:32:03:83:81:63:3e:5f:54:14:c1:64:66:
-                    73:22:13:e0:6c:c7:4c:07:df:46:7a:cd:71:d6:4a:
-                    1d:28:97:72:10:00:42:d9:3a:5e:73:ab:92:d6:e4:
-                    30:59:14:89:4b:8a:58:8c:0d:ba:1e:7a:b5:fd:c5:
-                    31:b2:2f:c8:37:e6:47:05:23:7a:71:db:f0:66:7f:
-                    cc:0a:a8:1e:26:ca:80:2d:8c:a1:e3:af:4a:49:61:
-                    8f:94:99:70:48:9b:06:26:bd
+                    00:c2:a5:41:96:ca:af:a4:6e:84:61:33:30:0c:87:
+                    17:ae:a9:35:16:d0:4a:db:c1:23:e0:33:1d:2d:d6:
+                    76:d0:f6:79:d3:69:6e:2c:5a:c0:04:c8:27:e0:75:
+                    86:03:43:61:61:71:33:1a:9f:30:c5:77:78:10:2c:
+                    93:95:dc:4b:b0:14:19:78:63:f0:de:cd:5a:20:fe:
+                    7f:8e:96:60:ab:94:5a:df:26:fb:d2:34:d4:73:7a:
+                    ca:bf:73:bb:e4:60:ac:15:dc:f7:37:40:cb:4c:ad:
+                    d2:4c:f7:5f:ee:dd:b4:c4:cb:91:6d:5d:7d:18:ca:
+                    99:85:4e:bd:55:6f:f4:de:61:d1:ee:45:63:21:22:
+                    00:7e:8b:85:18:35:09:02:f0:61:58:af:e0:cc:21:
+                    0f:cd:c8:10:df:e9:2f:b7:f1:b9:2b:88:da:9a:90:
+                    91:ea:bc:55:cd:d6:42:90:fe:06:9a:0d:c2:44:d1:
+                    7c:0a:86:72:3e:d0:f4:05:62:e6:fa:e0:74:51:2b:
+                    36:3e:c9:98:fa:0a:be:5f:ac:c7:fd:bf:4b:81:de:
+                    f1:b7:c5:43:73:02:66:98:1f:89:60:48:f9:53:a4:
+                    75:c9:68:ab:00:3d:e9:4d:2c:84:9f:a7:a5:71:14:
+                    89:fb:f5:d9:fa:0a:7e:9e:c8:b4:32:65:a1:05:52:
+                    18:39
                 Exponent: 65537 (0x10001)
         Attributes:
             a0:00
     Signature Algorithm: sha256WithRSAEncryption
-         21:02:1f:71:ac:e2:45:85:f7:87:b0:ee:e9:3b:c9:86:21:a7:
-         6e:2c:bd:3b:ee:69:8f:c2:97:bd:25:83:84:b0:92:58:a7:b0:
-         b5:a5:35:3e:bf:55:3e:d4:6f:28:4f:3f:1f:97:a7:f1:da:c0:
-         11:ab:85:16:cf:27:77:8e:2b:9a:de:6e:96:7c:de:49:87:e8:
-         53:14:b8:9d:c4:b8:a0:92:7f:ef:22:16:62:a5:39:72:2d:2a:
-         e7:8f:0b:31:46:62:d5:ed:7c:fb:a5:3a:5a:75:84:3c:ec:6d:
-         66:53:36:13:78:a6:71:f2:cc:fa:1c:35:5d:56:89:0e:8e:be:
-         dd:19
+         2c:83:d0:c6:69:03:58:68:79:15:b8:ad:5a:ba:d5:c6:05:d1:
+         6a:f0:e3:48:c4:c0:6d:ce:d1:a7:b6:4a:61:b8:56:de:e5:98:
+         a2:32:56:88:cc:a5:2a:7e:8e:22:0c:c5:27:b6:20:78:68:98:
+         00:56:48:5f:54:9c:c4:a5:4c:79:26:72:81:20:c6:c1:ad:80:
+         b8:80:0e:27:0a:ec:ae:57:1d:33:bf:8c:4f:1b:d5:86:d2:8d:
+         32:9a:c5:e2:37:f6:24:86:fa:1d:e0:8e:80:e4:99:e3:27:32:
+         4f:94:4c:b2:4d:28:5e:86:37:02:1c:b6:b3:86:7e:fd:10:63:
+         88:eb:fc:24:60:be:cb:6f:ff:9a:95:5a:1f:fd:de:bb:1e:1e:
+         ab:da:56:36:40:1a:3a:4b:08:79:74:eb:16:b8:b1:f9:5a:92:
+         25:f0:60:78:39:53:86:9e:a7:cc:81:70:17:50:4f:28:fa:d2:
+         b9:69:aa:a2:44:e6:6d:3c:9c:bf:6b:d2:00:fd:56:f9:3b:f0:
+         8e:83:12:2a:bc:c9:12:13:1c:81:f8:03:03:05:9a:24:6d:e0:
+         cc:b7:20:9e:d2:01:21:24:4d:71:09:f6:5e:28:9e:11:6b:21:
+         78:ea:01:2d:f0:27:f4:ce:f4:7d:43:cc:91:49:78:d1:37:e4:
+         48:74:32:ef
 -----BEGIN CERTIFICATE REQUEST-----
-MIIBUTCBuwIBAjASMRAwDgYDVQQDDAdwZW5kaW5nMIGfMA0GCSqGSIb3DQEBAQUA
-A4GNADCBiQKBgQCaYaFiWJ0ELopT0Gh6AJYbLJu6ttV4aZ9jUS5lILveNDIDg4Fj
-Pl9UFMFkZnMiE+Bsx0wH30Z6zXHWSh0ol3IQAELZOl5zq5LW5DBZFIlLiliMDboe
-erX9xTGyL8g35kcFI3px2/Bmf8wKqB4myoAtjKHjr0pJYY+UmXBImwYmvQIDAQAB
-oAAwDQYJKoZIhvcNAQELBQADgYEAIQIfcaziRYX3h7Du6TvJhiGnbiy9O+5pj8KX
-vSWDhLCSWKewtaU1Pr9VPtRvKE8/H5en8drAEauFFs8nd44rmt5ulnzeSYfoUxS4
-ncS4oJJ/7yIWYqU5ci0q548LMUZi1e18+6U6WnWEPOxtZlM2E3imcfLM+hw1XVaJ
-Do6+3Rk=
+MIICVzCCAT8CAQIwEjEQMA4GA1UEAwwHcGVuZGluZzCCASIwDQYJKoZIhvcNAQEB
+BQADggEPADCCAQoCggEBAMKlQZbKr6RuhGEzMAyHF66pNRbQStvBI+AzHS3WdtD2
+edNpbixawATIJ+B1hgNDYWFxMxqfMMV3eBAsk5XcS7AUGXhj8N7NWiD+f46WYKuU
+Wt8m+9I01HN6yr9zu+RgrBXc9zdAy0yt0kz3X+7dtMTLkW1dfRjKmYVOvVVv9N5h
+0e5FYyEiAH6LhRg1CQLwYViv4MwhD83IEN/pL7fxuSuI2pqQkeq8Vc3WQpD+BpoN
+wkTRfAqGcj7Q9AVi5vrgdFErNj7JmPoKvl+sx/2/S4He8bfFQ3MCZpgfiWBI+VOk
+dcloqwA96U0shJ+npXEUifv12foKfp7ItDJloQVSGDkCAwEAAaAAMA0GCSqGSIb3
+DQEBCwUAA4IBAQAsg9DGaQNYaHkVuK1autXGBdFq8ONIxMBtztGntkphuFbe5Zii
+MlaIzKUqfo4iDMUntiB4aJgAVkhfVJzEpUx5JnKBIMbBrYC4gA4nCuyuVx0zv4xP
+G9WG0o0ymsXiN/Ykhvod4I6A5JnjJzJPlEyyTShehjcCHLazhn79EGOI6/wkYL7L
+b/+alVof/d67Hh6r2lY2QBo6Swh5dOsWuLH5WpIl8GB4OVOGnqfMgXAXUE8o+tK5
+aaqiROZtPJy/a9IA/Vb5O/COgxIqvMkSExyB+AMDBZokbeDMtyCe0gEhJE1xCfZe
+KJ4RayF46gEt8Cf0zvR9Q8yRSXjRN+RIdDLv
 -----END CERTIFICATE REQUEST-----

--- a/spec/fixtures/ssl/revoked-key.pem
+++ b/spec/fixtures/ssl/revoked-key.pem
@@ -1,67 +1,117 @@
-Private-Key: (1024 bit)
+RSA Private-Key: (2048 bit, 2 primes)
 modulus:
-    00:ac:50:a2:73:53:48:80:77:b1:93:92:2e:8e:99:
-    f7:60:ba:41:fe:ac:a8:d6:57:88:67:25:40:a2:88:
-    66:e8:d8:0a:32:68:a2:79:41:30:76:e4:31:4b:3e:
-    28:62:6b:6d:52:db:4b:61:27:a5:44:29:4f:41:43:
-    da:5a:b4:aa:37:38:19:68:50:60:3c:35:27:ef:51:
-    55:da:7d:17:01:3a:e7:96:70:e8:12:8f:6f:ee:1c:
-    43:65:fe:e6:c7:dc:a9:0d:b9:57:a7:a2:8b:dd:ed:
-    89:08:3e:59:d1:d1:3f:39:6f:95:03:c5:e6:a2:2c:
-    cd:a3:3b:82:29:9e:35:83:1d
+    00:d6:7b:d8:19:56:82:ff:86:58:15:2b:40:db:c9:
+    88:55:c4:af:51:81:f9:89:e4:8b:fa:93:42:98:63:
+    74:9c:ed:71:4a:16:1c:ef:95:2e:89:dc:28:83:91:
+    d1:f7:31:66:a8:9c:7d:7b:0c:dc:62:9f:97:84:13:
+    a7:35:ab:c3:8f:41:4b:d1:0c:13:fe:f4:17:83:ae:
+    00:28:6c:c6:d9:46:1c:4f:8d:ba:40:ab:52:8a:bc:
+    47:53:41:9d:ea:4d:eb:eb:3f:c7:de:bc:3c:d8:16:
+    35:0d:16:da:45:c2:50:90:12:6a:4e:f3:f2:ff:c7:
+    b2:24:5e:18:ca:3d:ca:a2:be:e3:24:89:f9:58:70:
+    d5:d1:a7:d1:01:78:20:6a:15:ab:96:75:2c:7e:f1:
+    72:1b:3c:56:53:4e:11:d7:93:5e:44:31:59:ce:4c:
+    8a:f6:cd:61:30:16:e1:50:18:25:3c:f9:22:a9:7c:
+    fb:38:78:f1:b9:0a:45:68:9c:f7:2f:c7:f8:d6:36:
+    6c:00:34:24:f7:69:0d:38:d1:03:e9:48:79:79:01:
+    ba:63:74:f0:9e:f6:b9:74:78:b3:94:48:61:9e:26:
+    22:02:9e:f7:88:78:08:13:7e:71:75:39:b1:2d:e5:
+    6a:ed:06:e3:10:36:c0:c2:8b:3e:dd:07:4a:c5:51:
+    96:1b
 publicExponent: 65537 (0x10001)
 privateExponent:
-    41:6b:f3:e1:79:33:43:a3:2e:06:6b:2f:c5:f0:6a:
-    dd:8c:99:d5:c9:53:e8:dd:1e:ea:9a:58:29:dd:43:
-    c5:0f:90:ff:86:7e:79:2e:e8:e9:9a:c5:a4:5d:9b:
-    13:92:d9:d4:e5:71:7f:17:80:45:9a:b1:7e:83:f6:
-    79:0d:b2:b9:d8:60:cf:92:69:7b:96:55:1c:e0:cd:
-    e8:87:06:65:19:38:d0:51:f0:71:aa:12:45:e1:54:
-    0b:c7:d0:72:b8:cd:ab:0e:5c:5e:ae:2d:21:eb:03:
-    b6:80:d2:66:0a:64:a5:5d:ae:46:2b:d8:dc:84:18:
-    3b:ca:27:74:0b:0b:26:39
+    00:84:6a:cf:3e:cd:6f:70:ec:73:43:16:82:23:6f:
+    67:f1:73:cd:bd:67:9e:35:28:d9:d6:e8:c5:ab:a9:
+    73:5c:53:27:a7:52:c1:a8:94:94:b7:de:29:51:19:
+    5c:e4:dd:26:01:21:24:43:2c:ec:7f:23:02:7b:33:
+    5a:ff:42:bd:28:9b:6a:80:74:91:7f:cd:19:1b:5d:
+    f8:90:fc:9f:43:93:0a:75:7f:0d:a7:51:5e:53:72:
+    ec:22:15:97:b6:09:47:86:e4:c8:b3:d5:c9:46:ab:
+    67:33:5e:91:81:91:f7:05:0b:a9:80:77:11:e6:22:
+    56:f4:26:f7:ed:1c:7b:17:3f:db:22:a3:b6:1f:28:
+    4e:e6:2f:c6:6c:22:b5:4d:48:61:00:30:c5:ff:ce:
+    ea:2c:02:96:c9:5b:9e:f3:98:bf:14:95:19:f7:2e:
+    de:92:7c:6c:47:0e:4f:cf:4b:a9:42:4c:4e:b1:22:
+    13:bd:99:19:6b:75:07:a2:72:de:1d:96:92:62:d1:
+    00:f4:4c:f7:3b:90:0f:1a:cf:e1:50:ad:a2:50:8b:
+    63:9b:95:78:5f:36:02:a4:c2:19:41:07:23:a8:8a:
+    23:53:6d:52:54:b8:13:38:bb:de:12:e9:39:50:00:
+    4b:d3:2d:61:b3:9e:80:f4:1f:9d:59:82:f8:43:6b:
+    83:89
 prime1:
-    00:e2:79:5e:74:b3:46:79:2c:c6:cf:b3:85:cf:c3:
-    79:f3:bd:c2:f4:6e:a5:c7:5c:35:37:d5:ff:21:fa:
-    14:f3:97:e3:99:22:e6:16:04:34:1a:17:53:b9:21:
-    78:d6:b4:97:9e:79:ce:6b:99:33:0b:80:ef:ff:be:
-    6e:fa:63:eb:ef
+    00:f2:48:d3:f1:ef:bc:6b:57:fa:ce:ab:28:32:b8:
+    52:2b:4b:c1:ef:3a:54:85:ea:74:86:08:de:e7:54:
+    ae:04:ff:18:72:65:6e:03:94:8b:f4:61:11:ee:b0:
+    ec:16:75:4c:b6:cc:24:e3:d8:f1:54:2e:00:f8:7f:
+    93:b9:4e:7a:3a:38:e3:b5:d1:5a:f5:1d:fe:11:b0:
+    0a:1e:f6:f8:1d:38:e6:1a:4e:e2:cc:c3:da:c4:32:
+    c8:c3:4c:3a:d3:7d:93:36:19:23:f9:f3:81:78:02:
+    ec:6c:a7:44:f3:9a:7f:6c:cc:bb:06:cb:63:ad:40:
+    99:9b:02:e7:6d:c3:b4:ee:b7
 prime2:
-    00:c2:c7:b0:ee:88:b3:f8:c2:3a:bd:12:c5:63:91:
-    81:65:99:0c:d8:f5:eb:ac:e5:32:a6:b7:a1:f6:40:
-    b0:6d:a4:35:ca:f0:bc:e9:d9:5f:c9:b7:08:d1:c1:
-    fa:a5:1e:6b:63:10:43:4d:83:72:00:43:ff:48:53:
-    0b:f4:a2:25:b3
+    00:e2:a0:21:41:67:62:d0:b1:46:20:7f:b8:dd:de:
+    d3:c0:ec:f7:44:53:4a:d7:6e:8f:45:11:ec:ac:a5:
+    34:07:2a:ea:27:f0:0f:9f:49:07:8f:1e:0d:b1:4f:
+    4f:07:c3:74:c3:17:e2:3b:32:fb:56:6c:57:3f:dd:
+    fd:fe:b3:89:1a:fc:ca:39:ae:e0:9a:ee:89:2d:6f:
+    d1:12:e3:e8:4f:c2:77:74:a1:e9:38:4e:99:ef:fc:
+    d3:2f:ca:b9:41:51:8a:5c:a1:b8:8d:f8:d0:86:54:
+    1c:85:0f:e9:f8:6d:c9:50:f8:4e:d0:e1:4d:f8:43:
+    fa:ad:ae:fc:02:58:a4:6f:bd
 exponent1:
-    48:5b:b4:c5:1e:7e:56:ba:ea:ae:73:d2:3e:06:5b:
-    91:77:c0:b1:2e:25:03:64:3f:90:9e:6b:cc:a4:45:
-    4b:6a:ed:0a:01:6f:77:fb:51:d6:40:3b:bc:bb:a8:
-    0b:19:5a:14:05:20:e1:99:ea:08:33:e2:fa:58:12:
-    c7:27:63:bb
+    00:9e:1f:d1:d3:90:77:14:47:b3:34:b6:97:e1:a2:
+    52:5e:57:6f:16:c6:a6:eb:4f:7d:05:0d:3d:0d:15:
+    43:0d:97:bf:48:c9:d1:e7:1c:47:cb:12:9f:35:7c:
+    da:58:3d:ed:f7:4f:7c:b4:07:9e:59:26:3d:13:f1:
+    8f:63:dd:48:00:3f:a8:bd:bd:08:f3:f8:c3:1c:a0:
+    1b:ba:e1:cc:44:a6:21:e7:01:9d:1b:ae:a7:54:6d:
+    20:81:f5:7a:5f:15:11:c2:b8:dd:b5:ff:aa:7b:bc:
+    cc:b8:8c:e2:7f:6a:51:c7:9c:46:63:c4:d2:24:fc:
+    88:43:96:bd:9b:f1:a2:60:39
 exponent2:
-    3c:60:a0:34:e0:c5:40:f8:1c:33:1d:cd:78:16:d3:
-    90:85:c7:d8:bd:2a:67:f6:c8:23:ab:ca:95:c5:e9:
-    aa:a2:fb:55:c4:18:1b:39:19:9b:32:94:96:48:d6:
-    04:37:10:bc:ad:7e:df:59:3e:8e:5c:85:96:8a:bf:
-    aa:fe:54:47
+    0b:92:e7:ff:e2:1a:ce:d3:ae:e4:2c:01:b1:fb:16:
+    4f:6d:0a:b7:c7:95:33:e9:66:91:bd:77:9b:dd:98:
+    09:a1:ac:71:bb:b5:e0:89:a7:44:2c:e1:c0:23:6f:
+    c2:d2:bd:9c:d5:14:6d:b7:8d:d4:7d:15:fb:a2:07:
+    bd:c1:47:88:44:4e:c3:a1:65:c1:23:db:87:a1:85:
+    48:f4:b0:c1:9a:09:e5:bf:fb:1c:30:0f:76:8d:2f:
+    ef:e9:e7:8a:29:72:ea:86:2b:d9:bc:52:51:f9:eb:
+    b6:f3:f8:1c:02:e7:5c:26:42:48:32:a9:7b:bb:65:
+    0b:07:bb:c1:16:eb:d6:f5
 coefficient:
-    07:af:dc:84:19:f0:d9:df:15:40:18:d7:bc:66:1a:
-    d1:73:29:b1:00:91:22:e5:87:f4:4f:d0:bc:b6:6f:
-    70:22:20:d3:d2:11:7d:e3:ce:0d:58:c6:80:c5:62:
-    76:c5:85:28:61:09:68:86:e1:68:7c:0f:5a:62:90:
-    d4:b5:2d:ef
+    60:07:2c:02:1e:90:75:6a:7c:c1:75:62:d0:76:dc:
+    02:31:69:ed:2a:74:14:a2:c8:c0:18:85:8c:48:16:
+    c5:ed:75:14:dd:f1:2d:ac:aa:37:16:b9:f8:21:07:
+    27:75:ee:ab:a3:de:d4:fd:76:ea:a9:ee:5f:4c:9e:
+    6c:e2:ee:50:7e:18:cd:d3:39:48:f6:ae:88:6c:a4:
+    ab:cc:4b:28:90:60:43:d0:1a:bc:8c:62:a5:d8:f5:
+    37:ac:a5:51:2b:e8:9a:d2:ce:89:15:65:2c:54:23:
+    9a:40:6d:fe:9c:4d:c8:bc:2a:1f:1b:2d:fc:b5:b5:
+    a0:af:ec:16:ab:5f:47:7e
 -----BEGIN RSA PRIVATE KEY-----
-MIICWwIBAAKBgQCsUKJzU0iAd7GTki6OmfdgukH+rKjWV4hnJUCiiGbo2AoyaKJ5
-QTB25DFLPihia21S20thJ6VEKU9BQ9patKo3OBloUGA8NSfvUVXafRcBOueWcOgS
-j2/uHENl/ubH3KkNuVenoovd7YkIPlnR0T85b5UDxeaiLM2jO4IpnjWDHQIDAQAB
-AoGAQWvz4XkzQ6MuBmsvxfBq3YyZ1clT6N0e6ppYKd1DxQ+Q/4Z+eS7o6ZrFpF2b
-E5LZ1OVxfxeARZqxfoP2eQ2yudhgz5Jpe5ZVHODN6IcGZRk40FHwcaoSReFUC8fQ
-crjNqw5cXq4tIesDtoDSZgpkpV2uRivY3IQYO8ondAsLJjkCQQDieV50s0Z5LMbP
-s4XPw3nzvcL0bqXHXDU31f8h+hTzl+OZIuYWBDQaF1O5IXjWtJeeec5rmTMLgO//
-vm76Y+vvAkEAwsew7oiz+MI6vRLFY5GBZZkM2PXrrOUypreh9kCwbaQ1yvC86dlf
-ybcI0cH6pR5rYxBDTYNyAEP/SFML9KIlswJASFu0xR5+VrrqrnPSPgZbkXfAsS4l
-A2Q/kJ5rzKRFS2rtCgFvd/tR1kA7vLuoCxlaFAUg4ZnqCDPi+lgSxydjuwJAPGCg
-NODFQPgcMx3NeBbTkIXH2L0qZ/bII6vKlcXpqqL7VcQYGzkZmzKUlkjWBDcQvK1+
-31k+jlyFloq/qv5URwJAB6/chBnw2d8VQBjXvGYa0XMpsQCRIuWH9E/QvLZvcCIg
-09IRfePODVjGgMVidsWFKGEJaIbhaHwPWmKQ1LUt7w==
+MIIEpAIBAAKCAQEA1nvYGVaC/4ZYFStA28mIVcSvUYH5ieSL+pNCmGN0nO1xShYc
+75Uuidwog5HR9zFmqJx9ewzcYp+XhBOnNavDj0FL0QwT/vQXg64AKGzG2UYcT426
+QKtSirxHU0Gd6k3r6z/H3rw82BY1DRbaRcJQkBJqTvPy/8eyJF4Yyj3Kor7jJIn5
+WHDV0afRAXggahWrlnUsfvFyGzxWU04R15NeRDFZzkyK9s1hMBbhUBglPPkiqXz7
+OHjxuQpFaJz3L8f41jZsADQk92kNONED6Uh5eQG6Y3Twnva5dHizlEhhniYiAp73
+iHgIE35xdTmxLeVq7QbjEDbAwos+3QdKxVGWGwIDAQABAoIBAQCEas8+zW9w7HND
+FoIjb2fxc829Z541KNnW6MWrqXNcUyenUsGolJS33ilRGVzk3SYBISRDLOx/IwJ7
+M1r/Qr0om2qAdJF/zRkbXfiQ/J9Dkwp1fw2nUV5TcuwiFZe2CUeG5Miz1clGq2cz
+XpGBkfcFC6mAdxHmIlb0JvftHHsXP9sio7YfKE7mL8ZsIrVNSGEAMMX/zuosApbJ
+W57zmL8UlRn3Lt6SfGxHDk/PS6lCTE6xIhO9mRlrdQeict4dlpJi0QD0TPc7kA8a
+z+FQraJQi2OblXhfNgKkwhlBByOoiiNTbVJUuBM4u94S6TlQAEvTLWGznoD0H51Z
+gvhDa4OJAoGBAPJI0/HvvGtX+s6rKDK4UitLwe86VIXqdIYI3udUrgT/GHJlbgOU
+i/RhEe6w7BZ1TLbMJOPY8VQuAPh/k7lOejo447XRWvUd/hGwCh72+B045hpO4szD
+2sQyyMNMOtN9kzYZI/nzgXgC7GynRPOaf2zMuwbLY61AmZsC523DtO63AoGBAOKg
+IUFnYtCxRiB/uN3e08Ds90RTStduj0UR7KylNAcq6ifwD59JB48eDbFPTwfDdMMX
+4jsy+1ZsVz/d/f6ziRr8yjmu4JruiS1v0RLj6E/Cd3Sh6ThOme/80y/KuUFRilyh
+uI340IZUHIUP6fhtyVD4TtDhTfhD+q2u/AJYpG+9AoGBAJ4f0dOQdxRHszS2l+Gi
+Ul5XbxbGputPfQUNPQ0VQw2Xv0jJ0eccR8sSnzV82lg97fdPfLQHnlkmPRPxj2Pd
+SAA/qL29CPP4wxygG7rhzESmIecBnRuup1RtIIH1el8VEcK43bX/qnu8zLiM4n9q
+UcecRmPE0iT8iEOWvZvxomA5AoGAC5Ln/+IaztOu5CwBsfsWT20Kt8eVM+lmkb13
+m92YCaGscbu14ImnRCzhwCNvwtK9nNUUbbeN1H0V+6IHvcFHiEROw6FlwSPbh6GF
+SPSwwZoJ5b/7HDAPdo0v7+nniily6oYr2bxSUfnrtvP4HALnXCZCSDKpe7tlCwe7
+wRbr1vUCgYBgBywCHpB1anzBdWLQdtwCMWntKnQUosjAGIWMSBbF7XUU3fEtrKo3
+Frn4IQcnde6ro97U/Xbqqe5fTJ5s4u5QfhjN0zlI9q6IbKSrzEsokGBD0Bq8jGKl
+2PU3rKVRK+ia0s6JFWUsVCOaQG3+nE3IvCofGy38tbWgr+wWq19Hfg==
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/revoked.pem
+++ b/spec/fixtures/ssl/revoked.pem
@@ -1,44 +1,66 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 4 (0x4)
-    Signature Algorithm: sha256WithRSAEncryption
+        Serial Number: 6 (0x6)
+        Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA Subauthority
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Apr 19 22:31:22 2029 GMT
+            Not After : Apr 18 18:46:23 2031 GMT
         Subject: CN=revoked
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                Public-Key: (1024 bit)
+                RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:ac:50:a2:73:53:48:80:77:b1:93:92:2e:8e:99:
-                    f7:60:ba:41:fe:ac:a8:d6:57:88:67:25:40:a2:88:
-                    66:e8:d8:0a:32:68:a2:79:41:30:76:e4:31:4b:3e:
-                    28:62:6b:6d:52:db:4b:61:27:a5:44:29:4f:41:43:
-                    da:5a:b4:aa:37:38:19:68:50:60:3c:35:27:ef:51:
-                    55:da:7d:17:01:3a:e7:96:70:e8:12:8f:6f:ee:1c:
-                    43:65:fe:e6:c7:dc:a9:0d:b9:57:a7:a2:8b:dd:ed:
-                    89:08:3e:59:d1:d1:3f:39:6f:95:03:c5:e6:a2:2c:
-                    cd:a3:3b:82:29:9e:35:83:1d
+                    00:d6:7b:d8:19:56:82:ff:86:58:15:2b:40:db:c9:
+                    88:55:c4:af:51:81:f9:89:e4:8b:fa:93:42:98:63:
+                    74:9c:ed:71:4a:16:1c:ef:95:2e:89:dc:28:83:91:
+                    d1:f7:31:66:a8:9c:7d:7b:0c:dc:62:9f:97:84:13:
+                    a7:35:ab:c3:8f:41:4b:d1:0c:13:fe:f4:17:83:ae:
+                    00:28:6c:c6:d9:46:1c:4f:8d:ba:40:ab:52:8a:bc:
+                    47:53:41:9d:ea:4d:eb:eb:3f:c7:de:bc:3c:d8:16:
+                    35:0d:16:da:45:c2:50:90:12:6a:4e:f3:f2:ff:c7:
+                    b2:24:5e:18:ca:3d:ca:a2:be:e3:24:89:f9:58:70:
+                    d5:d1:a7:d1:01:78:20:6a:15:ab:96:75:2c:7e:f1:
+                    72:1b:3c:56:53:4e:11:d7:93:5e:44:31:59:ce:4c:
+                    8a:f6:cd:61:30:16:e1:50:18:25:3c:f9:22:a9:7c:
+                    fb:38:78:f1:b9:0a:45:68:9c:f7:2f:c7:f8:d6:36:
+                    6c:00:34:24:f7:69:0d:38:d1:03:e9:48:79:79:01:
+                    ba:63:74:f0:9e:f6:b9:74:78:b3:94:48:61:9e:26:
+                    22:02:9e:f7:88:78:08:13:7e:71:75:39:b1:2d:e5:
+                    6a:ed:06:e3:10:36:c0:c2:8b:3e:dd:07:4a:c5:51:
+                    96:1b
                 Exponent: 65537 (0x10001)
     Signature Algorithm: sha256WithRSAEncryption
-         37:b6:44:8d:06:42:a0:9f:7f:fd:61:18:04:c4:f6:ae:f9:8a:
-         14:98:63:a8:08:01:0a:7d:80:7f:4b:a5:e4:3d:27:6d:36:ef:
-         6a:99:44:bb:70:c8:1f:18:64:35:47:07:34:71:c9:96:2f:e0:
-         c7:fe:61:ce:71:2b:20:1b:2f:11:92:e3:37:51:03:f2:71:2a:
-         53:2f:94:11:41:2e:48:45:15:0a:95:71:d2:49:03:38:8e:6f:
-         ab:dd:7b:e8:77:82:4c:29:29:e8:41:4d:c9:3b:ec:08:d0:2e:
-         42:6a:26:bc:d3:a9:e8:ce:fd:5e:f4:4f:b9:ea:60:72:01:04:
-         d6:66
+         8c:38:83:61:c1:4c:2f:c0:8a:fd:0b:4b:8e:fc:fd:28:cd:5d:
+         45:45:73:bb:c0:82:d1:41:4b:8c:c2:ae:62:91:dc:42:50:6b:
+         bb:b0:27:4c:90:f3:91:c2:1a:46:bb:31:3c:de:e5:cc:3c:da:
+         94:6c:40:86:7f:38:36:e5:a0:22:77:fc:9a:06:e7:b5:cc:35:
+         70:ff:06:4e:20:38:98:9d:03:85:73:26:35:3a:7e:9d:13:89:
+         94:52:10:8a:c0:c4:c0:f3:56:8e:47:88:f5:1e:c8:fc:68:e6:
+         70:28:b9:0d:5b:f3:6d:3c:b4:94:2f:38:40:61:77:33:c6:f2:
+         25:7d:6b:d4:0c:75:05:15:89:ed:d4:1f:55:10:80:0a:b9:71:
+         20:f3:73:84:d1:a4:3c:21:1c:64:b9:cf:bd:e1:21:24:dc:cf:
+         2d:7e:d8:08:d5:1e:d6:6c:7d:bb:8f:66:5d:2b:29:a8:41:52:
+         e4:30:3f:43:22:a4:06:94:f5:2d:3b:3b:e5:9b:f1:24:dc:5e:
+         ad:ed:fe:cc:ec:f5:99:de:4a:f2:13:de:c7:94:29:18:e4:21:
+         5e:f5:21:ec:0c:dd:2f:1f:5c:c5:9c:f9:c3:72:8b:cd:63:b1:
+         e3:2c:f3:04:db:73:43:ed:6e:59:f1:86:8b:f3:90:63:74:cf:
+         74:80:8a:32
 -----BEGIN CERTIFICATE-----
-MIIBpTCCAQ6gAwIBAgIBBDANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0
-IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0yOTA0MTkyMjMxMjJa
-MBIxEDAOBgNVBAMMB3Jldm9rZWQwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGB
-AKxQonNTSIB3sZOSLo6Z92C6Qf6sqNZXiGclQKKIZujYCjJoonlBMHbkMUs+KGJr
-bVLbS2EnpUQpT0FD2lq0qjc4GWhQYDw1J+9RVdp9FwE655Zw6BKPb+4cQ2X+5sfc
-qQ25V6eii93tiQg+WdHRPzlvlQPF5qIszaM7gimeNYMdAgMBAAEwDQYJKoZIhvcN
-AQELBQADgYEAN7ZEjQZCoJ9//WEYBMT2rvmKFJhjqAgBCn2Af0ul5D0nbTbvaplE
-u3DIHxhkNUcHNHHJli/gx/5hznErIBsvEZLjN1ED8nEqUy+UEUEuSEUVCpVx0kkD
-OI5vq9176HeCTCkp6EFNyTvsCNAuQmomvNOp6M79XvRPuepgcgEE1mY=
+MIICqjCCAZKgAwIBAgIBBjANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0
+IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zMTA0MTgxODQ2MjNa
+MBIxEDAOBgNVBAMMB3Jldm9rZWQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
+AoIBAQDWe9gZVoL/hlgVK0DbyYhVxK9RgfmJ5Iv6k0KYY3Sc7XFKFhzvlS6J3CiD
+kdH3MWaonH17DNxin5eEE6c1q8OPQUvRDBP+9BeDrgAobMbZRhxPjbpAq1KKvEdT
+QZ3qTevrP8fevDzYFjUNFtpFwlCQEmpO8/L/x7IkXhjKPcqivuMkiflYcNXRp9EB
+eCBqFauWdSx+8XIbPFZTThHXk15EMVnOTIr2zWEwFuFQGCU8+SKpfPs4ePG5CkVo
+nPcvx/jWNmwANCT3aQ040QPpSHl5AbpjdPCe9rl0eLOUSGGeJiICnveIeAgTfnF1
+ObEt5WrtBuMQNsDCiz7dB0rFUZYbAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAIw4
+g2HBTC/Aiv0LS478/SjNXUVFc7vAgtFBS4zCrmKR3EJQa7uwJ0yQ85HCGka7MTze
+5cw82pRsQIZ/ODbloCJ3/JoG57XMNXD/Bk4gOJidA4VzJjU6fp0TiZRSEIrAxMDz
+Vo5HiPUeyPxo5nAouQ1b8208tJQvOEBhdzPG8iV9a9QMdQUVie3UH1UQgAq5cSDz
+c4TRpDwhHGS5z73hISTczy1+2AjVHtZsfbuPZl0rKahBUuQwP0MipAaU9S07O+Wb
+8STcXq3t/szs9ZneSvIT3seUKRjkIV71IewM3S8fXMWc+cNyi81jseMs8wTbc0Pt
+blnxhovzkGN0z3SAijI=
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/signed-key.pem
+++ b/spec/fixtures/ssl/signed-key.pem
@@ -1,67 +1,117 @@
-Private-Key: (1024 bit)
+RSA Private-Key: (2048 bit, 2 primes)
 modulus:
-    00:ef:bc:2c:47:fa:12:2d:09:ef:16:96:90:8b:84:
-    45:c7:86:f1:5e:8f:58:59:23:87:df:a1:e3:be:8c:
-    2f:ad:70:96:1a:f5:67:7f:5c:9c:54:5e:82:de:05:
-    7f:8f:9d:c9:f3:24:72:39:4f:1c:b4:a6:e0:d0:19:
-    af:bd:e4:29:65:bb:d7:43:3e:66:d3:4f:74:05:0b:
-    8a:e4:d5:52:08:af:9b:f4:f4:7d:6c:92:5f:cc:bb:
-    c2:2d:ca:d0:12:28:e5:c8:fd:f6:09:90:dd:85:f9:
-    85:d9:37:a6:fe:83:c7:24:e4:af:28:e3:ff:5a:1b:
-    72:5f:29:c6:39:88:5b:48:19
+    00:db:90:d7:cf:fe:81:bc:51:d1:a1:d2:d9:0f:c2:
+    21:16:06:3d:12:87:7c:e9:45:97:28:f4:33:12:51:
+    d2:b3:31:be:13:5d:28:a8:b5:fb:8f:0e:ce:3e:bb:
+    42:7a:3f:ba:35:e9:58:2a:fb:61:38:c0:6b:37:9f:
+    3f:de:b9:64:5b:c3:08:21:64:d7:c2:af:0a:ac:21:
+    0b:ed:c1:8a:71:fe:05:27:eb:4b:31:ba:79:62:e5:
+    41:ef:dd:66:85:76:28:bb:03:08:c7:35:26:85:c2:
+    f8:3b:1f:67:45:39:73:ce:d8:5d:df:4a:0b:4e:8c:
+    85:29:02:98:04:95:e9:d3:f6:d1:9f:6c:25:ce:a3:
+    81:4c:c7:4d:b5:ce:43:12:d9:b2:f1:68:c8:fd:a3:
+    57:16:f5:7a:42:85:fe:19:b5:ee:e8:3f:da:27:85:
+    82:c9:ec:d6:63:bf:cd:4b:75:1e:a0:c5:8f:ce:90:
+    b8:ca:25:ba:45:52:6d:e4:ea:6d:e5:1d:41:8e:4f:
+    33:4a:97:23:8e:c1:98:d4:60:a7:1e:1c:28:31:0d:
+    05:c8:a2:d2:d7:7a:d9:c3:46:26:a1:e7:ef:67:e7:
+    6b:ce:97:8a:37:0b:d7:e2:28:b0:33:85:b0:89:6b:
+    38:83:ae:a3:02:a7:d2:1a:87:f0:88:a6:a3:1a:db:
+    97:53
 publicExponent: 65537 (0x10001)
 privateExponent:
-    75:11:3b:c2:6e:30:60:04:00:d7:d3:f0:83:e0:b4:
-    be:89:7b:e6:84:33:4d:5c:17:66:b2:44:67:71:47:
-    7a:f7:86:a5:65:7f:03:e7:b2:83:54:9f:ad:51:9c:
-    08:02:b2:72:64:32:cf:1f:7d:d2:0d:c7:ac:77:4e:
-    a5:78:fc:69:3a:88:12:5b:81:81:19:c9:1f:9d:aa:
-    fa:35:2e:cd:df:71:ee:50:f9:59:53:99:52:22:f7:
-    48:ba:17:4f:47:b5:72:16:47:d1:1d:31:29:47:80:
-    b1:e1:3c:e0:a0:4b:ef:05:c5:ea:0a:b2:c7:4a:b9:
-    d3:06:c0:b7:7b:0a:2e:81
+    00:9d:74:93:af:8f:1e:4e:84:86:46:fc:43:b9:2f:
+    48:36:d9:26:76:e1:3e:cc:b2:a1:22:37:6d:60:97:
+    d8:f7:b4:96:50:a0:a0:05:cc:eb:a7:bd:c0:5d:f0:
+    40:4e:16:e1:5c:c4:07:fc:5a:e5:6f:a3:5d:c0:37:
+    ad:bf:f5:47:69:1e:c5:f7:dc:af:75:e7:bd:49:8f:
+    31:54:c1:54:9d:46:c3:3f:cb:56:d3:44:9c:c4:35:
+    10:42:09:8d:f9:eb:b0:6d:dc:51:31:3a:86:73:aa:
+    4c:05:6a:11:ce:ec:d2:85:e5:57:fc:46:c7:30:ff:
+    48:87:0e:5b:21:fe:b7:fe:ce:4f:8c:2c:cf:ea:d1:
+    0c:59:83:7e:d4:3f:db:0c:09:8d:8d:af:c5:38:8d:
+    96:44:37:7c:a3:4f:79:09:fe:11:cb:cf:20:40:6c:
+    fd:a3:cc:d9:f2:f4:35:79:63:c3:f8:1c:c1:6e:d4:
+    76:2b:67:84:4d:d3:af:81:72:17:ba:9d:98:0c:58:
+    0a:c8:4d:8f:28:95:2b:fa:d9:31:1d:31:ad:c5:87:
+    90:1b:2c:69:42:22:b1:1b:73:4a:22:82:af:b7:5b:
+    82:b4:38:39:3b:f2:47:ef:3d:7d:09:9b:e8:5b:b5:
+    d8:56:1c:16:e7:3a:6e:7d:85:3f:1c:1d:3f:ee:dd:
+    f1:d1
 prime1:
-    00:fa:cc:b0:ba:9e:06:c5:f7:63:09:37:e7:9f:aa:
-    4d:f8:f1:b4:7f:aa:c6:8a:04:16:93:73:af:ba:1f:
-    e3:97:76:11:a9:4d:fb:42:8b:f0:51:0a:7d:6c:69:
-    fa:2f:d8:7b:ad:20:79:de:71:ea:e2:e0:a3:69:1b:
-    1e:e3:6c:9b:e9
+    00:f2:0c:fe:99:b5:ed:bb:24:f6:79:61:75:f5:a8:
+    9b:56:f9:f3:ee:5b:84:1c:31:00:5e:01:02:b4:50:
+    ea:fb:a8:13:22:73:c2:12:1b:c2:53:55:14:f3:2e:
+    a3:62:f8:82:04:4c:23:09:50:98:c1:ab:45:18:96:
+    c7:a4:e8:29:84:04:ab:24:37:17:45:0b:b3:02:7f:
+    c3:4a:30:3f:ad:69:49:0b:49:c5:89:e0:07:b7:b3:
+    d7:50:19:85:c0:f1:73:60:b4:76:f8:c2:c5:01:7c:
+    09:23:49:57:2a:cc:d7:e1:d6:d9:b4:6b:54:20:61:
+    7f:3a:70:9b:9d:01:12:fa:e7
 prime2:
-    00:f4:b4:bf:cf:56:a0:fa:94:15:5c:24:9c:45:fd:
-    54:31:72:75:7b:ef:d5:de:5b:64:c9:6a:88:42:e0:
-    0d:f0:63:c2:46:9e:59:81:be:60:ee:05:01:b0:dd:
-    e4:12:d0:5b:77:76:c0:5b:f2:21:0c:5b:42:af:f5:
-    c2:5b:c6:1c:b1
+    00:e8:38:1f:fb:1b:f6:4d:e1:be:f0:80:c1:a1:55:
+    2b:d1:db:09:98:cc:70:eb:99:f0:9e:0b:2c:2d:60:
+    20:96:f7:b3:c5:6b:98:22:c5:bf:c3:20:5e:91:be:
+    d1:81:fc:14:36:70:9b:37:9e:6d:c8:6e:84:f6:fa:
+    65:30:64:0e:b0:50:05:85:a8:07:0b:be:4e:de:c1:
+    17:71:39:03:e3:9e:4e:69:5c:51:02:af:97:b8:30:
+    da:95:2e:24:b4:78:76:46:bc:db:a2:27:66:5a:ce:
+    e5:0f:01:82:fe:cb:31:bc:fe:19:6a:e5:73:b6:a5:
+    ad:3a:f3:61:ec:f7:a9:fe:b5
 exponent1:
-    15:d0:1f:be:db:67:b3:68:24:d0:f4:6f:cc:cf:3f:
-    20:db:c4:db:25:bb:46:dd:bc:28:ee:f2:e5:b9:48:
-    4e:30:12:b1:2a:fb:23:7a:90:58:3c:15:54:8c:93:
-    19:fe:36:23:84:a3:94:d9:4b:98:97:f9:1e:77:21:
-    64:9e:59:a1
+    04:5d:93:a1:f6:14:09:92:0b:17:f9:58:05:4c:3b:
+    31:00:65:13:e1:76:aa:83:7f:bc:32:4c:78:30:15:
+    6c:e0:85:27:d3:ea:a6:24:f6:06:46:bc:8f:fe:41:
+    58:21:9f:46:b0:90:d9:34:28:ed:25:47:a3:bf:e4:
+    6d:e6:fa:08:b5:84:d8:ac:5d:b1:13:1a:f1:6a:98:
+    7d:18:0d:ad:f4:fe:2a:43:f4:5a:1e:3e:45:63:ea:
+    f8:38:dd:9e:b3:3c:1f:7c:61:c0:ee:d2:5a:ca:7f:
+    e7:b1:04:ef:72:ae:5a:16:63:ea:cb:1c:c3:50:be:
+    d8:b0:fb:3d:83:ad:71:f5
 exponent2:
-    00:81:96:5e:a5:5c:48:ef:aa:10:0d:b5:cd:94:3a:
-    ed:a5:29:ea:11:72:17:1e:23:e4:21:cd:ea:cf:0f:
-    7c:12:3b:a2:1c:67:ab:1a:cc:48:e4:83:7e:3b:bd:
-    a6:14:58:86:b7:a3:09:87:27:98:5c:c4:cf:72:03:
-    81:a3:bc:2c:61
+    69:f2:f9:7c:6b:44:94:42:14:08:cc:e6:0b:42:bd:
+    cc:70:80:4f:6b:af:75:7e:f5:ce:55:d0:a1:1f:43:
+    9f:3d:82:92:e7:45:31:50:41:ee:b7:fd:0d:c8:1e:
+    f4:8c:5b:78:7f:26:02:59:51:43:6a:51:56:11:e6:
+    4b:0e:cb:b8:db:b9:b9:42:71:7c:85:26:9c:f1:42:
+    4d:d1:32:9a:0e:67:3e:20:f5:81:21:36:3a:be:67:
+    6c:3a:f2:5a:38:bf:d6:04:62:bc:f7:f6:f6:25:81:
+    52:b8:60:d8:f9:42:47:35:33:c9:96:c8:95:a3:bf:
+    86:ae:f6:95:d4:65:86:25
 coefficient:
-    7d:b4:b6:78:c7:d3:0c:44:6f:a2:aa:83:8a:79:65:
-    69:24:b2:31:ac:59:ed:6c:bf:4c:1a:1a:27:f0:c8:
-    e9:38:ff:84:50:df:b5:10:c2:6e:4b:5c:c2:4c:c9:
-    82:2a:db:0a:6f:59:dd:12:93:8c:c1:9d:57:f3:dd:
-    66:41:9a:e0
+    28:91:92:b0:3c:bb:1c:58:e9:95:6c:70:fb:66:1d:
+    19:b5:eb:ca:17:83:b9:b6:90:83:9f:18:e4:f2:69:
+    72:e8:20:17:30:0f:dc:9c:4b:8a:9a:38:53:e1:c6:
+    01:ff:bc:1b:2b:22:84:95:48:6f:9e:01:8e:6b:b6:
+    50:f8:42:9d:76:67:e8:34:86:2d:b8:66:32:9d:01:
+    8e:3a:a4:1d:3c:9a:02:85:a5:1d:74:ef:8d:6a:d2:
+    2f:61:2c:e9:17:02:d7:22:9c:ee:8e:4c:cb:de:76:
+    6d:c2:1c:17:af:a3:3c:6a:f2:6a:6a:9c:b5:fb:9b:
+    2f:1e:c9:15:29:97:d2:3d
 -----BEGIN RSA PRIVATE KEY-----
-MIICXAIBAAKBgQDvvCxH+hItCe8WlpCLhEXHhvFej1hZI4ffoeO+jC+tcJYa9Wd/
-XJxUXoLeBX+PncnzJHI5Txy0puDQGa+95Cllu9dDPmbTT3QFC4rk1VIIr5v09H1s
-kl/Mu8ItytASKOXI/fYJkN2F+YXZN6b+g8ck5K8o4/9aG3JfKcY5iFtIGQIDAQAB
-AoGAdRE7wm4wYAQA19Pwg+C0vol75oQzTVwXZrJEZ3FHeveGpWV/A+eyg1SfrVGc
-CAKycmQyzx990g3HrHdOpXj8aTqIEluBgRnJH52q+jUuzd9x7lD5WVOZUiL3SLoX
-T0e1chZH0R0xKUeAseE84KBL7wXF6gqyx0q50wbAt3sKLoECQQD6zLC6ngbF92MJ
-N+efqk348bR/qsaKBBaTc6+6H+OXdhGpTftCi/BRCn1safov2HutIHneceri4KNp
-Gx7jbJvpAkEA9LS/z1ag+pQVXCScRf1UMXJ1e+/V3ltkyWqIQuAN8GPCRp5Zgb5g
-7gUBsN3kEtBbd3bAW/IhDFtCr/XCW8YcsQJAFdAfvttns2gk0PRvzM8/INvE2yW7
-Rt28KO7y5blITjASsSr7I3qQWDwVVIyTGf42I4SjlNlLmJf5HnchZJ5ZoQJBAIGW
-XqVcSO+qEA21zZQ67aUp6hFyFx4j5CHN6s8PfBI7ohxnqxrMSOSDfju9phRYhrej
-CYcnmFzEz3IDgaO8LGECQH20tnjH0wxEb6Kqg4p5ZWkksjGsWe1sv0waGifwyOk4
-/4RQ37UQwm5LXMJMyYIq2wpvWd0Sk4zBnVfz3WZBmuA=
+MIIEowIBAAKCAQEA25DXz/6BvFHRodLZD8IhFgY9Eod86UWXKPQzElHSszG+E10o
+qLX7jw7OPrtCej+6NelYKvthOMBrN58/3rlkW8MIIWTXwq8KrCEL7cGKcf4FJ+tL
+Mbp5YuVB791mhXYouwMIxzUmhcL4Ox9nRTlzzthd30oLToyFKQKYBJXp0/bRn2wl
+zqOBTMdNtc5DEtmy8WjI/aNXFvV6QoX+GbXu6D/aJ4WCyezWY7/NS3UeoMWPzpC4
+yiW6RVJt5Opt5R1Bjk8zSpcjjsGY1GCnHhwoMQ0FyKLS13rZw0YmoefvZ+drzpeK
+NwvX4iiwM4WwiWs4g66jAqfSGofwiKajGtuXUwIDAQABAoIBAQCddJOvjx5OhIZG
+/EO5L0g22SZ24T7MsqEiN21gl9j3tJZQoKAFzOunvcBd8EBOFuFcxAf8WuVvo13A
+N62/9UdpHsX33K91571JjzFUwVSdRsM/y1bTRJzENRBCCY3567Bt3FExOoZzqkwF
+ahHO7NKF5Vf8Rscw/0iHDlsh/rf+zk+MLM/q0QxZg37UP9sMCY2Nr8U4jZZEN3yj
+T3kJ/hHLzyBAbP2jzNny9DV5Y8P4HMFu1HYrZ4RN06+Bche6nZgMWArITY8olSv6
+2TEdMa3Fh5AbLGlCIrEbc0oigq+3W4K0ODk78kfvPX0Jm+hbtdhWHBbnOm59hT8c
+HT/u3fHRAoGBAPIM/pm17bsk9nlhdfWom1b58+5bhBwxAF4BArRQ6vuoEyJzwhIb
+wlNVFPMuo2L4ggRMIwlQmMGrRRiWx6ToKYQEqyQ3F0ULswJ/w0owP61pSQtJxYng
+B7ez11AZhcDxc2C0dvjCxQF8CSNJVyrM1+HW2bRrVCBhfzpwm50BEvrnAoGBAOg4
+H/sb9k3hvvCAwaFVK9HbCZjMcOuZ8J4LLC1gIJb3s8VrmCLFv8MgXpG+0YH8FDZw
+mzeebchuhPb6ZTBkDrBQBYWoBwu+Tt7BF3E5A+OeTmlcUQKvl7gw2pUuJLR4dka8
+26InZlrO5Q8Bgv7LMbz+GWrlc7alrTrzYez3qf61AoGABF2TofYUCZILF/lYBUw7
+MQBlE+F2qoN/vDJMeDAVbOCFJ9PqpiT2Bka8j/5BWCGfRrCQ2TQo7SVHo7/kbeb6
+CLWE2KxdsRMa8WqYfRgNrfT+KkP0Wh4+RWPq+DjdnrM8H3xhwO7SWsp/57EE73Ku
+WhZj6sscw1C+2LD7PYOtcfUCgYBp8vl8a0SUQhQIzOYLQr3McIBPa691fvXOVdCh
+H0OfPYKS50UxUEHut/0NyB70jFt4fyYCWVFDalFWEeZLDsu427m5QnF8hSac8UJN
+0TKaDmc+IPWBITY6vmdsOvJaOL/WBGK89/b2JYFSuGDY+UJHNTPJlsiVo7+GrvaV
+1GWGJQKBgCiRkrA8uxxY6ZVscPtmHRm168oXg7m2kIOfGOTyaXLoIBcwD9ycS4qa
+OFPhxgH/vBsrIoSVSG+eAY5rtlD4Qp12Z+g0hi24ZjKdAY46pB08mgKFpR10741q
+0i9hLOkXAtcinO6OTMvedm3CHBevozxq8mpqnLX7my8eyRUpl9I9
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/signed.pem
+++ b/spec/fixtures/ssl/signed.pem
@@ -1,44 +1,66 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 2 (0x2)
-    Signature Algorithm: sha256WithRSAEncryption
+        Serial Number: 4 (0x4)
+        Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA Subauthority
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Apr 19 22:31:22 2029 GMT
+            Not After : Apr 18 18:46:23 2031 GMT
         Subject: CN=signed
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                Public-Key: (1024 bit)
+                RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:ef:bc:2c:47:fa:12:2d:09:ef:16:96:90:8b:84:
-                    45:c7:86:f1:5e:8f:58:59:23:87:df:a1:e3:be:8c:
-                    2f:ad:70:96:1a:f5:67:7f:5c:9c:54:5e:82:de:05:
-                    7f:8f:9d:c9:f3:24:72:39:4f:1c:b4:a6:e0:d0:19:
-                    af:bd:e4:29:65:bb:d7:43:3e:66:d3:4f:74:05:0b:
-                    8a:e4:d5:52:08:af:9b:f4:f4:7d:6c:92:5f:cc:bb:
-                    c2:2d:ca:d0:12:28:e5:c8:fd:f6:09:90:dd:85:f9:
-                    85:d9:37:a6:fe:83:c7:24:e4:af:28:e3:ff:5a:1b:
-                    72:5f:29:c6:39:88:5b:48:19
+                    00:db:90:d7:cf:fe:81:bc:51:d1:a1:d2:d9:0f:c2:
+                    21:16:06:3d:12:87:7c:e9:45:97:28:f4:33:12:51:
+                    d2:b3:31:be:13:5d:28:a8:b5:fb:8f:0e:ce:3e:bb:
+                    42:7a:3f:ba:35:e9:58:2a:fb:61:38:c0:6b:37:9f:
+                    3f:de:b9:64:5b:c3:08:21:64:d7:c2:af:0a:ac:21:
+                    0b:ed:c1:8a:71:fe:05:27:eb:4b:31:ba:79:62:e5:
+                    41:ef:dd:66:85:76:28:bb:03:08:c7:35:26:85:c2:
+                    f8:3b:1f:67:45:39:73:ce:d8:5d:df:4a:0b:4e:8c:
+                    85:29:02:98:04:95:e9:d3:f6:d1:9f:6c:25:ce:a3:
+                    81:4c:c7:4d:b5:ce:43:12:d9:b2:f1:68:c8:fd:a3:
+                    57:16:f5:7a:42:85:fe:19:b5:ee:e8:3f:da:27:85:
+                    82:c9:ec:d6:63:bf:cd:4b:75:1e:a0:c5:8f:ce:90:
+                    b8:ca:25:ba:45:52:6d:e4:ea:6d:e5:1d:41:8e:4f:
+                    33:4a:97:23:8e:c1:98:d4:60:a7:1e:1c:28:31:0d:
+                    05:c8:a2:d2:d7:7a:d9:c3:46:26:a1:e7:ef:67:e7:
+                    6b:ce:97:8a:37:0b:d7:e2:28:b0:33:85:b0:89:6b:
+                    38:83:ae:a3:02:a7:d2:1a:87:f0:88:a6:a3:1a:db:
+                    97:53
                 Exponent: 65537 (0x10001)
     Signature Algorithm: sha256WithRSAEncryption
-         15:6b:ed:44:0d:41:6e:10:98:10:34:d6:c0:f8:18:38:2f:13:
-         20:19:12:54:53:9f:7c:29:50:93:0a:15:7d:50:0a:95:a0:ce:
-         e4:4f:a7:8a:d1:f6:b2:86:44:33:07:d3:1b:28:37:9d:71:21:
-         90:fe:41:06:ab:79:5a:5f:7c:bf:dc:83:8a:64:63:8b:04:81:
-         33:7e:0f:94:4a:54:7c:58:5c:68:60:b3:25:03:1d:6c:d3:f1:
-         d0:97:e0:8d:ac:75:37:76:0c:11:6c:81:fe:72:3a:90:80:c8:
-         32:c0:89:f9:6b:b9:9c:1d:06:64:42:4e:18:86:06:e2:7d:ed:
-         93:ec
+         53:37:9e:35:1c:d7:55:72:4c:2f:1b:47:52:0a:cf:ca:39:8f:
+         c7:4d:8e:07:89:7e:cd:f8:9d:44:f5:81:a6:de:89:1a:c0:4d:
+         d7:bd:92:da:84:3b:e3:47:ac:11:c3:98:65:08:65:bf:b8:9b:
+         2f:24:c1:73:2e:55:03:fc:79:c9:91:07:34:15:1e:14:ec:60:
+         5f:d1:82:7a:35:aa:06:74:59:48:35:b6:cd:05:b7:2f:4d:f0:
+         08:c3:06:3b:cd:52:02:2e:b6:a4:b8:41:26:b3:49:85:85:e8:
+         eb:c0:9e:3d:94:16:3b:23:93:b7:3e:32:d2:f6:7f:8d:30:fd:
+         c2:f8:7c:3b:b1:62:c6:a4:dc:4b:d2:5c:b2:4c:83:7e:b5:dc:
+         75:bf:36:d3:1b:f2:ab:37:2d:6b:30:8a:fc:c1:d8:e3:32:a2:
+         4a:d1:bc:2d:9b:a4:91:62:cd:06:b6:8c:5d:51:89:21:87:61:
+         02:d4:b8:41:6e:80:e5:3e:3b:2e:47:df:fc:2a:35:19:00:36:
+         28:ba:ef:8c:00:4d:38:0e:f9:1a:a5:a9:d0:9b:ec:66:5a:54:
+         40:f8:39:bc:32:f4:55:a7:9e:93:82:90:0a:8c:cf:51:76:a9:
+         fb:03:1d:9e:eb:92:90:b2:bd:a5:2a:98:a2:23:a0:ac:5d:f0:
+         34:e3:e3:2a
 -----BEGIN CERTIFICATE-----
-MIIBpDCCAQ2gAwIBAgIBAjANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0
-IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0yOTA0MTkyMjMxMjJa
-MBExDzANBgNVBAMMBnNpZ25lZDCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA
-77wsR/oSLQnvFpaQi4RFx4bxXo9YWSOH36HjvowvrXCWGvVnf1ycVF6C3gV/j53J
-8yRyOU8ctKbg0BmvveQpZbvXQz5m0090BQuK5NVSCK+b9PR9bJJfzLvCLcrQEijl
-yP32CZDdhfmF2Tem/oPHJOSvKOP/WhtyXynGOYhbSBkCAwEAATANBgkqhkiG9w0B
-AQsFAAOBgQAVa+1EDUFuEJgQNNbA+Bg4LxMgGRJUU598KVCTChV9UAqVoM7kT6eK
-0fayhkQzB9MbKDedcSGQ/kEGq3laX3y/3IOKZGOLBIEzfg+USlR8WFxoYLMlAx1s
-0/HQl+CNrHU3dgwRbIH+cjqQgMgywIn5a7mcHQZkQk4Yhgbife2T7A==
+MIICqTCCAZGgAwIBAgIBBDANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0
+IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zMTA0MTgxODQ2MjNa
+MBExDzANBgNVBAMMBnNpZ25lZDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC
+ggEBANuQ18/+gbxR0aHS2Q/CIRYGPRKHfOlFlyj0MxJR0rMxvhNdKKi1+48Ozj67
+Qno/ujXpWCr7YTjAazefP965ZFvDCCFk18KvCqwhC+3BinH+BSfrSzG6eWLlQe/d
+ZoV2KLsDCMc1JoXC+DsfZ0U5c87YXd9KC06MhSkCmASV6dP20Z9sJc6jgUzHTbXO
+QxLZsvFoyP2jVxb1ekKF/hm17ug/2ieFgsns1mO/zUt1HqDFj86QuMolukVSbeTq
+beUdQY5PM0qXI47BmNRgpx4cKDENBcii0td62cNGJqHn72fna86XijcL1+IosDOF
+sIlrOIOuowKn0hqH8Iimoxrbl1MCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAUzee
+NRzXVXJMLxtHUgrPyjmPx02OB4l+zfidRPWBpt6JGsBN172S2oQ740esEcOYZQhl
+v7ibLyTBcy5VA/x5yZEHNBUeFOxgX9GCejWqBnRZSDW2zQW3L03wCMMGO81SAi62
+pLhBJrNJhYXo68CePZQWOyOTtz4y0vZ/jTD9wvh8O7FixqTcS9JcskyDfrXcdb82
+0xvyqzctazCK/MHY4zKiStG8LZukkWLNBraMXVGJIYdhAtS4QW6A5T47Lkff/Co1
+GQA2KLrvjABNOA75GqWp0JvsZlpUQPg5vDL0Vaeek4KQCozPUXap+wMdnuuSkLK9
+pSqYoiOgrF3wNOPjKg==
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/tampered-cert.pem
+++ b/spec/fixtures/ssl/tampered-cert.pem
@@ -1,44 +1,66 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 9 (0x9)
-    Signature Algorithm: sha256WithRSAEncryption
+        Serial Number: 11 (0xb)
+        Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA Subauthority
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Apr 19 22:31:22 2029 GMT
+            Not After : Apr 18 18:46:23 2031 GMT
         Subject: CN=signed
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                Public-Key: (1024 bit)
+                RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:a9:7c:f9:23:fa:ff:7d:12:60:1a:04:d0:80:0c:
-                    41:97:e0:5a:d0:b6:83:ce:1c:f1:8f:43:86:94:60:
-                    80:7d:fe:13:42:36:81:b4:31:33:01:89:0d:6d:ea:
-                    70:76:2d:6d:73:1c:24:95:48:55:62:2d:b4:99:b2:
-                    d7:6c:ea:cc:88:5e:69:83:79:01:99:59:0d:fe:93:
-                    9c:9c:5c:77:33:29:28:98:74:75:1b:f4:9b:8d:f4:
-                    42:83:55:69:b5:2b:1c:38:89:1b:c0:ba:0c:16:0c:
-                    e3:3f:8c:83:bc:ac:31:22:aa:47:03:85:c3:1b:3e:
-                    45:1b:ab:2b:3f:3c:80:c0:61
+                    00:cb:ce:cb:7b:df:9b:4a:d7:f5:72:a6:a7:a0:04:
+                    d9:8b:16:b9:47:9f:50:27:d8:0a:bf:cb:47:d3:54:
+                    ae:bc:68:54:78:cf:fb:cd:2f:ae:b0:9b:48:c1:9f:
+                    3b:87:d6:86:ad:99:fb:ff:4a:dd:2f:cc:3a:bc:6f:
+                    bd:02:65:6f:87:de:f6:9b:8b:96:1a:2c:4d:30:89:
+                    8b:e4:87:56:b0:5b:83:d7:98:5a:b9:9c:77:15:75:
+                    50:ed:7d:07:fe:2b:83:3d:43:13:6f:fd:78:71:d1:
+                    e6:47:52:8e:b8:d1:ac:88:f4:d9:76:3e:b1:df:d9:
+                    0c:de:5f:a8:21:51:62:35:d0:00:d0:a8:72:73:f3:
+                    b0:8b:c6:94:fe:b2:11:96:d3:de:ba:11:9f:69:1f:
+                    15:e5:2f:8c:ce:8c:aa:ec:7d:f3:57:d6:db:9e:f8:
+                    5f:1f:43:e2:42:1b:31:a5:46:e3:ac:c0:f8:4f:e1:
+                    6a:f5:39:2e:d3:1a:a4:3b:36:72:f5:9f:eb:33:cb:
+                    3d:8a:26:aa:92:ca:67:83:9d:40:b1:10:3c:be:15:
+                    1c:7a:49:74:b8:48:0c:55:e3:8c:ce:25:e3:c4:65:
+                    3f:cb:f9:fa:09:b7:2f:c7:6e:b5:ba:35:56:b2:92:
+                    7a:be:69:1b:aa:08:31:24:80:f1:68:6d:76:b1:d0:
+                    5b:83
                 Exponent: 65537 (0x10001)
     Signature Algorithm: sha256WithRSAEncryption
-         9f:61:e2:9b:06:b2:84:67:53:c3:da:72:3e:d6:46:d8:37:8a:
-         a1:2e:72:5f:cf:1d:cf:75:63:da:ad:0b:50:3a:71:e0:70:66:
-         23:0e:54:5d:5a:af:4e:58:20:c5:64:0c:ec:e7:ed:f8:7a:c1:
-         be:cd:fc:8d:cb:24:10:47:24:1f:b1:79:98:40:cc:37:00:15:
-         ab:7b:0b:80:89:3a:e5:e5:d5:98:d5:12:3f:a6:ac:37:7b:30:
-         1b:1b:d0:3b:72:c0:51:f7:50:e9:a1:bf:d5:06:f9:c1:c1:d7:
-         30:c4:0e:38:73:4d:06:de:52:42:cf:d1:6d:04:d0:2b:94:ef:
-         95:ff
+         78:3c:51:49:d1:81:dd:c9:e0:14:bf:ff:86:44:5b:b6:50:a5:
+         ca:8e:27:cc:2a:2d:1e:97:2b:6a:de:04:e7:f6:b3:d1:61:bb:
+         63:c9:2b:60:0e:ec:f6:bd:7f:84:77:85:62:b8:b8:bf:a0:63:
+         85:56:b5:8b:7b:8a:01:f5:31:f2:5d:82:df:ef:2b:69:a5:bd:
+         c0:d8:61:7f:28:e9:cb:7f:18:af:77:8e:af:f3:53:dd:bc:aa:
+         cb:74:8f:e8:f2:26:e7:d9:8b:bc:de:58:b6:b8:da:e2:1d:03:
+         ca:7a:3e:b0:1c:9d:05:9c:04:11:84:94:f4:df:36:04:61:8d:
+         88:f7:ce:3d:9a:96:7c:1b:10:d3:85:e5:84:ab:59:b1:b6:5b:
+         96:7e:93:c6:fb:87:a4:00:c1:8a:e3:6b:47:4b:fd:c1:4e:1a:
+         1c:f7:73:e3:69:eb:4a:71:c9:7a:11:4a:ec:3a:d0:d2:fc:a4:
+         41:38:27:cd:51:92:8c:1a:c4:a3:61:21:eb:e1:24:5d:5b:08:
+         da:6c:0d:04:37:c3:7c:26:fd:22:c1:38:ff:d9:1e:01:f6:a2:
+         8a:37:de:bb:e2:59:6e:2d:40:e2:81:83:3a:2e:6d:1b:99:be:
+         1e:4b:4f:f8:c1:ee:97:81:59:39:b8:6a:3b:aa:99:5f:2c:86:
+         65:47:bc:10
 -----BEGIN CERTIFICATE-----
-MIIBpDCCAQ2gAwIBAgIBCTANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0
-IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0yOTA0MTkyMjMxMjJa
-MBExDzANBgNVBAMMBnNpZ25lZDCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA
-qXz5I/r/fRJgGgTQgAxBl+Ba0LaDzhzxj0OGlGCAff4TQjaBtDEzAYkNbepwdi1t
-cxwklUhVYi20mbLXbOrMiF5pg3kBmVkN/pOcnFx3MykomHR1G/SbjfRCg1VptSsc
-OIkbwLoMFgzjP4yDvKwxIqpHA4XDGz5FG6srPzyAwGECAwEAATANBgkqhkiG9w0B
-AQsFAAOBgQCfYeKbBrKEZ1PD2nI+1kbYN4qhLnJfzx3PdWParQtQOnHgcGYjDlRd
-Wq9OWCDFZAzs5+34esG+zfyNyyQQRyQfsXmYQMw3ABWrewuAiTrl5dWY1RI/pqw3
-ezAbG9A7csBR91Dpob/VBvnBwdcwxA44c00G3lJCz9FtBNArlO+V/w==
+MIICqTCCAZGgAwIBAgIBCzANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0
+IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zMTA0MTgxODQ2MjNa
+MBExDzANBgNVBAMMBnNpZ25lZDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC
+ggEBAMvOy3vfm0rX9XKmp6AE2YsWuUefUCfYCr/LR9NUrrxoVHjP+80vrrCbSMGf
+O4fWhq2Z+/9K3S/MOrxvvQJlb4fe9puLlhosTTCJi+SHVrBbg9eYWrmcdxV1UO19
+B/4rgz1DE2/9eHHR5kdSjrjRrIj02XY+sd/ZDN5fqCFRYjXQANCocnPzsIvGlP6y
+EZbT3roRn2kfFeUvjM6Mqux981fW2574Xx9D4kIbMaVG46zA+E/havU5LtMapDs2
+cvWf6zPLPYomqpLKZ4OdQLEQPL4VHHpJdLhIDFXjjM4l48RlP8v5+gm3L8dutbo1
+VrKSer5pG6oIMSSA8WhtdrHQW4MCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAeDxR
+SdGB3cngFL//hkRbtlClyo4nzCotHpcrat4E5/az0WG7Y8krYA7s9r1/hHeFYri4
+v6BjhVa1i3uKAfUx8l2C3+8raaW9wNhhfyjpy38Yr3eOr/NT3byqy3SP6PIm59mL
+vN5Ytrja4h0Dyno+sBydBZwEEYSU9N82BGGNiPfOPZqWfBsQ04XlhKtZsbZbln6T
+xvuHpADBiuNrR0v9wU4aHPdz42nrSnHJehFK7DrQ0vykQTgnzVGSjBrEo2Eh6+Ek
+XVsI2mwNBDfDfCb9IsE4/9keAfaiijfeu+JZbi1A4oGDOi5tG5m+HktP+MHul4FZ
+ObhqO6qZXyyGZUe8EA==
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/tampered-csr.pem
+++ b/spec/fixtures/ssl/tampered-csr.pem
@@ -4,36 +4,57 @@ Certificate Request:
         Subject: CN=signed
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                Public-Key: (1024 bit)
+                RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:e9:53:65:ee:3a:eb:2d:ab:c3:23:22:68:70:25:
-                    e8:c3:d9:1a:c6:42:82:79:98:38:75:65:39:7b:b8:
-                    67:ba:ae:5b:f0:61:05:c5:a5:ff:b2:63:b3:ce:50:
-                    30:84:61:44:ab:18:e1:85:19:c1:fa:01:a5:79:00:
-                    b7:ab:99:e5:36:7f:37:6e:c9:9e:f2:98:2a:a1:54:
-                    eb:b0:20:37:b6:97:08:62:bc:27:31:b2:af:da:59:
-                    47:e9:92:f3:ee:40:2a:75:fe:ef:ba:3a:22:70:65:
-                    32:be:4b:fb:bd:75:87:5c:3f:2f:03:cd:b6:e4:3e:
-                    4e:af:a3:f4:2a:30:17:99:6d
+                    00:a8:3e:27:31:e2:33:8e:51:90:06:55:5b:ee:bc:
+                    8b:a2:b3:53:74:7d:06:6d:43:cf:12:57:46:fc:56:
+                    79:f0:cd:af:d1:dc:19:b3:3c:54:39:85:b4:6a:1e:
+                    a3:0f:f4:ee:e7:8f:1c:c9:99:79:5d:92:b5:7e:a6:
+                    49:1a:ec:e5:f4:12:8e:6d:57:9a:86:29:b2:38:42:
+                    1e:a9:c7:73:b1:a9:e3:9c:fc:5c:f9:51:a5:47:ce:
+                    45:af:21:20:d8:45:40:fe:a2:bf:5e:77:34:eb:6f:
+                    17:bc:fd:06:33:2a:6f:64:6c:61:03:76:ad:dd:e4:
+                    11:02:3f:48:b2:39:94:cc:da:30:41:36:8e:be:24:
+                    74:b2:45:60:ba:59:0e:b5:1d:fd:0f:e8:97:47:61:
+                    c4:9d:88:ef:09:69:01:d7:7e:cd:1b:ad:ff:d2:19:
+                    7d:c8:35:cf:72:55:cd:1e:68:58:8a:b2:78:9c:76:
+                    b2:2c:8e:34:3d:91:9c:c2:d8:fd:21:b3:bd:72:43:
+                    85:dd:6e:4e:0a:47:92:0f:e4:f9:e6:43:20:f6:25:
+                    22:7e:e3:94:70:a8:02:2e:f6:0b:e1:2d:22:bf:94:
+                    00:4e:31:23:83:79:00:70:28:a0:b6:32:1b:ee:c8:
+                    d4:ff:16:d7:1a:17:41:38:c0:5c:ed:18:de:d7:1a:
+                    f4:01
                 Exponent: 65537 (0x10001)
         Attributes:
             a0:00
     Signature Algorithm: sha256WithRSAEncryption
-         89:dd:58:fe:dc:45:c2:52:a1:58:16:e3:59:a1:45:ab:5b:1c:
-         ae:a6:ca:63:f2:95:82:41:09:71:68:26:b3:6d:20:03:9c:c5:
-         f3:23:54:b9:a2:8a:66:3f:68:a7:c2:4a:16:81:3d:93:c5:c4:
-         10:2c:1d:20:59:9d:7c:b2:b1:1a:62:72:fd:4d:90:86:b7:8e:
-         ab:2e:05:b1:52:cb:4e:38:f0:85:e8:58:5f:64:a8:f4:5c:b3:
-         73:75:f5:bb:76:4f:93:c1:8c:e6:23:cf:e9:ff:c0:22:8f:a3:
-         09:a8:57:51:31:9b:7d:ef:97:b6:70:2e:90:d5:40:33:ca:37:
-         d3:b5
+         17:09:e2:b8:c6:d5:1e:44:60:86:bf:8b:7c:b9:7a:43:55:76:
+         38:32:fa:9d:ad:0a:6b:ea:56:9e:4d:45:5d:58:ae:08:93:20:
+         d6:79:99:20:7e:88:6a:bb:14:b6:62:a3:e1:2a:82:a6:2e:9d:
+         1a:9e:7a:86:36:d0:a6:b2:b6:43:24:7f:4f:b9:4a:e3:50:e4:
+         c6:d6:ac:85:ce:a8:e6:07:d1:44:b3:b8:e8:b4:54:79:68:4f:
+         36:29:b3:f8:e2:d0:05:40:d9:ca:05:6b:16:56:c9:6f:9f:63:
+         ff:99:fc:e0:69:b7:e3:cd:93:4c:1d:29:8c:23:40:bd:0b:eb:
+         fd:2d:88:fc:28:4e:77:76:6b:2c:85:ca:5c:61:31:9e:50:f0:
+         7e:41:ab:c3:5e:73:e5:1c:3e:03:52:5a:07:12:d9:b8:6d:5e:
+         af:f4:6a:5c:e6:f5:01:8a:66:6e:bc:4a:f0:fb:b3:0a:48:5a:
+         6d:e6:ef:aa:ea:22:12:6b:c5:70:28:ac:8e:57:9e:54:9a:27:
+         6a:37:d7:8f:d8:0e:7d:c8:38:1d:de:d6:e0:3a:c6:81:2d:f9:
+         bb:f4:ae:4e:ad:c2:b2:e3:90:8f:e0:24:98:b3:ea:ef:0d:95:
+         2e:3c:e3:65:b4:d8:e3:99:10:80:4f:35:61:df:7d:77:c3:4f:
+         ab:ff:5b:ed
 -----BEGIN CERTIFICATE REQUEST-----
-MIIBUDCBugIBAjARMQ8wDQYDVQQDDAZzaWduZWQwgZ8wDQYJKoZIhvcNAQEBBQAD
-gY0AMIGJAoGBAOlTZe466y2rwyMiaHAl6MPZGsZCgnmYOHVlOXu4Z7quW/BhBcWl
-/7Jjs85QMIRhRKsY4YUZwfoBpXkAt6uZ5TZ/N27JnvKYKqFU67AgN7aXCGK8JzGy
-r9pZR+mS8+5AKnX+77o6InBlMr5L+711h1w/LwPNtuQ+Tq+j9CowF5ltAgMBAAGg
-ADANBgkqhkiG9w0BAQsFAAOBgQCJ3Vj+3EXCUqFYFuNZoUWrWxyupspj8pWCQQlx
-aCazbSADnMXzI1S5oopmP2inwkoWgT2TxcQQLB0gWZ18srEaYnL9TZCGt46rLgWx
-UstOOPCF6FhfZKj0XLNzdfW7dk+TwYzmI8/p/8Aij6MJqFdRMZt975e2cC6Q1UAz
-yjfTtQ==
+MIICVjCCAT4CAQIwETEPMA0GA1UEAwwGc2lnbmVkMIIBIjANBgkqhkiG9w0BAQEF
+AAOCAQ8AMIIBCgKCAQEAqD4nMeIzjlGQBlVb7ryLorNTdH0GbUPPEldG/FZ58M2v
+0dwZszxUOYW0ah6jD/Tu548cyZl5XZK1fqZJGuzl9BKObVeahimyOEIeqcdzsanj
+nPxc+VGlR85FryEg2EVA/qK/Xnc0628XvP0GMypvZGxhA3at3eQRAj9IsjmUzNow
+QTaOviR0skVgulkOtR39D+iXR2HEnYjvCWkB137NG63/0hl9yDXPclXNHmhYirJ4
+nHayLI40PZGcwtj9IbO9ckOF3W5OCkeSD+T55kMg9iUifuOUcKgCLvYL4S0iv5QA
+TjEjg3kAcCigtjIb7sjU/xbXGhdBOMBc7Rje1xr0AQIDAQABoAAwDQYJKoZIhvcN
+AQELBQADggEBABcJ4rjG1R5EYIa/i3y5ekNVdjgy+p2tCmvqVp5NRV1YrgiTINZ5
+mSB+iGq7FLZio+EqgqYunRqeeoY20KaytkMkf0+5SuNQ5MbWrIXOqOYH0USzuOi0
+VHloTzYps/ji0AVA2coFaxZWyW+fY/+Z/OBpt+PNk0wdKYwjQL0L6/0tiPwoTnd2
+ayyFylxhMZ5Q8H5Bq8Nec+UcPgNSWgcS2bhtXq/0alzm9QGKZm68SvD7swpIWm3m
+76rqIhJrxXAorI5XnlSaJ2o314/YDn3IOB3e1uA6xoEt+bv0rk6twrLjkI/gJJiz
+6u8NlS4842W02OOZEIBPNWHffXfDT6v/W+0=
 -----END CERTIFICATE REQUEST-----

--- a/spec/fixtures/ssl/unknown-127.0.0.1-key.pem
+++ b/spec/fixtures/ssl/unknown-127.0.0.1-key.pem
@@ -1,67 +1,117 @@
-RSA Private-Key: (1024 bit, 2 primes)
+RSA Private-Key: (2048 bit, 2 primes)
 modulus:
-    00:c9:00:0c:66:d2:2d:df:a0:cc:4c:a5:7a:5b:67:
-    10:f1:d2:06:ac:01:0e:da:55:19:a3:dd:b7:85:9c:
-    f1:53:e6:a9:b4:c7:33:43:55:12:0e:e5:ec:cc:75:
-    28:e4:d2:36:2a:02:85:9e:a6:58:4e:f3:ba:91:83:
-    54:d2:b7:46:d4:00:b4:fc:86:9b:db:10:07:a7:8e:
-    47:e5:f0:27:1f:62:eb:94:68:37:c8:c4:d4:fc:ea:
-    0e:b0:94:5d:c3:5a:99:08:6c:f3:27:33:71:5a:47:
-    62:3e:df:18:10:d4:c0:08:2d:f1:47:6b:c1:19:46:
-    3e:32:2f:b4:57:91:50:4c:8f
+    00:c3:c8:2b:f4:88:83:50:13:f7:3d:f8:b6:b8:7b:
+    d0:58:7e:88:9c:a5:c2:30:72:36:9d:9a:d1:73:79:
+    c1:6d:06:3f:3b:f3:10:b6:87:3d:55:a4:e2:a9:c1:
+    48:d4:fd:30:8f:36:46:2f:96:bc:a5:e4:35:d9:89:
+    b2:8b:8b:90:ab:9a:b1:f9:ed:fa:67:3e:ea:27:42:
+    59:67:bb:69:18:e6:d7:0d:1a:0e:ad:c2:58:62:24:
+    05:6e:18:39:db:09:7d:96:a5:c9:c7:56:ba:68:e0:
+    06:27:37:15:e9:5c:f3:bf:b0:29:9b:0d:c7:ea:54:
+    a7:41:3f:11:11:db:23:3b:23:33:3e:c7:9c:d7:82:
+    99:23:df:c2:5a:4d:90:2f:73:64:92:bc:b8:f5:b5:
+    3f:56:e2:5d:95:e2:a8:3f:fa:ed:96:af:b8:3d:63:
+    fd:cd:24:2d:27:32:c8:41:7e:38:e8:02:3e:87:ce:
+    ab:f2:40:4d:a2:ec:42:ea:b5:14:ff:9d:ca:4b:d9:
+    de:84:4d:45:b7:d9:d9:56:7b:e3:7d:af:de:19:76:
+    91:cb:72:e9:b0:02:ca:8b:75:f8:54:23:ae:03:ab:
+    ec:48:ba:d6:c9:1a:0b:5b:7d:f9:f1:d7:9a:1a:83:
+    89:b9:f7:e7:ea:2c:11:2f:0f:c4:63:78:ff:5b:80:
+    be:0f
 publicExponent: 65537 (0x10001)
 privateExponent:
-    1b:d6:c2:e0:f6:d9:5d:b0:d2:bb:06:ec:54:7e:88:
-    ed:45:4e:a1:42:20:41:83:29:e2:f5:51:76:d3:0e:
-    e5:b4:fb:ea:4a:f0:c1:b1:a5:a7:a4:96:d0:96:a5:
-    8c:53:c5:26:ba:64:b1:5d:8e:bb:98:ac:4d:7d:28:
-    21:6b:3b:06:e1:0b:a8:3f:d4:1a:24:26:47:2f:cf:
-    cd:be:37:73:dd:b6:e1:7b:11:18:3b:80:ec:19:9c:
-    d0:d7:22:47:6b:01:e3:af:5c:89:8f:16:dc:b0:b4:
-    b1:ed:e2:c2:09:84:be:ae:e8:c8:31:df:83:7d:f3:
-    10:75:4f:3a:6c:72:59:f9
+    3e:63:47:3e:81:51:f6:ee:a5:d6:e5:ae:b4:53:20:
+    2d:53:05:0d:85:f4:bf:a3:65:ac:0b:6d:bb:32:8d:
+    64:c4:9c:d9:e9:b6:e5:b3:6a:e4:23:ca:e6:f5:64:
+    d4:1a:6a:a2:f8:54:9d:4d:97:87:f5:95:03:61:51:
+    b8:0e:1d:67:d1:bf:ed:38:dc:96:92:01:e3:c8:cc:
+    dc:b5:67:e4:3b:8b:43:ed:8d:c7:e9:2a:68:fb:b9:
+    8f:3f:c1:0f:ff:92:39:b3:52:fd:66:b1:b8:41:cb:
+    34:2b:e5:9b:9b:b7:40:da:4e:27:ce:d8:69:df:d7:
+    fc:7e:b0:5d:d4:4b:01:c8:c3:18:1f:fa:ac:46:45:
+    1f:3a:87:82:49:56:30:3a:6b:88:61:1c:62:a8:b4:
+    e9:c3:9b:ac:78:e4:86:f0:96:71:11:54:b5:0b:c7:
+    28:c0:0b:d0:b5:ce:9a:2e:db:e6:e4:75:52:1a:72:
+    09:6c:b4:5c:d0:ff:0e:87:ec:74:59:2b:21:12:39:
+    ce:d3:45:89:91:75:1a:4b:20:59:d3:bd:ba:92:78:
+    f8:58:c8:db:48:30:d6:43:72:24:4a:2d:de:18:09:
+    66:2c:27:eb:b9:ab:16:66:d0:85:6e:b5:d0:89:80:
+    95:fc:e1:7f:6e:c0:52:1b:15:d3:3c:4f:ce:81:b8:
+    a1
 prime1:
-    00:ee:90:d8:4e:14:a3:a1:c7:28:4d:73:de:44:b9:
-    36:fd:96:5c:68:4e:65:96:6e:c6:55:06:8e:c1:8d:
-    dc:f7:f6:92:39:bb:bd:29:cd:4a:d3:e5:97:bc:65:
-    f9:48:40:fd:06:f8:ce:33:0b:03:cc:00:ed:62:00:
-    29:e4:4b:f7:7d
+    00:e1:7c:e4:10:00:3d:05:88:93:5a:ca:02:58:6e:
+    71:08:7e:a6:5e:04:19:13:43:4f:8f:30:b7:9b:04:
+    07:8b:1a:ac:a6:d8:21:aa:4b:60:5b:29:ae:47:bb:
+    d1:c0:e2:13:bb:85:d1:c6:72:82:8a:8f:59:24:5c:
+    64:11:36:84:61:55:6b:7d:b7:1b:34:93:7f:c5:1a:
+    dc:99:10:b4:0d:6b:69:f7:d6:63:32:8a:c7:56:e3:
+    ea:36:60:2a:3c:83:98:e3:e7:99:22:c3:cd:93:80:
+    e9:72:a9:37:f8:b4:2a:5c:1c:17:0c:14:ae:4d:d3:
+    cc:63:bf:ec:53:be:95:28:83
 prime2:
-    00:d7:b0:6a:67:9e:17:13:16:68:93:4b:65:f3:c3:
-    cf:f0:61:ad:d5:7a:57:da:db:6f:ca:90:4f:f7:1b:
-    2f:d1:76:de:4a:73:18:25:6f:f2:78:70:97:9b:7f:
-    a3:83:64:8e:1b:f5:4f:d4:3b:4e:27:1b:e4:97:90:
-    07:8d:ea:49:fb
+    00:de:46:3d:58:07:8e:b7:61:d6:1a:9f:0a:d4:fb:
+    98:8c:c8:5f:74:26:42:01:95:74:6f:f5:05:f8:7e:
+    d1:56:cb:59:8a:3b:6d:9e:9e:5c:5a:af:31:40:bb:
+    0d:6e:18:da:9a:12:1f:5d:62:ba:b3:38:61:b2:26:
+    7a:43:86:58:85:85:71:6e:91:1e:02:14:22:64:e5:
+    13:9c:ef:a7:a1:a1:0d:96:70:fe:a3:23:a6:7d:23:
+    01:c6:45:69:f2:73:fd:2b:9b:5d:0e:63:b7:5f:c7:
+    23:d0:bb:52:11:e3:e1:6d:2b:5e:70:1a:eb:28:80:
+    24:a2:82:ab:dd:ef:5f:e6:85
 exponent1:
-    11:f9:a3:f2:ae:27:6e:27:1d:68:48:94:b4:c4:e7:
-    d9:cf:9c:82:d7:75:5c:12:58:ab:4b:65:32:3c:48:
-    2b:fe:ce:21:bf:7d:8f:4a:c2:9a:98:b0:08:27:fe:
-    d2:6c:e3:23:c5:57:74:0d:1e:6a:1e:9f:c4:44:92:
-    e3:7a:bd:d9
+    28:e9:93:2b:c0:0f:52:58:b4:7b:cd:99:5d:58:34:
+    94:18:fe:b0:a2:47:b6:72:09:16:6e:fd:71:57:ea:
+    d2:77:75:8a:14:3f:0f:79:fb:b2:ae:be:5b:6f:9d:
+    a0:44:a4:d5:ea:72:e4:71:d4:73:b5:8c:b4:07:3b:
+    74:d0:12:76:e2:9b:cd:44:92:e0:18:3f:1f:91:3f:
+    23:5a:9f:80:ab:d3:9f:4f:3b:d2:68:d1:c0:57:3c:
+    20:bf:94:0a:44:ca:51:d7:ac:b6:5d:16:88:c3:e4:
+    17:94:d2:7e:02:9a:88:f9:e3:c8:a2:5b:f9:ed:0a:
+    f1:b2:59:fb:db:e1:8e:67
 exponent2:
-    28:eb:ed:a4:2f:18:4d:a4:c8:be:79:65:a4:74:18:
-    35:91:32:bb:f7:f4:47:2f:ae:ec:0d:a9:3e:46:c8:
-    31:c3:8d:b5:2e:54:fc:75:5a:d9:82:f3:20:ab:7c:
-    c8:67:01:97:48:59:96:f8:91:81:56:07:6e:c2:02:
-    cc:e8:10:95
+    00:99:7a:bc:be:fd:30:f1:b5:6f:c6:a0:0d:35:b5:
+    a8:c7:85:50:4b:fe:62:d3:7f:24:90:6e:0b:3a:64:
+    2f:1e:94:79:76:76:c4:a1:a3:4d:b8:1c:82:90:e4:
+    d8:48:2e:87:3b:9d:c9:e4:8c:d8:c8:09:e5:83:c3:
+    07:e7:7a:6b:c3:7e:ba:2d:93:ac:b9:d8:b7:4b:1d:
+    d6:a6:25:e1:85:3c:95:0a:4d:69:b6:b2:56:32:d0:
+    2a:58:82:f3:be:43:93:0c:3a:52:4e:2e:52:9f:a2:
+    fd:3b:13:2d:7f:46:f0:10:96:c2:b5:fc:10:66:bd:
+    dd:0e:0d:d6:a8:ff:b2:23:95
 coefficient:
-    00:86:a8:b9:c6:24:d8:bc:eb:11:24:d5:e6:e7:17:
-    b4:a8:fc:3d:53:33:e5:a8:d0:f2:45:9d:aa:4e:0d:
-    14:46:cb:99:88:78:c9:ed:d2:9f:9f:dd:a3:81:71:
-    b6:ce:ff:df:06:3e:4c:bb:77:fa:bd:17:27:23:14:
-    4c:32:36:db:87
+    00:ba:b1:87:cb:c7:3d:32:91:59:87:c0:9b:2f:54:
+    d3:a1:ef:98:87:51:8e:2e:2f:6c:de:5c:cc:cb:b9:
+    29:b5:7e:7a:cc:75:d1:a0:91:55:c7:c5:ac:6f:ad:
+    bb:c7:58:76:ee:8d:b0:cb:40:fb:6c:b8:c4:ec:b6:
+    a8:24:c5:74:ea:b6:19:79:e8:da:71:0d:e4:ba:ab:
+    cc:8c:50:9d:51:91:ec:81:17:20:46:bf:e6:49:e0:
+    e8:8e:bd:ed:64:32:9e:66:67:92:3e:7f:c7:65:8d:
+    68:ae:b8:6f:e8:37:8a:ac:ec:d0:94:14:09:a7:a9:
+    90:47:d0:e7:bf:10:36:d7:91
 -----BEGIN RSA PRIVATE KEY-----
-MIICXAIBAAKBgQDJAAxm0i3foMxMpXpbZxDx0gasAQ7aVRmj3beFnPFT5qm0xzND
-VRIO5ezMdSjk0jYqAoWeplhO87qRg1TSt0bUALT8hpvbEAenjkfl8CcfYuuUaDfI
-xNT86g6wlF3DWpkIbPMnM3FaR2I+3xgQ1MAILfFHa8EZRj4yL7RXkVBMjwIDAQAB
-AoGAG9bC4PbZXbDSuwbsVH6I7UVOoUIgQYMp4vVRdtMO5bT76krwwbGlp6SW0Jal
-jFPFJrpksV2Ou5isTX0oIWs7BuELqD/UGiQmRy/Pzb43c9224XsRGDuA7Bmc0Nci
-R2sB469ciY8W3LC0se3iwgmEvq7oyDHfg33zEHVPOmxyWfkCQQDukNhOFKOhxyhN
-c95EuTb9llxoTmWWbsZVBo7Bjdz39pI5u70pzUrT5Ze8ZflIQP0G+M4zCwPMAO1i
-ACnkS/d9AkEA17BqZ54XExZok0tl88PP8GGt1XpX2ttvypBP9xsv0XbeSnMYJW/y
-eHCXm3+jg2SOG/VP1DtOJxvkl5AHjepJ+wJAEfmj8q4nbicdaEiUtMTn2c+cgtd1
-XBJYq0tlMjxIK/7OIb99j0rCmpiwCCf+0mzjI8VXdA0eah6fxESS43q92QJAKOvt
-pC8YTaTIvnllpHQYNZEyu/f0Ry+u7A2pPkbIMcONtS5U/HVa2YLzIKt8yGcBl0hZ
-lviRgVYHbsICzOgQlQJBAIaoucYk2LzrESTV5ucXtKj8PVMz5ajQ8kWdqk4NFEbL
-mYh4ye3Sn5/do4Fxts7/3wY+TLt3+r0XJyMUTDI224c=
+MIIEpAIBAAKCAQEAw8gr9IiDUBP3Pfi2uHvQWH6InKXCMHI2nZrRc3nBbQY/O/MQ
+toc9VaTiqcFI1P0wjzZGL5a8peQ12Ymyi4uQq5qx+e36Zz7qJ0JZZ7tpGObXDRoO
+rcJYYiQFbhg52wl9lqXJx1a6aOAGJzcV6Vzzv7Apmw3H6lSnQT8REdsjOyMzPsec
+14KZI9/CWk2QL3Nkkry49bU/VuJdleKoP/rtlq+4PWP9zSQtJzLIQX446AI+h86r
+8kBNouxC6rUU/53KS9nehE1Ft9nZVnvjfa/eGXaRy3LpsALKi3X4VCOuA6vsSLrW
+yRoLW3358deaGoOJuffn6iwRLw/EY3j/W4C+DwIDAQABAoIBAD5jRz6BUfbupdbl
+rrRTIC1TBQ2F9L+jZawLbbsyjWTEnNnptuWzauQjyub1ZNQaaqL4VJ1Nl4f1lQNh
+UbgOHWfRv+043JaSAePIzNy1Z+Q7i0PtjcfpKmj7uY8/wQ//kjmzUv1msbhByzQr
+5Zubt0DaTifO2Gnf1/x+sF3USwHIwxgf+qxGRR86h4JJVjA6a4hhHGKotOnDm6x4
+5IbwlnERVLULxyjAC9C1zpou2+bkdVIacglstFzQ/w6H7HRZKyESOc7TRYmRdRpL
+IFnTvbqSePhYyNtIMNZDciRKLd4YCWYsJ+u5qxZm0IVutdCJgJX84X9uwFIbFdM8
+T86BuKECgYEA4XzkEAA9BYiTWsoCWG5xCH6mXgQZE0NPjzC3mwQHixqsptghqktg
+WymuR7vRwOITu4XRxnKCio9ZJFxkETaEYVVrfbcbNJN/xRrcmRC0DWtp99ZjMorH
+VuPqNmAqPIOY4+eZIsPNk4Dpcqk3+LQqXBwXDBSuTdPMY7/sU76VKIMCgYEA3kY9
+WAeOt2HWGp8K1PuYjMhfdCZCAZV0b/UF+H7RVstZijttnp5cWq8xQLsNbhjamhIf
+XWK6szhhsiZ6Q4ZYhYVxbpEeAhQiZOUTnO+noaENlnD+oyOmfSMBxkVp8nP9K5td
+DmO3X8cj0LtSEePhbStecBrrKIAkooKr3e9f5oUCgYAo6ZMrwA9SWLR7zZldWDSU
+GP6woke2cgkWbv1xV+rSd3WKFD8Pefuyrr5bb52gRKTV6nLkcdRztYy0Bzt00BJ2
+4pvNRJLgGD8fkT8jWp+Aq9OfTzvSaNHAVzwgv5QKRMpR16y2XRaIw+QXlNJ+ApqI
++ePIolv57Qrxsln72+GOZwKBgQCZery+/TDxtW/GoA01tajHhVBL/mLTfySQbgs6
+ZC8elHl2dsSho024HIKQ5NhILoc7ncnkjNjICeWDwwfnemvDfrotk6y52LdLHdam
+JeGFPJUKTWm2slYy0CpYgvO+Q5MMOlJOLlKfov07Ey1/RvAQlsK1/BBmvd0ODdao
+/7IjlQKBgQC6sYfLxz0ykVmHwJsvVNOh75iHUY4uL2zeXMzLuSm1fnrMddGgkVXH
+xaxvrbvHWHbujbDLQPtsuMTstqgkxXTqthl56NpxDeS6q8yMUJ1RkeyBFyBGv+ZJ
+4OiOve1kMp5mZ5I+f8dljWiuuG/oN4qs7NCUFAmnqZBH0Oe/EDbXkQ==
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/unknown-127.0.0.1.pem
+++ b/spec/fixtures/ssl/unknown-127.0.0.1.pem
@@ -6,43 +6,64 @@ Certificate:
         Issuer: CN=Unknown CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Mar 10 06:54:16 2030 GMT
+            Not After : Apr 18 18:46:23 2031 GMT
         Subject: CN=127.0.0.1
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                RSA Public-Key: (1024 bit)
+                RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:c9:00:0c:66:d2:2d:df:a0:cc:4c:a5:7a:5b:67:
-                    10:f1:d2:06:ac:01:0e:da:55:19:a3:dd:b7:85:9c:
-                    f1:53:e6:a9:b4:c7:33:43:55:12:0e:e5:ec:cc:75:
-                    28:e4:d2:36:2a:02:85:9e:a6:58:4e:f3:ba:91:83:
-                    54:d2:b7:46:d4:00:b4:fc:86:9b:db:10:07:a7:8e:
-                    47:e5:f0:27:1f:62:eb:94:68:37:c8:c4:d4:fc:ea:
-                    0e:b0:94:5d:c3:5a:99:08:6c:f3:27:33:71:5a:47:
-                    62:3e:df:18:10:d4:c0:08:2d:f1:47:6b:c1:19:46:
-                    3e:32:2f:b4:57:91:50:4c:8f
+                    00:c3:c8:2b:f4:88:83:50:13:f7:3d:f8:b6:b8:7b:
+                    d0:58:7e:88:9c:a5:c2:30:72:36:9d:9a:d1:73:79:
+                    c1:6d:06:3f:3b:f3:10:b6:87:3d:55:a4:e2:a9:c1:
+                    48:d4:fd:30:8f:36:46:2f:96:bc:a5:e4:35:d9:89:
+                    b2:8b:8b:90:ab:9a:b1:f9:ed:fa:67:3e:ea:27:42:
+                    59:67:bb:69:18:e6:d7:0d:1a:0e:ad:c2:58:62:24:
+                    05:6e:18:39:db:09:7d:96:a5:c9:c7:56:ba:68:e0:
+                    06:27:37:15:e9:5c:f3:bf:b0:29:9b:0d:c7:ea:54:
+                    a7:41:3f:11:11:db:23:3b:23:33:3e:c7:9c:d7:82:
+                    99:23:df:c2:5a:4d:90:2f:73:64:92:bc:b8:f5:b5:
+                    3f:56:e2:5d:95:e2:a8:3f:fa:ed:96:af:b8:3d:63:
+                    fd:cd:24:2d:27:32:c8:41:7e:38:e8:02:3e:87:ce:
+                    ab:f2:40:4d:a2:ec:42:ea:b5:14:ff:9d:ca:4b:d9:
+                    de:84:4d:45:b7:d9:d9:56:7b:e3:7d:af:de:19:76:
+                    91:cb:72:e9:b0:02:ca:8b:75:f8:54:23:ae:03:ab:
+                    ec:48:ba:d6:c9:1a:0b:5b:7d:f9:f1:d7:9a:1a:83:
+                    89:b9:f7:e7:ea:2c:11:2f:0f:c4:63:78:ff:5b:80:
+                    be:0f
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Subject Alternative Name: 
                 DNS:127.0.0.1, DNS:127.0.0.2
     Signature Algorithm: sha256WithRSAEncryption
-         4a:a3:2e:2a:8f:6f:0e:5e:70:19:26:59:05:1d:59:3f:c5:39:
-         49:c4:cd:73:99:f2:08:8c:bc:fa:28:e4:33:38:f1:50:a3:0c:
-         8e:3b:a3:93:9e:37:5c:69:c0:d9:2d:f2:2e:31:d7:5a:61:d6:
-         91:22:6d:3c:1b:4f:c3:b6:57:13:5e:c9:5a:c8:6c:2e:bc:d6:
-         42:5b:f0:64:ec:7e:03:3c:f1:43:d9:f9:b7:f1:37:db:a5:0f:
-         b9:87:f5:4d:01:93:b4:a6:40:05:dc:ca:fd:31:5b:14:66:f0:
-         84:70:48:0c:b8:49:11:3d:f6:9e:aa:e7:b4:21:5b:e6:cc:67:
-         ca:d9
+         c5:f2:04:d3:b9:16:b1:fa:4a:2f:b8:0c:30:ef:ce:bd:2e:4f:
+         25:b6:aa:6f:c8:ae:1a:b4:e7:e6:86:51:28:34:53:ff:58:07:
+         68:d8:a0:ce:79:c7:2f:71:2c:55:1c:67:82:05:7d:f4:ce:d8:
+         b7:d7:71:67:03:e8:a2:38:34:16:83:8c:df:c3:27:80:e2:f9:
+         12:83:a0:49:e1:f3:5f:1d:c0:e2:68:91:77:f0:1d:a6:63:8b:
+         1d:96:ee:46:ec:41:cd:3c:55:63:a9:4b:5c:68:d6:44:67:47:
+         43:4a:21:8b:13:a2:10:06:5c:0f:1b:d5:e7:4d:b3:72:aa:bd:
+         cc:ac:e7:cf:8b:89:51:3c:d0:d3:0e:75:37:91:a0:e4:73:5b:
+         74:80:7d:64:a3:ee:4d:69:7d:97:15:35:1a:a9:a8:2a:f6:12:
+         d1:b7:73:ad:f1:ca:d9:9b:96:d6:66:ac:14:e5:88:2d:7e:ce:
+         20:61:94:4a:18:41:27:8e:2d:ad:45:d7:2e:ff:a8:d6:2c:a2:
+         01:54:28:16:15:84:5e:94:2d:56:a2:90:b3:31:40:3a:a8:04:
+         8d:42:55:45:10:7a:fe:19:4d:d9:b4:ef:95:2e:cf:6e:28:3f:
+         cb:12:7d:aa:34:96:60:b2:29:7e:6c:c3:bd:3b:f7:4c:6e:31:
+         25:60:b5:96
 -----BEGIN CERTIFICATE-----
-MIIBwjCCASugAwIBAgIBATANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDDApVbmtu
-b3duIENBMB4XDTcwMDEwMTAwMDAwMFoXDTMwMDMxMDA2NTQxNlowFDESMBAGA1UE
-AwwJMTI3LjAuMC4xMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDJAAxm0i3f
-oMxMpXpbZxDx0gasAQ7aVRmj3beFnPFT5qm0xzNDVRIO5ezMdSjk0jYqAoWeplhO
-87qRg1TSt0bUALT8hpvbEAenjkfl8CcfYuuUaDfIxNT86g6wlF3DWpkIbPMnM3Fa
-R2I+3xgQ1MAILfFHa8EZRj4yL7RXkVBMjwIDAQABoyMwITAfBgNVHREEGDAWggkx
-MjcuMC4wLjGCCTEyNy4wLjAuMjANBgkqhkiG9w0BAQsFAAOBgQBKoy4qj28OXnAZ
-JlkFHVk/xTlJxM1zmfIIjLz6KOQzOPFQowyOO6OTnjdcacDZLfIuMddaYdaRIm08
-G0/DtlcTXslayGwuvNZCW/Bk7H4DPPFD2fm38TfbpQ+5h/VNAZO0pkAF3Mr9MVsU
-ZvCEcEgMuEkRPfaeque0IVvmzGfK2Q==
+MIICxzCCAa+gAwIBAgIBATANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDDApVbmtu
+b3duIENBMB4XDTcwMDEwMTAwMDAwMFoXDTMxMDQxODE4NDYyM1owFDESMBAGA1UE
+AwwJMTI3LjAuMC4xMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAw8gr
+9IiDUBP3Pfi2uHvQWH6InKXCMHI2nZrRc3nBbQY/O/MQtoc9VaTiqcFI1P0wjzZG
+L5a8peQ12Ymyi4uQq5qx+e36Zz7qJ0JZZ7tpGObXDRoOrcJYYiQFbhg52wl9lqXJ
+x1a6aOAGJzcV6Vzzv7Apmw3H6lSnQT8REdsjOyMzPsec14KZI9/CWk2QL3Nkkry4
+9bU/VuJdleKoP/rtlq+4PWP9zSQtJzLIQX446AI+h86r8kBNouxC6rUU/53KS9ne
+hE1Ft9nZVnvjfa/eGXaRy3LpsALKi3X4VCOuA6vsSLrWyRoLW3358deaGoOJuffn
+6iwRLw/EY3j/W4C+DwIDAQABoyMwITAfBgNVHREEGDAWggkxMjcuMC4wLjGCCTEy
+Ny4wLjAuMjANBgkqhkiG9w0BAQsFAAOCAQEAxfIE07kWsfpKL7gMMO/OvS5PJbaq
+b8iuGrTn5oZRKDRT/1gHaNigznnHL3EsVRxnggV99M7Yt9dxZwPoojg0FoOM38Mn
+gOL5EoOgSeHzXx3A4miRd/AdpmOLHZbuRuxBzTxVY6lLXGjWRGdHQ0ohixOiEAZc
+DxvV502zcqq9zKznz4uJUTzQ0w51N5Gg5HNbdIB9ZKPuTWl9lxU1GqmoKvYS0bdz
+rfHK2ZuW1masFOWILX7OIGGUShhBJ44trUXXLv+o1iyiAVQoFhWEXpQtVqKQszFA
+OqgEjUJVRRB6/hlN2bTvlS7Pbig/yxJ9qjSWYLIpfmzDvTv3TG4xJWC1lg==
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/unknown-ca-key.pem
+++ b/spec/fixtures/ssl/unknown-ca-key.pem
@@ -1,67 +1,117 @@
-RSA Private-Key: (1024 bit, 2 primes)
+RSA Private-Key: (2048 bit, 2 primes)
 modulus:
-    00:c1:5e:5d:26:ae:73:17:5a:70:37:ac:42:25:ca:
-    05:10:86:17:23:6c:28:84:48:2a:4a:d4:b0:3a:2a:
-    d8:33:ae:58:67:6f:9b:4f:a6:b4:87:b1:ec:37:00:
-    69:8d:d5:cf:71:8a:96:e1:4a:f8:c8:81:36:f9:43:
-    ad:d8:d6:76:83:27:99:a4:48:17:c2:ef:9c:22:40:
-    4b:c6:58:21:88:e5:1d:37:79:4e:ba:31:e6:52:ec:
-    8c:23:ed:d6:ce:3b:58:ad:82:c7:ae:28:47:d4:e7:
-    cc:31:ac:78:c9:02:87:d0:b1:91:09:f6:1e:9a:c3:
-    4f:f6:5a:fe:a2:21:0e:c0:95
+    00:ea:16:4c:26:71:56:ac:35:bb:2b:f6:1b:18:58:
+    16:0f:1c:39:3f:4d:02:e4:b2:a7:8b:bd:fe:99:57:
+    f2:a5:a8:15:01:79:0d:1d:f6:d9:12:db:d5:26:a2:
+    f6:58:af:4b:2c:aa:46:7a:53:63:9f:1f:1a:9e:1c:
+    fc:9a:8e:20:c8:c8:c8:db:4d:50:8d:4e:19:83:a1:
+    9d:54:49:26:7b:3a:e0:77:1d:7d:88:01:80:46:32:
+    70:47:16:08:71:de:12:94:67:fd:71:1f:41:56:93:
+    15:91:68:bd:05:3b:67:96:1f:7a:4d:d5:1e:b6:ac:
+    41:1f:f0:ce:d3:2d:96:d9:7c:ad:cd:be:b3:32:66:
+    18:03:2c:83:98:f1:e8:96:6f:85:0f:e1:1f:93:d0:
+    f9:09:43:8c:b1:ea:43:26:32:a5:c6:d2:32:75:2d:
+    ed:72:9d:bf:3a:bb:f3:4e:d0:0c:ac:ba:6b:fd:7f:
+    66:d8:12:40:4e:49:e7:d4:ec:70:03:71:37:cb:5e:
+    cc:d3:4f:f3:d2:cc:e2:39:eb:79:6c:71:e5:d1:0e:
+    45:4c:7a:3d:6f:39:e8:16:e7:de:60:eb:01:e7:80:
+    4e:42:1d:1c:33:0a:eb:f9:10:2c:5c:ed:0c:58:0b:
+    8c:fd:6d:f4:19:49:8a:a2:81:ab:04:b0:cb:7a:61:
+    1f:d3
 publicExponent: 65537 (0x10001)
 privateExponent:
-    60:5b:b7:ab:98:ee:fd:4a:31:f5:6c:3f:a2:39:23:
-    80:f2:71:01:53:da:74:e0:c9:42:74:ee:44:6e:29:
-    42:c7:b4:82:06:d9:ac:3d:74:64:d2:42:d5:bd:bc:
-    db:d3:1a:06:88:7b:5b:55:52:d8:07:9b:ef:66:cc:
-    70:eb:9e:2e:2b:7e:c1:34:84:9a:83:34:b2:70:c6:
-    59:72:60:a0:f4:f5:d9:f2:76:ae:bf:7d:23:35:ee:
-    ad:b1:2d:c1:fe:05:7d:5b:7f:2c:da:87:ec:6e:b0:
-    a3:08:c9:bd:e5:30:a4:c2:6e:6e:50:c0:5e:31:f6:
-    33:ef:86:57:64:45:b7:c1
+    00:b5:87:11:0a:86:bd:d5:d1:dd:12:1c:49:aa:b9:
+    34:72:07:4b:05:a1:ac:ea:b8:f8:60:cf:b7:8e:26:
+    bb:8e:67:27:d2:fa:92:87:78:13:a2:22:43:cb:30:
+    78:a5:11:5a:d4:8a:3f:19:41:6d:71:c9:e7:14:52:
+    1a:39:a8:9a:17:da:4c:98:73:fe:51:76:0d:27:1c:
+    bf:2a:cb:87:41:ec:c8:80:d6:a7:b0:3e:a9:c0:c6:
+    00:77:bf:c8:50:b5:0b:e7:76:34:fd:f2:64:f2:c4:
+    20:e7:a0:37:64:c5:4a:71:0a:7c:07:bb:8b:93:d1:
+    44:b7:86:40:7d:57:4f:31:db:98:22:21:d5:f3:b0:
+    57:4e:f6:c9:a4:08:43:3d:d8:ce:59:aa:a7:1f:da:
+    93:40:11:cf:8c:14:9d:f3:10:9f:cf:0a:d0:cf:2b:
+    b6:ea:e5:3c:92:9f:c2:6f:24:86:71:15:61:49:7b:
+    77:48:c1:d2:13:67:1a:f7:c0:89:3d:3d:87:cf:6e:
+    5c:e4:46:28:fe:33:89:3c:09:fc:50:3c:b7:a9:25:
+    3c:f2:a5:a0:e1:e0:9c:d1:4a:3e:11:5b:10:1a:33:
+    29:c7:ca:0b:ac:bf:c2:be:90:27:1f:ef:d7:d2:ca:
+    5f:37:b3:b3:b9:3a:35:87:be:ca:c3:f7:59:03:f7:
+    7e:f1
 prime1:
-    00:e1:d6:07:8c:c6:4d:90:fa:d6:40:9a:1f:e5:34:
-    50:16:72:9f:5b:83:c1:60:d5:73:39:c2:c6:ec:3a:
-    ed:24:fe:aa:5d:16:14:ba:85:a4:7d:5a:94:e8:63:
-    f9:dd:25:a8:2c:6b:ca:7c:43:c7:a9:92:ae:35:5c:
-    85:47:9e:51:e9
+    00:f7:83:23:4b:6f:82:af:b6:7a:0f:1f:1a:05:21:
+    d1:a1:84:d1:07:24:db:dd:64:9f:16:84:eb:c4:bf:
+    ec:cf:2f:69:92:21:b8:88:05:24:8c:bc:c1:db:d0:
+    38:53:bf:43:dc:5b:5e:42:7b:ad:de:d6:3a:04:9e:
+    a5:a7:f0:0b:2e:4e:2a:20:6f:95:7d:f0:be:ff:12:
+    c6:f4:d2:ca:39:e1:a5:c9:34:58:3b:3d:40:c1:88:
+    63:c3:cc:87:02:25:70:88:58:df:ec:b6:d6:0c:9e:
+    15:2d:57:e1:34:e9:2e:ac:51:cf:c4:83:dd:b6:11:
+    44:23:b8:95:50:6c:40:ae:ed
 prime2:
-    00:db:32:2e:59:ea:22:83:ce:d3:d5:7b:cb:b9:81:
-    b9:c2:4e:5b:08:ab:8f:66:21:34:55:61:50:57:02:
-    5e:d2:d9:09:8d:39:81:85:cd:4c:08:f3:b1:1a:b5:
-    b4:0c:3b:77:5e:c1:e0:95:f1:98:c6:f5:58:88:42:
-    50:b0:c3:41:cd
+    00:f2:1d:4d:7f:ee:9e:a5:0f:c9:73:a5:4d:fe:7c:
+    0a:94:8e:c6:77:c8:ec:53:e0:03:f5:65:42:39:40:
+    26:02:46:8f:05:3d:b9:ba:f2:29:8a:b4:3c:60:37:
+    85:ee:e0:ba:e2:35:69:be:84:95:53:f3:fd:b8:b9:
+    5b:51:76:10:2a:f8:b2:54:58:ab:e5:89:18:46:df:
+    08:c0:4f:57:56:cc:1c:f2:53:e6:b6:91:c0:bd:9c:
+    c6:a8:8c:bf:a0:d4:b6:86:37:50:f9:69:78:95:bd:
+    83:6f:5e:64:1a:b7:75:31:2c:a2:c5:c9:b7:b7:80:
+    c4:61:ac:fd:f7:c7:88:71:bf
 exponent1:
-    00:b2:c8:27:4d:f0:a6:f3:41:40:60:00:23:83:e5:
-    f8:08:ed:50:ee:b7:cd:5d:05:5d:a4:ba:67:94:17:
-    ca:28:e1:5a:a9:3a:93:ca:5d:86:2c:9e:8b:07:b6:
-    2d:d6:3e:bb:75:ff:17:5b:6c:a5:21:bf:37:1e:93:
-    52:07:b2:74:11
+    3c:63:9c:9a:ed:2c:1f:9f:10:0c:dc:73:c6:c8:c7:
+    92:f7:0a:e1:09:57:33:9f:37:49:91:48:cd:0a:5e:
+    c6:f6:34:75:d9:10:62:ef:8e:49:60:4c:94:4b:2b:
+    53:13:99:85:0c:2d:e5:5e:b3:bf:68:d9:63:03:2a:
+    3b:dd:4f:7d:0e:c9:2c:7c:cd:26:9b:34:9e:9b:80:
+    3b:7f:aa:a3:90:b0:98:74:d3:0a:31:19:b9:9e:83:
+    68:e4:60:14:5f:fa:22:ea:3c:48:4f:1b:ce:9c:4b:
+    62:72:cc:99:d2:42:f6:fc:47:0b:15:79:64:d0:b5:
+    a5:59:85:e4:c7:64:c8:c9
 exponent2:
-    63:f3:51:e7:76:38:1e:da:65:05:e7:d9:51:d1:b1:
-    9e:c4:94:06:34:14:c3:81:48:97:d6:34:08:38:f0:
-    7c:3c:b3:7a:4e:4a:9d:74:ab:c3:39:3b:fc:ed:f6:
-    17:cd:d5:f4:c3:7b:61:64:35:42:24:06:26:bb:f6:
-    87:63:c1:d1
+    00:d5:ba:32:58:d5:cf:6c:0c:94:9c:26:f7:c3:c7:
+    c2:1b:44:32:45:39:b4:0d:92:ba:4b:dd:38:69:8b:
+    8c:42:04:01:6a:f2:03:4b:d9:4b:fc:aa:80:85:bb:
+    5d:da:f2:bd:66:c5:19:f4:d9:db:6c:81:fd:9f:1c:
+    d9:54:fe:f0:e4:ce:27:b6:37:94:7f:0a:d7:c8:70:
+    48:ac:63:1d:c9:7c:63:ad:33:8d:7d:eb:0a:87:17:
+    a7:72:d0:d4:b4:e8:31:bc:27:86:ae:b5:81:82:46:
+    0a:89:bc:7c:87:ed:1d:61:ec:72:40:41:82:91:55:
+    f5:85:f8:0d:35:b7:09:66:c7
 coefficient:
-    00:8a:5b:12:c8:57:3c:1e:95:32:eb:5e:e3:92:50:
-    2c:7b:6a:02:a4:18:48:30:cc:23:9f:79:91:dd:56:
-    e8:ae:f7:93:47:ed:a6:26:35:6b:aa:7c:2c:f2:36:
-    01:33:f3:0f:df:50:c9:c8:0a:e7:6e:ec:ba:54:a0:
-    8d:0f:09:40:fd
+    3d:9b:b0:01:4b:43:c3:bf:50:86:d8:c8:52:d4:4d:
+    7a:05:40:2d:20:50:d4:4a:a9:33:a3:b8:d1:fc:6b:
+    eb:be:c9:df:44:f7:70:51:05:d8:58:d2:a0:d8:e0:
+    36:fc:56:43:25:0f:2a:b6:41:a2:25:99:01:8b:d5:
+    93:f4:d6:04:ae:4f:40:44:f6:f2:85:a8:9f:35:99:
+    63:9d:ef:f9:f5:3e:5d:07:3c:96:23:a6:26:8c:28:
+    d1:60:cd:13:18:3b:41:e9:30:31:83:50:73:91:ba:
+    5a:a3:69:d1:6e:a8:40:f2:72:df:e8:88:73:9c:a7:
+    ce:e7:9f:11:97:e5:04:6d
 -----BEGIN RSA PRIVATE KEY-----
-MIICXQIBAAKBgQDBXl0mrnMXWnA3rEIlygUQhhcjbCiESCpK1LA6Ktgzrlhnb5tP
-prSHsew3AGmN1c9xipbhSvjIgTb5Q63Y1naDJ5mkSBfC75wiQEvGWCGI5R03eU66
-MeZS7Iwj7dbOO1itgseuKEfU58wxrHjJAofQsZEJ9h6aw0/2Wv6iIQ7AlQIDAQAB
-AoGAYFu3q5ju/Uox9Ww/ojkjgPJxAVPadODJQnTuRG4pQse0ggbZrD10ZNJC1b28
-29MaBoh7W1VS2Aeb72bMcOueLit+wTSEmoM0snDGWXJgoPT12fJ2rr99IzXurbEt
-wf4FfVt/LNqH7G6wowjJveUwpMJublDAXjH2M++GV2RFt8ECQQDh1geMxk2Q+tZA
-mh/lNFAWcp9bg8Fg1XM5wsbsOu0k/qpdFhS6haR9WpToY/ndJagsa8p8Q8epkq41
-XIVHnlHpAkEA2zIuWeoig87T1XvLuYG5wk5bCKuPZiE0VWFQVwJe0tkJjTmBhc1M
-CPOxGrW0DDt3XsHglfGYxvVYiEJQsMNBzQJBALLIJ03wpvNBQGAAI4Pl+AjtUO63
-zV0FXaS6Z5QXyijhWqk6k8pdhiyeiwe2LdY+u3X/F1tspSG/Nx6TUgeydBECQGPz
-Ued2OB7aZQXn2VHRsZ7ElAY0FMOBSJfWNAg48Hw8s3pOSp10q8M5O/zt9hfN1fTD
-e2FkNUIkBia79odjwdECQQCKWxLIVzwelTLrXuOSUCx7agKkGEgwzCOfeZHdVuiu
-95NH7aYmNWuqfCzyNgEz8w/fUMnICudu7LpUoI0PCUD9
+MIIEpAIBAAKCAQEA6hZMJnFWrDW7K/YbGFgWDxw5P00C5LKni73+mVfypagVAXkN
+HfbZEtvVJqL2WK9LLKpGelNjnx8anhz8mo4gyMjI201QjU4Zg6GdVEkmezrgdx19
+iAGARjJwRxYIcd4SlGf9cR9BVpMVkWi9BTtnlh96TdUetqxBH/DO0y2W2Xytzb6z
+MmYYAyyDmPHolm+FD+Efk9D5CUOMsepDJjKlxtIydS3tcp2/OrvzTtAMrLpr/X9m
+2BJATknn1OxwA3E3y17M00/z0sziOet5bHHl0Q5FTHo9bznoFufeYOsB54BOQh0c
+Mwrr+RAsXO0MWAuM/W30GUmKooGrBLDLemEf0wIDAQABAoIBAQC1hxEKhr3V0d0S
+HEmquTRyB0sFoazquPhgz7eOJruOZyfS+pKHeBOiIkPLMHilEVrUij8ZQW1xyecU
+Uho5qJoX2kyYc/5Rdg0nHL8qy4dB7MiA1qewPqnAxgB3v8hQtQvndjT98mTyxCDn
+oDdkxUpxCnwHu4uT0US3hkB9V08x25giIdXzsFdO9smkCEM92M5Zqqcf2pNAEc+M
+FJ3zEJ/PCtDPK7bq5TySn8JvJIZxFWFJe3dIwdITZxr3wIk9PYfPblzkRij+M4k8
+CfxQPLepJTzypaDh4JzRSj4RWxAaMynHygusv8K+kCcf79fSyl83s7O5OjWHvsrD
+91kD937xAoGBAPeDI0tvgq+2eg8fGgUh0aGE0Qck291knxaE68S/7M8vaZIhuIgF
+JIy8wdvQOFO/Q9xbXkJ7rd7WOgSepafwCy5OKiBvlX3wvv8SxvTSyjnhpck0WDs9
+QMGIY8PMhwIlcIhY3+y21gyeFS1X4TTpLqxRz8SD3bYRRCO4lVBsQK7tAoGBAPId
+TX/unqUPyXOlTf58CpSOxnfI7FPgA/VlQjlAJgJGjwU9ubryKYq0PGA3he7guuI1
+ab6ElVPz/bi5W1F2ECr4slRYq+WJGEbfCMBPV1bMHPJT5raRwL2cxqiMv6DUtoY3
+UPlpeJW9g29eZBq3dTEsosXJt7eAxGGs/ffHiHG/AoGAPGOcmu0sH58QDNxzxsjH
+kvcK4QlXM583SZFIzQpexvY0ddkQYu+OSWBMlEsrUxOZhQwt5V6zv2jZYwMqO91P
+fQ7JLHzNJps0npuAO3+qo5CwmHTTCjEZuZ6DaORgFF/6Iuo8SE8bzpxLYnLMmdJC
+9vxHCxV5ZNC1pVmF5MdkyMkCgYEA1boyWNXPbAyUnCb3w8fCG0QyRTm0DZK6S904
+aYuMQgQBavIDS9lL/KqAhbtd2vK9ZsUZ9NnbbIH9nxzZVP7w5M4ntjeUfwrXyHBI
+rGMdyXxjrTONfesKhxenctDUtOgxvCeGrrWBgkYKibx8h+0dYexyQEGCkVX1hfgN
+NbcJZscCgYA9m7ABS0PDv1CG2MhS1E16BUAtIFDUSqkzo7jR/GvrvsnfRPdwUQXY
+WNKg2OA2/FZDJQ8qtkGiJZkBi9WT9NYErk9ARPbyhaifNZljne/59T5dBzyWI6Ym
+jCjRYM0TGDtB6TAxg1Bzkbpao2nRbqhA8nLf6IhznKfO558Rl+UEbQ==
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/unknown-ca.pem
+++ b/spec/fixtures/ssl/unknown-ca.pem
@@ -6,21 +6,30 @@ Certificate:
         Issuer: CN=Unknown CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Mar 10 06:54:16 2030 GMT
+            Not After : Apr 18 18:46:23 2031 GMT
         Subject: CN=Unknown CA
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                RSA Public-Key: (1024 bit)
+                RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:c1:5e:5d:26:ae:73:17:5a:70:37:ac:42:25:ca:
-                    05:10:86:17:23:6c:28:84:48:2a:4a:d4:b0:3a:2a:
-                    d8:33:ae:58:67:6f:9b:4f:a6:b4:87:b1:ec:37:00:
-                    69:8d:d5:cf:71:8a:96:e1:4a:f8:c8:81:36:f9:43:
-                    ad:d8:d6:76:83:27:99:a4:48:17:c2:ef:9c:22:40:
-                    4b:c6:58:21:88:e5:1d:37:79:4e:ba:31:e6:52:ec:
-                    8c:23:ed:d6:ce:3b:58:ad:82:c7:ae:28:47:d4:e7:
-                    cc:31:ac:78:c9:02:87:d0:b1:91:09:f6:1e:9a:c3:
-                    4f:f6:5a:fe:a2:21:0e:c0:95
+                    00:ea:16:4c:26:71:56:ac:35:bb:2b:f6:1b:18:58:
+                    16:0f:1c:39:3f:4d:02:e4:b2:a7:8b:bd:fe:99:57:
+                    f2:a5:a8:15:01:79:0d:1d:f6:d9:12:db:d5:26:a2:
+                    f6:58:af:4b:2c:aa:46:7a:53:63:9f:1f:1a:9e:1c:
+                    fc:9a:8e:20:c8:c8:c8:db:4d:50:8d:4e:19:83:a1:
+                    9d:54:49:26:7b:3a:e0:77:1d:7d:88:01:80:46:32:
+                    70:47:16:08:71:de:12:94:67:fd:71:1f:41:56:93:
+                    15:91:68:bd:05:3b:67:96:1f:7a:4d:d5:1e:b6:ac:
+                    41:1f:f0:ce:d3:2d:96:d9:7c:ad:cd:be:b3:32:66:
+                    18:03:2c:83:98:f1:e8:96:6f:85:0f:e1:1f:93:d0:
+                    f9:09:43:8c:b1:ea:43:26:32:a5:c6:d2:32:75:2d:
+                    ed:72:9d:bf:3a:bb:f3:4e:d0:0c:ac:ba:6b:fd:7f:
+                    66:d8:12:40:4e:49:e7:d4:ec:70:03:71:37:cb:5e:
+                    cc:d3:4f:f3:d2:cc:e2:39:eb:79:6c:71:e5:d1:0e:
+                    45:4c:7a:3d:6f:39:e8:16:e7:de:60:eb:01:e7:80:
+                    4e:42:1d:1c:33:0a:eb:f9:10:2c:5c:ed:0c:58:0b:
+                    8c:fd:6d:f4:19:49:8a:a2:81:ab:04:b0:cb:7a:61:
+                    1f:d3
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Basic Constraints: critical
@@ -28,32 +37,45 @@ Certificate:
             X509v3 Key Usage: critical
                 Certificate Sign, CRL Sign
             X509v3 Subject Key Identifier: 
-                E9:58:70:FE:F1:C1:AA:5A:70:7A:C1:02:11:1D:9A:F4:60:4F:70:76
+                16:C5:98:B8:84:0B:0A:43:CB:5A:D2:E0:55:C0:64:AB:89:F8:50:FD
             Netscape Comment: 
                 Puppet Server Internal Certificate
             X509v3 Authority Key Identifier: 
-                keyid:E9:58:70:FE:F1:C1:AA:5A:70:7A:C1:02:11:1D:9A:F4:60:4F:70:76
+                keyid:16:C5:98:B8:84:0B:0A:43:CB:5A:D2:E0:55:C0:64:AB:89:F8:50:FD
 
     Signature Algorithm: sha256WithRSAEncryption
-         00:45:89:e8:68:a7:50:8c:92:84:3c:c4:e6:10:00:29:27:99:
-         c6:82:aa:aa:b5:0b:ef:97:58:bc:bb:e6:e7:93:7c:a7:ea:e5:
-         9a:61:1d:e3:4f:3f:f9:ac:c4:96:14:a5:1f:77:a6:01:dc:08:
-         15:9c:3f:66:29:92:80:49:e9:db:d9:22:fb:c3:86:bf:40:ab:
-         46:bf:c5:47:bb:c8:89:df:d4:ca:36:f5:08:c4:08:c6:0b:d6:
-         9e:8a:86:41:1e:7e:6f:a9:75:ef:8a:94:a9:fd:1a:9b:0f:55:
-         3a:55:e5:04:82:71:c3:47:78:62:8e:07:ed:dc:4e:ac:f9:33:
-         7b:27
+         7d:0b:a0:2e:d4:fb:6b:29:04:d6:86:4e:89:94:4c:b5:d4:f7:
+         79:5a:38:95:51:9a:80:03:82:93:c8:a7:4e:93:4a:4b:41:1a:
+         85:f3:46:57:e1:70:50:ad:bb:4e:b9:d6:0c:00:e5:9e:4c:f7:
+         26:3b:88:61:27:ad:fa:39:a7:36:e1:62:87:7a:dc:7d:f9:f6:
+         c1:ee:bc:db:f7:65:a1:b0:2a:06:ae:4b:cb:99:82:f5:8e:38:
+         51:ac:c9:92:33:b9:7b:50:8b:c6:72:36:d3:f2:73:7d:58:13:
+         00:21:4d:c6:70:9d:eb:70:58:bf:dc:34:94:7e:bc:ef:17:2d:
+         9d:00:bd:55:f9:48:11:c0:8f:88:ea:a8:7c:5d:fb:88:fd:8c:
+         b4:00:1d:61:a7:4b:2a:90:ef:96:c1:28:2a:a0:95:ad:bb:b3:
+         af:3a:d5:93:1c:54:d7:c5:5b:26:a3:24:87:df:bd:68:74:fa:
+         e6:07:4e:13:b9:5f:54:19:ae:da:00:8c:ca:d6:ff:b7:94:6b:
+         4f:ff:71:ca:2b:7d:ee:7e:32:ff:03:3e:60:a4:30:d4:7d:9c:
+         ab:97:0e:f7:80:ee:69:c0:28:a8:ec:6b:89:05:38:64:34:e8:
+         b2:e9:f3:a1:85:e7:3d:e1:64:3c:86:e4:fd:44:4f:3b:2a:f8:
+         d2:b4:93:22
 -----BEGIN CERTIFICATE-----
-MIICODCCAaGgAwIBAgIBADANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDDApVbmtu
-b3duIENBMB4XDTcwMDEwMTAwMDAwMFoXDTMwMDMxMDA2NTQxNlowFTETMBEGA1UE
-AwwKVW5rbm93biBDQTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAwV5dJq5z
-F1pwN6xCJcoFEIYXI2wohEgqStSwOirYM65YZ2+bT6a0h7HsNwBpjdXPcYqW4Ur4
-yIE2+UOt2NZ2gyeZpEgXwu+cIkBLxlghiOUdN3lOujHmUuyMI+3WzjtYrYLHrihH
-1OfMMax4yQKH0LGRCfYemsNP9lr+oiEOwJUCAwEAAaOBlzCBlDAPBgNVHRMBAf8E
-BTADAQH/MA4GA1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQU6Vhw/vHBqlpwesECER2a
-9GBPcHYwMQYJYIZIAYb4QgENBCQWIlB1cHBldCBTZXJ2ZXIgSW50ZXJuYWwgQ2Vy
-dGlmaWNhdGUwHwYDVR0jBBgwFoAU6Vhw/vHBqlpwesECER2a9GBPcHYwDQYJKoZI
-hvcNAQELBQADgYEAAEWJ6GinUIyShDzE5hAAKSeZxoKqqrUL75dYvLvm55N8p+rl
-mmEd408/+azElhSlH3emAdwIFZw/ZimSgEnp29ki+8OGv0CrRr/FR7vIid/Uyjb1
-CMQIxgvWnoqGQR5+b6l174qUqf0amw9VOlXlBIJxw0d4Yo4H7dxOrPkzeyc=
+MIIDPTCCAiWgAwIBAgIBADANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDDApVbmtu
+b3duIENBMB4XDTcwMDEwMTAwMDAwMFoXDTMxMDQxODE4NDYyM1owFTETMBEGA1UE
+AwwKVW5rbm93biBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOoW
+TCZxVqw1uyv2GxhYFg8cOT9NAuSyp4u9/plX8qWoFQF5DR322RLb1Sai9livSyyq
+RnpTY58fGp4c/JqOIMjIyNtNUI1OGYOhnVRJJns64HcdfYgBgEYycEcWCHHeEpRn
+/XEfQVaTFZFovQU7Z5Yfek3VHrasQR/wztMtltl8rc2+szJmGAMsg5jx6JZvhQ/h
+H5PQ+QlDjLHqQyYypcbSMnUt7XKdvzq7807QDKy6a/1/ZtgSQE5J59TscANxN8te
+zNNP89LM4jnreWxx5dEORUx6PW856Bbn3mDrAeeATkIdHDMK6/kQLFztDFgLjP1t
+9BlJiqKBqwSwy3phH9MCAwEAAaOBlzCBlDAPBgNVHRMBAf8EBTADAQH/MA4GA1Ud
+DwEB/wQEAwIBBjAdBgNVHQ4EFgQUFsWYuIQLCkPLWtLgVcBkq4n4UP0wMQYJYIZI
+AYb4QgENBCQWIlB1cHBldCBTZXJ2ZXIgSW50ZXJuYWwgQ2VydGlmaWNhdGUwHwYD
+VR0jBBgwFoAUFsWYuIQLCkPLWtLgVcBkq4n4UP0wDQYJKoZIhvcNAQELBQADggEB
+AH0LoC7U+2spBNaGTomUTLXU93laOJVRmoADgpPIp06TSktBGoXzRlfhcFCtu065
+1gwA5Z5M9yY7iGEnrfo5pzbhYod63H359sHuvNv3ZaGwKgauS8uZgvWOOFGsyZIz
+uXtQi8ZyNtPyc31YEwAhTcZwnetwWL/cNJR+vO8XLZ0AvVX5SBHAj4jqqHxd+4j9
+jLQAHWGnSyqQ75bBKCqgla27s6861ZMcVNfFWyajJIffvWh0+uYHThO5X1QZrtoA
+jMrW/7eUa0//ccorfe5+Mv8DPmCkMNR9nKuXDveA7mnAKKjsa4kFOGQ06LLp86GF
+5z3hZDyG5P1ETzsq+NK0kyI=
 -----END CERTIFICATE-----

--- a/spec/lib/puppet/test_ca.rb
+++ b/spec/lib/puppet/test_ca.rb
@@ -30,7 +30,7 @@ module Puppet
     end
 
     def create_request(name)
-      key = OpenSSL::PKey::RSA.new(1024)
+      key = OpenSSL::PKey::RSA.new(2048)
       csr = OpenSSL::X509::Request.new
       csr.public_key = key.public_key
       csr.subject = OpenSSL::X509::Name.new([["CN", name]])
@@ -127,7 +127,7 @@ module Puppet
       key = if opts[:key_type] == :ec
               key = OpenSSL::PKey::EC.generate('prime256v1')
             else
-              key = OpenSSL::PKey::RSA.new(1024)
+              key = OpenSSL::PKey::RSA.new(2048)
             end
       cert = OpenSSL::X509::Certificate.new
       cert.public_key = if key.is_a?(OpenSSL::PKey::EC)

--- a/tasks/generate_cert_fixtures.rake
+++ b/tasks/generate_cert_fixtures.rake
@@ -173,12 +173,12 @@ task(:gen_cert_fixtures) do
 
   # Create a request, but replace its public key after it's signed
   tampered_csr = ca.create_request('signed')[:csr]
-  tampered_csr.public_key = OpenSSL::PKey::RSA.new(1024).public_key
+  tampered_csr.public_key = OpenSSL::PKey::RSA.new(2048).public_key
   save(dir, 'tampered-csr.pem', tampered_csr)
 
   # Create a cert issued from the real intermediate CA, but replace its
   # public key
   tampered_cert = ca.create_cert('signed', inter[:cert], inter[:private_key])[:cert]
-  tampered_cert.public_key = OpenSSL::PKey::RSA.new(1024).public_key
+  tampered_cert.public_key = OpenSSL::PKey::RSA.new(2048).public_key
   save(dir, 'tampered-cert.pem', tampered_cert)
 end


### PR DESCRIPTION
Newer openssl (1.1.1f) rejects test fixtures with private key length 1024:

    SSL_CTX_use_certificate:ee key too small

Increased the length and regenerate all fixtures using:

    bundle exec rake gen_cert_fixtures

Also removed hardcoded fingerprints from tests so we can automate cert fixture regeneration.