### PR TITLE
(PUP-7493) Record desired mode with leading zeros in the report

### DIFF
--- a/lib/puppet/type/file/mode.rb
+++ b/lib/puppet/type/file/mode.rb
@@ -90,7 +90,13 @@ module Puppet
         raise Puppet::Error, "The file mode specification is invalid: #{value.inspect}"
       end
 
+      # normalizes to symbolic form, e.g. u+a, an octal string without leading 0
       normalize_symbolic_mode(value)
+    end
+
+    unmunge do |value|
+      # return symbolic form or octal string *with* leading 0's
+      display_mode(value) if value
     end
 
     def desired_mode_from_current(desired, current)

--- a/lib/puppet/util/symbolic_file_mode.rb
+++ b/lib/puppet/util/symbolic_file_mode.rb
@@ -35,7 +35,7 @@ module SymbolicFileMode
     # "A numeric mode is from one to four octal digits (0-7), derived by adding
     # up the bits with values 4, 2, and 1. Omitted digits are assumed to be
     # leading zeros."
-    if value.is_a? Numeric then
+    if value.is_a? Numeric
       value.to_s(8)
     elsif value =~ /^0?[0-7]{1,4}$/
       value.to_i(8).to_s(8) # strip leading 0's
@@ -45,11 +45,11 @@ module SymbolicFileMode
   end
 
   def symbolic_mode_to_int(modification, to_mode = 0, is_a_directory = false)
-    if modification.nil? or modification == '' then
+    if modification.nil? or modification == ''
       raise Puppet::Error, _("An empty mode string is illegal")
-    end
-    if modification =~ /^[0-7]+$/ then return modification.to_i(8) end
-    if modification =~ /^\d+$/ then
+    elsif modification =~ /^[0-7]+$/
+      return modification.to_i(8)
+    elsif modification =~ /^\d+$/
       raise Puppet::Error, _("Numeric modes must be in octal, not decimal!")
     end
 
@@ -96,31 +96,31 @@ module SymbolicFileMode
 
           dsl.split('').each do |op|
             case op
-            when /[-+=]/ then
+            when /[-+=]/
               action = op
               # Clear all bits, if this is assignment
               value  = 0 if op == '='
 
-            when /[ugo]/ then
+            when /[ugo]/
               value = actions[action].call(value, snapshot_mode[op])
 
-            when /[rwx]/ then
+            when /[rwx]/
               value = actions[action].call(value, SymbolicMode[op])
 
-            when 'X' then
+            when 'X'
               # Only meaningful in combination with "set" actions.
-              if action != '+' then
+              if action != '+'
                 raise Puppet::Error, _("X only works with the '+' operator")
               end
 
               # As per the BSD manual page, set if this is a directory, or if
               # any execute bit is set on the original (unmodified) mode.
               # Ignored otherwise; it is "add if", not "add or clear".
-              if is_a_directory or original_mode['any x?'] then
+              if is_a_directory or original_mode['any x?']
                 value = actions[action].call(value, ExecBit)
               end
 
-            when /[st]/ then
+            when /[st]/
               bit = SymbolicSpecialToBit[op][who] or fail _("internal error")
               final_mode['s'] = actions[action].call(final_mode['s'], bit)
 
@@ -134,7 +134,7 @@ module SymbolicFileMode
         end
 
       rescue Puppet::Error => e
-        if part.inspect != modification.inspect then
+        if part.inspect != modification.inspect
           rest = " at #{part.inspect}"
         else
           rest = ''

--- a/lib/puppet/util/symbolic_file_mode.rb
+++ b/lib/puppet/util/symbolic_file_mode.rb
@@ -19,16 +19,28 @@ module SymbolicFileMode
     return false
   end
 
+  def display_mode(value)
+    if value =~ /^0?[0-7]{1,4}$/
+      value.rjust(4, "0")
+    else
+      value
+    end
+  end
+
   def normalize_symbolic_mode(value)
     return nil if value.nil?
 
     # We need to treat integers as octal numbers.
+    #
+    # "A numeric mode is from one to four octal digits (0-7), derived by adding
+    # up the bits with values 4, 2, and 1. Omitted digits are assumed to be
+    # leading zeros."
     if value.is_a? Numeric then
-      return value.to_s(8)
-    elsif value =~ /^0?[0-7]{1,4}$/ then
-      return value.to_i(8).to_s(8)
+      value.to_s(8)
+    elsif value =~ /^0?[0-7]{1,4}$/
+      value.to_i(8).to_s(8) # strip leading 0's
     else
-      return value
+      value
     end
   end
 

--- a/spec/unit/type/file/source_spec.rb
+++ b/spec/unit/type/file/source_spec.rb
@@ -264,7 +264,7 @@ describe Puppet::Type.type(:file).attrclass(:source), :uses_checksums => true do
 
           expect(@resource[:owner]).to eq(100)
           expect(@resource[:group]).to eq(200)
-          expect(@resource[:mode]).to eq("173")
+          expect(@resource[:mode]).to eq("0173")
 
           # Metadata calls it checksum and checksum_type, we call it content and checksum.
           expect(@resource[:content]).to eq(@metadata.checksum)
@@ -281,7 +281,7 @@ describe Puppet::Type.type(:file).attrclass(:source), :uses_checksums => true do
 
           expect(@resource[:owner]).to eq(1)
           expect(@resource[:group]).to eq(2)
-          expect(@resource[:mode]).to eq('173')
+          expect(@resource[:mode]).to eq('0173')
           expect(@resource[:content]).not_to eq(@metadata.checksum)
           expect(@resource[:checksum]).not_to eq(@metadata.checksum_type.to_sym)
         end
@@ -318,7 +318,7 @@ describe Puppet::Type.type(:file).attrclass(:source), :uses_checksums => true do
 
             expect(@resource[:owner]).to eq(100)
             expect(@resource[:group]).to eq(200)
-            expect(@resource[:mode]).to eq("173")
+            expect(@resource[:mode]).to eq("0173")
           end
 
           it "copies the remote owner" do
@@ -336,7 +336,7 @@ describe Puppet::Type.type(:file).attrclass(:source), :uses_checksums => true do
           it "copies the remote mode" do
             @source.copy_source_values
 
-            expect(@resource[:mode]).to eq("173")
+            expect(@resource[:mode]).to eq("0173")
           end
         end
 


### PR DESCRIPTION
When creating an event for a mode property change, the `desired_value` in the
report is obtained from the `Property#should` method, which calls `unmunge` to
convert the internal representation to its external form. The desired mode
may be an octal string without leading 0's or symbolic form (u+a). Ensure the
latter is padded with 0's so the `desired_value` matches the `previous_value`.