### PR TITLE
(PUP-10974) Allow masking of nonexistent systemd services

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -164,8 +164,13 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   end
 
   def mask
-    self.disable
+    disable if exist?
     systemctl_change_enable(:mask)
+  end
+
+  def exist?
+    result = execute([command(:systemctl), 'cat', '--', @resource[:name]], :failonfail => false)
+    result.exitstatus == 0
   end
 
   def unmask


### PR DESCRIPTION
CIS controls may require services to be masked, even if they don't exist. So
check if the service exists using `systemctl cat -- <name>` before trying to
disable it.