### PR TITLE
(PUP-9570) Retry pluginsync if the agent's environment is wrong

### DIFF
--- a/lib/puppet/http/service/compiler.rb
+++ b/lib/puppet/http/service/compiler.rb
@@ -69,6 +69,9 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
   # @param [String] environment The name of the environment we are operating in
   # @param [String] configured_environment Optional, the name of the configured
   #   environment. If unset, `environment` is used.
+  # @param [Boolean] if true, request that the server check if our `environment`
+  #   matches the server specified environment. If they are mismatched, it will
+  #   return an empty catalog with the server specified environment.
   # @param [String] transaction_uuid An agent generated transaction uuid, used
   #   for connecting catalogs and reports.
   # @param [String] job_uuid A unique job identifier defined when the orchestrator
@@ -85,7 +88,7 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
   #   containing the request response and the deserialized catalog returned by
   #   the server
   #
-  def post_catalog(name, facts:, environment:, configured_environment: nil, transaction_uuid: nil, job_uuid: nil, static_catalog: true, checksum_type: Puppet[:supported_checksum_types])
+  def post_catalog(name, facts:, environment:, configured_environment: nil, transaction_uuid: nil, job_uuid: nil, static_catalog: true, checksum_type: Puppet[:supported_checksum_types], check_environment: true)
     if Puppet[:preferred_serialization_format] == "pson"
       formatter = Puppet::Network::FormatHandler.format_for(:pson)
       # must use 'pson' instead of 'text/pson'
@@ -103,6 +106,7 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
       facts: Puppet::Util.uri_query_encode(facts_as_string),
       environment: environment,
       configured_environment: configured_environment || environment,
+      check_environment: check_environment,
       transaction_uuid: transaction_uuid,
       job_uuid: job_uuid,
       static_catalog: static_catalog,


### PR DESCRIPTION
Previously, puppet agent could download plugins and facts from one
environment (A), but puppetserver could try to compile a catalog in a different
environment (B). If puppet code in B relied on a fact that only existed in B,
then compilation could fail, depending on how the fact was used. If fact
versions were different in A and B, then results were undefined.

This change ensures the agent's pluginsync and server's compiler environments
are consistent. If they are different, then the server returns an empty catalog
with the server specified environment. The agent will detect the mismatch and
retry its convergence loop, up to a maximum limit.

Note the agent won't cache the empty catalog, because caching only occurs if the
environment converges and it successfully converts it to a RAL catalog.

The check for :'*root*' is because some tests don't stub the request
environment. When running in puppetserver, the request's environment is always
resolved from the 'environment' query parameter.