### PR TITLE
(Docs)(maint) Fix formatting issues in strings

### DIFF
--- a/lib/puppet/functions/camelcase.rb
+++ b/lib/puppet/functions/camelcase.rb
@@ -3,7 +3,7 @@
 # This function is compatible with the stdlib function with the same name.
 #
 # The function does the following:
-# * For a `String` the conversion replaces all combinations of *_<char>* with an upcased version of the
+# * For a `String` the conversion replaces all combinations of `*_<char>*` with an upcased version of the
 #   character following the _.  This is done using Ruby system locale which handles some, but not all
 #   special international up-casing rules (for example German double-s ß is upcased to "Ss").
 # * For an `Iterable[Variant[String, Numeric]]` (for example an `Array`) each value is capitalized and the conversion is not recursive.

--- a/lib/puppet/functions/new.rb
+++ b/lib/puppet/functions/new.rb
@@ -661,12 +661,12 @@
 # | Format    | Default formats
 # | ------    | ---------------
 # | s         | binary as unquoted UTF-8 characters (errors if byte sequence is invalid UTF-8). Alternate form escapes non ascii bytes.
-# | p         | 'Binary("<base64strict>")'
-# | b         | '<base64>' - base64 string with newlines inserted
-# | B         | '<base64strict>' - base64 strict string (without newlines inserted)
-# | u         | '<base64urlsafe>' - base64 urlsafe string
-# | t         | 'Binary' - outputs the name of the type only
-# | T         | 'BINARY' - output the name of the type in all caps only
+# | p         | `'Binary("<base64strict>")'`
+# | b         | `'<base64>'` - base64 string with newlines inserted
+# | B         | `'<base64strict>'` - base64 strict string (without newlines inserted)
+# | u         | `'<base64urlsafe>'` - base64 urlsafe string
+# | t         | `'Binary'` - outputs the name of the type only
+# | T         | `'BINARY'` - output the name of the type in all caps only
 #
 # * The alternate form flag `#` will quote the binary or base64 text output.
 # * The format `%#s` allows invalid UTF-8 characters and outputs all non ascii bytes


### PR DESCRIPTION
Adding backticks to some strings that are causing issues in the
generated docs. These revolve around unescaped angle brackets `<>`.

Please merge this up to 7 as well.