### PR TITLE
(PUP-4884) Accept native windows module_working_dir path

### DIFF
--- a/lib/puppet/forge/cache.rb
+++ b/lib/puppet/forge/cache.rb
@@ -47,7 +47,7 @@ class Puppet::Forge
 
     # Return the base Pathname for all the caches.
     def self.base_path
-      (Pathname(Puppet.settings[:module_working_dir]) + 'cache').tap do |o|
+      (Pathname(Puppet.settings[:module_working_dir]) + 'cache').cleanpath.tap do |o|
         o.mkpath unless o.exist?
       end
     end

--- a/lib/puppet/module_tool/tar/mini.rb
+++ b/lib/puppet/module_tool/tar/mini.rb
@@ -107,7 +107,7 @@ class Puppet::ModuleTool::Tar::Mini
       raise Puppet::ModuleTool::Errors::InvalidPathInPackageError, :entry_path => path, :directory => destdir
     end
 
-    path = File.expand_path File.join(destdir, path)
+    path = Pathname.new(File.join(destdir, path)).cleanpath.to_path
 
     if path !~ /\A#{Regexp.escape destdir}/
       raise Puppet::ModuleTool::Errors::InvalidPathInPackageError, :entry_path => path, :directory => destdir

--- a/spec/unit/module_tool/applications/installer_spec.rb
+++ b/spec/unit/module_tool/applications/installer_spec.rb
@@ -34,8 +34,7 @@ describe Puppet::ModuleTool::Applications::Installer, :unless => RUBY_PLATFORM =
 
   if Puppet::Util::Platform.windows?
     before :each do
-      allow(Puppet.settings).to receive(:[])
-      allow(Puppet.settings).to receive(:[]).with(:module_working_dir).and_return(Dir.mktmpdir('installertmp'))
+      Puppet[:module_working_dir] = tmpdir('module_tool_install').gsub('/', '\\')
     end
   end
 


### PR DESCRIPTION
On Windows the default forge cache base directory is created from Dir.mktmpdir
and contains forward slashes: "C:/Users/josh/AppData/Local/Temp/...".
When unpacking a tarball we check that the entry to be unpacked has the
same prefix. The prefix is the result of File.expand_path, which also
returns a path with forward slashes. When the cache base directory is
changed to a Windows native path, e.g. C:\Temp, to work around long file
path issues, the check will fail.

This commit cleans the base_dir and the tar entry, so that the comparison
is always done using forward slashes.