### PR TITLE
(PUP-3631) Fix regular expressions in the `nim` package provider

### DIFF
--- a/lib/puppet/provider/package/nim.rb
+++ b/lib/puppet/provider/package/nim.rb
@@ -156,7 +156,7 @@ Puppet::Type.type(:package).provide :nim, :parent => :aix, :source => :aix do
   # do so.
   self::HEADER_LINE_REGEX      = /^([^\s]+)\s+[^@]+@@(I|R|S):(\1)\s+[^\s]+$/
   self::PACKAGE_LINE_REGEX     = /^.*@@(I|R|S):(.*)$/
-  self::RPM_PACKAGE_REGEX      = /^(.*)-(.*-\d+) \2$/
+  self::RPM_PACKAGE_REGEX      = /^(.*)-(.*-\d+\w*) \2$/
   self::INSTALLP_PACKAGE_REGEX = /^(.*) (.*)$/
 
   # Here is some sample output that shows what the above regexes will be up

--- a/lib/puppet/provider/package/nim.rb
+++ b/lib/puppet/provider/package/nim.rb
@@ -154,19 +154,24 @@ Puppet::Type.type(:package).provide :nim, :parent => :aix, :source => :aix do
   # I spent a lot of time trying to figure out a solution that didn't
   # require parsing the `nimclient -o showres` output and was unable to
   # do so.
-  self::HEADER_LINE_REGEX      = /^([^\s]+)\s+[^@]+@@(I|R):(\1)\s+[^\s]+$/
-  self::PACKAGE_LINE_REGEX     = /^.*@@(I|R):(.*)$/
+  self::HEADER_LINE_REGEX      = /^([^\s]+)\s+[^@]+@@(I|R|S):(\1)\s+[^\s]+$/
+  self::PACKAGE_LINE_REGEX     = /^.*@@(I|R|S):(.*)$/
   self::RPM_PACKAGE_REGEX      = /^(.*)-(.*-\d+) \2$/
   self::INSTALLP_PACKAGE_REGEX = /^(.*) (.*)$/
 
   # Here is some sample output that shows what the above regexes will be up
   # against:
-  # FOR AN INSTALLP PACKAGE:
+  # FOR AN INSTALLP(bff) PACKAGE:
   #
   #    mypackage.foo                                                           ALL  @@I:mypackage.foo _all_filesets
-  #    @ 1.2.3.1  MyPackage Runtime Environment                       @@I:mypackage.foo 1.2.3.1
   #    + 1.2.3.4  MyPackage Runtime Environment                       @@I:mypackage.foo 1.2.3.4
   #    + 1.2.3.8  MyPackage Runtime Environment                       @@I:mypackage.foo 1.2.3.8
+  #
+  # FOR AN INSTALLP(bff) PACKAGE with security update:
+  #
+  #    bos.net                                                                 ALL  @@S:bos.net _all_filesets
+  #    + 7.2.0.1  TCP/IP ntp Applications                             @@S:bos.net.tcp.ntp 7.2.0.1
+  #    + 7.2.0.2  TCP/IP ntp Applications                             @@S:bos.net.tcp.ntp 7.2.0.2
   #
   # FOR AN RPM PACKAGE:
   #
@@ -243,7 +248,7 @@ Puppet::Type.type(:package).provide :nim, :parent => :aix, :source => :aix do
     package_string = match.captures[1]
 
     case package_type_flag
-      when "I"
+      when "I","S"
         parse_installp_package_string(package_string)
       when "R"
         parse_rpm_package_string(package_string)

--- a/spec/unit/provider/package/nim_spec.rb
+++ b/spec/unit/provider/package/nim_spec.rb
@@ -220,6 +220,27 @@ END
       it "should return :installp for installp/bff packages" do
         expect(subject.send(:determine_package_type, bff_showres_output, 'mypackage.foo', '1.2.3.4')).to eq(:installp)
       end
+
+      it "should return :installp for security updates" do
+        nimclient_showres_output = <<END
+bos.net                                                            ALL  @@S:bos.net _all_filesets
+ + 7.2.0.1  TCP/IP ntp Applications                                     @@S:bos.net.tcp.ntp 7.2.0.1
+ + 7.2.0.2  TCP/IP ntp Applications                                     @@S:bos.net.tcp.ntp 7.2.0.2
+
+END
+        expect(subject.send(:determine_package_type, nimclient_showres_output, 'bos.net.tcp.ntp', '7.2.0.2')).to eq(:installp)
+      end
+
+      it "should raise error when invalid header format is given" do
+        nimclient_showres_output = <<END
+bos.net                                                            ALL  @@INVALID_TYPE:bos.net _all_filesets
+ + 7.2.0.1  TCP/IP ntp Applications                                     @@INVALID_TYPE:bos.net.tcp.ntp 7.2.0.1
+ + 7.2.0.2  TCP/IP ntp Applications                                     @@INVALID_TYPE:bos.net.tcp.ntp 7.2.0.2
+
+END
+        expect{ subject.send(:determine_package_type, nimclient_showres_output, 'bos.net.tcp.ntp', '7.2.0.2') }.to raise_error(
+          Puppet::Error, /Unable to parse output from nimclient showres: line does not match expected package header format/)
+      end
     end
   end
 end

--- a/spec/unit/provider/package/nim_spec.rb
+++ b/spec/unit/provider/package/nim_spec.rb
@@ -191,6 +191,27 @@ OUTPUT
           expect(versions[version]).to eq(:rpm)
         end
       end
+
+      it "should be able to parse RPM package listings with letters in version" do
+        showres_output = <<END
+cairo                                                              ALL  @@R:cairo _all_filesets
+   @@R:cairo-1.14.6-2waixX11 1.14.6-2waixX11
+END
+        packages = subject.send(:parse_showres_output, showres_output)
+        expect(Set.new(packages.keys)).to eq(Set.new(['cairo']))
+        versions = packages['cairo']
+        expect(versions.has_key?('1.14.6-2waixX11')).to eq(true)
+        expect(versions['1.14.6-2waixX11']).to eq(:rpm)
+      end
+
+      it "should raise error when parsing invalid RPM package listings" do
+              showres_output = <<END
+cairo                                                              ALL  @@R:cairo _all_filesets
+   @@R:cairo-invalid_version invalid_version
+END
+        expect{ subject.send(:parse_showres_output, showres_output) }.to raise_error(Puppet::Error,
+          /Unable to parse output from nimclient showres: package string does not match expected rpm package string format/)
+      end
     end
 
     context "#determine_latest_version" do


### PR DESCRIPTION
20f2499 adapts the regular expression used in the `nim` package provider to allow packages with `S` (security update) in their header to be installed instead of throwing the error:
`Unable to parse output from nimclient showres: line does not match expected package header format`


2c9bb7e adapts the regular expression from the `nim` package provider used for parsing RPM package versions to allow installation of RPM packages that have letters in their version instead of throwing the error:
`Unable to parse output from nimclient showres: package string does not match expected rpm package string format`