### PR TITLE
(PUP-11049) Update external encoding tests on Windows for Ruby 3

### DIFF
--- a/spec/unit/pops/loaders/dependency_loader_spec.rb
+++ b/spec/unit/pops/loaders/dependency_loader_spec.rb
@@ -84,10 +84,6 @@ Puppet::Functions.create_function('testmodule::foo') {
 
       context 'when loading files from disk' do
         it 'should always read files as UTF-8' do
-          if Puppet::Util::Platform.windows? && Encoding.default_external == Encoding::UTF_8
-            raise 'This test must be run in a codepage other than 65001 to validate behavior'
-          end
-
           module_dir = dir_containing('testmodule', {
           'lib' => { 'puppet' => { 'functions' => { 'testmodule' => {
             'foo.rb' => code_utf8
@@ -101,11 +97,6 @@ Puppet::Functions.create_function('testmodule::foo') {
 
         it 'currently ignores the UTF-8 BOM (Byte Order Mark) when loading module files' do
           bom = "\uFEFF"
-
-          if Puppet::Util::Platform.windows? && Encoding.default_external == Encoding::UTF_8
-            raise 'This test must be run in a codepage other than 65001 to validate behavior'
-          end
-
           module_dir = dir_containing('testmodule', {
           'lib' => { 'puppet' => { 'functions' => { 'testmodule' => {
             'foo.rb' => "#{bom}#{code_utf8}"

--- a/spec/unit/pops/parser/lexer2_spec.rb
+++ b/spec/unit/pops/parser/lexer2_spec.rb
@@ -918,10 +918,6 @@ describe Puppet::Pops::Parser::Lexer2 do
 
   context 'when lexing files from disk' do
     it 'should always read files as UTF-8' do
-      if Puppet::Util::Platform.windows? && Encoding.default_external == Encoding::UTF_8
-        raise 'This test must be run in a codepage other than 65001 to validate behavior'
-      end
-
       manifest_code = "notify { '#{rune_utf8}': }"
       manifest = file_containing('manifest.pp', manifest_code)
       lexed_file = described_class.new.lex_file(manifest)

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -142,9 +142,7 @@ describe Puppet::Util do
 
     # In 2.3, the behavior is mostly correct when external codepage is 65001 / UTF-8
     it "works around Ruby bug 8822 (which fails to preserve UTF-8 properly when accessing ENV) (Ruby >= 2.3.x) ",
-      :if => Puppet::Util::Platform.windows? do
-
-      raise 'This test requires a non-UTF8 codepage' if Encoding.default_external == Encoding::UTF_8
+      :if => Puppet::Util::Platform.windows? && RUBY_VERSION.to_f < 3 do
 
       withenv_utf8 do |utf_8_key, utf_8_value, codepage_key|
         # Ruby 2.3 fixes access by the original UTF-8 key, and behaves differently than 2.1


### PR DESCRIPTION
The lexer and dependency_loader issues are still tested in older ruby
versions on Windows, so we don't need to fail the test on Ruby 3.

The util/env test is predicated on ruby returning environment values
that aren't UTF-8, so skip it when ruby version is 3 or greater.