### PR TITLE
(PUP-6801) Honor agent section for agent_specified_environment fact

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -205,9 +205,9 @@ module Puppet
 
     Facter.add(:agent_specified_environment) do
       setcode do
-        if Puppet.settings.set_by_config?(:environment)
-          Puppet[:environment]
-        end
+        Puppet.settings.set_by_cli(:environment) ||
+          Puppet.settings.set_in_section(:environment, :agent) ||
+          Puppet.settings.set_in_section(:environment, :main)
       end
     end
   end

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -891,9 +891,16 @@ class Puppet::Settings
   # Allow later inspection to determine if the setting was set on the
   # command line, or through some other code path.  Used for the
   # `dns_alt_names` option during cert generate. --daniel 2011-10-18
-  def set_by_cli?(param)
+  #
+  # @param param [String, Symbol] the setting to look up
+  # @return [Object, nil] the value of the setting or nil if unset
+  def set_by_cli(param)
     param = param.to_sym
-    !@value_sets[:cli].lookup(param).nil?
+    @value_sets[:cli].lookup(param)
+  end
+
+  def set_by_cli?(param)
+    !!set_by_cli(param)
   end
 
   # Get values from a search path entry.
@@ -926,14 +933,22 @@ class Puppet::Settings
     end
   end
 
-  # Allow later inspection to determine if the setting was set by user
-  # config, rather than a default setting.
-  def set_in_section?(param, section)
+  # Allow later inspection to determine if the setting was set in a specific
+  # section
+  #
+  # @param param [String, Symbol] the setting to look up
+  # @param section [Symbol] the section in which to look up the setting
+  # @return [Object, nil] the value of the setting or nil if unset
+  def set_in_section(param, section)
     param = param.to_sym
     vals = searchpath_values(SearchPathElement.new(section, :section))
     if vals
       vals.lookup(param)
     end
+  end
+
+  def set_in_section?(param, section)
+    !!set_in_section(param, section)
   end
 
   # Patches the value for a param in a section.

--- a/spec/integration/environments/settings_interpolation_spec.rb
+++ b/spec/integration/environments/settings_interpolation_spec.rb
@@ -9,10 +9,6 @@ describe "interpolating $environment" do
   let(:confdir) { Puppet[:confdir] }
   let(:cmdline_args) { ['--confdir', confdir, '--vardir', Puppet[:vardir], '--hiera_config', Puppet[:hiera_config]] }
 
-  before(:each) do
-    FileUtils.mkdir_p(confdir)
-  end
-
   shared_examples_for "a setting that does not interpolate $environment" do
 
     before(:each) do

--- a/spec/lib/puppet_spec/settings.rb
+++ b/spec/lib/puppet_spec/settings.rb
@@ -20,6 +20,7 @@ module PuppetSpec::Settings
   end.freeze
 
   def set_puppet_conf(confdir, settings)
+    FileUtils.mkdir_p(confdir)
     write_file(File.join(confdir, "puppet.conf"), settings)
   end
 


### PR DESCRIPTION
When running `facter -p`, if the environment is set in the agent section of puppet.conf, it would not be reported in the agent_specified_environment fact due to Puppet running in the user run mode.

Now an additional check is made to see if the setting is explicitly set in the agent section, and the fact prioritizes the agent section over other sections.

