### PR TITLE
(PUP-10922) Add optional argument to downcase fqdn

### DIFF
--- a/lib/puppet/parser/functions/fqdn_rand.rb
+++ b/lib/puppet/parser/functions/fqdn_rand.rb
@@ -24,7 +24,7 @@ Puppet::Parser::Functions::newfunction(:fqdn_rand, :arity => -2, :type => :rvalu
     downcase = !!args.shift
 
     fqdn = self['::fqdn']
-    fqdn.downcase! if downcase
+    fqdn = fqdn.downcase if downcase
 
     # Puppet 5.4's fqdn_rand function produces a different value than earlier versions
     # for the same set of inputs.

--- a/lib/puppet/parser/functions/fqdn_rand.rb
+++ b/lib/puppet/parser/functions/fqdn_rand.rb
@@ -2,13 +2,16 @@ require 'digest/md5'
 require 'digest/sha2'
 
 Puppet::Parser::Functions::newfunction(:fqdn_rand, :arity => -2, :type => :rvalue, :doc =>
-  "Usage: `fqdn_rand(MAX, [SEED])`. MAX is required and must be a positive
-  integer; SEED is optional and may be any number or string.
+  "Usage: `fqdn_rand(MAX, [SEED], [DOWNCASE])`. MAX is required and must be a positive
+  integer; SEED is optional and may be any number or string; DOWNCASE is optional
+  and should be a boolean true or false.
 
   Generates a random Integer number greater than or equal to 0 and less than MAX,
   combining the `$fqdn` fact and the value of SEED for repeatable randomness.
   (That is, each node will get a different random number from this function, but
-  a given node's result will be the same every time unless its hostname changes.)
+  a given node's result will be the same every time unless its hostname changes.) If
+  DOWNCASE is true, then the `fqdn` fact will be downcased when computing the value
+  so that the result is not sensitive to the case of the `fqdn` fact.
 
   This function is usually used for spacing out runs of resource-intensive cron
   tasks that run on many nodes, which could cause a thundering herd or degrade
@@ -17,7 +20,12 @@ Puppet::Parser::Functions::newfunction(:fqdn_rand, :arity => -2, :type => :rvalu
   node. (For example, `fqdn_rand(30)`, `fqdn_rand(30, 'expensive job 1')`, and
   `fqdn_rand(30, 'expensive job 2')` will produce totally different numbers.)") do |args|
     max = args.shift.to_i
- 
+    initial_seed = args.shift
+    downcase = !!args.shift
+
+    fqdn = self['::fqdn']
+    fqdn.downcase! if downcase
+
     # Puppet 5.4's fqdn_rand function produces a different value than earlier versions
     # for the same set of inputs.
     # This causes problems because the values are often written into service configuration files.
@@ -27,9 +35,9 @@ Puppet::Parser::Functions::newfunction(:fqdn_rand, :arity => -2, :type => :rvalu
     # when running on a non-FIPS enabled platform and only using SHA256 on FIPS enabled
     # platforms.
     if Puppet::Util::Platform.fips_enabled?
-      seed = Digest::SHA256.hexdigest([self['::fqdn'],max,args].join(':')).hex
+      seed = Digest::SHA256.hexdigest([fqdn,max,initial_seed].join(':')).hex
     else
-      seed = Digest::MD5.hexdigest([self['::fqdn'],max,args].join(':')).hex
+      seed = Digest::MD5.hexdigest([fqdn,max,initial_seed].join(':')).hex
     end
 
     Puppet::Util.deterministic_rand_int(seed,max)

--- a/spec/unit/parser/functions/fqdn_rand_spec.rb
+++ b/spec/unit/parser/functions/fqdn_rand_spec.rb
@@ -61,6 +61,20 @@ describe "the fqdn_rand function" do
     expect(fqdn_rand(5000, :extra_identifier => ['expensive job 33'])).to eql(2389)
   end
 
+  it "returns the same value if only host differs by case" do
+    val1 = fqdn_rand(1000000000, :host => "host.example.com", :extra_identifier => [nil, true])
+    val2 = fqdn_rand(1000000000, :host => "HOST.example.com", :extra_identifier => [nil, true])
+
+    expect(val1).to eql(val2)
+  end
+
+  it "returns the same value if only host differs by case and an initial seed is given" do
+    val1 = fqdn_rand(1000000000, :host => "host.example.com", :extra_identifier => ['a seed', true])
+    val2 = fqdn_rand(1000000000, :host => "HOST.example.com", :extra_identifier => ['a seed', true])
+
+    expect(val1).to eql(val2)
+  end
+
   def fqdn_rand(max, args = {})
     host = args[:host] || '127.0.0.1'
     extra = args[:extra_identifier] || []

--- a/spec/unit/parser/functions/fqdn_rand_spec.rb
+++ b/spec/unit/parser/functions/fqdn_rand_spec.rb
@@ -80,7 +80,7 @@ describe "the fqdn_rand function" do
     extra = args[:extra_identifier] || []
 
     scope = create_test_scope_for_node('localhost')
-    allow(scope).to receive(:[]).with("::fqdn").and_return(host)
+    scope.compiler.topscope['fqdn'] = host.freeze
 
     scope.function_fqdn_rand([max] + extra)
   end


### PR DESCRIPTION
Adds an optional argument to the `fqdn_rand` function so that the `fqdn` fact is
downcased when computing the seed. This way the function always produces the
same value if the fqdn fact only differs by case, but all of the `fqdn_rand`
arguments are the same. Note the downcase argument must be passed after the SEED
argument:

    fqdn_rand(100, 'expensive job 1', true)

The SEED argument defaults to nil, so this is also possible:

    fqdn_rand(100, nil, true)