### PR TITLE
(PUP-8243) Strip leading BOM from ERB templates

### DIFF
--- a/lib/puppet/file_system/file_impl.rb
+++ b/lib/puppet/file_system/file_impl.rb
@@ -84,7 +84,7 @@ class Puppet::FileSystem::FileImpl
   end
 
   def read_preserve_line_endings(path)
-    read(path)
+    read(path, encoding: "bom|#{Encoding.default_external.name}")
   end
 
   def binread(path)

--- a/lib/puppet/file_system/windows.rb
+++ b/lib/puppet/file_system/windows.rb
@@ -109,8 +109,8 @@ class Puppet::FileSystem::Windows < Puppet::FileSystem::Posix
   end
 
   def read_preserve_line_endings(path)
-    contents = path.read( :mode => 'rb', :encoding => Encoding::UTF_8)
-    contents = path.read( :mode => 'rb', :encoding => Encoding::default_external) unless contents.valid_encoding?
+    contents = path.read( :mode => 'rb', :encoding => 'bom|utf-8')
+    contents = path.read( :mode => 'rb', :encoding => "bom|#{Encoding::default_external.name}") unless contents.valid_encoding?
     contents = path.read unless contents.valid_encoding?
 
     contents

--- a/spec/unit/file_system_spec.rb
+++ b/spec/unit/file_system_spec.rb
@@ -290,6 +290,12 @@ describe "Puppet::FileSystem" do
         expect(Puppet::FileSystem.read_preserve_line_endings(file)).to eq("file content \r\nsecond line \n")
       end
     end
+
+    it "should ignore leading BOM" do
+      with_file_content("\uFEFFfile content \n") do |file|
+        expect(Puppet::FileSystem.read_preserve_line_endings(file)).to eq("file content \n")
+      end
+    end
   end
 
   context "read without an encoding specified" do

--- a/spec/unit/parser/templatewrapper_spec.rb
+++ b/spec/unit/parser/templatewrapper_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 require 'puppet/parser/templatewrapper'
 
 describe Puppet::Parser::TemplateWrapper do
+  include PuppetSpec::Files
+
   let(:known_resource_types) { Puppet::Resource::TypeCollection.new("env") }
   let(:scope) do
     compiler = Puppet::Parser::Compiler.new(Puppet::Node.new("mynode"))
@@ -90,11 +92,12 @@ describe Puppet::Parser::TemplateWrapper do
   end
 
   def given_a_template_file(name, contents)
-    full_name = "/full/path/to/#{name}"
+    full_name = tmpfile("template_#{name}")
+    File.binwrite(full_name, contents)
+
     allow(Puppet::Parser::Files).to receive(:find_template).
       with(name, anything()).
       and_return(full_name)
-    allow(Puppet::FileSystem).to receive(:read_preserve_line_endings).with(full_name).and_return(contents)
 
     full_name
   end

--- a/spec/unit/parser/templatewrapper_spec.rb
+++ b/spec/unit/parser/templatewrapper_spec.rb
@@ -43,6 +43,13 @@ describe Puppet::Parser::TemplateWrapper do
     expect(tw.result).to eq(full_file_name)
   end
 
+  it "ignores a leading BOM" do
+    full_file_name = given_a_template_file("bom_template", "\uFEFF<%= file %>")
+
+    tw.file = "bom_template"
+    expect(tw.result).to eq(full_file_name)
+  end
+
   it "evaluates a given string as a template" do
     expect(tw.result("template contents")).to eql("template contents")
   end


### PR DESCRIPTION
Previously, if a template contained a BOM, then it was preserved by the `template` function, and would end up in the resulting file or powershell command. Now we pass the `bom` option when reading the file, which strips the BOM as it is read.

For example, given a template with a leading BOM:

```shell
$ cat test.ps1.erb
﻿<%= 42 %>
$ od -t x1 test.ps1.erb
0000000 ef bb bf 3c 25 3d 20 34 32 20 25 3e
```

Puppet used to include the BOM in the rendered output:

```
C:\Users\josh\projects\puppet>bundle exec puppet apply -e "notify { 'thing': message => template('C:\Users\josh\projects\puppet\test.ps1.erb') }"
...
Notice: /Stage[main]/Main/Notify[thing]/message: defined 'message' as '﻿ 42'
```

Note the unprintable character before 42 above:

With this change:

```
C:\Users\josh\projects\puppet>bundle exec puppet apply -e "notify { 'thing': message => template('C:\Users\josh\projects\puppet\test.ps1.erb') }"
...
Notice: /Stage[main]/Main/Notify[thing]/message: defined 'message' as '﻿42'
```