### PR TITLE
(PUP-11045) Ruby 3 returns V_ERR_HOSTNAME_MISMATCH

### DIFF
--- a/lib/puppet/ssl/verifier.rb
+++ b/lib/puppet/ssl/verifier.rb
@@ -117,6 +117,10 @@ class Puppet::SSL::Verifier
         return false
       end
 
+    when OpenSSL::X509::V_ERR_HOSTNAME_MISMATCH # new in ruby-openssl 2.2.0/ruby 3.0
+      @last_error = Puppet::SSL::CertMismatchError.new(peer_cert, @hostname)
+      return false
+
     when OpenSSL::X509::V_ERR_CRL_NOT_YET_VALID
       crl = store_context.current_crl
       if crl && crl.last_update && crl.last_update < Time.now + FIVE_MINUTES_AS_SECONDS

--- a/lib/puppet/util/monkey_patches.rb
+++ b/lib/puppet/util/monkey_patches.rb
@@ -90,6 +90,10 @@ if Puppet::Util::Platform.windows?
 end
 
 unless Puppet::Util::Platform.jruby_fips?
+  unless OpenSSL::X509.const_defined?(:V_ERR_HOSTNAME_MISMATCH)
+    OpenSSL::X509.const_set(:V_ERR_HOSTNAME_MISMATCH, 62)
+  end
+
   unless OpenSSL::X509::Name.instance_methods.include?(:to_utf8)
     class OpenSSL::X509::Name
       # https://github.com/openssl/openssl/blob/OpenSSL_1_1_0j/include/openssl/asn1.h#L362


### PR DESCRIPTION
Previously, puppet on ruby 3 raised a generic CertVerifyError if the hostname
was mismatched rather than the more specific CertMismatchError. This is because
Ruby 3 changed the StoreContext#error from V_ERR_OK to V_ERR_HOSTNAME_MISMATCH.
This was fixed in ruby-openssl#2.2.0 first released in ruby 3.

[1] https://github.com/ruby/openssl/commit/035a04ece237105ba3c91a8db8f81dc81d2dc452