### PR TITLE
(maint) Relax win32-dir

### DIFF
--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -19,7 +19,6 @@ jobs:
           - {os: ubuntu-18.04, ruby: 2.6}
           - {os: ubuntu-18.04, ruby: 2.7}
           - {os: ubuntu-18.04, ruby: jruby-9.2.9.0}
-          - {os: windows-2016, ruby: 2.3}
           - {os: windows-2016, ruby: 2.4}
           - {os: windows-2016, ruby: 2.5}
           - {os: windows-2016, ruby: 2.6}

--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ group(:development, optional: true) do
   gem 'memory_profiler', require: false, platforms: [:mri]
   gem 'pry', require: false, platforms: [:ruby]
   gem "racc", "1.4.9", require: false, platforms: [:ruby]
-  if RUBY_PLATFORM != 'java'
+  if RUBY_PLATFORM != 'java' && RUBY_VERSION.to_f >= 2.5
     gem 'ruby-prof', '>= 0.16.0', require: false
   end
 end

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -41,7 +41,7 @@ gem_platform_dependencies:
     gem_runtime_dependencies:
       ffi: ['> 1.9.24', '< 2']
       # win32-xxxx gems are pinned due to PUP-6445
-      win32-dir: '= 0.4.9'
+      win32-dir: ['>= 0.4.9', '<= 0.7.2']
       win32-process: '= 0.7.5'
       # Use of win32-security is deprecated
       win32-security: '= 0.2.5'
@@ -51,7 +51,7 @@ gem_platform_dependencies:
     gem_runtime_dependencies:
       ffi: ['> 1.9.24', '< 2']
       # win32-xxxx gems are pinned due to PUP-6445
-      win32-dir: '= 0.4.9'
+      win32-dir: ['>= 0.4.9', '<= 0.7.2']
       win32-process: '= 0.7.5'
       # Use of win32-security is deprecated
       win32-security: '= 0.2.5'

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -205,7 +205,7 @@ describe Puppet::Resource::Catalog, "when compiling" do
     end
 
     it "should set itself as the catalog for each converted resource" do
-      @catalog.vertices.each { |v| expect(v.catalog.object_id).to equal(@catalog.object_id) }
+      @catalog.vertices.each { |v| expect(v.catalog.object_id).to eql(@catalog.object_id) }
     end
 
     # This tests #931.


### PR DESCRIPTION
Allow bundler to install win32-dir 0.7.2 that contains the ASLR fix.

This change affects bundler and the runtime dependencies for the win32
specific versions of the puppet gem. It is important to continue accepting
win32-dir 0.4.9, because that is what we ship in the puppet-runtime.

Since win32-dir 0.7.2 only supports ruby 2.4 and up, this change drops the ruby
2.3 and windows rspec combination. Ruby 2.3 went EOL March 28, 2018.

The change to ruby-prof was due to bundler pulling in a a version that wasn't
compatible with older ruby versions. So restrict that to ruby >= 2.5. It's only
needed when running the memory related benchmarks.