### PR TITLE
(PUP-3995) Raise if a node and hostclass name conflict

### DIFF
--- a/lib/puppet/resource/type_collection.rb
+++ b/lib/puppet/resource/type_collection.rb
@@ -61,6 +61,7 @@ class Puppet::Resource::TypeCollection
   def add_hostclass(instance)
     handle_hostclass_merge(instance)
     dupe_check(instance, @hostclasses) { |dupe| _("Class '%{klass}' is already defined%{error}; cannot redefine") % { klass: instance.name, error: dupe.error_context } }
+    dupe_check(instance, @nodes)       { |dupe| _("Node '%{klass}' is already defined%{error}; cannot be redefined as a class") % { klass: instance.name, error: dupe.error_context } }
     dupe_check(instance, @definitions) { |dupe| _("Definition '%{klass}' is already defined%{error}; cannot be redefined as a class") % { klass: instance.name, error: dupe.error_context } }
 
     @hostclasses[instance.name] = instance
@@ -93,6 +94,7 @@ class Puppet::Resource::TypeCollection
 
   def add_node(instance)
     dupe_check(instance, @nodes) { |dupe| _("Node '%{name}' is already defined%{error}; cannot redefine") % { name: instance.name, error: dupe.error_context } }
+    dupe_check(instance, @hostclasses) { |dupe| _("Class '%{klass}' is already defined%{error}; cannot be redefined as a node") % { klass: instance.name, error: dupe.error_context } }
 
     @node_list << instance
     @nodes[instance.name] = instance

--- a/spec/unit/resource/type_collection_spec.rb
+++ b/spec/unit/resource/type_collection_spec.rb
@@ -43,6 +43,14 @@ describe Puppet::Resource::TypeCollection do
     end.to raise_error(Puppet::ParseError, /cannot redefine/)
   end
 
+  it "should fail if a hostclass duplicates a node" do
+    @code.add(Puppet::Resource::Type.new(:node, "foo"))
+
+    expect do
+      @code.add(Puppet::Resource::Type.new(:hostclass, "foo"))
+    end.to raise_error(Puppet::ParseError, /Node 'foo' is already defined; cannot be redefined as a class/)
+  end
+
   it "should store hostclasses as hostclasses" do
     klass = Puppet::Resource::Type.new(:hostclass, "foo")
 
@@ -58,6 +66,14 @@ describe Puppet::Resource::TypeCollection do
       @code.add(klass1)
       @code.add(klass2)
     }.to raise_error(/.*is already defined; cannot redefine/)
+  end
+
+  it "should fail if a node duplicates a hostclass" do
+    @code.add(Puppet::Resource::Type.new(:hostclass, "foo"))
+
+    expect do
+      @code.add(Puppet::Resource::Type.new(:node, "foo"))
+    end.to raise_error(Puppet::ParseError, /Class 'foo' is already defined; cannot be redefined as a node/)
   end
 
   it "should store definitions as definitions" do

--- a/spec/unit/resource/type_spec.rb
+++ b/spec/unit/resource/type_spec.rb
@@ -462,9 +462,9 @@ describe Puppet::Resource::Type do
     end
 
     it "should be able to find parent nodes" do
-      parent = Puppet::Resource::Type.new(:node, "bar")
+      parent = Puppet::Resource::Type.new(:node, "node_bar")
       @krt.add parent
-      child = Puppet::Resource::Type.new(:node, "foo", :parent => "bar")
+      child = Puppet::Resource::Type.new(:node, "node_foo", :parent => "node_bar")
       @krt.add child
 
       expect(child.parent_type(@scope)).to equal(parent)


### PR DESCRIPTION
Node and class scopes are both added to the topscope, so given a manifest like:

    node 'abc' { include abc }

We will add the node scope, but not the class scope, because we think it's
already been added. As a result the class is ignored, making it difficult to
debug. This also occurs when using hiera lookup/include:

    node 'abc' { lookup('classes').include }

This adds dup checks when adding a node or hostclass to the type collection,
similar to our existing checks. As a result, we will now fail compilation and
the error message will indicate where the node or hostclass was first defined
and where the redefinition was attempted.

    Error: Class 'mynode' is already defined (file: manifest.pp, line: 1); \
      cannot redefine as a node (file: manifest.pp, line: 2) on node mynode

It also adds tests that show how a conflicting node can be specified as a
regexp, but a node as a string cannot.

Ironically this readds logic that existed a long time ago: https://github.com/puppetlabs/puppet/commit/0ff7827d4d7f42fe59c10af35266f197e83b2b17

Supersedes #8494