### PR TITLE
(PUP-7792) Improve error message when function arguments don't match

### DIFF
--- a/lib/puppet/pops/types/type_mismatch_describer.rb
+++ b/lib/puppet/pops/types/type_mismatch_describer.rb
@@ -640,7 +640,7 @@ module Types
           result = ["#{label} expects (#{signature_string(sig)})"]
           result.concat(error_arrays[0].map { |e| "  rejected:#{e.chop_path(0).format}" })
         else
-          result = ["#{label} expects one of:"]
+          result = ["The function #{label} was called with arguments it does not accept. It expects one of:"]
           signatures.each_with_index do |sg, index|
             result << "  (#{signature_string(sg)})"
             result.concat(error_arrays[index].map { |e| "    rejected:#{e.chop_path(0).format}" })

--- a/spec/unit/functions/assert_type_spec.rb
+++ b/spec/unit/functions/assert_type_spec.rb
@@ -28,7 +28,7 @@ describe 'the assert_type function' do
   it 'checks that first argument is a type' do
     expect do
       func.call({}, 10, 10)
-    end.to raise_error(ArgumentError, "'assert_type' expects one of:
+    end.to raise_error(ArgumentError, "The function 'assert_type' was called with arguments it does not accept. It expects one of:
   (Type type, Any value, Callable[Type, Type] block?)
     rejected: parameter 'type' expects a Type value, got Integer
   (String type_string, Any value, Callable[Type, Type] block?)

--- a/spec/unit/functions4_spec.rb
+++ b/spec/unit/functions4_spec.rb
@@ -160,7 +160,7 @@ describe 'the 4x function api' do
       expect(func.is_a?(Puppet::Functions::Function)).to be_truthy
       expect do
         func.call({}, 3, 10, 3, "4")
-      end.to raise_error(ArgumentError, "'min' expects one of:
+      end.to raise_error(ArgumentError, "The function 'min' was called with arguments it does not accept. It expects one of:
   (Numeric x, Numeric y, Numeric a?, Numeric b?, Numeric c*)
     rejected: parameter 'b' expects a Numeric value, got String
   (String x, String y, String a+)
@@ -231,7 +231,7 @@ describe 'the 4x function api' do
       expect(func.is_a?(Puppet::Functions::Function)).to be_truthy
       expect do
         func.call({}, 10, '20')
-      end.to raise_error(ArgumentError, "'min' expects one of:
+      end.to raise_error(ArgumentError, "The function 'min' was called with arguments it does not accept. It expects one of:
   (Numeric a, Numeric b)
     rejected: parameter 'b' expects a Numeric value, got String
   (String s1, String s2)


### PR DESCRIPTION
Make the error message clearer if a function is called with arguments that
don't match any of its signatures.