### PR TITLE
(maint) Fix rc-scripts edition on FreeBSD when managing services

### DIFF
--- a/lib/puppet/provider/service/freebsd.rb
+++ b/lib/puppet/provider/service/freebsd.rb
@@ -74,7 +74,7 @@ Puppet::Type.type(:service).provide :freebsd, :parent => :init do
       if Puppet::FileSystem.exist?(filename)
         s = File.read(filename)
         if s.gsub!(/^(#{rcvar}(_enable)?)=\"?(YES|NO)\"?/, "\\1=\"#{yesno}\"")
-          File.open(filename, File::WRONLY | File::TRUNC) { |f| f << s }
+          Puppet::FileSystem.replace_file(filename) { |f| f << s  }
           self.debug("Replaced in #{filename}")
           success = true
         end

--- a/lib/puppet/provider/service/freebsd.rb
+++ b/lib/puppet/provider/service/freebsd.rb
@@ -74,7 +74,7 @@ Puppet::Type.type(:service).provide :freebsd, :parent => :init do
       if Puppet::FileSystem.exist?(filename)
         s = File.read(filename)
         if s.gsub!(/^(#{rcvar}(_enable)?)=\"?(YES|NO)\"?/, "\\1=\"#{yesno}\"")
-          File.open(filename, File::WRONLY) { |f| f << s }
+          File.open(filename, File::WRONLY | File::TRUNC) { |f| f << s }
           self.debug("Replaced in #{filename}")
           success = true
         end

--- a/spec/unit/provider/service/freebsd_spec.rb
+++ b/spec/unit/provider/service/freebsd_spec.rb
@@ -82,7 +82,7 @@ OUTPUT
     allow(Puppet::FileSystem).to receive(:exist?).with('/etc/rc.conf').and_return(true)
     allow(File).to receive(:read).with('/etc/rc.conf').and_return("openntpd_enable=\"NO\"\nntpd_enable=\"NO\"\n")
     fh = double('fh')
-    allow(File).to receive(:open).with('/etc/rc.conf', File::WRONLY | File::TRUNC).and_yield(fh)
+    allow(Puppet::FileSystem).to receive(:replace_file).with('/etc/rc.conf').and_yield(fh)
     expect(fh).to receive(:<<).with("openntpd_enable=\"NO\"\nntpd_enable=\"YES\"\n")
     allow(Puppet::FileSystem).to receive(:exist?).with('/etc/rc.conf.local').and_return(false)
     allow(Puppet::FileSystem).to receive(:exist?).with('/etc/rc.conf.d/ntpd').and_return(false)

--- a/spec/unit/provider/service/freebsd_spec.rb
+++ b/spec/unit/provider/service/freebsd_spec.rb
@@ -82,7 +82,7 @@ OUTPUT
     allow(Puppet::FileSystem).to receive(:exist?).with('/etc/rc.conf').and_return(true)
     allow(File).to receive(:read).with('/etc/rc.conf').and_return("openntpd_enable=\"NO\"\nntpd_enable=\"NO\"\n")
     fh = double('fh')
-    allow(File).to receive(:open).with('/etc/rc.conf', File::WRONLY).and_yield(fh)
+    allow(File).to receive(:open).with('/etc/rc.conf', File::WRONLY | File::TRUNC).and_yield(fh)
     expect(fh).to receive(:<<).with("openntpd_enable=\"NO\"\nntpd_enable=\"YES\"\n")
     allow(Puppet::FileSystem).to receive(:exist?).with('/etc/rc.conf.local').and_return(false)
     allow(Puppet::FileSystem).to receive(:exist?).with('/etc/rc.conf.d/ntpd').and_return(false)


### PR DESCRIPTION
Previously, we did not truncate the script when updating a variable. Since the module only support setting variables to "YES" and "NO", the only consequence was that when switching from "YES" to "NO" the last character of the file was kept and we ended up with a blank line:

sshd_enable="YES"\n  -> sshd_enable="NO"\n\n

With the introduction of the support of more variables for the freebsd provider, this result however in more breakage so we have to fix it.

Discovered while working on #8607