### PR TITLE
(PUP-11051) Add Ubuntu 18.04 and 20.04 to systemd service provider

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -25,7 +25,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   defaultfor :osfamily => :coreos
   defaultfor :operatingsystem => :amazon, :operatingsystemmajrelease => ["2"]
   defaultfor :operatingsystem => :debian, :operatingsystemmajrelease => ["8", "stretch/sid", "9", "buster/sid"]
-  defaultfor :operatingsystem => :ubuntu, :operatingsystemmajrelease => ["15.04","15.10","16.04","16.10","17.04","17.10"]
+  defaultfor :operatingsystem => :ubuntu, :operatingsystemmajrelease => ["15.04","15.10","16.04","16.10","17.04","17.10","18.04","20.04"]
   defaultfor :operatingsystem => :cumuluslinux, :operatingsystemmajrelease => ["3"]
 
   def self.instances


### PR DESCRIPTION
# Summary

These changes are in reference to PUP-11051

For Ubuntu versions past 17.10 and Puppet version 4.10.x, the `service_provider` is recognized as `debian`, rather than `systemd`. This is not an issue for versions past 4.10.x, as the versions are explicitly added, or are covered by the `notdefaultfor` function.  

The versions `18.04` and `20.04` were selected to be added here as they are [long term supported versions](https://wiki.ubuntu.com/Releases).

# Validation 

Test Instance: 

```
$ puppet --version
4.10.12

$ hostnamectl | grep "Operating System"
  Operating System: Ubuntu 20.04.2 LTS
```

Without fix: 

```
$ facter -p | grep service_provider
service_provider => debian
```

With fix: 

```
$ facter -p | grep service_provider
service_provider => systemd
```

