### PR TITLE
(PUP-11062) Add required feature for delayed service setting

### DIFF
--- a/lib/puppet/type/service.rb
+++ b/lib/puppet/type/service.rb
@@ -41,6 +41,9 @@ module Puppet
     feature :delayed_startable, "The provider can set service to delayed start",
       :methods => [:delayed_start]
 
+    feature :manual_startable, "The provider can set service to manual start",
+      :methods => [:manual_start]
+
     feature :controllable, "The provider uses a control variable."
 
     feature :flaggable, "The provider can pass flags to the service."
@@ -70,7 +73,7 @@ module Puppet
         provider.disable
       end
 
-      newvalue(:manual, :event => :service_manual_start) do
+      newvalue(:manual, :event => :service_manual_start, :required_features => :manual_startable) do
         provider.manual_start
       end
 
@@ -91,13 +94,6 @@ module Puppet
       def insync?(current)
         return provider.enabled_insync?(current) if provider.respond_to?(:enabled_insync?)
         super(current)
-      end
-
-      validate do |value|
-        super(value)
-        if (value == :manual) && !Puppet::Util::Platform.windows?
-          raise Puppet::Error.new(_("Setting enable to %{value} is only supported on Microsoft Windows.") % { value: value.to_s} )
-        end
       end
     end
 

--- a/lib/puppet/type/service.rb
+++ b/lib/puppet/type/service.rb
@@ -92,6 +92,7 @@ module Puppet
       end
 
       validate do |value|
+        super(value)
         if (value == :manual || value == :delayed) && !Puppet::Util::Platform.windows?
           raise Puppet::Error.new(_("Setting enable to %{value} is only supported on Microsoft Windows.") % { value: value.to_s} )
         end

--- a/lib/puppet/type/service.rb
+++ b/lib/puppet/type/service.rb
@@ -38,6 +38,9 @@ module Puppet
     feature :enableable, "The provider can enable and disable the service.",
       :methods => [:disable, :enable, :enabled?]
 
+    feature :delayed_startable, "The provider can set service to delayed start",
+      :methods => [:delayed_start]
+
     feature :controllable, "The provider uses a control variable."
 
     feature :flaggable, "The provider can pass flags to the service."
@@ -81,8 +84,7 @@ module Puppet
         provider.enabled?
       end
 
-      # This only works on Windows systems.
-      newvalue(:delayed, :event => :service_delayed_start) do
+      newvalue(:delayed, :event => :service_delayed_start, :required_features => :delayed_startable) do
         provider.delayed_start
       end
 
@@ -93,7 +95,7 @@ module Puppet
 
       validate do |value|
         super(value)
-        if (value == :manual || value == :delayed) && !Puppet::Util::Platform.windows?
+        if (value == :manual) && !Puppet::Util::Platform.windows?
           raise Puppet::Error.new(_("Setting enable to %{value} is only supported on Microsoft Windows.") % { value: value.to_s} )
         end
       end

--- a/spec/unit/type/service_spec.rb
+++ b/spec/unit/type/service_spec.rb
@@ -72,50 +72,69 @@ describe test_title, "when validating attribute values" do
       allow(@provider.class).to receive(:supports_parameter?).and_return(true)
     end
 
-    it "should support :true as a value" do
-      srv = Puppet::Type.type(:service).new(:name => "yay", :enable => :true)
-      expect(srv.should(:enable)).to eq(:true)
+    describe "for value without required features" do
+      before :each do
+        allow(@provider).to receive(:satisfies?)
+      end
+
+      it "should not support :mask as a value" do
+        expect { Puppet::Type.type(:service).new(:name => "yay", :enable => :mask) }.to raise_error(
+          Puppet::ResourceError,
+          /Provider .+ must have features 'maskable' to set 'enable' to 'mask'/
+        )
+      end
+
+      it "should not support :manual as a value when not on Windows" do
+        allow(Puppet::Util::Platform).to receive(:windows?).and_return(false)
+
+        expect { Puppet::Type.type(:service).new(:name => "yay", :enable => :manual) }.to raise_error(
+          Puppet::Error,
+          /Setting enable to manual is only supported on Microsoft Windows\./
+        )
+      end
+
+      it "should not support :delayed as a value when not on Windows" do
+        allow(Puppet::Util::Platform).to receive(:windows?).and_return(false)
+
+        expect { Puppet::Type.type(:service).new(:name => "yay", :enable => :delayed) }.to raise_error(
+          Puppet::Error,
+          /Setting enable to delayed is only supported on Microsoft Windows\./
+        )
+      end
     end
 
-    it "should support :false as a value" do
-      srv = Puppet::Type.type(:service).new(:name => "yay", :enable => :false)
-      expect(srv.should(:enable)).to eq(:false)
-    end
+    describe "for value with required features" do
+      before :each do
+        allow(@provider).to receive(:satisfies?).and_return(:true)
+      end
 
-    it "should support :mask as a value" do
-      srv = Puppet::Type.type(:service).new(:name => "yay", :enable => :mask)
-      expect(srv.should(:enable)).to eq(:mask)
-    end
+      it "should support :true as a value" do
+        srv = Puppet::Type.type(:service).new(:name => "yay", :enable => :true)
+        expect(srv.should(:enable)).to eq(:true)
+      end
 
-    it "should support :manual as a value on Windows" do
-      allow(Puppet::Util::Platform).to receive(:windows?).and_return(true)
-      srv = Puppet::Type.type(:service).new(:name => "yay", :enable => :manual)
-      expect(srv.should(:enable)).to eq(:manual)
-    end
+      it "should support :false as a value" do
+        srv = Puppet::Type.type(:service).new(:name => "yay", :enable => :false)
+        expect(srv.should(:enable)).to eq(:false)
+      end
 
-    it "should support :delayed as a value on Windows" do
-      allow(Puppet::Util::Platform).to receive(:windows?).and_return(true)
+      it "should support :mask as a value" do
+        srv = Puppet::Type.type(:service).new(:name => "yay", :enable => :mask)
+        expect(srv.should(:enable)).to eq(:mask)
+      end
 
-      srv = Puppet::Type.type(:service).new(:name => "yay", :enable => :delayed)
-      expect(srv.should(:enable)).to eq(:delayed)
-    end
+      it "should support :manual as a value on Windows" do
+        allow(Puppet::Util::Platform).to receive(:windows?).and_return(true)
+        srv = Puppet::Type.type(:service).new(:name => "yay", :enable => :manual)
+        expect(srv.should(:enable)).to eq(:manual)
+      end
 
-    it "should not support :manual as a value when not on Windows" do
-      allow(Puppet::Util::Platform).to receive(:windows?).and_return(false)
+      it "should support :delayed as a value on Windows" do
+        allow(Puppet::Util::Platform).to receive(:windows?).and_return(true)
 
-      expect { Puppet::Type.type(:service).new(:name => "yay", :enable => :manual) }.to raise_error(
-        Puppet::Error,
-        /Setting enable to manual is only supported on Microsoft Windows\./
-      )
-    end
-
-    it "should not support :delayed as a value when not on Windows" do
-      allow(Puppet::Util::Platform).to receive(:windows?).and_return(false)
-
-      expect { Puppet::Type.type(:service).new(:name => "yay", :enable => :delayed) }.to raise_error(
-        Puppet::Error,
-        /Setting enable to delayed is only supported on Microsoft Windows\./
-      )
+        srv = Puppet::Type.type(:service).new(:name => "yay", :enable => :delayed)
+        expect(srv.should(:enable)).to eq(:delayed)
+      end
     end
   end
 

--- a/spec/unit/type/service_spec.rb
+++ b/spec/unit/type/service_spec.rb
@@ -84,12 +84,10 @@ describe test_title, "when validating attribute values" do
         )
       end
 
-      it "should not support :manual as a value when not on Windows" do
-        allow(Puppet::Util::Platform).to receive(:windows?).and_return(false)
-
+      it "should not support :manual as a value" do
         expect { Puppet::Type.type(:service).new(:name => "yay", :enable => :manual) }.to raise_error(
-          Puppet::Error,
-          /Setting enable to manual is only supported on Microsoft Windows\./
+          Puppet::ResourceError,
+          /Provider .+ must have features 'manual_startable' to set 'enable' to 'manual'/
         )
       end
 

--- a/spec/unit/type/service_spec.rb
+++ b/spec/unit/type/service_spec.rb
@@ -93,12 +93,10 @@ describe test_title, "when validating attribute values" do
         )
       end
 
-      it "should not support :delayed as a value when not on Windows" do
-        allow(Puppet::Util::Platform).to receive(:windows?).and_return(false)
-
+      it "should not support :mask as a value" do
         expect { Puppet::Type.type(:service).new(:name => "yay", :enable => :delayed) }.to raise_error(
-          Puppet::Error,
-          /Setting enable to delayed is only supported on Microsoft Windows\./
+          Puppet::ResourceError,
+          /Provider .+ must have features 'delayed_startable' to set 'enable' to 'delayed'/
         )
       end
     end


### PR DESCRIPTION
Before, validation on values from the `enable` property was overwritten with a custom one which omitted checking required features for values such as :mask. This resulted in a not very useful error message instead of the intended:
`Provider x must have features y to set z`.

8d6c5ba92076babba07a42d8f82c9e6f86f8ef8b re-enables check for required features on enable service values before the custom validation.

9b9e7489839b8e55d3c18790278aff01a2adce0b adds required feature for `delayed` value on enable service property.

16181a58b125aaed17e84eab882e326bccadcb53 adds required feature for `manual` value on enable service property and removes custom validation since it is completely replaced by above changes of adding required features.
