### PR TITLE
(PUP-9825) Raise if the user or group provider is not suitable

### DIFF
--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -862,7 +862,11 @@ class Puppet::Settings
     if self[:user]
       user = Puppet::Type.type(:user).new :name => self[:user], :audit => :ensure
 
-      @service_user_available = user.exists?
+      if user.suitable?
+        @service_user_available = user.exists?
+      else
+        raise Puppet::Error, (_("Cannot manage owner permissions, because the provider for '%{name}' is not functional") % { name: user })
+      end
     else
       @service_user_available = false
     end
@@ -874,7 +878,11 @@ class Puppet::Settings
     if self[:group]
       group = Puppet::Type.type(:group).new :name => self[:group], :audit => :ensure
 
-      @service_group_available = group.exists?
+      if group.suitable?
+        @service_group_available = group.exists?
+      else
+        raise Puppet::Error, (_("Cannot manage group permissions, because the provider for '%{name}' is not functional") % { name: group })
+      end
     else
       @service_group_available = false
     end

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -2120,7 +2120,7 @@ describe Puppet::Settings do
     end
 
     def a_user_type_for(username)
-      user = double('user')
+      user = double('user', 'suitable?': true, to_s: "User[#{username}]")
       expect(Puppet::Type.type(:user)).to receive(:new).with(hash_including(name: username)).and_return(user)
       user
     end
@@ -2153,6 +2153,16 @@ describe Puppet::Settings do
 
       expect(settings).to be_service_user_available
     end
+
+    it "raises if the user is not suitable" do
+      settings[:user] = "foo"
+
+      expect(a_user_type_for("foo")).to receive(:suitable?).and_return(false)
+
+      expect {
+        settings.service_user_available?
+      }.to raise_error(Puppet::Error, /Cannot manage owner permissions, because the provider for 'User\[foo\]' is not functional/)
+    end
   end
 
   describe "when determining if the service group is available" do
@@ -2163,7 +2173,7 @@ describe Puppet::Settings do
     end
 
     def a_group_type_for(groupname)
-      group = double('group')
+      group = double('group', 'suitable?': true, to_s: "Group[#{groupname}]")
       expect(Puppet::Type.type(:group)).to receive(:new).with(hash_including(name: groupname)).and_return(group)
       group
     end
@@ -2195,6 +2205,16 @@ describe Puppet::Settings do
       expect(settings).to be_service_group_available
 
       expect(settings).to be_service_group_available
+    end
+
+    it "raises if the group is not suitable" do
+      settings[:group] = "foo"
+
+      expect(a_group_type_for("foo")).to receive(:suitable?).and_return(false)
+
+      expect {
+        settings.service_group_available?
+      }.to raise_error(Puppet::Error, /Cannot manage group permissions, because the provider for 'Group\[foo\]' is not functional/)
     end
   end
 


### PR DESCRIPTION
If user/group providers were not suitable and puppet tried to manage its
internal file-related settings, then puppet printed a cryptic error:

    Could not create resources for managing Puppet's files and directories in
    sections [:main, :agent, :ssl]: undefined method `exists?' for nil:NilClass

Now we raise if the user or group provider is not functional. It's not a
breaking change, since we raised previously too.