### PR TITLE
(PUP-11081) Allow access to user keychains from macOS daemon

### DIFF
--- a/ext/osx/puppet.plist
+++ b/ext/osx/puppet.plist
@@ -26,5 +26,7 @@
         <string>/var/log/puppetlabs/puppet/puppet.log</string>
         <key>StandardOutPath</key>
         <string>/var/log/puppetlabs/puppet/puppet.log</string>
+        <key>SessionCreate</key>
+        <true />
 </dict>
 </plist>


### PR DESCRIPTION
By default, launchd plists do not provide access to user keychains (i.e. having the daemon run `security list-keychains` as a different user will not list the user's keychains).

There isn't really any reason why we shouldn't allow this in the puppet plist especially since having `puppet agent -t` run the same command works, it's just runs from the daemon that are affected.

Apple documentation for `SessionCreate` states the following:

> SessionCreate <boolean>
> This key specifies that the job should be spawned into a new security
> audit session rather than the default session for the context is belongs
> to. See auditon(2) for details.

Relevant SO answer: https://stackoverflow.com/a/9482707/1074558