### PR TITLE
(maint) Splat hash explicitly

### DIFF
--- a/spec/unit/http/service/compiler_spec.rb
+++ b/spec/unit/http/service/compiler_spec.rb
@@ -287,7 +287,7 @@ describe Puppet::HTTP::Service::Compiler do
         expect(request.headers).to_not include('X-Puppet-Profiling')
       end.to_return(**catalog_response)
 
-      subject.post_catalog4(certname, payload)
+      subject.post_catalog4(certname, **payload)
     end
 
     it 'defaults the server and port based on settings' do
@@ -297,7 +297,7 @@ describe Puppet::HTTP::Service::Compiler do
       stub_request(:post, "https://compiler2.example.com:8141/puppet/v4/catalog")
         .to_return(**catalog_response)
 
-      subject.post_catalog4(certname, payload)
+      subject.post_catalog4(certname, **payload)
     end
 
     it 'includes puppet headers set via the :http_extra_headers and :profile settings' do
@@ -307,14 +307,14 @@ describe Puppet::HTTP::Service::Compiler do
       Puppet[:http_extra_headers] = 'Example-Header:real-thing,another:thing'
       Puppet[:profile] = true
 
-      subject.post_catalog4(certname, payload)
+      subject.post_catalog4(certname, **payload)
     end
 
     it 'returns a deserialized catalog' do
       stub_request(:post, uri)
         .to_return(**catalog_response)
 
-      _, cat, _ = subject.post_catalog4(certname, payload)
+      _, cat, _ = subject.post_catalog4(certname, **payload)
       expect(cat).to be_a(Puppet::Resource::Catalog)
       expect(cat.name).to eq(certname)
     end
@@ -323,7 +323,7 @@ describe Puppet::HTTP::Service::Compiler do
       stub_request(:post, uri)
         .to_return(**catalog_response)
 
-      resp, _, _ = subject.post_catalog4(certname, payload)
+      resp, _, _ = subject.post_catalog4(certname, **payload)
       expect(resp).to be_a(Puppet::HTTP::Response)
     end
 
@@ -332,7 +332,7 @@ describe Puppet::HTTP::Service::Compiler do
         .to_return(status: [500, "Server Error"])
 
       expect {
-        subject.post_catalog4(certname, payload)
+        subject.post_catalog4(certname, **payload)
       }.to raise_error do |err|
         expect(err).to be_an_instance_of(Puppet::HTTP::ResponseError)
         expect(err.message).to eq('Server Error')
@@ -345,7 +345,7 @@ describe Puppet::HTTP::Service::Compiler do
         .to_return(body: "this isn't valid JSON", headers: {'Content-Type' => 'application/json'})
 
       expect {
-        subject.post_catalog4(certname, payload)
+        subject.post_catalog4(certname, **payload)
       }.to raise_error do |err|
         expect(err).to be_an_instance_of(Puppet::HTTP::SerializationError)
         expect(err.message).to match(/Failed to deserialize catalog from puppetserver response/)
@@ -357,7 +357,7 @@ describe Puppet::HTTP::Service::Compiler do
         .to_return(body: {oops: 'bad response data'}.to_json, headers: {'Content-Type' => 'application/json'})
 
       expect {
-        subject.post_catalog4(certname, payload)
+        subject.post_catalog4(certname, **payload)
       }.to raise_error do |err|
         expect(err).to be_an_instance_of(Puppet::HTTP::SerializationError)
         expect(err.message).to match(/Failed to deserialize catalog from puppetserver response/)
@@ -366,7 +366,7 @@ describe Puppet::HTTP::Service::Compiler do
 
     it 'raises ArgumentError when the `persistence` hash does not contain required keys' do
       payload[:persistence].delete(:facts)
-      expect { subject.post_catalog4(certname, payload) }.to raise_error do |err|
+      expect { subject.post_catalog4(certname, **payload) }.to raise_error do |err|
         expect(err).to be_an_instance_of(ArgumentError)
         expect(err.message).to match(/The 'persistence' hash is missing the keys: facts/)
       end
@@ -374,7 +374,7 @@ describe Puppet::HTTP::Service::Compiler do
 
     it 'raises ArgumentError when `facts` are not a Hash' do
       payload[:facts] = Puppet::Node::Facts.new(certname)
-      expect { subject.post_catalog4(certname, payload) }.to raise_error do |err|
+      expect { subject.post_catalog4(certname, **payload) }.to raise_error do |err|
         expect(err).to be_an_instance_of(ArgumentError)
         expect(err.message).to match(/Facts must be a Hash not a Puppet::Node::Facts/)
       end


### PR DESCRIPTION
Ruby 3 removed support for passing a hash as the last parameter and having it
auto convert to keyword parameters. Use double splat so it's clear we're passing
keyword arguments.