### PR TITLE
(PUP-11048) Correct changes from system to execute

### DIFF
--- a/lib/puppet/provider/service/debian.rb
+++ b/lib/puppet/provider/service/debian.rb
@@ -34,7 +34,7 @@ Puppet::Type.type(:service).provide :debian, :parent => :init do
   end
 
   def enabled?
-    status = execute("/usr/sbin/invoke-rc.d", "--quiet", "--query", @resource[:name], "start")
+    status = execute(["/usr/sbin/invoke-rc.d", "--quiet", "--query", @resource[:name], "start"], :failonfail => false)
 
     # 104 is the exit status when you query start an enabled service.
     # 106 is the exit status when the policy layer supplies a fallback action

--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -119,7 +119,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   # whether it is enabled or not. See PUP-5016 for more details.
   #
   def debian_enabled?
-    status = execute("/usr/sbin/invoke-rc.d", "--quiet", "--query", @resource[:name], "start")
+    status = execute(["/usr/sbin/invoke-rc.d", "--quiet", "--query", @resource[:name], "start"], :failonfail => false)
     if [104, 106].include?(status.exitstatus)
       return :true
     elsif [101, 105].include?(status.exitstatus)

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -330,6 +330,16 @@ Jun 14 21:43:23 foo.example.com systemd[1]: sshd.service lacks both ExecStart= a
                             and_return(Puppet::Util::Execution::ProcessOutput.new("masked\n", 1))
       expect(provider.enabled?).to eq(:mask)
     end
+
+    it "should consider nonexistent services to be disabled" do
+      provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'doesnotexist'))
+      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled', '--', 'doesnotexist'], :failonfail => false)
+                            .and_return(Puppet::Util::Execution::ProcessOutput.new("", 1))
+      expect(provider).to receive(:execute).with(["/usr/sbin/invoke-rc.d", "--quiet", "--query", "doesnotexist", "start"], :failonfail => false)
+                            .and_return(Puppet::Util::Execution::ProcessOutput.new("", 1))
+
+      expect(provider.enabled?).to be(:false)
+    end
   end
 
   describe "#enable" do


### PR DESCRIPTION
Commit 2f14ddd26 changed the debian and systemd service providers from calling
`Kernel.system` to `Puppet::Provider.execute`, but the methods don't take
arguments in the same way, resulting in:

    wrong number of arguments (given 5, expected 1..2)

This code path only seems to occur when ensuring a non-existent service isn't
enabled such as:

    # puppet resource service doesnotexist ensure=false enable=false

Prior to 2f14ddd26 we did not use a shell when calling Kernel.system:

    # strace -fi -e trace=execve ruby -e "system('ls','*')"
    ..
    [pid  1631] [00007fe41e5d1e37] execve("/bin/ls", ["ls", "*"], 0x55c1d97b3c50 /* 20 vars */) = 0

So we preserve that behavior when calling Puppet::Provider#execute:

    # strace -fi -e trace=execve /opt/puppetlabs/puppet/bin/ruby -e \
      "require 'puppet'; Puppet::Util::Execution.execute(['ls', '*'])"
    ..
    [pid  1613] [00007f1231b57e37] execve("/bin/ls", ["ls", "*"], 0x5615349c44d0 /* 18 vars */) = 0

We also have to pass `failonfail => false` to prevent puppet from raising on
non-zero exit status.