### PR TITLE
(PUP-10214) Avoid replacing dangling symlinks on 'replace => false'

### DIFF
--- a/lib/puppet/type/file/target.rb
+++ b/lib/puppet/type/file/target.rb
@@ -63,8 +63,13 @@ module Puppet
     def insync?(currentvalue)
       if [:nochange, :notlink].include?(self.should) or @resource.recurse?
         return true
-      elsif ! @resource.replace? and Puppet::FileSystem.exist?(@resource[:path])
-        return true
+      elsif ! @resource.replace?
+        begin
+          Puppet::FileSystem.lstat(@resource[:path])
+          return true
+        rescue Errno::ENOENT
+          return false
+        end
       else
         return super(currentvalue)
       end


### PR DESCRIPTION
Puppet::FileSystem.exist? explicitly follows symlinks, so the check for
in-sync will fail on a dangling symlink. A dangling symlink is still an
existing file, however, so when 'replace => false' is in effect, puppet
should not replace it.

Change the test to use Puppet::FileSystem.lstat in order to avoid
following symlinks.