### PR TITLE
(PUP-11076) remove sorted_set usage

### DIFF
--- a/lib/puppet/provider/package/apt.rb
+++ b/lib/puppet/provider/package/apt.rb
@@ -91,20 +91,20 @@ Puppet::Type.type(:package).provide :apt, :parent => :dpkg, :source => :dpkg do
   end
 
   def best_version(should_range)
-    available_versions = SortedSet.new
+    versions = []
 
     output = aptcache :madison, @resource[:name]
     output.each_line do |line|
       is = line.split('|')[1].strip
       begin
         is_version = DebianVersion.parse(is)
-        available_versions << is_version if should_range.include?(is_version)
+        versions << is_version if should_range.include?(is_version)
       rescue DebianVersion::ValidationFailure
         Puppet.debug("Cannot parse #{is} as a debian version")
       end
     end
 
-    return available_versions.to_a.last unless available_versions.empty?
+    return versions.sort.last if versions.any?
 
     Puppet.debug("No available version for package #{@resource[:name]} is included in range #{should_range}")
     should_range

--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -203,17 +203,17 @@ defaultfor :osfamily => :redhat, :operatingsystemmajrelease => (4..7).to_a
         Puppet.debug("Cannot parse #{should} as a RPM version range")
         return should
       end
-      sorted_versions = SortedSet.new
+      versions = []
       available_versions(@resource[:name]).each do |version|
         begin
           rpm_version = RPM_VERSION.parse(version)
-          sorted_versions << rpm_version if should_range.include?(rpm_version)
+          versions << rpm_version if should_range.include?(rpm_version)
         rescue RPM_VERSION::ValidationFailure
           Puppet.debug("Cannot parse #{version} as a RPM version")
         end
       end
 
-      version = sorted_versions.entries.last
+      version = versions.sort.last if versions.any?
 
       if version
         version = version.to_s.sub(/^\d+:/, '')

--- a/lib/puppet/provider/package/zypper.rb
+++ b/lib/puppet/provider/package/zypper.rb
@@ -63,7 +63,7 @@ Puppet::Type.type(:package).provide :zypper, :parent => :rpm, :source => :rpm do
         return should
       end
 
-      sorted_versions = SortedSet.new
+      versions = []
 
       output = zypper('search', '--match-exact', '--type', 'package', '--uninstalled-only', '-s', @resource[:name])
       output.lines.each do |line|
@@ -72,13 +72,13 @@ Puppet::Type.type(:package).provide :zypper, :parent => :rpm, :source => :rpm do
         begin
           rpm_version = Puppet::Util::Package::Version::Rpm.parse(pkg_ver[3])
 
-          sorted_versions << rpm_version if should_range.include?(rpm_version)
+          versions << rpm_version if should_range.include?(rpm_version)
         rescue Puppet::Util::Package::Version::Rpm::ValidationFailure
           Puppet.debug("Cannot parse #{pkg_ver[3]} as a RPM version")
         end
       end
 
-      return sorted_versions.entries.last if sorted_versions.any?
+      return versions.sort.last if versions.any?
 
       Puppet.debug("No available version for package #{@resource[:name]} is included in range #{should_range}")
       should


### PR DESCRIPTION
Ruby 3 has removed sorted_set from the core and
exposes it as an external gem.
In puppet, we use it to store the versions of a package.
This can be safely replaced by an Array.