### PR TITLE
(maint) Merge 6.x to main

### DIFF
--- a/acceptance/tests/allow_arbitrary_node_name_fact_for_agent.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_fact_for_agent.rb
@@ -24,6 +24,7 @@ end
 teardown do
   modify_tk_config(master, options['puppetserver-config'], {'jruby-puppet' => {'use-legacy-auth-conf' => true}})
   on master, 'cp /etc/puppetlabs/puppetserver/conf.d/auth.bak /etc/puppetlabs/puppetserver/conf.d/auth.conf'
+  on master, "service #{master['puppetservice']} reload"
 end
 
 step "Setup tk-auth rules" do

--- a/acceptance/tests/allow_arbitrary_node_name_for_agent.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_for_agent.rb
@@ -16,6 +16,7 @@ end
 teardown do
   on master, 'cp /etc/puppetlabs/puppetserver/conf.d/auth.bak /etc/puppetlabs/puppetserver/conf.d/auth.conf'
   modify_tk_config(master, options['puppetserver-config'], {'jruby-puppet' => {'use-legacy-auth-conf' => true}})
+  on master, "service #{master['puppetservice']} reload"
 end
 
 step "Setup tk-auth rules" do

--- a/ext/osx/puppet.plist
+++ b/ext/osx/puppet.plist
@@ -26,5 +26,7 @@
         <string>/var/log/puppetlabs/puppet/puppet.log</string>
         <key>StandardOutPath</key>
         <string>/var/log/puppetlabs/puppet/puppet.log</string>
+        <key>SessionCreate</key>
+        <true />
 </dict>
 </plist>

--- a/lib/puppet/pops/types/p_sem_ver_type.rb
+++ b/lib/puppet/pops/types/p_sem_ver_type.rb
@@ -95,15 +95,21 @@ class PSemVerType < PScalarType
       end
 
       def from_args(major, minor, patch, prerelease = nil, build = nil)
-        SemanticPuppet::Version.new(major, minor, patch, prerelease, build)
+        SemanticPuppet::Version.new(major, minor, patch, to_array(prerelease), to_array(build))
       end
 
       def from_hash(hash)
-        SemanticPuppet::Version.new(hash['major'], hash['minor'], hash['patch'], hash['prerelease'], hash['build'])
+        SemanticPuppet::Version.new(hash['major'], hash['minor'], hash['patch'], to_array(hash['prerelease']), to_array(hash['build']))
       end
 
       def on_error(str)
         _("The string '%{str}' cannot be converted to a SemVer") % { str: str }
+      end
+
+      private
+
+      def to_array(component)
+        component ? [component] : nil
       end
     end
   end

--- a/lib/puppet/provider/package/nim.rb
+++ b/lib/puppet/provider/package/nim.rb
@@ -154,19 +154,24 @@ Puppet::Type.type(:package).provide :nim, :parent => :aix, :source => :aix do
   # I spent a lot of time trying to figure out a solution that didn't
   # require parsing the `nimclient -o showres` output and was unable to
   # do so.
-  self::HEADER_LINE_REGEX      = /^([^\s]+)\s+[^@]+@@(I|R):(\1)\s+[^\s]+$/
-  self::PACKAGE_LINE_REGEX     = /^.*@@(I|R):(.*)$/
-  self::RPM_PACKAGE_REGEX      = /^(.*)-(.*-\d+) \2$/
+  self::HEADER_LINE_REGEX      = /^([^\s]+)\s+[^@]+@@(I|R|S):(\1)\s+[^\s]+$/
+  self::PACKAGE_LINE_REGEX     = /^.*@@(I|R|S):(.*)$/
+  self::RPM_PACKAGE_REGEX      = /^(.*)-(.*-\d+\w*) \2$/
   self::INSTALLP_PACKAGE_REGEX = /^(.*) (.*)$/
 
   # Here is some sample output that shows what the above regexes will be up
   # against:
-  # FOR AN INSTALLP PACKAGE:
+  # FOR AN INSTALLP(bff) PACKAGE:
   #
   #    mypackage.foo                                                           ALL  @@I:mypackage.foo _all_filesets
-  #    @ 1.2.3.1  MyPackage Runtime Environment                       @@I:mypackage.foo 1.2.3.1
   #    + 1.2.3.4  MyPackage Runtime Environment                       @@I:mypackage.foo 1.2.3.4
   #    + 1.2.3.8  MyPackage Runtime Environment                       @@I:mypackage.foo 1.2.3.8
+  #
+  # FOR AN INSTALLP(bff) PACKAGE with security update:
+  #
+  #    bos.net                                                                 ALL  @@S:bos.net _all_filesets
+  #    + 7.2.0.1  TCP/IP ntp Applications                             @@S:bos.net.tcp.ntp 7.2.0.1
+  #    + 7.2.0.2  TCP/IP ntp Applications                             @@S:bos.net.tcp.ntp 7.2.0.2
   #
   # FOR AN RPM PACKAGE:
   #
@@ -243,7 +248,7 @@ Puppet::Type.type(:package).provide :nim, :parent => :aix, :source => :aix do
     package_string = match.captures[1]
 
     case package_type_flag
-      when "I"
+      when "I","S"
         parse_installp_package_string(package_string)
       when "R"
         parse_rpm_package_string(package_string)

--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -164,8 +164,13 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   end
 
   def mask
-    self.disable
+    disable if exist?
     systemctl_change_enable(:mask)
+  end
+
+  def exist?
+    result = execute([command(:systemctl), 'cat', '--', @resource[:name]], :failonfail => false)
+    result.exitstatus == 0
   end
 
   def unmask

--- a/lib/puppet/provider/user/directoryservice.rb
+++ b/lib/puppet/provider/user/directoryservice.rb
@@ -591,11 +591,7 @@ Puppet::Type.type(:user).provide :directoryservice do
     else
       users_plist['ShadowHashData'] = [binary_plist]
     end
-    if Puppet::Util::Package.versioncmp(self.class.get_os_version, '10.15') < 0
-      write_users_plist_to_disk(users_plist)
-    else
-      write_and_import_shadow_hash_data(users_plist['ShadowHashData'].first)
-    end
+    write_and_import_shadow_hash_data(users_plist['ShadowHashData'].first)
   end
 
   # This method writes the ShadowHashData plist in a temporary file,
@@ -669,12 +665,6 @@ Puppet::Type.type(:user).provide :directoryservice do
     # back to the user's plist.
     binary_plist = self.class.convert_hash_to_binary(shadow_hash_data)
     set_shadow_hash_data(users_plist, binary_plist)
-  end
-
-  # This method will accept a plist in XML format, save it to disk, convert
-  # the plist to a binary format, and flush the dscl cache.
-  def write_users_plist_to_disk(users_plist)
-    Puppet::Util::Plist.write_plist_file(users_plist, "#{users_plist_dir}/#{@resource.name}.plist", :binary)
   end
 
   private

--- a/lib/puppet/transaction/additional_resource_generator.rb
+++ b/lib/puppet/transaction/additional_resource_generator.rb
@@ -137,7 +137,7 @@ class Puppet::Transaction::AdditionalResourceGenerator
       else
         @catalog.add_resource_after(parent_resource, res)
       end
-      @catalog.add_edge(@catalog.container_of(parent_resource), res)
+      @catalog.add_edge(@catalog.container_of(parent_resource), res) if @catalog.container_of(parent_resource)
       if @relationship_graph && priority
         # If we have a relationship_graph we should add the resource
         # to it (this is an eval_generate). If we don't, then the

--- a/spec/integration/application/resource_spec.rb
+++ b/spec/integration/application/resource_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+require 'puppet_spec/files'
+
+describe "puppet resource", unless: Puppet::Util::Platform.jruby? do
+  include PuppetSpec::Files
+
+  let(:resource) { Puppet::Application[:resource] }
+
+  describe "when handling file and tidy types" do
+    let!(:dir) { dir_containing('testdir', 'testfile' => 'contents') }
+
+    it 'does not raise when generating file resources' do
+      resource.command_line.args = ['file', dir, 'ensure=directory', 'recurse=true']
+
+      expect {
+        resource.run
+      }.to output(/ensure.+=> 'directory'/).to_stdout
+    end
+
+    it 'correctly cleans up a given path' do
+      resource.command_line.args = ['tidy', dir, 'rmdirs=true', 'recurse=true']
+
+      expect {
+        resource.run
+      }.to output(/Notice: \/File\[#{dir}\]\/ensure: removed/).to_stdout
+
+      expect(Puppet::FileSystem.exist?(dir)).to be false
+    end
+  end
+end

--- a/spec/unit/pops/types/p_sem_ver_type_spec.rb
+++ b/spec/unit/pops/types/p_sem_ver_type_spec.rb
@@ -125,6 +125,24 @@ describe 'Semantic Versions' do
         expect(eval_and_collect_notices(code)).to eql(['true', 'false'])
       end
 
+      it 'can be compared to another instance created from arguments' do
+        code = <<-CODE
+          $x = SemVer('1.2.3-rc4+5')
+          $y = SemVer(1, 2, 3, 'rc4', '5')
+          notice($x == $y)
+        CODE
+        expect(eval_and_collect_notices(code)).to eql(['true'])
+      end
+
+      it 'can be compared to another instance created from a hash' do
+        code = <<-CODE
+          $x = SemVer('1.2.3-rc4+5')
+          $y = SemVer(major => 1, minor => 2, patch => 3, prerelease => 'rc4', build => '5')
+          notice($x == $y)
+        CODE
+        expect(eval_and_collect_notices(code)).to eql(['true'])
+      end
+
       it 'can be compared to another instance for magnitude' do
         code = <<-CODE
           $x = SemVer('1.1.1')

--- a/spec/unit/provider/package/nim_spec.rb
+++ b/spec/unit/provider/package/nim_spec.rb
@@ -191,6 +191,27 @@ OUTPUT
           expect(versions[version]).to eq(:rpm)
         end
       end
+
+      it "should be able to parse RPM package listings with letters in version" do
+        showres_output = <<END
+cairo                                                              ALL  @@R:cairo _all_filesets
+   @@R:cairo-1.14.6-2waixX11 1.14.6-2waixX11
+END
+        packages = subject.send(:parse_showres_output, showres_output)
+        expect(Set.new(packages.keys)).to eq(Set.new(['cairo']))
+        versions = packages['cairo']
+        expect(versions.has_key?('1.14.6-2waixX11')).to eq(true)
+        expect(versions['1.14.6-2waixX11']).to eq(:rpm)
+      end
+
+      it "should raise error when parsing invalid RPM package listings" do
+              showres_output = <<END
+cairo                                                              ALL  @@R:cairo _all_filesets
+   @@R:cairo-invalid_version invalid_version
+END
+        expect{ subject.send(:parse_showres_output, showres_output) }.to raise_error(Puppet::Error,
+          /Unable to parse output from nimclient showres: package string does not match expected rpm package string format/)
+      end
     end
 
     context "#determine_latest_version" do
@@ -219,6 +240,27 @@ END
 
       it "should return :installp for installp/bff packages" do
         expect(subject.send(:determine_package_type, bff_showres_output, 'mypackage.foo', '1.2.3.4')).to eq(:installp)
+      end
+
+      it "should return :installp for security updates" do
+        nimclient_showres_output = <<END
+bos.net                                                            ALL  @@S:bos.net _all_filesets
+ + 7.2.0.1  TCP/IP ntp Applications                                     @@S:bos.net.tcp.ntp 7.2.0.1
+ + 7.2.0.2  TCP/IP ntp Applications                                     @@S:bos.net.tcp.ntp 7.2.0.2
+
+END
+        expect(subject.send(:determine_package_type, nimclient_showres_output, 'bos.net.tcp.ntp', '7.2.0.2')).to eq(:installp)
+      end
+
+      it "should raise error when invalid header format is given" do
+        nimclient_showres_output = <<END
+bos.net                                                            ALL  @@INVALID_TYPE:bos.net _all_filesets
+ + 7.2.0.1  TCP/IP ntp Applications                                     @@INVALID_TYPE:bos.net.tcp.ntp 7.2.0.1
+ + 7.2.0.2  TCP/IP ntp Applications                                     @@INVALID_TYPE:bos.net.tcp.ntp 7.2.0.2
+
+END
+        expect{ subject.send(:determine_package_type, nimclient_showres_output, 'bos.net.tcp.ntp', '7.2.0.2') }.to raise_error(
+          Puppet::Error, /Unable to parse output from nimclient showres: line does not match expected package header format/)
       end
     end
   end

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -362,11 +362,23 @@ Jun 14 21:43:23 foo.example.com systemd[1]: sshd.service lacks both ExecStart= a
   describe "#mask" do
     it "should run systemctl to disable and mask a service" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
+      expect(provider).to receive(:execute).
+                            with(['/bin/systemctl','cat', '--', 'sshd.service'], :failonfail => false).
+                            and_return(Puppet::Util::Execution::ProcessOutput.new("# /lib/systemd/system/sshd.service\n...", 0))
       # :disable is the only call in the provider that uses a symbol instead of
       # a string.
       # This should be made consistent in the future and all tests updated.
       expect(provider).to receive(:systemctl).with(:disable, '--', 'sshd.service')
       expect(provider).to receive(:systemctl).with(:mask, '--', 'sshd.service')
+      provider.mask
+    end
+
+    it "masks a service that doesn't exist" do
+      provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'doesnotexist.service'))
+      expect(provider).to receive(:execute).
+                            with(['/bin/systemctl','cat', '--', 'doesnotexist.service'], :failonfail => false).
+                            and_return(Puppet::Util::Execution::ProcessOutput.new("No files found for doesnotexist.service.\n", 1))
+      expect(provider).to receive(:systemctl).with(:mask, '--', 'doesnotexist.service')
       provider.mask
     end
   end

--- a/spec/unit/provider/user/directoryservice_spec.rb
+++ b/spec/unit/provider/user/directoryservice_spec.rb
@@ -1021,16 +1021,7 @@ end
   describe '#set_shadow_hash_data' do
     let(:users_plist) { {'ShadowHashData' => ['string_data'] } }
 
-    it 'should flush the plist data to disk on OS X < 10.15' do
-      allow(provider.class).to receive(:get_os_version).and_return('10.12')
-
-      expect(provider).to receive(:write_users_plist_to_disk)
-      provider.set_shadow_hash_data(users_plist, pbkdf2_embedded_plist)
-    end
-
-    it 'should flush the plist data a temporary file on OS X >= 10.15' do
-      allow(provider.class).to receive(:get_os_version).and_return('10.15')
-
+    it 'should flush the plist data to a temporary file' do
       expect(provider).to receive(:write_and_import_shadow_hash_data)
       provider.set_shadow_hash_data(users_plist, pbkdf2_embedded_plist)
     end
@@ -1077,13 +1068,6 @@ end
       expect(provider).to receive(:set_shadow_hash_data).with(users_plist, pbkdf2_embedded_plist)
       expect(users_plist).to receive(:[]=).with('passwd', '********')
       provider.set_salted_pbkdf2(users_plist, pbkdf2_embedded_bplist_hash, 'iterations', pbkdf2_iterations_value)
-    end
-  end
-
-  describe '#write_users_plist_to_disk' do
-    it 'should save the passed plist to disk and convert it to a binary plist' do
-      expect(Puppet::Util::Plist).to receive(:write_plist_file).with(user_plist_xml, "#{users_plist_dir}/nonexistent_user.plist", :binary)
-      provider.write_users_plist_to_disk(user_plist_xml)
     end
   end
 


### PR DESCRIPTION
 6.x:
  (PUP-10974) Allow masking of nonexistent systemd services
  (maint) Reload puppetserver service on tests teardown
  (PUP-11095) Align user password management method on all macOS versions
  (PUP-11077) Pass SemVer prerelease and build as an array
  (PUP-3631) Allow `nim` to install RPM packages with letters in version
  (PUP-3631) Allow bff security update packages with nim package provider
  (PUP-11081) Allow access to user keychains from macOS daemon
  (PUP-11074) Add catalog edge only if parent resource has a container
```
 Conflicts:
	acceptance/tests/allow_arbitrary_node_name_fact_for_agent.rb
	acceptance/tests/allow_arbitrary_node_name_for_agent.rb
        -- alignment errors
	lib/puppet/provider/user/directoryservice.rb
        -- accepted 6.x changes
```