### PR TITLE
(docs) Document that 'reports = none' disables reporting

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1517,7 +1517,9 @@ EOT
         See the report reference for information on the built-in report
         handlers; custom report handlers can also be loaded from modules.
         (Report handlers are loaded from the lib directory, at
-        `puppet/reports/NAME.rb`.)",
+        `puppet/reports/NAME.rb`.)
+
+        To turn off reports entirely, set this to `none`",
     },
     :reportdir => {
       :default => "$vardir/reports",


### PR DESCRIPTION
Prior to this, the configuration reference page of the docs didn't mention how to disable reporting with the reports setting.

The docs page on reporting mentions it: https://puppet.com/docs/puppet/7.6/reporting_about.html
But not the config reference page: https://puppet.com/docs/puppet/7.6/configuration.html

This change aligns those docs by updating `defaults.rb` with info on disabling reporting.