### PR TITLE
(PUP-8700) Hide extra face option

### DIFF
--- a/lib/puppet/face/help/action.erb
+++ b/lib/puppet/face/help/action.erb
@@ -54,6 +54,7 @@ undocumented option
 	end
 	unless action.options.empty?
       action.options.sort.each do |name|
+        next if name == :extra
         option = action.get_option name -%>
 <%= "  " + option.optparse.join(" | ")[0,(optionroom - 1)].ljust(optionroom) + ' - ' -%>
 <%     if !(option.summary) -%>

--- a/lib/puppet/face/help/face.erb
+++ b/lib/puppet/face/help/face.erb
@@ -49,6 +49,7 @@ undocumented option
 	end
  	unless face.options.empty?
       face.options.sort.each do |name|
+        next if name == :extra
         option = face.get_option name -%>
 <%= "  " + option.optparse.join(" | ")[0,(optionroom - 1)].ljust(optionroom) + ' - ' -%>
 <%     if !(option.summary) -%>

--- a/lib/puppet/interface/documentation.rb
+++ b/lib/puppet/interface/documentation.rb
@@ -76,6 +76,7 @@ class Puppet::Interface
         s.text(" ")
 
         options.each do |option|
+          next if option == :extra
           option = get_option(option)
           wrap = option.required? ? %w{ < > } : %w{ [ ] }
 


### PR DESCRIPTION
The CLI for face applications accept an `--extra` option, but it doesn't work,
because the string is passed to Puppet::Indirector::Request#initialize, which
expects a Hash[1]. Since this has never worked and we've never specified the
string format, hide the option.

[1] https://github.com/puppetlabs/puppet/blob/7.8.0/lib/puppet/indirector/request.rb#L69