### PR TITLE
(PUP-11079) Tidy files with age equal or greater

### DIFF
--- a/lib/puppet/type/tidy.rb
+++ b/lib/puppet/type/tidy.rb
@@ -144,7 +144,7 @@ Puppet::Type.newtype(:tidy) do
 
     def tidy?(path, stat)
       # If the file's older than we allow, we should get rid of it.
-      (Time.now.to_i - stat.send(resource[:type]).to_i) > value
+      (Time.now.to_i - stat.send(resource[:type]).to_i) >= value
     end
 
     munge do |age|

--- a/spec/unit/type/tidy_spec.rb
+++ b/spec/unit/type/tidy_spec.rb
@@ -280,6 +280,13 @@ describe tidy do
         @ager.tidy?(@basepath, @stat)
       end
 
+      it "should return true if the specified age is 0" do
+        @tidy[:age] = "0"
+        expect(@stat).to receive(:mtime).and_return(Time.now)
+
+        expect(@ager).to be_tidy(@basepath, @stat)
+      end
+
       it "should return false if the file is more recent than the specified age" do
         expect(@stat).to receive(:mtime).and_return(Time.now)
 


### PR DESCRIPTION
Tidy resource documentation for the age parameter states that files whose age is equal or greater than the specified time will be removed, and that setting age to 0 will remove all files.[1]

The actual implementation only removes the file if the age is greater, not equal, so fix the comparison.

Note that the size parameter is documented similarly, and the implementation is correct there.

[1] https://puppet.com/docs/puppet/7.7/types/tidy.html#tidy-attribute-age