### PR TITLE
(PUP-10796) Don't require environment to exist for filebucket CLI

### DIFF
--- a/lib/puppet/application/filebucket.rb
+++ b/lib/puppet/application/filebucket.rb
@@ -1,6 +1,7 @@
 require 'puppet/application'
 
 class Puppet::Application::Filebucket < Puppet::Application
+  environment_mode :not_required
 
   option("--bucket BUCKET","-b")
   option("--debug","-d")

--- a/spec/integration/application/filebucket_spec.rb
+++ b/spec/integration/application/filebucket_spec.rb
@@ -126,6 +126,17 @@ describe "puppet filebucket", unless: Puppet::Util::Platform.jruby? do
     end
   end
 
+  it "lists the local filebucket even if the environment doesn't exist locally" do
+    Puppet[:environment] = 'doesnotexist'
+    Puppet::FileSystem.mkpath(Puppet[:clientbucketdir])
+
+    filebucket.command_line.args = ['backup', '--local', backup_file]
+    expect {
+      result = filebucket.run
+      expect(result).to eq([backup_file])
+    }.to output(/Computing checksum on file/).to_stdout
+  end
+
   context 'diff', unless: Puppet::Util::Platform.windows? || Puppet::Util::Platform.jruby? do
     context 'using a remote bucket' do
       it 'outputs a diff between a local and remote file' do


### PR DESCRIPTION
The filebucket predates environments (all files are available from all
environments), yet running filebucket commands would fail if the configured
environment doesn't exist. Set the environment mode for the filebucket
application so it's not required, similar to how it's done for plugins, config,
help, etc.