### PR TITLE
(PUP-10946) Ignore max file warnings during pluginsync

### DIFF
--- a/lib/puppet/configurer/downloader.rb
+++ b/lib/puppet/configurer/downloader.rb
@@ -73,7 +73,8 @@ class Puppet::Configurer::Downloader
       :purge => true,
       :force => true,
       :backup => false,
-      :noop => false
+      :noop => false,
+      :max_files => -1
     }
     if !Puppet::Util::Platform.windows?
       defargs[:owner] = Process.uid

--- a/lib/puppet/file_serving/fileset.rb
+++ b/lib/puppet/file_serving/fileset.rb
@@ -61,7 +61,7 @@ class Puppet::FileServing::Fileset
     files = perform_recursion
     soft_max_files = 1000
 
-    if max_files != 0  && files.size > max_files
+    if max_files > 0  && files.size > max_files
       raise Puppet::Error.new _("The directory '%{path}' contains %{entries} entries, which exceeds the limit of %{max_files} specified by the max_files parameter for this resource. The limit may be increased, but be aware that large number of file resources can result in excessive resource consumption and degraded performance. Consider using an alternate method to manage large directory trees") % { path: path, entries: files.size, max_files: max_files }
     elsif max_files == 0 && files.size > soft_max_files
       Puppet.warning _("The directory '%{path}' contains %{entries} entries, which exceeds the default soft limit %{max_files} and may cause excessive resource consumption and degraded performance. To remove this warning set a value for `max_files` parameter or consider using an alternate method to manage large directory trees") % { path: path, entries: files.size, max_files: soft_max_files }

--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -229,11 +229,12 @@ Puppet::Type.newtype(:file) do
       will eventually be created and will raise a resource argument error if the
       limit will be exceeded.
 
-      Use value `0` to disable the check. In this case, a warning is logged if
-      the number of files exceeds 1000."
+      Use value `0` to log a warning instead of raising an error.
+
+      Use value `-1` to disable errors and warnings due to max files."
 
     defaultto 0
-    newvalues(/^[0-9]+$/)
+    newvalues(/^[0-9]+$/, /^-1$/)
   end
 
   newparam(:replace, :boolean => true, :parent => Puppet::Parameter::Boolean) do

--- a/spec/unit/configurer/downloader_spec.rb
+++ b/spec/unit/configurer/downloader_spec.rb
@@ -81,6 +81,12 @@ describe Puppet::Configurer::Downloader do
       expect(file[:source_permissions]).to eq(:ignore)
     end
 
+    it "should ignore the max file limit" do
+      file = generate_file_resource
+
+      expect(file[:max_files]).to eq(-1)
+    end
+
     describe "on POSIX", :if => Puppet.features.posix? do
       it "should allow source_permissions to be overridden" do
         file = generate_file_resource(:source_permissions => :use)

--- a/spec/unit/file_serving/fileset_spec.rb
+++ b/spec/unit/file_serving/fileset_spec.rb
@@ -302,6 +302,14 @@ describe Puppet::FileServing::Fileset do
       expect { @fileset.files }.to_not raise_error
     end
 
+    it "does not emit a warning if max_files is -1" do
+      mock_big_dir_structure(@path)
+      @fileset.recurse = true
+      @fileset.max_files = -1
+      expect(Puppet).to receive(:warning).never
+      @fileset.files
+    end
+
     it "ignores files that match a pattern given as a boolean" do
       mock_dir_structure(@path)
       @fileset.recurse = true


### PR DESCRIPTION
* Update the file type to accept -1 `max_files` which will disable warnings
* Update pluginsync to pass `max_files => -1`