### PR TITLE
(PUP-11034) Allow systemd static services to be masked

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -45,8 +45,13 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   def enabled_insync?(current)
     case cached_enabled?[:output]
     when 'static'
-      Puppet.debug("Unable to enable or disable static service #{@resource[:name]}")
-      return true
+      # masking static services is OK, but enabling/disabling them is not
+      if @resource[:enable] == :mask
+        current == @resource[:enable]
+      else
+        Puppet.debug("Unable to enable or disable static service #{@resource[:name]}")
+        return true
+      end
     when 'indirect'
       Puppet.debug("Service #{@resource[:name]} is in 'indirect' state and cannot be enabled/disabled")
       return true

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -467,17 +467,39 @@ Jun 14 21:43:23 foo.example.com systemd[1]: sshd.service lacks both ExecStart= a
     context 'when service state is static' do
       let(:service_state) { 'static' }
 
-      it 'is always enabled_insync even if current value is the same as expected' do
-        expect(provider).to be_enabled_insync(:false)
+      context 'when enable is not mask' do
+        it 'is always enabled_insync even if current value is the same as expected' do
+          expect(provider).to be_enabled_insync(:false)
+        end
+
+        it 'is always enabled_insync even if current value is not the same as expected' do
+          expect(provider).to be_enabled_insync(:true)
+        end
+
+        it 'logs a debug messsage' do
+          expect(Puppet).to receive(:debug).with("Unable to enable or disable static service sshd.service")
+          provider.enabled_insync?(:true)
+        end
       end
 
-      it 'is always enabled_insync even if current value is not the same as expected' do
-        expect(provider).to be_enabled_insync(:true)
-      end
+      context 'when enable is mask' do
+        let(:provider) do
+          provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service',
+                                                             :enable => 'mask'))
+        end
 
-      it 'logs a debug messsage' do
-        expect(Puppet).to receive(:debug).with("Unable to enable or disable static service sshd.service")
-        provider.enabled_insync?(:true)
+        it 'is enabled_insync if current value is the same as expected' do
+          expect(provider).to be_enabled_insync(:mask)
+        end
+
+        it 'is not enabled_insync if current value is not the same as expected' do
+          expect(provider).not_to be_enabled_insync(:true)
+        end
+
+        it 'logs no debug messsage' do
+          expect(Puppet).not_to receive(:debug)
+          provider.enabled_insync?(:true)
+        end
       end
     end
 


### PR DESCRIPTION
Closes https://tickets.puppetlabs.com/browse/PUP-11034

Previously the `service` provider for `systemd` threw a debug message and prevented `static` services from being `enable => 'mask'`. Turns out this is a valid configuration (corner case) and the `systemctl` commands work just fine.

Specifically this happens on CentOS/RHEL 8 when trying to disable core dumps by masking the `systemd-coredump.socket` service using the following resource declaration:
```puppet
    service { 'systemd-coredump.socket':
      ensure => 'stopped',
      enable => 'mask',
    }
 ```
 
Now, we provide an extra case when checking the enabled value to allow `static` services to be `masked`, but not allow them to be `enabled` or `disabled` via `true` and `false`. 

