### PR TITLE
Easier Linux FHS support

### DIFF
--- a/lib/puppet/provider/package/puppet_gem.rb
+++ b/lib/puppet/provider/package/puppet_gem.rb
@@ -6,20 +6,7 @@ Puppet::Type.type(:package).provide :puppet_gem, :parent => :gem do
 
   confine :true => Facter.value(:aio_agent_version)
 
-  def self.windows_gemcmd
-    puppet_dir = Puppet::Util.get_env('PUPPET_DIR')
-    if puppet_dir
-      File.join(Puppet::Util.get_env('PUPPET_DIR').to_s, 'bin', 'gem.bat')
-    else
-      File.join(Gem.default_bindir, 'gem.bat')
-    end
-  end
-
-  if Puppet::Util::Platform.windows?
-    commands :gemcmd => windows_gemcmd
-  else
-    commands :gemcmd => "/opt/puppetlabs/puppet/bin/gem"
-  end
+  commands :gemcmd => Puppet.run_mode.gem_cmd
 
   def uninstall
     super
@@ -28,7 +15,9 @@ Puppet::Type.type(:package).provide :puppet_gem, :parent => :gem do
   end
 
   def self.execute_gem_command(command, command_options, custom_environment = {})
-    custom_environment['PKG_CONFIG_PATH'] = '/opt/puppetlabs/puppet/lib/pkgconfig' unless Puppet::Util::Platform.windows?
+    if (pkg_config_path = Puppet.run_mode.pkg_config_path)
+      custom_environment['PKG_CONFIG_PATH'] = pkg_config_path
+    end
     super(command, command_options, custom_environment)
   end
 end

--- a/lib/puppet/util/run_mode.rb
+++ b/lib/puppet/util/run_mode.rb
@@ -95,6 +95,42 @@ module Puppet
       end
     end
 
+    class LinuxFHSRunMode < RunMode
+      def conf_dir
+        which_dir("/etc/puppet", "~/.puppetlabs/etc/puppet")
+      end
+
+      def code_dir
+        which_dir("/etc/puppet/code", "~/.puppetlabs/etc/code")
+      end
+
+      def var_dir
+        which_dir("/var/lib/puppet", "~/.puppetlabs/opt/puppet/cache")
+      end
+
+      def public_dir
+        which_dir("/var/lib/puppet/public", "~/.puppetlabs/opt/puppet/public")
+      end
+
+      def run_dir
+        which_dir("/run/puppet", "~/.puppetlabs/var/run")
+      end
+
+      def log_dir
+        which_dir("/var/log/puppet", "~/.puppetlabs/var/log")
+      end
+
+      def pkg_config_path
+        # TODO: not always
+        '/usr/lib64/pkgconfig'
+      end
+
+      def gem_cmd
+        # TODO: not always
+        '/usr/bin/gem'
+      end
+    end
+
     class WindowsRunMode < RunMode
       def conf_dir
         which_dir(File.join(windows_common_base("puppet/etc")), "~/.puppetlabs/etc/puppet")

--- a/lib/puppet/util/run_mode.rb
+++ b/lib/puppet/util/run_mode.rb
@@ -85,6 +85,14 @@ module Puppet
       def log_dir
         which_dir("/var/log/puppetlabs/puppet", "~/.puppetlabs/var/log")
       end
+
+      def pkg_config_path
+        '/opt/puppetlabs/puppet/lib/pkgconfig'
+      end
+
+      def gem_cmd
+        '/opt/puppetlabs/puppet/bin/gem'
+      end
     end
 
     class WindowsRunMode < RunMode
@@ -110,6 +118,19 @@ module Puppet
 
       def log_dir
         which_dir(File.join(windows_common_base("puppet/var/log")), "~/.puppetlabs/var/log")
+      end
+
+      def pkg_config_path
+        nil
+      end
+
+      def gem_cmd
+        puppet_dir = Puppet::Util.get_env('PUPPET_DIR')
+        if puppet_dir
+          File.join(Puppet::Util.get_env('PUPPET_DIR').to_s, 'bin', 'gem.bat')
+        else
+          File.join(Gem.default_bindir, 'gem.bat')
+        end
       end
 
     private

--- a/lib/puppet/util/run_mode.rb
+++ b/lib/puppet/util/run_mode.rb
@@ -14,7 +14,7 @@ module Puppet
         if Puppet::Util::Platform.windows?
           @run_modes[name] ||= WindowsRunMode.new(name)
         else
-          @run_modes[name] ||= UnixRunMode.new(name)
+          @run_modes[name] ||= LinuxFHSRunMode.new(name)
         end
       end
 


### PR DESCRIPTION
The goal of these patches is to make Linux FHS mode easier. Right now multiple distributions struggle and maintain similar patches.

The idea of this series is to introduce a Linux FHS run mode. The distributions can then choose to use this without having to patch too much. Perhaps install.rb can even ensure this runmode is selected.

Currently a draft since this requires some discussion. First of all, I'd like to get agreement on whether the general approach makes sense. If it doesn't and will never be accepted, then there's no point in trying to push for this.