### PR TITLE
(PUP-11077) Pass SemVer prerelease and build as an array

### DIFF
--- a/lib/puppet/pops/types/p_sem_ver_type.rb
+++ b/lib/puppet/pops/types/p_sem_ver_type.rb
@@ -95,15 +95,21 @@ class PSemVerType < PScalarType
       end
 
       def from_args(major, minor, patch, prerelease = nil, build = nil)
-        SemanticPuppet::Version.new(major, minor, patch, prerelease, build)
+        SemanticPuppet::Version.new(major, minor, patch, to_array(prerelease), to_array(build))
       end
 
       def from_hash(hash)
-        SemanticPuppet::Version.new(hash['major'], hash['minor'], hash['patch'], hash['prerelease'], hash['build'])
+        SemanticPuppet::Version.new(hash['major'], hash['minor'], hash['patch'], to_array(hash['prerelease']), to_array(hash['build']))
       end
 
       def on_error(str)
         _("The string '%{str}' cannot be converted to a SemVer") % { str: str }
+      end
+
+      private
+
+      def to_array(component)
+        component ? [component] : nil
       end
     end
   end

--- a/spec/unit/pops/types/p_sem_ver_type_spec.rb
+++ b/spec/unit/pops/types/p_sem_ver_type_spec.rb
@@ -125,6 +125,24 @@ describe 'Semantic Versions' do
         expect(eval_and_collect_notices(code)).to eql(['true', 'false'])
       end
 
+      it 'can be compared to another instance created from arguments' do
+        code = <<-CODE
+          $x = SemVer('1.2.3-rc4+5')
+          $y = SemVer(1, 2, 3, 'rc4', '5')
+          notice($x == $y)
+        CODE
+        expect(eval_and_collect_notices(code)).to eql(['true'])
+      end
+
+      it 'can be compared to another instance created from a hash' do
+        code = <<-CODE
+          $x = SemVer('1.2.3-rc4+5')
+          $y = SemVer(major => 1, minor => 2, patch => 3, prerelease => 'rc4', build => '5')
+          notice($x == $y)
+        CODE
+        expect(eval_and_collect_notices(code)).to eql(['true'])
+      end
+
       it 'can be compared to another instance for magnitude' do
         code = <<-CODE
           $x = SemVer('1.1.1')


### PR DESCRIPTION
Passing SemVer prerelease or build components as a list of arguments or a hash
added dots between each character due to confusion between Strings vs Arrays.
For example, SemVer(1, 0, 0, "rc0") resulted in prerelease "r.c.0". This isn't
an issue when passing the entire version as a string, eg "1.0.0-rc0".

Automatically wrapping the prerelease or build components in an array isn't a
breaking change, because it wasn't possible to do it previously. That's because
the function signature is defined to accept a `SemVerQualifier` which `Array` is
not:

    $ bx puppet apply -e 'notice(SemVer(1, 2, 3, ["rc4"], ["5"]))'
    Error: Evaluation Error: Error while evaluating a Function Call...
    rejected: parameter 'prerelease' expects a match for SemVerQualifier