### PR TITLE
(PUP-9369) Raise if parsedfile providers returns nil

### DIFF
--- a/lib/puppet/provider/parsedfile.rb
+++ b/lib/puppet/provider/parsedfile.rb
@@ -280,6 +280,9 @@ class Puppet::Provider::ParsedFile < Puppet::Provider
   def self.prefetch_target(target)
     begin
       target_records = retrieve(target)
+      unless target_records
+        raise Puppet::DevError, _("Prefetching %{target} for provider %{name} returned nil") % { target: target, name: self.name }
+      end
     rescue Puppet::Util::FileType::FileReadError => detail
       if @raise_prefetch_errors
         # We will raise an error later in flush_target. This way,

--- a/spec/unit/provider/parsedfile_spec.rb
+++ b/spec/unit/provider/parsedfile_spec.rb
@@ -79,6 +79,16 @@ describe Puppet::Provider::ParsedFile do
 
       provider.instances
     end
+
+    it "should raise if parsing returns nil" do
+      expect(provider).to receive(:targets).and_return(%w{/one})
+      expect_any_instance_of(Puppet::Util::FileType::FileTypeFlat).to receive(:read).and_return('a=b')
+      expect(provider).to receive(:parse).and_return(nil)
+
+      expect {
+        provider.instances
+      }.to raise_error(Puppet::DevError, %r{Prefetching /one for provider parsedfile_provider returned nil})
+    end
   end
 
   describe "when matching resources to existing records" do


### PR DESCRIPTION
Custom providers like Nagios subclass the `parse` method and may return nil,
causing `retrieve` to return nil. Previously that caused a hard to debug error
trying to call `each` on nil. Now we raise an error with the `target` and name
of the provider. Note the same check is made again after prefetch_hooks are
called.