### PR TITLE
(PUP-7785) Don't prematurely convert setting values

### DIFF
--- a/lib/puppet/settings/config_file.rb
+++ b/lib/puppet/settings/config_file.rb
@@ -98,14 +98,7 @@ private
 
   def parse_setting(setting, section)
     var = setting.name.intern
-
-    # We don't want to munge modes, because they're specified in octal, so we'll
-    # just leave them as a String, since Puppet handles that case correctly.
-    if var == :mode
-      value = setting.value
-    else
-      value = @value_converter[setting.value]
-    end
+    value = @value_converter[setting.value]
 
     # Check to see if this is a file argument and it has extra options
     begin

--- a/lib/puppet/settings/value_translator.rb
+++ b/lib/puppet/settings/value_translator.rb
@@ -5,7 +5,6 @@ class Puppet::Settings::ValueTranslator
     return case value
       when /^false$/i; false
       when /^true$/i; true
-      when /^\d+$/i; Integer(value)
       when true; true
       when false; false
       else

--- a/spec/integration/defaults_spec.rb
+++ b/spec/integration/defaults_spec.rb
@@ -48,6 +48,11 @@ describe "Puppet defaults" do
     it "should fail if the certname is not downcased" do
       expect { Puppet.settings[:certname] = "Host.Domain.Com" }.to raise_error(ArgumentError)
     end
+
+    it 'can set it to a value containing all digits' do
+      Puppet.settings[:certname] = "000000000180"
+      expect(Puppet.settings[:certname]).to eq("000000000180")
+    end
   end
 
   describe "when setting :node_name_value" do

--- a/spec/unit/settings/config_file_spec.rb
+++ b/spec/unit/settings/config_file_spec.rb
@@ -135,16 +135,6 @@ badline
                                          with_setting(:var, "value changed", NO_META)))
   end
 
-  it "does not try to transform an entry named 'mode'" do
-    config = Puppet::Settings::ConfigFile.new(Proc.new { raise "Should not transform" })
-
-    result = config.parse_file(filename, "mode = value")
-
-    expect(result).to eq(Conf.new.
-                            with_section(Section.new(:main).
-                                         with_setting(:mode, "value", NO_META)))
-  end
-
   it "accepts non-UTF8 encoded text" do
     result = the_parse_of("var = value".encode("UTF-16LE"))
 
@@ -152,6 +142,6 @@ badline
                            with_section(Section.new(:main).
                                           with_setting(:var, "value", NO_META)))
 
-    end
+  end
 end
 

--- a/spec/unit/settings/value_translator_spec.rb
+++ b/spec/unit/settings/value_translator_spec.rb
@@ -25,13 +25,12 @@ describe Puppet::Settings::ValueTranslator do
   end
 
   context "numbers" do
-    it "translates integer strings to integers" do
-      expect(translator["1"]).to eq(1)
-      expect(translator["2"]).to eq(2)
+    it "leaves integer strings" do
+      expect(translator["1"]).to eq("1")
     end
 
-    it "translates numbers starting with a 0 as octal" do
-      expect(translator["011"]).to eq(9)
+    it "leaves octal numbers as strings" do
+      expect(translator["011"]).to eq("011")
     end
 
     it "leaves hex numbers as strings" do

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -1087,10 +1087,10 @@ describe Puppet::Settings do
     context "when setting serverport and masterport" do
       before(:each) do
         @settings.define_settings :main, PuppetSpec::Settings::TEST_APP_DEFAULT_DEFINITIONS
-        @settings.define_settings :server, :masterport => { :desc => "a", :default => 1000 }
+        @settings.define_settings :server, :masterport => { :desc => "a", :default => 1000, :type => :port }
         @settings.define_settings :server, :serverport => { :type => :alias, :alias_for => :masterport }
-        @settings.define_settings :server, :ca_port => { :desc => "a", :default => "$serverport" }
-        @settings.define_settings :server, :report_port => { :desc => "a", :default => "$serverport" }
+        @settings.define_settings :server, :ca_port => { :desc => "a", :default => "$serverport", :type => :port }
+        @settings.define_settings :server, :report_port => { :desc => "a", :default => "$serverport", :type => :port }
 
         config_file = tmpfile('config')
         @settings[:config] = config_file
@@ -1111,8 +1111,8 @@ describe Puppet::Settings do
         end
 
         it { expect(@settings[:serverport]).to eq(444) }
-        it { expect(@settings[:ca_port]).to eq("444") }
-        it { expect(@settings[:report_port]).to eq("444") }
+        it { expect(@settings[:ca_port]).to eq(444) }
+        it { expect(@settings[:report_port]).to eq(444) }
         it { expect(@settings[:masterport]).to eq(445) }
       end
 
@@ -1125,8 +1125,8 @@ describe Puppet::Settings do
         end
 
         it { expect(@settings[:serverport]).to eq(445) }
-        it { expect(@settings[:ca_port]).to eq("445") }
-        it { expect(@settings[:report_port]).to eq("445") }
+        it { expect(@settings[:ca_port]).to eq(445) }
+        it { expect(@settings[:report_port]).to eq(445) }
         it { expect(@settings[:masterport]).to eq(444) }
       end
 
@@ -1139,8 +1139,8 @@ describe Puppet::Settings do
         end
 
         it { expect(@settings[:serverport]).to eq(445) }
-        it { expect(@settings[:ca_port]).to eq("445") }
-        it { expect(@settings[:report_port]).to eq("445") }
+        it { expect(@settings[:ca_port]).to eq(445) }
+        it { expect(@settings[:report_port]).to eq(445) }
         it { expect(@settings[:masterport]).to eq(444) }
       end
 
@@ -1156,8 +1156,8 @@ describe Puppet::Settings do
         end
 
         it { expect(@settings[:serverport]).to eq(445) }
-        it { expect(@settings[:ca_port]).to eq("445") }
-        it { expect(@settings[:report_port]).to eq("445") }
+        it { expect(@settings[:ca_port]).to eq(445) }
+        it { expect(@settings[:report_port]).to eq(445) }
         it { expect(@settings[:masterport]).to eq(444) }
       end
 
@@ -1171,8 +1171,8 @@ describe Puppet::Settings do
         end
 
         it { expect(@settings[:serverport]).to eq(444) }
-        it { expect(@settings[:ca_port]).to eq("444") }
-        it { expect(@settings[:report_port]).to eq("444") }
+        it { expect(@settings[:ca_port]).to eq(444) }
+        it { expect(@settings[:report_port]).to eq(444) }
         it { expect(@settings[:masterport]).to eq(445) }
       end
 
@@ -1184,8 +1184,8 @@ describe Puppet::Settings do
         end
 
         it { expect(@settings[:serverport]).to eq(445) }
-        it { expect(@settings[:ca_port]).to eq("445") }
-        it { expect(@settings[:report_port]).to eq("445") }
+        it { expect(@settings[:ca_port]).to eq(445) }
+        it { expect(@settings[:report_port]).to eq(445) }
         it { expect(@settings[:masterport]).to eq(445) }
       end
 
@@ -1197,8 +1197,8 @@ describe Puppet::Settings do
         end
 
         it { expect(@settings[:serverport]).to eq(445) }
-        it { expect(@settings[:ca_port]).to eq("445") }
-        it { expect(@settings[:report_port]).to eq("445") }
+        it { expect(@settings[:ca_port]).to eq(445) }
+        it { expect(@settings[:report_port]).to eq(445) }
         it { expect(@settings[:masterport]).to eq(445) }
       end
 
@@ -1211,8 +1211,8 @@ describe Puppet::Settings do
 
         it { expect(@settings[:serverport]).to eq(445) }
         it { expect(@settings[:masterport]).to eq(1000) }
-        it { expect(@settings[:ca_port]).to eq("445") }
-        it { expect(@settings[:report_port]).to eq("445") }
+        it { expect(@settings[:ca_port]).to eq(445) }
+        it { expect(@settings[:report_port]).to eq(445) }
       end
 
       context 'with serverport in main' do
@@ -1224,8 +1224,8 @@ describe Puppet::Settings do
 
         it { expect(@settings[:serverport]).to eq(445) }
         it { expect(@settings[:masterport]).to eq(1000) }
-        it { expect(@settings[:ca_port]).to eq("445") }
-        it { expect(@settings[:report_port]).to eq("445") }
+        it { expect(@settings[:ca_port]).to eq(445) }
+        it { expect(@settings[:report_port]).to eq(445) }
       end
     end
 

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -1024,7 +1024,7 @@ describe Puppet::Settings do
       expect(@settings[:two]).to eq(false)
     end
 
-    it "should convert integers in the configuration file into Ruby Integers" do
+    it "doesn't convert integers in the configuration file" do
       File.write(@file, <<~CONF)
         [main]
         one = 65
@@ -1032,7 +1032,7 @@ describe Puppet::Settings do
 
       @settings.initialize_global_settings
 
-      expect(@settings[:one]).to eq(65)
+      expect(@settings[:one]).to eq('65')
     end
 
     it "should support specifying all metadata (owner, group, mode) in the configuration file" do


### PR DESCRIPTION
It was not possible to set a setting to a string consisting of all digits such
as `certname=000000000180`. This occurred, because the ConfigFile class
prematurely converted any value that matched /\d+/ to an integer and Ruby will
raise when given `Integer('000000000180')`. Similar problems were reported with
the `environment` setting.

The problem is that the conversion is done before we know the setting's type.
The conversion is also only done when parsing puppet.conf or CLI arguments. So
the value as stored in memory could be a string (if that was the default value),
or it could be an integer (if set in puppet.conf).

This change means settings must explicitly convert to an integer in their
"munge" method which is called during interpolation. This is already done for
autosign, duration, integer, port, priority and ttl settings.

I targeted main because the `integer` and `port` settings don't exist in 6.x