### PR TITLE
(PUP-2153) Add support for FreeBSD profiles

### DIFF
--- a/lib/puppet/provider/service/freebsd.rb
+++ b/lib/puppet/provider/service/freebsd.rb
@@ -23,6 +23,7 @@ Puppet::Type.type(:service).provide :freebsd, :parent => :init do
     rcvar = execute([self.initscript, :rcvar], :failonfail => true, :combine => false, :squelch => false)
     rcvar = rcvar.split("\n")
     rcvar.delete_if {|str| str =~ /^#\s*$/}
+    rcvar.delete_if {|str| str =~ /^===> /}
     rcvar[1] = rcvar[1].gsub(/^\$/, '')
     rcvar
   end


### PR DESCRIPTION
When a FreeBSD rc-script has support for profiles, when running it with
the `rcvar` parameter the output is modified to list the profiles.

With a single profile:
```
root@localhost # /usr/local/etc/rc.d/fcgiwrap rcvar
===> fcgiwrap profile: nagios
# fcgiwrap
#
fcgiwrap_enable="YES"
#   (default: "")
```

With multiple profiles:
```
root@localhost # /usr/local/etc/rc.d/fcgiwrap rcvar
===> fcgiwrap profile: nagios1
# fcgiwrap
#
fcgiwrap_enable="YES"
#   (default: "")

===> fcgiwrap profile: nagios2
# fcgiwrap
#
fcgiwrap_enable="YES"
#   (default: "")

===> fcgiwrap profile: nagios3
# fcgiwrap
#
fcgiwrap_enable="YES"
#   (default: "")
```

Compare with the output for another service that has no support for
profiles:

```
root@localhost # /usr/local/etc/rc.d/nagios rcvar
# nagios
#
nagios_enable="YES"
#   (default: "")
```

Because the code assumes the rcvar is on a fixed line, the presence of
the `===> <service> profile: <profile>` line breaks the parsing of the
output.

Adjust this by removing the profile information lines too.