### PR TITLE
(maint) Reload puppetserver service on tests teardown

### DIFF
--- a/acceptance/tests/allow_arbitrary_node_name_fact_for_agent.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_fact_for_agent.rb
@@ -25,6 +25,7 @@ if @options[:is_puppetserver]
   teardown do
     modify_tk_config(master, options['puppetserver-config'], {'jruby-puppet' => {'use-legacy-auth-conf' => true}})
     on master, 'cp /etc/puppetlabs/puppetserver/conf.d/auth.bak /etc/puppetlabs/puppetserver/conf.d/auth.conf'
+    on master, "service #{master['puppetservice']} reload"
   end
 
   step "Setup tk-auth rules" do

--- a/acceptance/tests/allow_arbitrary_node_name_for_agent.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_for_agent.rb
@@ -17,6 +17,7 @@ if @options[:is_puppetserver]
   teardown do
     on master, 'cp /etc/puppetlabs/puppetserver/conf.d/auth.bak /etc/puppetlabs/puppetserver/conf.d/auth.conf'
     modify_tk_config(master, options['puppetserver-config'], {'jruby-puppet' => {'use-legacy-auth-conf' => true}})
+    on master, "service #{master['puppetservice']} reload"
   end
 
   step "Setup tk-auth rules" do


### PR DESCRIPTION
For tests that modify auth.conf, make sure we reload the puppetserver service after copying back the old auth.conf, otherwise subsequent tests may fail.

For example, running `tests/agent/agent_parses_json_catalog.rb` after `allow_arbitrary_node_name_for_agent.rb` will fail without this change.