### PR TITLE
(PUP-11120) Readd support for `trusted_oid_mapping_file`

### DIFF
--- a/lib/puppet/application/ssl.rb
+++ b/lib/puppet/application/ssl.rb
@@ -117,6 +117,7 @@ HELP
     end
 
     Puppet::SSL::Oids.register_puppet_oids
+    Puppet::SSL::Oids.load_custom_oid_file(Puppet[:trusted_oid_mapping_file])
 
     certname = Puppet[:certname]
     action = command_line.args.first

--- a/spec/fixtures/ssl/127.0.0.1-key.pem
+++ b/spec/fixtures/ssl/127.0.0.1-key.pem
@@ -1,117 +1,117 @@
 RSA Private-Key: (2048 bit, 2 primes)
 modulus:
-    00:ac:e5:d9:12:cd:61:69:66:ca:b9:6d:cf:b7:b5:
-    be:b9:21:de:d5:7d:dd:35:bc:c7:2a:23:a3:46:11:
-    ad:a7:23:02:f9:d1:71:ec:8c:34:c2:9b:bb:dd:6b:
-    b4:1f:4c:01:e9:c3:55:f4:ad:aa:17:24:ce:03:59:
-    54:fc:ce:f0:c0:c0:df:1e:89:b2:99:45:8d:49:cd:
-    68:7e:77:00:65:c2:ed:4a:90:fc:18:d7:50:3c:21:
-    28:a8:93:a1:47:ee:58:da:09:47:7d:67:70:a7:a8:
-    83:ea:38:d8:97:96:fd:f0:b7:17:3b:ab:fc:db:2b:
-    80:cf:e4:eb:4a:0f:0c:80:b0:18:d0:44:9a:6e:74:
-    70:a3:26:35:98:ad:f5:0c:b1:47:43:57:8a:ac:08:
-    30:b7:a0:9a:77:60:07:70:69:ef:50:9d:06:85:90:
-    20:71:67:2e:f5:c8:b0:1b:b2:fd:ff:57:4b:b6:0e:
-    18:d9:7b:95:e1:12:6b:fa:d2:8b:70:f8:1a:d3:36:
-    8d:c8:91:e0:d1:75:5a:21:17:f7:fe:70:e8:46:14:
-    d8:e1:f2:77:7d:21:76:0c:3b:e4:02:b9:d7:18:ac:
-    86:a3:1e:33:fc:34:72:c6:ea:7f:20:fe:39:74:cf:
-    ff:89:47:47:45:e1:71:13:46:7e:84:8c:23:2e:41:
-    1d:87
+    00:df:40:52:59:4f:eb:dd:d8:06:f5:c0:e8:eb:11:
+    52:31:80:a1:45:8e:3e:07:81:5c:cd:90:ea:2a:d0:
+    84:d3:6d:54:8a:78:0c:6b:34:eb:fc:dd:90:e9:9a:
+    5a:23:24:3b:31:99:17:d9:06:70:a8:51:95:68:50:
+    9d:59:aa:76:2f:28:18:99:81:be:ca:1d:79:75:8b:
+    85:3c:a4:05:39:06:f6:d8:25:13:54:e8:bb:d2:b4:
+    30:35:9e:10:64:2d:25:44:2a:f8:75:1f:60:ec:8a:
+    57:fc:fe:4d:57:f2:9c:e2:0d:6b:c5:f7:2d:ce:f5:
+    9e:93:f8:83:1a:b6:94:e3:c0:e2:b2:56:92:7e:e5:
+    d2:bd:f8:3c:9d:07:b4:85:93:77:5f:62:bd:ba:0e:
+    30:cc:77:46:07:2a:6a:aa:18:bf:0c:f0:23:ef:7d:
+    d9:84:86:35:3e:b5:76:1a:02:f3:9a:11:70:3f:f0:
+    6d:58:d1:2a:19:f8:e1:ed:77:ab:0a:e7:98:12:33:
+    5e:f9:b0:a8:f8:a5:98:c9:4e:3f:6c:01:8a:94:30:
+    c9:19:a1:29:46:18:5e:83:9f:9d:2a:cb:70:db:8a:
+    de:ca:2d:c1:47:82:ba:0b:20:b9:20:09:3c:1d:1c:
+    62:77:a7:85:83:5a:08:28:34:6b:75:e1:cd:7b:b7:
+    e7:e5
 publicExponent: 65537 (0x10001)
 privateExponent:
-    00:87:54:8d:59:63:3a:89:06:b5:4c:f8:bf:ea:7a:
-    ae:63:38:38:b4:00:85:82:47:55:d9:0c:f6:02:a5:
-    59:b8:05:f6:91:55:b8:07:40:23:17:e4:4f:e2:db:
-    27:ac:8b:90:bf:c9:6e:61:4b:01:64:86:21:5e:8b:
-    b0:b3:04:c3:7b:0c:3c:58:29:cd:8a:9c:df:1f:52:
-    51:25:13:be:52:e8:85:55:a5:30:3d:bd:62:86:fe:
-    29:55:f1:df:fe:6e:78:4b:89:91:d4:7d:7f:b7:2b:
-    76:bd:81:6b:3f:14:27:86:1f:b9:66:b2:93:03:76:
-    04:a8:34:f5:5a:0d:77:6a:cd:a1:6a:34:43:1b:e8:
-    2f:d6:81:ca:68:fc:93:53:9d:16:30:22:e4:80:44:
-    6b:ec:dc:ec:f6:d0:48:69:5d:89:af:a3:02:09:40:
-    25:9a:23:48:ad:58:c1:8d:25:af:74:6e:38:ec:dc:
-    ee:b8:79:e1:94:36:62:64:93:94:9b:29:0c:44:8c:
-    40:ef:40:d3:4b:89:96:5d:9f:84:8a:f7:f6:9a:6a:
-    d4:19:ea:f6:90:07:3f:b8:b3:4e:33:dc:7f:e9:32:
-    00:58:1c:52:1e:80:3b:94:50:4e:f4:56:c4:77:97:
-    d4:66:9e:03:be:5a:be:b1:8f:73:3f:ea:e4:5e:d4:
-    5c:79
+    00:bc:48:9b:2b:07:e4:7d:2c:fc:71:b7:48:b9:37:
+    da:82:35:61:ce:2f:b0:d0:d3:a1:59:1d:a6:e0:85:
+    0c:00:e4:6c:30:7c:1e:bd:2b:dc:fb:5e:42:21:42:
+    34:52:fe:f3:8d:58:f8:6b:e8:aa:8a:ca:83:9f:7e:
+    9d:b6:49:b5:72:ff:f5:ff:41:15:8f:90:5c:27:6e:
+    8b:e8:20:cc:e6:d3:a0:cb:9a:39:3b:9b:2d:0c:ff:
+    3a:c9:7d:8d:85:6f:2d:c6:d8:16:c3:70:bb:65:c3:
+    27:82:0f:57:5b:9d:1a:02:ec:1e:c0:cf:3e:ab:15:
+    2b:b0:d0:1e:82:21:0a:61:29:70:2a:34:5b:15:18:
+    67:30:5e:88:ad:d9:e4:59:61:7f:cc:4b:b2:9a:cf:
+    ac:49:fe:49:63:0a:14:db:89:49:22:6f:64:8b:bc:
+    62:4d:61:44:05:be:cc:5c:0c:2f:0e:fa:5f:6a:2e:
+    10:64:a4:db:86:1a:a9:da:1a:0d:ce:57:ec:c1:03:
+    7a:00:bd:49:31:b4:8b:bd:56:99:a2:14:dd:78:82:
+    ea:09:9f:74:12:bd:45:56:b5:6e:ee:d6:69:47:68:
+    e6:6d:75:ea:87:e1:6a:88:8b:b1:c2:7a:ae:35:89:
+    a3:3c:86:97:d1:de:ba:14:2b:d0:d1:3e:d7:af:92:
+    86:01
 prime1:
-    00:de:cf:6e:40:b7:15:fc:7d:11:6d:bf:78:12:9e:
-    75:28:de:92:99:3f:70:e0:98:2f:2b:8b:a8:32:3a:
-    b5:c6:5b:da:7d:25:e2:c7:ff:bf:79:74:28:26:1f:
-    cd:75:84:2c:c0:99:9f:aa:dc:e0:8d:ec:0b:d8:f0:
-    89:11:d7:24:26:53:8a:62:77:ba:5b:07:c8:2a:62:
-    99:25:28:fc:00:9d:03:c0:d6:c3:28:2e:46:9d:5b:
-    71:8e:d0:1a:2f:3d:19:93:29:f4:89:a3:cd:41:d2:
-    8a:64:a2:cd:19:11:f9:6e:59:e4:35:9d:7f:d1:31:
-    74:5b:48:f4:7b:e8:1a:20:73
+    00:fc:aa:e9:66:8b:09:55:59:35:21:19:ff:72:8a:
+    47:cc:ed:36:24:3a:6c:ee:81:75:cd:aa:6d:af:1f:
+    4d:83:a5:e5:77:c8:a2:de:72:11:a0:72:af:79:0a:
+    b5:b0:e5:e4:28:75:11:b5:56:eb:86:32:f0:32:1f:
+    1d:a8:26:9f:40:d7:6c:ae:7c:7d:90:27:39:95:0f:
+    6b:0a:91:3e:03:c1:e8:04:01:2e:16:a0:dc:6e:70:
+    9f:1a:17:c1:7e:65:ea:4c:2d:33:00:23:83:d9:3b:
+    f7:a5:0b:5f:f5:a9:65:7d:bd:1e:79:e9:24:62:a3:
+    49:d7:d2:6f:5f:9e:2e:03:75
 prime2:
-    00:c6:a7:12:f0:68:f2:30:a9:c3:78:59:a6:f7:fb:
-    dc:05:93:14:c7:54:00:c6:f7:5c:1a:c4:3a:07:b2:
-    25:f2:fb:83:7e:20:f5:c4:dd:fc:46:54:2e:58:89:
-    c2:fc:4e:5c:d8:a8:a1:a7:98:76:59:ad:45:94:fc:
-    97:d4:a5:0b:1e:51:07:3e:86:e0:2e:f7:29:32:71:
-    65:a5:3b:97:33:bc:00:f4:f7:66:e6:ee:49:ec:19:
-    5c:b3:74:0e:61:ce:94:3e:f4:69:32:ea:df:b3:d8:
-    08:df:56:36:ca:af:c7:e8:f1:0d:91:b4:0b:fb:47:
-    05:fd:87:02:41:48:9d:2d:9d
+    00:e2:32:17:38:94:ba:d3:63:eb:a3:83:77:09:4f:
+    ef:52:ef:ce:1e:86:b2:4e:bc:30:eb:67:f2:c1:aa:
+    be:04:fd:c5:76:43:15:e7:7f:f7:c7:a3:6f:e9:e3:
+    df:7e:ad:9c:a1:eb:ee:dc:ad:6d:bc:4e:88:1c:d4:
+    d1:5c:1d:21:f0:7a:19:4d:cc:0d:4b:37:08:34:8d:
+    ac:1c:fd:3a:e9:f3:5e:f3:f2:5a:1c:15:76:38:d3:
+    ff:b5:2f:fd:59:37:c6:86:6e:29:4b:10:01:75:f0:
+    5e:46:aa:ab:32:e3:0f:4c:72:e7:36:d7:5a:9b:76:
+    e2:08:09:32:49:30:ac:f4:b1
 exponent1:
-    56:77:57:49:04:04:23:45:01:f3:7e:3f:81:b2:3e:
-    b3:4a:94:c7:a6:08:0f:10:e0:15:5d:10:3b:d5:ee:
-    de:f8:9c:74:be:b4:20:7b:4e:7a:3a:aa:ae:08:df:
-    7a:00:7e:41:8c:1c:9b:79:36:27:bd:77:e7:8b:89:
-    16:04:50:c2:12:df:7c:51:0c:5f:f1:48:2b:b2:b1:
-    cd:ea:f6:c8:e2:26:27:ba:f0:67:72:75:f2:f1:1e:
-    c3:96:5c:e3:02:2a:1f:a3:43:83:fa:ae:58:21:f5:
-    95:12:5c:d7:a2:d3:12:91:0d:f0:04:9c:2a:b9:af:
-    77:11:7b:d7:6d:fe:5d:a3
+    44:c4:8b:a3:d2:21:a7:2e:11:6c:c1:f3:a9:8c:03:
+    40:be:2b:27:2f:13:a8:d2:69:6a:a1:81:1a:d1:ad:
+    3a:30:73:c4:e7:41:94:c3:7d:12:ab:44:20:f0:8e:
+    44:e8:3c:f1:d9:f3:08:e4:f0:53:65:17:c4:bc:7d:
+    48:df:c2:26:56:bb:88:bd:ef:3a:c5:c2:41:54:a1:
+    f0:8d:59:50:92:7d:00:62:05:d6:38:cf:e5:eb:17:
+    12:75:f6:be:dd:24:28:b9:80:91:00:19:89:8d:6d:
+    b8:68:e1:24:2e:87:a5:f2:4c:12:28:27:34:05:77:
+    3a:9b:56:9e:b2:a1:99:65
 exponent2:
-    43:20:be:13:a3:43:04:12:b9:cc:f7:6e:a6:a9:e3:
-    25:b7:17:f4:6b:7c:7f:bf:a2:ce:20:b5:03:58:bd:
-    de:28:03:bd:21:62:2b:8e:5f:eb:5c:12:f5:34:48:
-    41:7e:31:7d:bd:2e:33:36:1f:f8:19:c7:43:9b:3f:
-    ab:49:c2:42:12:5b:82:53:8d:7a:11:67:48:76:6d:
-    44:b2:a8:5b:81:12:49:b5:38:7e:9c:d3:3a:07:2f:
-    fe:2c:1f:98:09:78:aa:f5:68:7f:1e:43:4d:c0:98:
-    ee:ef:71:40:78:b9:f3:0b:51:ec:84:8c:ef:f2:86:
-    21:af:f7:a1:1b:ea:91:39
+    00:d3:3b:d7:f7:9c:dd:43:9f:e2:64:56:d7:09:39:
+    3e:d4:02:e2:48:1b:9d:d4:6d:66:79:d0:1f:21:c0:
+    e3:a7:21:9e:0f:ac:e2:7d:c8:41:8a:8c:14:6d:25:
+    c2:87:38:76:37:b8:6e:de:62:8f:41:f5:4c:a3:30:
+    13:3b:a4:71:17:73:ce:c1:9a:37:27:f0:82:97:21:
+    5e:83:cb:f0:02:9e:a6:23:c6:45:64:48:9e:98:bf:
+    51:e2:d0:a8:15:73:42:d0:33:7c:18:7f:1f:fe:15:
+    b4:d4:e5:78:ef:12:a0:2c:d2:79:1d:fb:ca:bf:b8:
+    2b:a9:39:7d:5e:60:38:84:61
 coefficient:
-    37:50:c3:b7:3b:85:e4:0d:db:82:ac:12:23:ca:6c:
-    84:45:ed:16:c0:bb:9c:0d:58:1d:52:b0:c3:a8:8a:
-    4e:f6:b4:ac:6d:b5:d5:18:0c:bc:80:fe:53:55:13:
-    c7:92:e5:71:95:bc:93:e8:24:93:94:ef:f0:10:00:
-    db:00:20:c1:f4:50:6d:9d:53:e7:58:e8:7e:04:34:
-    2e:fd:b9:b0:51:ff:22:b0:d6:ad:84:9e:c0:22:6f:
-    f8:40:a7:22:b8:46:3a:92:47:76:16:de:af:8d:a2:
-    5e:02:1d:21:32:be:88:b3:83:f8:6d:b9:9c:ce:19:
-    55:38:7d:98:65:8a:4d:25
+    0b:f3:f3:f2:06:4d:f4:8d:dc:88:d0:da:24:f1:03:
+    4a:5f:91:40:29:ff:85:be:a1:6c:e2:00:ac:05:46:
+    79:db:9d:b6:5f:7e:92:a7:cb:f1:77:e6:4e:c6:b9:
+    ee:76:0e:fe:c3:ba:91:69:00:75:dc:d6:76:2e:f1:
+    dd:1b:75:5d:3b:f4:6b:d6:a2:3d:bf:8e:49:45:0f:
+    b1:4e:c6:e5:fb:c3:91:05:92:51:b1:c1:59:97:e0:
+    1a:a5:c9:ee:3f:af:32:dc:0c:4a:00:37:04:94:64:
+    fa:97:ab:47:17:fe:ce:bb:d4:6c:02:26:5d:41:1f:
+    42:8b:06:d9:e0:a0:ae:68
 -----BEGIN RSA PRIVATE KEY-----
-MIIEowIBAAKCAQEArOXZEs1haWbKuW3Pt7W+uSHe1X3dNbzHKiOjRhGtpyMC+dFx
-7Iw0wpu73Wu0H0wB6cNV9K2qFyTOA1lU/M7wwMDfHomymUWNSc1ofncAZcLtSpD8
-GNdQPCEoqJOhR+5Y2glHfWdwp6iD6jjYl5b98LcXO6v82yuAz+TrSg8MgLAY0ESa
-bnRwoyY1mK31DLFHQ1eKrAgwt6Cad2AHcGnvUJ0GhZAgcWcu9ciwG7L9/1dLtg4Y
-2XuV4RJr+tKLcPga0zaNyJHg0XVaIRf3/nDoRhTY4fJ3fSF2DDvkArnXGKyGox4z
-/DRyxup/IP45dM//iUdHReFxE0Z+hIwjLkEdhwIDAQABAoIBAQCHVI1ZYzqJBrVM
-+L/qeq5jODi0AIWCR1XZDPYCpVm4BfaRVbgHQCMX5E/i2yesi5C/yW5hSwFkhiFe
-i7CzBMN7DDxYKc2KnN8fUlElE75S6IVVpTA9vWKG/ilV8d/+bnhLiZHUfX+3K3a9
-gWs/FCeGH7lmspMDdgSoNPVaDXdqzaFqNEMb6C/Wgcpo/JNTnRYwIuSARGvs3Oz2
-0EhpXYmvowIJQCWaI0itWMGNJa90bjjs3O64eeGUNmJkk5SbKQxEjEDvQNNLiZZd
-n4SK9/aaatQZ6vaQBz+4s04z3H/pMgBYHFIegDuUUE70VsR3l9RmngO+Wr6xj3M/
-6uRe1Fx5AoGBAN7PbkC3Ffx9EW2/eBKedSjekpk/cOCYLyuLqDI6tcZb2n0l4sf/
-v3l0KCYfzXWELMCZn6rc4I3sC9jwiRHXJCZTimJ3ulsHyCpimSUo/ACdA8DWwygu
-Rp1bcY7QGi89GZMp9ImjzUHSimSizRkR+W5Z5DWdf9ExdFtI9HvoGiBzAoGBAMan
-EvBo8jCpw3hZpvf73AWTFMdUAMb3XBrEOgeyJfL7g34g9cTd/EZULliJwvxOXNio
-oaeYdlmtRZT8l9SlCx5RBz6G4C73KTJxZaU7lzO8APT3ZubuSewZXLN0DmHOlD70
-aTLq37PYCN9WNsqvx+jxDZG0C/tHBf2HAkFInS2dAoGAVndXSQQEI0UB834/gbI+
-s0qUx6YIDxDgFV0QO9Xu3vicdL60IHtOejqqrgjfegB+QYwcm3k2J71354uJFgRQ
-whLffFEMX/FIK7Kxzer2yOImJ7rwZ3J18vEew5Zc4wIqH6NDg/quWCH1lRJc16LT
-EpEN8AScKrmvdxF7123+XaMCgYBDIL4To0MEErnM926mqeMltxf0a3x/v6LOILUD
-WL3eKAO9IWIrjl/rXBL1NEhBfjF9vS4zNh/4GcdDmz+rScJCEluCU416EWdIdm1E
-sqhbgRJJtTh+nNM6By/+LB+YCXiq9Wh/HkNNwJju73FAeLnzC1HshIzv8oYhr/eh
-G+qROQKBgDdQw7c7heQN24KsEiPKbIRF7RbAu5wNWB1SsMOoik72tKxttdUYDLyA
-/lNVE8eS5XGVvJPoJJOU7/AQANsAIMH0UG2dU+dY6H4ENC79ubBR/yKw1q2EnsAi
-b/hApyK4RjqSR3YW3q+Nol4CHSEyvoizg/htuZzOGVU4fZhlik0l
+MIIEpAIBAAKCAQEA30BSWU/r3dgG9cDo6xFSMYChRY4+B4FczZDqKtCE021UingM
+azTr/N2Q6ZpaIyQ7MZkX2QZwqFGVaFCdWap2LygYmYG+yh15dYuFPKQFOQb22CUT
+VOi70rQwNZ4QZC0lRCr4dR9g7IpX/P5NV/Kc4g1rxfctzvWek/iDGraU48DislaS
+fuXSvfg8nQe0hZN3X2K9ug4wzHdGBypqqhi/DPAj733ZhIY1PrV2GgLzmhFwP/Bt
+WNEqGfjh7XerCueYEjNe+bCo+KWYyU4/bAGKlDDJGaEpRhheg5+dKstw24reyi3B
+R4K6CyC5IAk8HRxid6eFg1oIKDRrdeHNe7fn5QIDAQABAoIBAQC8SJsrB+R9LPxx
+t0i5N9qCNWHOL7DQ06FZHabghQwA5GwwfB69K9z7XkIhQjRS/vONWPhr6KqKyoOf
+fp22SbVy//X/QRWPkFwnbovoIMzm06DLmjk7my0M/zrJfY2Fby3G2BbDcLtlwyeC
+D1dbnRoC7B7Azz6rFSuw0B6CIQphKXAqNFsVGGcwXoit2eRZYX/MS7Kaz6xJ/klj
+ChTbiUkib2SLvGJNYUQFvsxcDC8O+l9qLhBkpNuGGqnaGg3OV+zBA3oAvUkxtIu9
+VpmiFN14guoJn3QSvUVWtW7u1mlHaOZtdeqH4WqIi7HCeq41iaM8hpfR3roUK9DR
+PtevkoYBAoGBAPyq6WaLCVVZNSEZ/3KKR8ztNiQ6bO6Bdc2qba8fTYOl5XfIot5y
+EaByr3kKtbDl5Ch1EbVW64Yy8DIfHagmn0DXbK58fZAnOZUPawqRPgPB6AQBLhag
+3G5wnxoXwX5l6kwtMwAjg9k796ULX/WpZX29HnnpJGKjSdfSb1+eLgN1AoGBAOIy
+FziUutNj66ODdwlP71Lvzh6Gsk68MOtn8sGqvgT9xXZDFed/98ejb+nj336tnKHr
+7tytbbxOiBzU0VwdIfB6GU3MDUs3CDSNrBz9OunzXvPyWhwVdjjT/7Uv/Vk3xoZu
+KUsQAXXwXkaqqzLjD0xy5zbXWpt24ggJMkkwrPSxAoGARMSLo9Ihpy4RbMHzqYwD
+QL4rJy8TqNJpaqGBGtGtOjBzxOdBlMN9EqtEIPCOROg88dnzCOTwU2UXxLx9SN/C
+Jla7iL3vOsXCQVSh8I1ZUJJ9AGIF1jjP5esXEnX2vt0kKLmAkQAZiY1tuGjhJC6H
+pfJMEignNAV3OptWnrKhmWUCgYEA0zvX95zdQ5/iZFbXCTk+1ALiSBud1G1medAf
+IcDjpyGeD6zifchBiowUbSXChzh2N7hu3mKPQfVMozATO6RxF3POwZo3J/CClyFe
+g8vwAp6mI8ZFZEiemL9R4tCoFXNC0DN8GH8f/hW01OV47xKgLNJ5HfvKv7grqTl9
+XmA4hGECgYAL8/PyBk30jdyI0Nok8QNKX5FAKf+FvqFs4gCsBUZ52522X36Sp8vx
+d+ZOxrnudg7+w7qRaQB13NZ2LvHdG3VdO/Rr1qI9v45JRQ+xTsbl+8ORBZJRscFZ
+l+AapcnuP68y3AxKADcElGT6l6tHF/7Ou9RsAiZdQR9CiwbZ4KCuaA==
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/127.0.0.1.pem
+++ b/spec/fixtures/ssl/127.0.0.1.pem
@@ -6,64 +6,64 @@ Certificate:
         Issuer: CN=Test CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Apr 18 18:46:23 2031 GMT
+            Not After : Jun 15 01:19:37 2031 GMT
         Subject: CN=127.0.0.1
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:ac:e5:d9:12:cd:61:69:66:ca:b9:6d:cf:b7:b5:
-                    be:b9:21:de:d5:7d:dd:35:bc:c7:2a:23:a3:46:11:
-                    ad:a7:23:02:f9:d1:71:ec:8c:34:c2:9b:bb:dd:6b:
-                    b4:1f:4c:01:e9:c3:55:f4:ad:aa:17:24:ce:03:59:
-                    54:fc:ce:f0:c0:c0:df:1e:89:b2:99:45:8d:49:cd:
-                    68:7e:77:00:65:c2:ed:4a:90:fc:18:d7:50:3c:21:
-                    28:a8:93:a1:47:ee:58:da:09:47:7d:67:70:a7:a8:
-                    83:ea:38:d8:97:96:fd:f0:b7:17:3b:ab:fc:db:2b:
-                    80:cf:e4:eb:4a:0f:0c:80:b0:18:d0:44:9a:6e:74:
-                    70:a3:26:35:98:ad:f5:0c:b1:47:43:57:8a:ac:08:
-                    30:b7:a0:9a:77:60:07:70:69:ef:50:9d:06:85:90:
-                    20:71:67:2e:f5:c8:b0:1b:b2:fd:ff:57:4b:b6:0e:
-                    18:d9:7b:95:e1:12:6b:fa:d2:8b:70:f8:1a:d3:36:
-                    8d:c8:91:e0:d1:75:5a:21:17:f7:fe:70:e8:46:14:
-                    d8:e1:f2:77:7d:21:76:0c:3b:e4:02:b9:d7:18:ac:
-                    86:a3:1e:33:fc:34:72:c6:ea:7f:20:fe:39:74:cf:
-                    ff:89:47:47:45:e1:71:13:46:7e:84:8c:23:2e:41:
-                    1d:87
+                    00:df:40:52:59:4f:eb:dd:d8:06:f5:c0:e8:eb:11:
+                    52:31:80:a1:45:8e:3e:07:81:5c:cd:90:ea:2a:d0:
+                    84:d3:6d:54:8a:78:0c:6b:34:eb:fc:dd:90:e9:9a:
+                    5a:23:24:3b:31:99:17:d9:06:70:a8:51:95:68:50:
+                    9d:59:aa:76:2f:28:18:99:81:be:ca:1d:79:75:8b:
+                    85:3c:a4:05:39:06:f6:d8:25:13:54:e8:bb:d2:b4:
+                    30:35:9e:10:64:2d:25:44:2a:f8:75:1f:60:ec:8a:
+                    57:fc:fe:4d:57:f2:9c:e2:0d:6b:c5:f7:2d:ce:f5:
+                    9e:93:f8:83:1a:b6:94:e3:c0:e2:b2:56:92:7e:e5:
+                    d2:bd:f8:3c:9d:07:b4:85:93:77:5f:62:bd:ba:0e:
+                    30:cc:77:46:07:2a:6a:aa:18:bf:0c:f0:23:ef:7d:
+                    d9:84:86:35:3e:b5:76:1a:02:f3:9a:11:70:3f:f0:
+                    6d:58:d1:2a:19:f8:e1:ed:77:ab:0a:e7:98:12:33:
+                    5e:f9:b0:a8:f8:a5:98:c9:4e:3f:6c:01:8a:94:30:
+                    c9:19:a1:29:46:18:5e:83:9f:9d:2a:cb:70:db:8a:
+                    de:ca:2d:c1:47:82:ba:0b:20:b9:20:09:3c:1d:1c:
+                    62:77:a7:85:83:5a:08:28:34:6b:75:e1:cd:7b:b7:
+                    e7:e5
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Subject Alternative Name: 
                 DNS:127.0.0.1, DNS:127.0.0.2
     Signature Algorithm: sha256WithRSAEncryption
-         7f:f0:00:00:e5:c3:8d:d1:bf:5a:6c:d5:36:86:8a:08:b6:dc:
-         26:b8:4e:af:25:5a:6b:e2:04:50:fe:b1:9a:4b:03:c2:d7:9b:
-         7b:6d:3c:51:a9:2b:d2:b1:53:ae:02:df:de:65:a5:95:38:a7:
-         72:ac:86:5d:af:fb:67:9a:5f:48:7b:ab:05:54:ea:4d:bf:be:
-         d0:45:2b:84:26:4c:c5:62:a8:62:bb:46:5d:6b:e4:b9:aa:1f:
-         b7:3d:44:32:ea:c5:b4:d1:3b:e3:ca:7f:47:46:f0:47:10:a5:
-         7a:93:65:23:e7:6b:42:2e:52:7f:4e:9d:89:b8:8c:26:de:8e:
-         b4:63:be:28:83:2e:06:6a:e6:fc:80:24:de:8a:3f:ab:2d:b6:
-         98:2e:60:d0:36:40:cc:52:1b:c9:1b:12:14:ee:2e:29:3f:5d:
-         57:6b:17:b0:23:57:e5:f0:64:03:ab:86:3c:1b:4f:d8:3a:27:
-         18:b2:82:4e:dc:ca:47:cf:d0:30:a2:d2:48:5a:89:f5:a2:93:
-         29:df:fb:dc:c4:a2:ee:40:2b:14:30:cb:ff:ff:a7:df:34:6a:
-         54:ae:47:0a:5b:e0:c4:9d:7c:0a:14:16:96:b3:8c:5c:d8:22:
-         50:2b:b4:59:01:6a:de:90:14:ea:5a:4d:eb:69:ee:bd:35:e3:
-         e6:5a:8b:68
+         6f:ef:ac:da:0b:a5:4f:d0:30:57:0c:8c:5a:90:be:18:11:ec:
+         e0:25:c2:0e:ef:05:cb:b5:50:43:ba:b7:25:1c:26:60:e8:ad:
+         b6:a5:1a:6a:2b:e2:66:e1:3a:b6:00:80:39:e1:19:ef:c2:e8:
+         fd:f2:04:0e:ed:fa:1e:e5:f8:f1:32:dc:4e:47:7e:43:a4:09:
+         3a:24:b4:fe:ab:7e:d6:b2:d4:4e:e0:9f:e5:c9:79:9b:87:f4:
+         7b:3d:40:a4:cf:0e:03:5c:dc:14:82:bf:1b:32:9a:18:0c:5b:
+         94:2d:1f:41:b6:a5:e7:89:d7:3b:dc:c8:17:f6:0e:ea:2d:7b:
+         a6:04:02:08:9a:b6:3d:66:03:67:16:94:2d:36:13:ee:61:18:
+         f9:17:04:6e:16:f3:65:9b:5c:34:ed:49:d8:6e:26:58:ca:68:
+         3f:2c:bb:0e:42:64:93:a7:8c:d4:d9:15:ae:fb:0f:f7:f7:ce:
+         be:99:6f:40:90:bf:e4:44:c5:44:4a:09:9a:8f:da:f6:b5:a6:
+         63:af:6b:37:ee:7c:b7:69:b6:67:76:98:f1:69:18:8e:2c:45:
+         bb:04:82:d9:03:31:85:c6:61:d3:38:60:39:45:43:a9:7b:d7:
+         f5:fd:18:f2:ec:43:42:0b:69:b8:c5:84:05:ae:a2:02:d3:19:
+         80:bd:88:a5
 -----BEGIN CERTIFICATE-----
 MIICxDCCAaygAwIBAgIBBTANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
-IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMxMDQxODE4NDYyM1owFDESMBAGA1UEAwwJ
-MTI3LjAuMC4xMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArOXZEs1h
-aWbKuW3Pt7W+uSHe1X3dNbzHKiOjRhGtpyMC+dFx7Iw0wpu73Wu0H0wB6cNV9K2q
-FyTOA1lU/M7wwMDfHomymUWNSc1ofncAZcLtSpD8GNdQPCEoqJOhR+5Y2glHfWdw
-p6iD6jjYl5b98LcXO6v82yuAz+TrSg8MgLAY0ESabnRwoyY1mK31DLFHQ1eKrAgw
-t6Cad2AHcGnvUJ0GhZAgcWcu9ciwG7L9/1dLtg4Y2XuV4RJr+tKLcPga0zaNyJHg
-0XVaIRf3/nDoRhTY4fJ3fSF2DDvkArnXGKyGox4z/DRyxup/IP45dM//iUdHReFx
-E0Z+hIwjLkEdhwIDAQABoyMwITAfBgNVHREEGDAWggkxMjcuMC4wLjGCCTEyNy4w
-LjAuMjANBgkqhkiG9w0BAQsFAAOCAQEAf/AAAOXDjdG/WmzVNoaKCLbcJrhOryVa
-a+IEUP6xmksDwtebe208Uakr0rFTrgLf3mWllTincqyGXa/7Z5pfSHurBVTqTb++
-0EUrhCZMxWKoYrtGXWvkuaoftz1EMurFtNE748p/R0bwRxClepNlI+drQi5Sf06d
-ibiMJt6OtGO+KIMuBmrm/IAk3oo/qy22mC5g0DZAzFIbyRsSFO4uKT9dV2sXsCNX
-5fBkA6uGPBtP2DonGLKCTtzKR8/QMKLSSFqJ9aKTKd/73MSi7kArFDDL//+n3zRq
-VK5HClvgxJ18ChQWlrOMXNgiUCu0WQFq3pAU6lpN62nuvTXj5lqLaA==
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMxMDYxNTAxMTkzN1owFDESMBAGA1UEAwwJ
+MTI3LjAuMC4xMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA30BSWU/r
+3dgG9cDo6xFSMYChRY4+B4FczZDqKtCE021UingMazTr/N2Q6ZpaIyQ7MZkX2QZw
+qFGVaFCdWap2LygYmYG+yh15dYuFPKQFOQb22CUTVOi70rQwNZ4QZC0lRCr4dR9g
+7IpX/P5NV/Kc4g1rxfctzvWek/iDGraU48DislaSfuXSvfg8nQe0hZN3X2K9ug4w
+zHdGBypqqhi/DPAj733ZhIY1PrV2GgLzmhFwP/BtWNEqGfjh7XerCueYEjNe+bCo
++KWYyU4/bAGKlDDJGaEpRhheg5+dKstw24reyi3BR4K6CyC5IAk8HRxid6eFg1oI
+KDRrdeHNe7fn5QIDAQABoyMwITAfBgNVHREEGDAWggkxMjcuMC4wLjGCCTEyNy4w
+LjAuMjANBgkqhkiG9w0BAQsFAAOCAQEAb++s2gulT9AwVwyMWpC+GBHs4CXCDu8F
+y7VQQ7q3JRwmYOittqUaaiviZuE6tgCAOeEZ78Lo/fIEDu36HuX48TLcTkd+Q6QJ
+OiS0/qt+1rLUTuCf5cl5m4f0ez1ApM8OA1zcFIK/GzKaGAxblC0fQbal54nXO9zI
+F/YO6i17pgQCCJq2PWYDZxaULTYT7mEY+RcEbhbzZZtcNO1J2G4mWMpoPyy7DkJk
+k6eM1NkVrvsP9/fOvplvQJC/5ETFREoJmo/a9rWmY69rN+58t2m2Z3aY8WkYjixF
+uwSC2QMxhcZh0zhgOUVDqXvX9f0Y8uxDQgtpuMWEBa6iAtMZgL2IpQ==
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/bad-basic-constraints.pem
+++ b/spec/fixtures/ssl/bad-basic-constraints.pem
@@ -1,35 +1,35 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 10 (0xa)
+        Serial Number: 11 (0xb)
         Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Apr 18 18:46:23 2031 GMT
+            Not After : Jun 15 01:19:37 2031 GMT
         Subject: CN=Test CA
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:dd:a5:83:44:db:51:be:98:ef:b1:63:a7:04:b9:
-                    ff:cd:71:d3:06:76:c4:25:68:e8:ea:ef:c5:b4:f9:
-                    c2:76:aa:c0:1b:1b:0f:44:13:da:db:cf:d4:f4:88:
-                    5c:cc:ac:f2:76:fb:9e:b6:2e:40:da:b8:c1:c8:cd:
-                    24:90:63:10:6c:99:ee:0c:10:74:cc:38:b8:f3:b4:
-                    d9:ed:1e:ac:07:29:b4:fe:f1:16:c2:18:7c:34:fd:
-                    50:25:0f:f7:45:84:e0:4b:21:41:a4:5b:19:42:85:
-                    a3:a8:d3:6a:ea:0f:80:f3:1a:06:f8:aa:31:4b:e5:
-                    44:a8:37:80:d1:1b:01:ae:f3:b8:35:c6:3f:10:82:
-                    84:fc:59:d9:47:d6:a9:e3:5e:f3:9f:89:23:6a:ed:
-                    bc:92:6a:a1:49:2c:99:c3:89:b3:ab:3a:9f:6b:2d:
-                    e6:39:95:15:e0:71:5f:6b:6a:23:2e:bc:cd:40:b2:
-                    47:42:13:f4:f5:e7:43:76:5c:db:9d:10:3b:91:10:
-                    cc:c7:27:db:a8:18:53:c9:50:eb:83:39:80:98:bf:
-                    c0:cf:75:a8:31:56:2c:0f:32:44:b0:b8:2d:22:f9:
-                    f6:a2:d6:0b:cf:5f:a2:89:7c:15:97:a9:01:5c:97:
-                    6a:b9:9c:c2:aa:fd:a3:d9:aa:61:04:65:e4:13:7e:
-                    58:7d
+                    00:b0:eb:f6:b5:c4:28:a8:18:53:85:91:20:76:5d:
+                    aa:be:78:ae:10:60:d3:b5:66:f7:41:c8:bf:42:00:
+                    c8:99:63:ed:d0:92:12:5a:71:c0:da:d2:fd:b3:65:
+                    3b:a5:fa:be:0d:e5:2a:20:2f:df:a1:c5:41:c3:c3:
+                    9c:04:eb:07:6c:8d:48:9c:14:be:24:81:7d:03:4d:
+                    56:62:80:6b:34:e0:ad:68:f0:17:3d:fa:3b:b4:f7:
+                    a9:a3:fb:7d:30:0d:dd:c5:0b:b6:32:b6:c2:d9:b1:
+                    e8:97:ce:19:66:89:1b:5d:d6:4a:d9:0e:a6:b2:ad:
+                    cc:57:e9:0a:12:83:98:a3:18:90:a3:ae:ec:8e:a1:
+                    96:ee:a4:36:7b:13:c4:95:45:02:69:89:f4:d3:49:
+                    17:e6:e4:d5:91:23:24:7e:94:52:b5:4f:f3:0b:11:
+                    d8:b2:69:7e:72:25:88:03:15:7b:2f:64:ca:8c:a9:
+                    ce:b0:ed:eb:00:aa:68:af:cd:e4:1c:13:af:a7:ff:
+                    54:b6:7d:be:b5:6c:bd:6a:20:be:47:2f:a8:dd:7a:
+                    1d:2a:44:a4:0b:15:eb:68:85:05:32:17:01:cf:a7:
+                    27:03:cb:85:12:c1:ec:4f:c1:4b:2a:11:34:55:7c:
+                    b3:6c:fa:79:6d:4f:be:31:92:b8:f3:01:90:8e:42:
+                    6b:71
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Basic Constraints: critical
@@ -37,45 +37,45 @@ Certificate:
             X509v3 Key Usage: critical
                 Certificate Sign, CRL Sign
             X509v3 Subject Key Identifier: 
-                61:DF:EE:CE:DA:49:6B:5E:F3:EF:94:FE:F9:DC:C7:C0:5A:74:FE:DB
+                B2:EE:24:88:34:99:18:60:81:9E:2A:D3:F4:5A:66:FA:91:F6:E1:C6
             Netscape Comment: 
                 Puppet Server Internal Certificate
             X509v3 Authority Key Identifier: 
-                keyid:61:DF:EE:CE:DA:49:6B:5E:F3:EF:94:FE:F9:DC:C7:C0:5A:74:FE:DB
+                keyid:B2:EE:24:88:34:99:18:60:81:9E:2A:D3:F4:5A:66:FA:91:F6:E1:C6
 
     Signature Algorithm: sha256WithRSAEncryption
-         86:10:78:cb:49:09:83:84:9c:7f:33:c8:fc:08:d6:db:02:b7:
-         d3:e7:6b:62:3a:fd:37:d6:b8:a7:5c:8c:42:fb:b0:d6:de:5c:
-         5b:47:2c:22:05:e3:9b:05:2d:96:23:96:2f:40:c7:22:aa:32:
-         5d:b9:73:31:44:c2:60:f1:e5:d8:a3:c1:38:68:ec:37:4e:b0:
-         da:5e:88:b6:64:6b:8d:c3:fc:bd:08:df:81:f9:16:5a:27:1b:
-         3e:7d:8c:ac:7c:59:52:b9:cd:f3:77:1a:dc:fe:4e:92:cd:2b:
-         29:1e:0b:ea:1a:90:a4:da:39:06:52:6f:15:db:58:58:b1:9f:
-         7a:3f:e2:a1:b2:8e:ce:32:e2:5c:f4:55:0d:21:0a:53:35:ce:
-         50:fd:98:6a:c1:1f:72:83:69:a3:43:0b:3b:f5:36:76:5e:c3:
-         cb:1d:47:51:a0:e4:1f:1f:2a:ce:8e:8c:da:41:ce:4b:ea:47:
-         2d:36:d5:2d:d5:e0:44:39:4d:07:1e:79:65:5c:69:46:1a:9a:
-         12:ba:ce:55:9c:73:ed:75:51:30:db:71:f9:34:87:08:ec:a0:
-         23:6e:c3:8e:da:81:4f:3d:3b:70:42:a6:f8:16:82:03:17:ca:
-         ba:73:4a:8d:34:36:c1:b6:2a:ef:85:89:26:2a:a2:34:db:fc:
-         c9:b8:1b:0b
+         82:de:f4:cb:97:76:b0:a7:52:71:6c:94:4c:e6:8d:d6:e5:32:
+         1d:ca:99:44:9c:a2:b5:e4:a5:ba:06:08:6b:e7:b5:55:76:02:
+         7e:ee:69:6a:0d:27:69:7b:e3:80:97:10:9c:40:98:13:e4:d1:
+         40:b6:e6:59:1d:c2:1c:6e:64:ba:b5:af:7b:aa:70:d7:34:1b:
+         d3:cb:9f:2b:c0:72:36:70:ad:04:a0:07:9c:dd:e5:fa:02:b3:
+         c9:f1:f0:6a:99:89:95:20:e2:31:7f:21:2e:8b:b8:76:5e:31:
+         82:ec:4b:31:43:e7:20:d9:97:0f:52:8e:26:1d:0b:31:2d:f6:
+         74:40:6b:09:cf:39:e8:d9:c8:27:ed:9d:76:a5:b2:2a:83:db:
+         16:8e:5f:ee:e7:90:44:68:34:92:33:bd:39:7c:96:8f:e3:61:
+         78:b5:4e:59:d8:12:0a:0d:90:17:22:7c:0e:34:bb:ad:94:66:
+         07:d5:4f:d9:79:34:6f:12:c1:77:69:a1:20:ae:cc:b0:2e:e9:
+         9c:bb:94:89:70:ee:d0:14:1c:05:89:40:76:bb:47:64:83:24:
+         73:95:cc:f1:65:ee:f8:bf:55:f0:c3:e6:34:6b:07:09:67:3e:
+         03:01:8d:ba:cb:5d:5b:89:d6:e3:cb:ce:55:dc:ad:8d:7f:de:
+         c6:5a:7c:9f
 -----BEGIN CERTIFICATE-----
-MIIDNDCCAhygAwIBAgIBCjANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
-IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMxMDQxODE4NDYyM1owEjEQMA4GA1UEAwwH
-VGVzdCBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAN2lg0TbUb6Y
-77FjpwS5/81x0wZ2xCVo6OrvxbT5wnaqwBsbD0QT2tvP1PSIXMys8nb7nrYuQNq4
-wcjNJJBjEGyZ7gwQdMw4uPO02e0erAcptP7xFsIYfDT9UCUP90WE4EshQaRbGUKF
-o6jTauoPgPMaBviqMUvlRKg3gNEbAa7zuDXGPxCChPxZ2UfWqeNe85+JI2rtvJJq
-oUksmcOJs6s6n2st5jmVFeBxX2tqIy68zUCyR0IT9PXnQ3Zc250QO5EQzMcn26gY
-U8lQ64M5gJi/wM91qDFWLA8yRLC4LSL59qLWC89fool8FZepAVyXarmcwqr9o9mq
-YQRl5BN+WH0CAwEAAaOBlDCBkTAMBgNVHRMBAf8EAjAAMA4GA1UdDwEB/wQEAwIB
-BjAdBgNVHQ4EFgQUYd/uztpJa17z75T++dzHwFp0/tswMQYJYIZIAYb4QgENBCQW
+MIIDNDCCAhygAwIBAgIBCzANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMxMDYxNTAxMTkzN1owEjEQMA4GA1UEAwwH
+VGVzdCBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALDr9rXEKKgY
+U4WRIHZdqr54rhBg07Vm90HIv0IAyJlj7dCSElpxwNrS/bNlO6X6vg3lKiAv36HF
+QcPDnATrB2yNSJwUviSBfQNNVmKAazTgrWjwFz36O7T3qaP7fTAN3cULtjK2wtmx
+6JfOGWaJG13WStkOprKtzFfpChKDmKMYkKOu7I6hlu6kNnsTxJVFAmmJ9NNJF+bk
+1ZEjJH6UUrVP8wsR2LJpfnIliAMVey9kyoypzrDt6wCqaK/N5BwTr6f/VLZ9vrVs
+vWogvkcvqN16HSpEpAsV62iFBTIXAc+nJwPLhRLB7E/BSyoRNFV8s2z6eW1PvjGS
+uPMBkI5Ca3ECAwEAAaOBlDCBkTAMBgNVHRMBAf8EAjAAMA4GA1UdDwEB/wQEAwIB
+BjAdBgNVHQ4EFgQUsu4kiDSZGGCBnirT9Fpm+pH24cYwMQYJYIZIAYb4QgENBCQW
 IlB1cHBldCBTZXJ2ZXIgSW50ZXJuYWwgQ2VydGlmaWNhdGUwHwYDVR0jBBgwFoAU
-Yd/uztpJa17z75T++dzHwFp0/tswDQYJKoZIhvcNAQELBQADggEBAIYQeMtJCYOE
-nH8zyPwI1tsCt9Pna2I6/TfWuKdcjEL7sNbeXFtHLCIF45sFLZYjli9AxyKqMl25
-czFEwmDx5dijwTho7DdOsNpeiLZka43D/L0I34H5FlonGz59jKx8WVK5zfN3Gtz+
-TpLNKykeC+oakKTaOQZSbxXbWFixn3o/4qGyjs4y4lz0VQ0hClM1zlD9mGrBH3KD
-aaNDCzv1NnZew8sdR1Gg5B8fKs6OjNpBzkvqRy021S3V4EQ5TQceeWVcaUYamhK6
-zlWcc+11UTDbcfk0hwjsoCNuw47agU89O3BCpvgWggMXyrpzSo00NsG2Ku+FiSYq
-ojTb/Mm4Gws=
+su4kiDSZGGCBnirT9Fpm+pH24cYwDQYJKoZIhvcNAQELBQADggEBAILe9MuXdrCn
+UnFslEzmjdblMh3KmUScorXkpboGCGvntVV2An7uaWoNJ2l744CXEJxAmBPk0UC2
+5lkdwhxuZLq1r3uqcNc0G9PLnyvAcjZwrQSgB5zd5foCs8nx8GqZiZUg4jF/IS6L
+uHZeMYLsSzFD5yDZlw9SjiYdCzEt9nRAawnPOejZyCftnXalsiqD2xaOX+7nkERo
+NJIzvTl8lo/jYXi1TlnYEgoNkBcifA40u62UZgfVT9l5NG8SwXdpoSCuzLAu6Zy7
+lIlw7tAUHAWJQHa7R2SDJHOVzPFl7vi/VfDD5jRrBwlnPgMBjbrLXVuJ1uPLzlXc
+rY1/3sZafJ8=
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/bad-int-basic-constraints.pem
+++ b/spec/fixtures/ssl/bad-int-basic-constraints.pem
@@ -6,30 +6,30 @@ Certificate:
         Issuer: CN=Test CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Apr 18 18:46:23 2031 GMT
+            Not After : Jun 15 01:19:37 2031 GMT
         Subject: CN=Test CA Subauthority
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:cd:ef:ef:31:c5:33:69:3b:ee:25:06:b9:73:a7:
-                    09:e5:c9:9c:0b:39:48:26:fb:88:26:50:2d:8a:52:
-                    29:86:df:7a:12:f0:08:ea:61:52:80:98:9f:a5:45:
-                    26:ad:6d:05:e6:b5:81:e5:91:b3:6b:98:53:09:0a:
-                    e9:05:4b:29:de:3c:64:44:a7:d2:5d:3f:fc:5f:f8:
-                    29:1f:b0:40:e2:74:8a:26:fd:e8:d7:74:a5:78:de:
-                    bf:23:10:73:74:8d:1b:0c:4b:d7:1d:a9:ae:86:14:
-                    05:63:7c:2a:00:38:d6:57:8a:b7:a8:45:80:27:f5:
-                    71:0b:fa:e2:bd:a2:d1:08:8d:fa:cd:9c:f6:ad:89:
-                    76:ea:ab:1c:78:f9:26:5b:a3:18:2a:f7:90:15:ed:
-                    a7:db:50:e9:7d:55:99:7e:05:10:ca:56:11:51:5e:
-                    de:8c:e2:be:2a:8a:34:41:1d:1d:23:92:04:50:05:
-                    c5:5b:b8:7a:45:90:ee:0d:7f:01:b1:ed:d4:dd:c5:
-                    28:ed:7d:4d:6a:70:21:3b:95:5e:e2:31:d7:17:bd:
-                    5b:af:e4:ce:ad:6b:9f:5f:9e:e1:1e:86:ff:83:c1:
-                    88:ec:87:bb:bf:a1:26:22:75:b9:57:31:10:fd:a5:
-                    ca:82:70:6d:c8:a1:a3:f6:3e:76:3d:2e:cd:07:f9:
-                    7b:3f
+                    00:af:36:20:41:45:0b:d1:13:0c:82:fd:b8:e5:ea:
+                    f8:32:6b:5e:f7:a5:1c:7d:21:24:cb:85:bf:cd:f5:
+                    ca:48:85:39:c1:42:a4:65:93:d2:a2:04:f9:c9:19:
+                    10:da:64:0d:be:e3:d0:a5:d3:85:17:79:aa:18:32:
+                    f7:0a:b9:8e:08:de:d8:97:06:28:99:ac:ed:d1:a6:
+                    d4:0a:34:de:3d:33:e3:08:17:c2:22:6c:1d:fc:51:
+                    df:98:e6:de:6e:c6:4b:26:f4:87:44:1e:86:b6:44:
+                    b2:f3:82:9c:9c:2f:5b:66:bf:27:71:49:53:bf:c9:
+                    d2:f5:06:7e:fe:fd:1c:59:ba:aa:a9:05:c8:cb:44:
+                    f5:f5:51:7b:80:1c:59:0e:a5:bf:bb:af:f5:96:68:
+                    26:ca:52:b6:a8:e3:f6:3f:b9:a0:60:09:67:4a:86:
+                    5b:b4:ae:13:d9:39:ca:e0:84:dc:2e:83:51:ce:09:
+                    34:36:30:9c:ff:54:32:a6:b6:5b:a6:41:bd:b3:2b:
+                    5d:1d:eb:79:45:f4:fb:de:47:56:3c:8d:b1:96:34:
+                    2d:ec:9a:66:4c:50:ab:c6:c4:05:3e:8c:27:7c:be:
+                    54:53:5e:ae:20:70:15:12:0f:85:ab:be:18:dd:da:
+                    f5:33:a5:55:6a:c7:d8:36:89:bb:1c:5d:ce:46:45:
+                    ba:7d
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Basic Constraints: critical
@@ -37,45 +37,45 @@ Certificate:
             X509v3 Key Usage: critical
                 Certificate Sign, CRL Sign
             X509v3 Subject Key Identifier: 
-                9A:15:19:07:A0:54:8D:C3:9D:4F:07:C4:05:A1:85:AC:92:D8:B1:E5
+                59:79:27:C1:94:D7:09:B0:B2:1C:23:44:22:E2:25:25:1B:83:5F:34
             Netscape Comment: 
                 Puppet Server Internal Certificate
             X509v3 Authority Key Identifier: 
-                keyid:61:DF:EE:CE:DA:49:6B:5E:F3:EF:94:FE:F9:DC:C7:C0:5A:74:FE:DB
+                keyid:B2:EE:24:88:34:99:18:60:81:9E:2A:D3:F4:5A:66:FA:91:F6:E1:C6
 
     Signature Algorithm: sha256WithRSAEncryption
-         d7:3a:0b:c1:06:57:c2:6c:f8:4e:79:c6:f9:0e:9c:a6:64:cc:
-         7b:c8:a5:7a:93:aa:d6:f5:e7:51:9a:26:6f:6c:b5:48:37:39:
-         ba:4b:6c:f8:d6:95:2d:db:e0:44:bd:f6:c9:a1:36:7a:12:0a:
-         b2:77:7b:84:c8:14:68:1e:c2:04:29:b5:83:3b:cf:29:dc:6b:
-         27:b3:ae:a3:24:aa:3b:0c:4c:4b:c0:7d:52:6d:5c:2c:d0:5d:
-         06:af:89:9a:0c:0f:2e:df:53:ae:82:23:36:e3:1a:cb:49:46:
-         e2:77:a1:3e:55:1c:81:f5:8e:c8:f2:da:8c:22:14:e6:84:47:
-         e9:56:8e:7a:c7:c4:54:e0:f1:f5:2f:00:c4:ad:e1:ff:ba:cb:
-         5e:66:22:f2:71:db:0e:31:22:5b:5e:ad:63:6e:bf:52:c9:4d:
-         91:cc:29:5d:b8:b3:d4:b0:a7:17:9b:bd:87:9b:09:ef:a2:68:
-         24:b2:1d:62:0a:f3:d6:15:7b:ba:26:7e:ca:e2:df:ac:4c:f9:
-         70:76:fc:fb:39:bf:d3:a8:21:19:2d:6d:a6:71:6f:e5:0f:c8:
-         9c:97:b0:5f:2c:85:d2:1f:b4:27:28:54:6f:30:f4:66:8a:bf:
-         cc:09:5c:0d:19:85:b6:04:8c:7c:03:a4:fc:a3:80:dc:1c:5b:
-         61:6d:12:0a
+         8e:52:e6:46:dc:23:4a:6f:09:4a:e5:72:96:90:9c:8c:c0:ff:
+         4c:cd:eb:16:a7:8d:fe:56:4a:c4:be:97:50:43:c9:a7:4b:97:
+         c1:fe:5f:e0:0c:17:ea:3b:cd:a8:27:03:21:9b:ee:33:eb:23:
+         46:e6:fc:e3:80:d4:4a:a2:29:5c:a3:d5:f3:0b:c9:74:41:49:
+         45:65:59:48:7f:93:49:5f:d0:20:e7:b1:93:dc:a9:78:ad:b7:
+         ef:97:cc:13:ef:29:04:56:c6:bc:10:97:3a:09:5b:fb:34:80:
+         a4:64:88:0d:b9:cb:bf:4e:e6:fe:98:bf:dc:e5:00:47:ad:7d:
+         74:c6:13:19:a9:d8:9c:1e:1c:60:55:f2:71:02:c9:7d:10:48:
+         b8:4e:8d:22:e8:b4:ee:e0:ce:a3:24:f9:33:d0:aa:d6:aa:cb:
+         dd:38:8a:bd:05:3f:b2:52:17:80:8c:a4:1a:97:44:19:1b:e5:
+         92:d3:b4:9b:58:44:91:dc:67:1d:e1:43:1a:85:1d:da:c3:52:
+         45:50:01:6c:f9:e2:64:a1:e9:2f:d6:88:20:fd:d0:8b:e4:c8:
+         76:50:f2:79:bf:6f:ad:8f:11:e5:81:3b:53:da:39:9e:d4:d7:
+         6c:f8:7c:36:ed:76:8c:b0:ca:86:a8:1d:01:d9:25:92:54:ae:
+         a9:dc:b2:73
 -----BEGIN CERTIFICATE-----
 MIIDQTCCAimgAwIBAgIBAzANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
-IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMxMDQxODE4NDYyM1owHzEdMBsGA1UEAwwU
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMxMDYxNTAxMTkzN1owHzEdMBsGA1UEAwwU
 VGVzdCBDQSBTdWJhdXRob3JpdHkwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
-AoIBAQDN7+8xxTNpO+4lBrlzpwnlyZwLOUgm+4gmUC2KUimG33oS8AjqYVKAmJ+l
-RSatbQXmtYHlkbNrmFMJCukFSynePGREp9JdP/xf+CkfsEDidIom/ejXdKV43r8j
-EHN0jRsMS9cdqa6GFAVjfCoAONZXireoRYAn9XEL+uK9otEIjfrNnPatiXbqqxx4
-+SZboxgq95AV7afbUOl9VZl+BRDKVhFRXt6M4r4qijRBHR0jkgRQBcVbuHpFkO4N
-fwGx7dTdxSjtfU1qcCE7lV7iMdcXvVuv5M6ta59fnuEehv+DwYjsh7u/oSYidblX
-MRD9pcqCcG3IoaP2PnY9Ls0H+Xs/AgMBAAGjgZQwgZEwDAYDVR0TAQH/BAIwADAO
-BgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFJoVGQegVI3DnU8HxAWhhayS2LHlMDEG
+AoIBAQCvNiBBRQvREwyC/bjl6vgya173pRx9ISTLhb/N9cpIhTnBQqRlk9KiBPnJ
+GRDaZA2+49Cl04UXeaoYMvcKuY4I3tiXBiiZrO3RptQKNN49M+MIF8IibB38Ud+Y
+5t5uxksm9IdEHoa2RLLzgpycL1tmvydxSVO/ydL1Bn7+/RxZuqqpBcjLRPX1UXuA
+HFkOpb+7r/WWaCbKUrao4/Y/uaBgCWdKhlu0rhPZOcrghNwug1HOCTQ2MJz/VDKm
+tlumQb2zK10d63lF9PveR1Y8jbGWNC3smmZMUKvGxAU+jCd8vlRTXq4gcBUSD4Wr
+vhjd2vUzpVVqx9g2ibscXc5GRbp9AgMBAAGjgZQwgZEwDAYDVR0TAQH/BAIwADAO
+BgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFFl5J8GU1wmwshwjRCLiJSUbg180MDEG
 CWCGSAGG+EIBDQQkFiJQdXBwZXQgU2VydmVyIEludGVybmFsIENlcnRpZmljYXRl
-MB8GA1UdIwQYMBaAFGHf7s7aSWte8++U/vncx8BadP7bMA0GCSqGSIb3DQEBCwUA
-A4IBAQDXOgvBBlfCbPhOecb5DpymZMx7yKV6k6rW9edRmiZvbLVINzm6S2z41pUt
-2+BEvfbJoTZ6Egqyd3uEyBRoHsIEKbWDO88p3Gsns66jJKo7DExLwH1SbVws0F0G
-r4maDA8u31OugiM24xrLSUbid6E+VRyB9Y7I8tqMIhTmhEfpVo56x8RU4PH1LwDE
-reH/usteZiLycdsOMSJbXq1jbr9SyU2RzClduLPUsKcXm72Hmwnvomgksh1iCvPW
-FXu6Jn7K4t+sTPlwdvz7Ob/TqCEZLW2mcW/lD8icl7BfLIXSH7QnKFRvMPRmir/M
-CVwNGYW2BIx8A6T8o4DcHFthbRIK
+MB8GA1UdIwQYMBaAFLLuJIg0mRhggZ4q0/RaZvqR9uHGMA0GCSqGSIb3DQEBCwUA
+A4IBAQCOUuZG3CNKbwlK5XKWkJyMwP9MzesWp43+VkrEvpdQQ8mnS5fB/l/gDBfq
+O82oJwMhm+4z6yNG5vzjgNRKoilco9XzC8l0QUlFZVlIf5NJX9Ag57GT3Kl4rbfv
+l8wT7ykEVsa8EJc6CVv7NICkZIgNucu/Tub+mL/c5QBHrX10xhMZqdicHhxgVfJx
+Asl9EEi4To0i6LTu4M6jJPkz0KrWqsvdOIq9BT+yUheAjKQal0QZG+WS07SbWESR
+3Gcd4UMahR3aw1JFUAFs+eJkoekv1ogg/dCL5Mh2UPJ5v2+tjxHlgTtT2jme1Nds
++Hw27XaMsMqGqB0B2SWSVK6p3LJz
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/ca.pem
+++ b/spec/fixtures/ssl/ca.pem
@@ -6,30 +6,30 @@ Certificate:
         Issuer: CN=Test CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Apr 18 18:46:23 2031 GMT
+            Not After : Jun 15 01:19:37 2031 GMT
         Subject: CN=Test CA
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:dd:a5:83:44:db:51:be:98:ef:b1:63:a7:04:b9:
-                    ff:cd:71:d3:06:76:c4:25:68:e8:ea:ef:c5:b4:f9:
-                    c2:76:aa:c0:1b:1b:0f:44:13:da:db:cf:d4:f4:88:
-                    5c:cc:ac:f2:76:fb:9e:b6:2e:40:da:b8:c1:c8:cd:
-                    24:90:63:10:6c:99:ee:0c:10:74:cc:38:b8:f3:b4:
-                    d9:ed:1e:ac:07:29:b4:fe:f1:16:c2:18:7c:34:fd:
-                    50:25:0f:f7:45:84:e0:4b:21:41:a4:5b:19:42:85:
-                    a3:a8:d3:6a:ea:0f:80:f3:1a:06:f8:aa:31:4b:e5:
-                    44:a8:37:80:d1:1b:01:ae:f3:b8:35:c6:3f:10:82:
-                    84:fc:59:d9:47:d6:a9:e3:5e:f3:9f:89:23:6a:ed:
-                    bc:92:6a:a1:49:2c:99:c3:89:b3:ab:3a:9f:6b:2d:
-                    e6:39:95:15:e0:71:5f:6b:6a:23:2e:bc:cd:40:b2:
-                    47:42:13:f4:f5:e7:43:76:5c:db:9d:10:3b:91:10:
-                    cc:c7:27:db:a8:18:53:c9:50:eb:83:39:80:98:bf:
-                    c0:cf:75:a8:31:56:2c:0f:32:44:b0:b8:2d:22:f9:
-                    f6:a2:d6:0b:cf:5f:a2:89:7c:15:97:a9:01:5c:97:
-                    6a:b9:9c:c2:aa:fd:a3:d9:aa:61:04:65:e4:13:7e:
-                    58:7d
+                    00:b0:eb:f6:b5:c4:28:a8:18:53:85:91:20:76:5d:
+                    aa:be:78:ae:10:60:d3:b5:66:f7:41:c8:bf:42:00:
+                    c8:99:63:ed:d0:92:12:5a:71:c0:da:d2:fd:b3:65:
+                    3b:a5:fa:be:0d:e5:2a:20:2f:df:a1:c5:41:c3:c3:
+                    9c:04:eb:07:6c:8d:48:9c:14:be:24:81:7d:03:4d:
+                    56:62:80:6b:34:e0:ad:68:f0:17:3d:fa:3b:b4:f7:
+                    a9:a3:fb:7d:30:0d:dd:c5:0b:b6:32:b6:c2:d9:b1:
+                    e8:97:ce:19:66:89:1b:5d:d6:4a:d9:0e:a6:b2:ad:
+                    cc:57:e9:0a:12:83:98:a3:18:90:a3:ae:ec:8e:a1:
+                    96:ee:a4:36:7b:13:c4:95:45:02:69:89:f4:d3:49:
+                    17:e6:e4:d5:91:23:24:7e:94:52:b5:4f:f3:0b:11:
+                    d8:b2:69:7e:72:25:88:03:15:7b:2f:64:ca:8c:a9:
+                    ce:b0:ed:eb:00:aa:68:af:cd:e4:1c:13:af:a7:ff:
+                    54:b6:7d:be:b5:6c:bd:6a:20:be:47:2f:a8:dd:7a:
+                    1d:2a:44:a4:0b:15:eb:68:85:05:32:17:01:cf:a7:
+                    27:03:cb:85:12:c1:ec:4f:c1:4b:2a:11:34:55:7c:
+                    b3:6c:fa:79:6d:4f:be:31:92:b8:f3:01:90:8e:42:
+                    6b:71
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Basic Constraints: critical
@@ -37,45 +37,45 @@ Certificate:
             X509v3 Key Usage: critical
                 Certificate Sign, CRL Sign
             X509v3 Subject Key Identifier: 
-                61:DF:EE:CE:DA:49:6B:5E:F3:EF:94:FE:F9:DC:C7:C0:5A:74:FE:DB
+                B2:EE:24:88:34:99:18:60:81:9E:2A:D3:F4:5A:66:FA:91:F6:E1:C6
             Netscape Comment: 
                 Puppet Server Internal Certificate
             X509v3 Authority Key Identifier: 
-                keyid:61:DF:EE:CE:DA:49:6B:5E:F3:EF:94:FE:F9:DC:C7:C0:5A:74:FE:DB
+                keyid:B2:EE:24:88:34:99:18:60:81:9E:2A:D3:F4:5A:66:FA:91:F6:E1:C6
 
     Signature Algorithm: sha256WithRSAEncryption
-         28:6c:ca:8a:1f:b2:01:4b:35:d1:55:07:c8:7c:79:5f:fb:a2:
-         e0:09:e9:25:d5:db:9f:d6:91:a8:cc:66:b1:63:bd:ad:f8:80:
-         80:32:43:eb:77:ee:d7:fd:48:27:26:bb:e1:48:67:83:7c:91:
-         4d:62:96:d6:6c:ce:37:5d:ff:f8:6a:f4:8d:31:3b:4c:f4:0d:
-         4f:75:61:08:01:99:f0:92:d2:d0:50:08:6e:c3:0d:25:3b:5b:
-         53:60:da:fa:90:02:2b:29:90:3f:f8:23:bb:9c:4c:0f:ad:d0:
-         cc:1b:21:56:26:40:97:7c:86:33:31:7d:fd:a9:5f:53:14:3e:
-         80:5f:91:09:f7:76:e4:ad:30:17:d0:aa:52:ef:e8:f6:6e:b7:
-         8e:68:47:9b:f8:63:3e:50:52:ba:eb:4a:9e:40:c5:84:aa:94:
-         49:0a:8a:ff:17:57:18:bd:fc:4d:71:6d:83:ee:4d:7e:40:6c:
-         08:c5:ee:6e:0d:c6:97:ba:6d:35:80:89:c5:c5:95:7b:f0:d0:
-         0a:39:2f:8e:70:03:bf:da:56:1d:59:6c:2c:c9:04:9b:d6:b2:
-         f3:1b:cf:4f:f3:12:47:eb:05:ea:42:70:4f:02:33:d1:5e:27:
-         a0:e3:66:d6:b0:d5:ab:e2:32:ad:e8:50:e1:f2:eb:17:ad:87:
-         31:22:fe:22
+         7a:7f:46:71:8a:41:c5:43:91:be:aa:2c:ca:96:12:6f:0a:1b:
+         7c:57:a7:cc:b3:8d:c5:ff:8c:77:f0:4e:ea:ae:b0:c3:af:01:
+         c5:17:32:4d:b5:c6:72:77:20:a7:05:02:a0:26:a3:0d:a6:da:
+         b4:cf:c8:96:36:76:c9:2f:db:90:db:e1:8e:83:5e:24:e5:47:
+         22:1f:e5:17:0b:16:19:db:a2:ae:55:db:3b:6a:2a:f2:a8:95:
+         25:d1:4f:13:bd:d8:07:b2:a1:63:18:0d:7d:4b:d8:74:be:bb:
+         c5:b2:26:3a:6c:7d:b1:84:20:6c:53:ab:fc:27:5a:06:84:a5:
+         f4:4d:63:ba:a2:43:40:76:c7:97:2a:ae:8f:5a:ca:0e:ab:4b:
+         59:c3:6c:b5:3e:f5:d2:bd:55:ce:88:19:de:e5:4e:ca:fe:c1:
+         83:02:9c:11:a2:97:88:64:8a:df:20:17:f3:47:9e:61:cf:c4:
+         bc:13:bb:e8:ba:97:37:90:8f:1a:5c:f5:b1:00:8d:70:fe:a2:
+         4c:8e:0a:bc:62:ed:8e:4e:e7:2a:15:13:59:7e:3b:a2:b8:41:
+         f0:13:41:39:29:99:1a:ca:c6:6a:b6:99:c5:ca:57:1d:53:c4:
+         c6:f5:7f:96:3b:11:05:96:10:a3:3c:96:d8:c3:07:2b:e2:66:
+         a5:93:13:98
 -----BEGIN CERTIFICATE-----
 MIIDNzCCAh+gAwIBAgIBAjANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
-IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMxMDQxODE4NDYyM1owEjEQMA4GA1UEAwwH
-VGVzdCBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAN2lg0TbUb6Y
-77FjpwS5/81x0wZ2xCVo6OrvxbT5wnaqwBsbD0QT2tvP1PSIXMys8nb7nrYuQNq4
-wcjNJJBjEGyZ7gwQdMw4uPO02e0erAcptP7xFsIYfDT9UCUP90WE4EshQaRbGUKF
-o6jTauoPgPMaBviqMUvlRKg3gNEbAa7zuDXGPxCChPxZ2UfWqeNe85+JI2rtvJJq
-oUksmcOJs6s6n2st5jmVFeBxX2tqIy68zUCyR0IT9PXnQ3Zc250QO5EQzMcn26gY
-U8lQ64M5gJi/wM91qDFWLA8yRLC4LSL59qLWC89fool8FZepAVyXarmcwqr9o9mq
-YQRl5BN+WH0CAwEAAaOBlzCBlDAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQE
-AwIBBjAdBgNVHQ4EFgQUYd/uztpJa17z75T++dzHwFp0/tswMQYJYIZIAYb4QgEN
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMxMDYxNTAxMTkzN1owEjEQMA4GA1UEAwwH
+VGVzdCBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALDr9rXEKKgY
+U4WRIHZdqr54rhBg07Vm90HIv0IAyJlj7dCSElpxwNrS/bNlO6X6vg3lKiAv36HF
+QcPDnATrB2yNSJwUviSBfQNNVmKAazTgrWjwFz36O7T3qaP7fTAN3cULtjK2wtmx
+6JfOGWaJG13WStkOprKtzFfpChKDmKMYkKOu7I6hlu6kNnsTxJVFAmmJ9NNJF+bk
+1ZEjJH6UUrVP8wsR2LJpfnIliAMVey9kyoypzrDt6wCqaK/N5BwTr6f/VLZ9vrVs
+vWogvkcvqN16HSpEpAsV62iFBTIXAc+nJwPLhRLB7E/BSyoRNFV8s2z6eW1PvjGS
+uPMBkI5Ca3ECAwEAAaOBlzCBlDAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQE
+AwIBBjAdBgNVHQ4EFgQUsu4kiDSZGGCBnirT9Fpm+pH24cYwMQYJYIZIAYb4QgEN
 BCQWIlB1cHBldCBTZXJ2ZXIgSW50ZXJuYWwgQ2VydGlmaWNhdGUwHwYDVR0jBBgw
-FoAUYd/uztpJa17z75T++dzHwFp0/tswDQYJKoZIhvcNAQELBQADggEBAChsyoof
-sgFLNdFVB8h8eV/7ouAJ6SXV25/WkajMZrFjva34gIAyQ+t37tf9SCcmu+FIZ4N8
-kU1iltZszjdd//hq9I0xO0z0DU91YQgBmfCS0tBQCG7DDSU7W1Ng2vqQAispkD/4
-I7ucTA+t0MwbIVYmQJd8hjMxff2pX1MUPoBfkQn3duStMBfQqlLv6PZut45oR5v4
-Yz5QUrrrSp5AxYSqlEkKiv8XVxi9/E1xbYPuTX5AbAjF7m4Nxpe6bTWAicXFlXvw
-0Ao5L45wA7/aVh1ZbCzJBJvWsvMbz0/zEkfrBepCcE8CM9FeJ6DjZtaw1aviMq3o
-UOHy6xethzEi/iI=
+FoAUsu4kiDSZGGCBnirT9Fpm+pH24cYwDQYJKoZIhvcNAQELBQADggEBAHp/RnGK
+QcVDkb6qLMqWEm8KG3xXp8yzjcX/jHfwTuqusMOvAcUXMk21xnJ3IKcFAqAmow2m
+2rTPyJY2dskv25Db4Y6DXiTlRyIf5RcLFhnboq5V2ztqKvKolSXRTxO92AeyoWMY
+DX1L2HS+u8WyJjpsfbGEIGxTq/wnWgaEpfRNY7qiQ0B2x5cqro9ayg6rS1nDbLU+
+9dK9Vc6IGd7lTsr+wYMCnBGil4hkit8gF/NHnmHPxLwTu+i6lzeQjxpc9bEAjXD+
+okyOCrxi7Y5O5yoVE1l+O6K4QfATQTkpmRrKxmq2mcXKVx1TxMb1f5Y7EQWWEKM8
+ltjDByviZqWTE5g=
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/crl.pem
+++ b/spec/fixtures/ssl/crl.pem
@@ -3,38 +3,38 @@ Certificate Revocation List (CRL):
         Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA
         Last Update: Jan  1 00:00:00 1970 GMT
-        Next Update: Apr 18 18:46:23 2031 GMT
+        Next Update: Jun 15 01:19:37 2031 GMT
         CRL extensions:
             X509v3 Authority Key Identifier: 
-                keyid:61:DF:EE:CE:DA:49:6B:5E:F3:EF:94:FE:F9:DC:C7:C0:5A:74:FE:DB
+                keyid:B2:EE:24:88:34:99:18:60:81:9E:2A:D3:F4:5A:66:FA:91:F6:E1:C6
 
             X509v3 CRL Number: 
                 0
 No Revoked Certificates.
     Signature Algorithm: sha256WithRSAEncryption
-         6e:b5:9c:17:8b:61:3c:41:07:ac:de:27:18:ba:92:56:51:50:
-         23:d8:f9:1f:70:b8:a6:eb:ae:6c:2c:67:c1:0e:ae:96:0f:f4:
-         bc:0a:f3:bc:23:15:67:b0:32:a2:e0:4f:2c:7f:f9:c2:9d:91:
-         2e:32:01:60:3b:e4:ad:05:b6:60:f1:90:9d:cd:63:a5:62:c1:
-         4d:04:d6:90:30:f8:43:97:e6:88:0a:2a:65:8f:49:12:d6:41:
-         5e:11:62:00:a5:ff:0f:c3:3e:97:e0:93:31:de:64:7c:11:a5:
-         7b:f1:77:0a:8e:00:23:4c:9d:b1:c5:b5:41:bf:96:da:b7:c7:
-         e7:8c:44:1b:c2:de:15:0f:da:32:52:45:65:54:dc:1b:a7:5b:
-         d3:a2:b5:6e:85:3b:97:d9:09:52:c6:4d:6c:18:a4:22:58:11:
-         bf:12:27:2f:64:00:a5:9a:7d:b8:10:0c:6d:eb:b8:70:ee:e2:
-         58:86:eb:31:48:c0:af:92:92:fc:2e:1f:0f:61:77:7c:5c:a8:
-         ca:bc:52:94:e4:f2:bc:c2:f1:fa:aa:16:63:9d:16:51:92:7b:
-         ad:da:fd:94:ed:3d:e9:8c:ad:ba:95:34:98:6a:ea:e6:9c:8e:
-         38:a3:20:34:19:63:1e:7f:f3:26:07:7f:46:27:01:85:91:46:
-         44:66:c7:03
+         94:c0:29:e4:a6:0d:fb:0f:8d:96:5a:74:40:0b:1f:c7:58:0d:
+         b8:a4:3d:44:b8:2e:93:82:c1:b0:56:4b:ee:c1:a3:a3:9d:cd:
+         dd:48:89:92:18:d0:d5:bf:87:06:6c:00:65:9e:73:30:9a:57:
+         8a:21:26:73:60:2b:a6:46:59:1a:9a:ca:64:3e:fa:ea:0b:f1:
+         07:4f:70:0a:27:eb:89:d7:51:5a:62:73:ec:ef:23:5e:c5:04:
+         07:b0:17:b9:7a:4a:b7:9f:77:8d:5e:7c:fe:30:d5:37:3a:f2:
+         22:d9:14:a6:cb:b3:10:36:27:49:87:28:42:2f:0e:9d:04:36:
+         6e:0a:8f:01:a8:35:b8:46:05:8b:02:25:69:5d:0c:55:a4:5b:
+         d1:7f:48:5a:e3:06:4f:13:f8:b6:fc:34:93:b7:20:27:7d:79:
+         44:a2:ce:1f:24:42:7e:c8:9b:3d:d4:62:db:0a:3a:1b:d4:30:
+         94:5e:ff:9b:b3:eb:c2:19:36:a9:71:a6:9a:d6:a5:04:f1:05:
+         7a:6b:3d:82:7f:8b:96:8c:27:41:13:8d:2e:82:94:68:a0:0b:
+         10:75:cb:e6:05:07:86:d7:44:7c:09:1d:e9:65:a9:29:13:dc:
+         ef:a6:c7:93:8e:e7:09:c2:14:7d:d4:31:e4:db:f9:1f:dd:15:
+         93:e5:23:2f
 -----BEGIN X509 CRL-----
 MIIBizB1AgEBMA0GCSqGSIb3DQEBCwUAMBIxEDAOBgNVBAMMB1Rlc3QgQ0EXDTcw
-MDEwMTAwMDAwMFoXDTMxMDQxODE4NDYyM1qgLzAtMB8GA1UdIwQYMBaAFGHf7s7a
-SWte8++U/vncx8BadP7bMAoGA1UdFAQDAgEAMA0GCSqGSIb3DQEBCwUAA4IBAQBu
-tZwXi2E8QQes3icYupJWUVAj2PkfcLim665sLGfBDq6WD/S8CvO8IxVnsDKi4E8s
-f/nCnZEuMgFgO+StBbZg8ZCdzWOlYsFNBNaQMPhDl+aICiplj0kS1kFeEWIApf8P
-wz6X4JMx3mR8EaV78XcKjgAjTJ2xxbVBv5bat8fnjEQbwt4VD9oyUkVlVNwbp1vT
-orVuhTuX2QlSxk1sGKQiWBG/EicvZAClmn24EAxt67hw7uJYhusxSMCvkpL8Lh8P
-YXd8XKjKvFKU5PK8wvH6qhZjnRZRknut2v2U7T3pjK26lTSYaurmnI44oyA0GWMe
-f/MmB39GJwGFkUZEZscD
+MDEwMTAwMDAwMFoXDTMxMDYxNTAxMTkzN1qgLzAtMB8GA1UdIwQYMBaAFLLuJIg0
+mRhggZ4q0/RaZvqR9uHGMAoGA1UdFAQDAgEAMA0GCSqGSIb3DQEBCwUAA4IBAQCU
+wCnkpg37D42WWnRACx/HWA24pD1EuC6TgsGwVkvuwaOjnc3dSImSGNDVv4cGbABl
+nnMwmleKISZzYCumRlkamspkPvrqC/EHT3AKJ+uJ11FaYnPs7yNexQQHsBe5ekq3
+n3eNXnz+MNU3OvIi2RSmy7MQNidJhyhCLw6dBDZuCo8BqDW4RgWLAiVpXQxVpFvR
+f0ha4wZPE/i2/DSTtyAnfXlEos4fJEJ+yJs91GLbCjob1DCUXv+bs+vCGTapcaaa
+1qUE8QV6az2Cf4uWjCdBE40ugpRooAsQdcvmBQeG10R8CR3pZakpE9zvpseTjucJ
+whR91DHk2/kf3RWT5SMv
 -----END X509 CRL-----

--- a/spec/fixtures/ssl/ec-key.pem
+++ b/spec/fixtures/ssl/ec-key.pem
@@ -1,18 +1,18 @@
 Private-Key: (256 bit)
 priv:
-    f6:29:ef:a1:4b:33:2a:e1:ed:f9:25:c3:d1:53:81:
-    26:8d:65:e7:be:33:ea:b4:0e:7b:fa:d8:f5:58:53:
-    a6:a3
+    27:12:6c:11:ab:f5:ea:31:bb:92:9d:6f:e5:8d:2c:
+    37:77:53:04:94:21:e7:ac:cd:b5:e1:95:fe:9b:3e:
+    2b:35
 pub:
-    04:c4:23:3b:de:c0:ca:4f:ea:d4:e9:b2:de:9f:df:
-    22:97:5b:89:48:de:a6:6c:82:f6:b6:fc:a9:e5:cb:
-    14:f9:e6:2c:ce:08:5c:e2:99:55:ff:55:c2:03:33:
-    90:49:13:9a:3f:25:29:70:19:2c:20:5e:8a:09:ad:
-    cd:9e:86:0a:e6
+    04:82:0e:06:bf:c4:ae:37:d8:b1:7f:49:07:20:0f:
+    0c:46:52:a5:f7:28:89:66:ed:70:0f:8d:f9:95:55:
+    74:27:78:9a:f7:8d:7b:9e:1f:3c:0c:1a:59:2b:64:
+    d4:66:d3:76:55:b7:a3:e6:11:c7:c1:5c:94:37:89:
+    01:21:58:07:3c
 ASN1 OID: prime256v1
 NIST CURVE: P-256
 -----BEGIN EC PRIVATE KEY-----
-MHcCAQEEIPYp76FLMyrh7fklw9FTgSaNZee+M+q0Dnv62PVYU6ajoAoGCCqGSM49
-AwEHoUQDQgAExCM73sDKT+rU6bLen98il1uJSN6mbIL2tvyp5csU+eYszghc4plV
-/1XCAzOQSROaPyUpcBksIF6KCa3NnoYK5g==
+MHcCAQEEICcSbBGr9eoxu5Kdb+WNLDd3UwSUIeeszbXhlf6bPis1oAoGCCqGSM49
+AwEHoUQDQgAEgg4Gv8SuN9ixf0kHIA8MRlKl9yiJZu1wD435lVV0J3ia9417nh88
+DBpZK2TUZtN2Vbej5hHHwVyUN4kBIVgHPA==
 -----END EC PRIVATE KEY-----

--- a/spec/fixtures/ssl/ec.pem
+++ b/spec/fixtures/ssl/ec.pem
@@ -1,49 +1,49 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 7 (0x7)
+        Serial Number: 8 (0x8)
         Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA Subauthority
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Apr 18 18:46:23 2031 GMT
+            Not After : Jun 15 01:19:37 2031 GMT
         Subject: CN=ec
         Subject Public Key Info:
             Public Key Algorithm: id-ecPublicKey
                 Public-Key: (256 bit)
                 pub:
-                    04:c4:23:3b:de:c0:ca:4f:ea:d4:e9:b2:de:9f:df:
-                    22:97:5b:89:48:de:a6:6c:82:f6:b6:fc:a9:e5:cb:
-                    14:f9:e6:2c:ce:08:5c:e2:99:55:ff:55:c2:03:33:
-                    90:49:13:9a:3f:25:29:70:19:2c:20:5e:8a:09:ad:
-                    cd:9e:86:0a:e6
+                    04:82:0e:06:bf:c4:ae:37:d8:b1:7f:49:07:20:0f:
+                    0c:46:52:a5:f7:28:89:66:ed:70:0f:8d:f9:95:55:
+                    74:27:78:9a:f7:8d:7b:9e:1f:3c:0c:1a:59:2b:64:
+                    d4:66:d3:76:55:b7:a3:e6:11:c7:c1:5c:94:37:89:
+                    01:21:58:07:3c
                 ASN1 OID: prime256v1
                 NIST CURVE: P-256
     Signature Algorithm: sha256WithRSAEncryption
-         27:2e:2b:92:93:5d:39:da:ea:0e:ae:02:eb:aa:30:a5:bb:1a:
-         d5:e0:41:41:b5:6c:12:49:4d:61:39:1a:49:fc:5e:6a:22:ec:
-         7a:b0:4d:3e:ee:aa:f4:e9:c8:62:fd:c1:72:6d:c0:ee:21:0c:
-         eb:fb:5b:b1:81:ff:4e:bf:a7:c9:e8:37:02:2d:e3:f4:5c:49:
-         5f:e1:6f:96:9f:02:46:a6:8c:1d:d1:e8:50:f8:40:b2:db:a8:
-         c9:2d:5d:40:39:e7:31:c8:8f:9c:5a:bc:f8:a2:97:70:8d:fc:
-         0c:f1:ce:a2:66:7b:14:c8:ae:30:c7:90:8e:cb:ce:e3:b9:69:
-         9c:b8:6e:9e:61:a9:1b:90:28:2d:10:b3:5a:a1:b5:49:5a:48:
-         2f:7b:80:ef:db:e3:41:c6:c4:a1:46:87:0c:d9:b2:fc:16:fb:
-         ff:b6:93:ca:5e:67:73:1c:14:8a:a4:33:44:13:be:75:7c:6b:
-         61:3a:42:79:fc:a2:20:1a:cc:90:a4:63:3c:a2:b2:e2:52:0a:
-         03:21:6b:94:57:0e:4b:ab:30:b4:49:21:2f:bf:ae:aa:fc:62:
-         62:f9:f7:03:ba:5f:99:6d:50:5c:03:61:7f:9e:96:1d:07:dd:
-         32:f0:b7:80:22:4c:4c:00:50:59:2b:c8:76:1e:c3:b8:e5:0f:
-         ad:f0:1c:d8
+         73:45:fa:9b:af:0b:0b:74:21:80:8b:4c:c7:25:ad:ed:aa:6e:
+         0a:5e:86:f3:77:93:fe:b5:7d:4d:9d:cf:16:e6:27:81:c7:2e:
+         a0:fd:6b:09:24:78:3e:d3:4f:48:c6:c0:55:a5:0e:ee:8a:b7:
+         c5:70:c3:ac:d1:67:fd:fb:92:81:85:ea:8f:0e:49:29:49:a0:
+         4f:92:5c:2c:39:db:7e:01:5b:4f:c6:36:4d:aa:84:36:b5:73:
+         70:a4:e2:b8:bc:0c:1c:a4:b7:84:f5:81:9d:31:31:57:46:e7:
+         0b:1c:53:20:0a:ee:0e:b0:93:a3:88:4a:66:33:c1:11:dc:b8:
+         f9:1d:ee:72:97:e0:3a:53:9d:e5:25:16:4c:8a:12:4d:d1:39:
+         21:68:21:cf:2f:f6:52:25:38:49:06:f5:41:d5:68:28:9c:73:
+         40:16:3f:57:fc:4a:85:e4:c7:a6:bf:8b:66:e8:d5:0c:ce:8b:
+         95:a8:53:e2:e9:a1:ef:53:5f:c4:87:a6:57:03:67:28:f1:eb:
+         19:db:2a:81:55:e7:d4:a1:e9:be:97:39:28:e8:fe:01:48:c0:
+         95:a6:3a:d5:f0:69:63:6c:ca:e8:74:f9:24:76:39:26:71:21:
+         ad:c7:f3:dc:4a:24:a8:16:22:15:35:2a:43:3b:30:9d:67:99:
+         a6:18:ec:77
 -----BEGIN CERTIFICATE-----
-MIIB2TCBwqADAgECAgEHMA0GCSqGSIb3DQEBCwUAMB8xHTAbBgNVBAMMFFRlc3Qg
-Q0EgU3ViYXV0aG9yaXR5MB4XDTcwMDEwMTAwMDAwMFoXDTMxMDQxODE4NDYyM1ow
-DTELMAkGA1UEAwwCZWMwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATEIzvewMpP
-6tTpst6f3yKXW4lI3qZsgva2/KnlyxT55izOCFzimVX/VcIDM5BJE5o/JSlwGSwg
-XooJrc2ehgrmMA0GCSqGSIb3DQEBCwUAA4IBAQAnLiuSk1052uoOrgLrqjCluxrV
-4EFBtWwSSU1hORpJ/F5qIux6sE0+7qr06chi/cFybcDuIQzr+1uxgf9Ov6fJ6DcC
-LeP0XElf4W+WnwJGpowd0ehQ+ECy26jJLV1AOecxyI+cWrz4opdwjfwM8c6iZnsU
-yK4wx5COy87juWmcuG6eYakbkCgtELNaobVJWkgve4Dv2+NBxsShRocM2bL8Fvv/
-tpPKXmdzHBSKpDNEE751fGthOkJ5/KIgGsyQpGM8orLiUgoDIWuUVw5LqzC0SSEv
-v66q/GJi+fcDul+ZbVBcA2F/npYdB90y8LeAIkxMAFBZK8h2HsO45Q+t8BzY
+MIIB2TCBwqADAgECAgEIMA0GCSqGSIb3DQEBCwUAMB8xHTAbBgNVBAMMFFRlc3Qg
+Q0EgU3ViYXV0aG9yaXR5MB4XDTcwMDEwMTAwMDAwMFoXDTMxMDYxNTAxMTkzN1ow
+DTELMAkGA1UEAwwCZWMwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASCDga/xK43
+2LF/SQcgDwxGUqX3KIlm7XAPjfmVVXQneJr3jXueHzwMGlkrZNRm03ZVt6PmEcfB
+XJQ3iQEhWAc8MA0GCSqGSIb3DQEBCwUAA4IBAQBzRfqbrwsLdCGAi0zHJa3tqm4K
+Xobzd5P+tX1Nnc8W5ieBxy6g/WsJJHg+009IxsBVpQ7uirfFcMOs0Wf9+5KBheqP
+DkkpSaBPklwsOdt+AVtPxjZNqoQ2tXNwpOK4vAwcpLeE9YGdMTFXRucLHFMgCu4O
+sJOjiEpmM8ER3Lj5He5yl+A6U53lJRZMihJN0TkhaCHPL/ZSJThJBvVB1WgonHNA
+Fj9X/EqF5Memv4tm6NUMzouVqFPi6aHvU1/Eh6ZXA2co8esZ2yqBVefUoem+lzko
+6P4BSMCVpjrV8GljbMrodPkkdjkmcSGtx/PcSiSoFiIVNSpDOzCdZ5mmGOx3
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/encrypted-ec-key.pem
+++ b/spec/fixtures/ssl/encrypted-ec-key.pem
@@ -1,21 +1,21 @@
 Private-Key: (256 bit)
 priv:
-    f6:29:ef:a1:4b:33:2a:e1:ed:f9:25:c3:d1:53:81:
-    26:8d:65:e7:be:33:ea:b4:0e:7b:fa:d8:f5:58:53:
-    a6:a3
+    27:12:6c:11:ab:f5:ea:31:bb:92:9d:6f:e5:8d:2c:
+    37:77:53:04:94:21:e7:ac:cd:b5:e1:95:fe:9b:3e:
+    2b:35
 pub:
-    04:c4:23:3b:de:c0:ca:4f:ea:d4:e9:b2:de:9f:df:
-    22:97:5b:89:48:de:a6:6c:82:f6:b6:fc:a9:e5:cb:
-    14:f9:e6:2c:ce:08:5c:e2:99:55:ff:55:c2:03:33:
-    90:49:13:9a:3f:25:29:70:19:2c:20:5e:8a:09:ad:
-    cd:9e:86:0a:e6
+    04:82:0e:06:bf:c4:ae:37:d8:b1:7f:49:07:20:0f:
+    0c:46:52:a5:f7:28:89:66:ed:70:0f:8d:f9:95:55:
+    74:27:78:9a:f7:8d:7b:9e:1f:3c:0c:1a:59:2b:64:
+    d4:66:d3:76:55:b7:a3:e6:11:c7:c1:5c:94:37:89:
+    01:21:58:07:3c
 ASN1 OID: prime256v1
 NIST CURVE: P-256
 -----BEGIN EC PRIVATE KEY-----
 Proc-Type: 4,ENCRYPTED
-DEK-Info: AES-128-CBC,7F75DD5C09F3396E0DE1F15482350FA4
+DEK-Info: AES-128-CBC,3000460EBCF5BF07FA28AC674DAC7481
 
-r576IEa+i0nLaChOpNHlM+krdE2sgt9INqxYZdL0bcUEHKC44QlPU3Wrq56jLj4n
-A9KtNG64NZTdVubOHqp41W2GSkehycFhdnItWfDCnK8Ru2/YDkDA+nIfMEgHS/uL
-Gsu2AAiBKIQsSX+CDDGwiBm5ayae30+o1nIdI/Y7fxU=
+DZ8eBxSQ3PNLVsXV62TdK+L7lvMvZl3kre28PVE4YfR8WFGDKK39OUpup8pOmy9p
+a0VcDRaQ0MGse43mWl7/JbQGPP9U4cswow4jqLUifprZTCoTlXy4mFleD0rLiT0F
+la0gg7fR+18maGiknmYam/euhmNx9dh4+E0HXQ8357Q=
 -----END EC PRIVATE KEY-----

--- a/spec/fixtures/ssl/encrypted-key.pem
+++ b/spec/fixtures/ssl/encrypted-key.pem
@@ -1,120 +1,120 @@
 RSA Private-Key: (2048 bit, 2 primes)
 modulus:
-    00:db:90:d7:cf:fe:81:bc:51:d1:a1:d2:d9:0f:c2:
-    21:16:06:3d:12:87:7c:e9:45:97:28:f4:33:12:51:
-    d2:b3:31:be:13:5d:28:a8:b5:fb:8f:0e:ce:3e:bb:
-    42:7a:3f:ba:35:e9:58:2a:fb:61:38:c0:6b:37:9f:
-    3f:de:b9:64:5b:c3:08:21:64:d7:c2:af:0a:ac:21:
-    0b:ed:c1:8a:71:fe:05:27:eb:4b:31:ba:79:62:e5:
-    41:ef:dd:66:85:76:28:bb:03:08:c7:35:26:85:c2:
-    f8:3b:1f:67:45:39:73:ce:d8:5d:df:4a:0b:4e:8c:
-    85:29:02:98:04:95:e9:d3:f6:d1:9f:6c:25:ce:a3:
-    81:4c:c7:4d:b5:ce:43:12:d9:b2:f1:68:c8:fd:a3:
-    57:16:f5:7a:42:85:fe:19:b5:ee:e8:3f:da:27:85:
-    82:c9:ec:d6:63:bf:cd:4b:75:1e:a0:c5:8f:ce:90:
-    b8:ca:25:ba:45:52:6d:e4:ea:6d:e5:1d:41:8e:4f:
-    33:4a:97:23:8e:c1:98:d4:60:a7:1e:1c:28:31:0d:
-    05:c8:a2:d2:d7:7a:d9:c3:46:26:a1:e7:ef:67:e7:
-    6b:ce:97:8a:37:0b:d7:e2:28:b0:33:85:b0:89:6b:
-    38:83:ae:a3:02:a7:d2:1a:87:f0:88:a6:a3:1a:db:
-    97:53
+    00:94:3b:fc:18:7e:09:d6:93:10:9a:d7:df:84:49:
+    74:7d:9a:0e:91:ff:31:ca:9f:c0:c0:cf:4a:6b:1e:
+    be:77:b0:82:9f:a6:17:fc:f3:99:f1:e5:ed:c4:d3:
+    e1:f4:e8:ee:d2:70:3b:98:b1:21:55:9a:9e:6d:89:
+    f1:82:ba:82:43:00:af:e6:05:7e:0f:a1:50:ff:ec:
+    77:88:28:92:a2:f0:f9:29:1d:cb:86:ca:63:a9:c7:
+    9e:01:99:6e:56:c8:39:f1:c6:33:b9:b4:96:b2:05:
+    5e:e1:f7:1c:55:58:23:ec:bd:bb:4d:a0:54:3c:09:
+    d0:c9:83:27:9b:3c:f5:50:8c:1e:54:22:b3:0a:0f:
+    97:c1:68:d5:07:b7:0d:b9:16:d6:f8:d0:2c:87:25:
+    5e:53:65:31:d5:d6:94:ab:8b:77:29:a2:78:4e:c7:
+    cf:66:f2:79:f2:66:ca:ce:c9:9a:04:a2:0d:47:6f:
+    a0:1c:cc:39:7d:f2:01:73:3d:9c:56:0f:15:f6:06:
+    92:98:19:9b:52:ed:43:f8:84:6c:1f:96:0b:dd:8e:
+    c7:0f:dc:13:08:7b:1a:07:c1:ac:de:ba:dc:ce:1b:
+    a8:c5:c5:d5:c8:6c:32:6a:e2:2c:aa:e2:56:ba:55:
+    b4:3c:2b:7f:87:99:3e:d0:0c:47:ba:6e:60:86:2b:
+    3d:51
 publicExponent: 65537 (0x10001)
 privateExponent:
-    00:9d:74:93:af:8f:1e:4e:84:86:46:fc:43:b9:2f:
-    48:36:d9:26:76:e1:3e:cc:b2:a1:22:37:6d:60:97:
-    d8:f7:b4:96:50:a0:a0:05:cc:eb:a7:bd:c0:5d:f0:
-    40:4e:16:e1:5c:c4:07:fc:5a:e5:6f:a3:5d:c0:37:
-    ad:bf:f5:47:69:1e:c5:f7:dc:af:75:e7:bd:49:8f:
-    31:54:c1:54:9d:46:c3:3f:cb:56:d3:44:9c:c4:35:
-    10:42:09:8d:f9:eb:b0:6d:dc:51:31:3a:86:73:aa:
-    4c:05:6a:11:ce:ec:d2:85:e5:57:fc:46:c7:30:ff:
-    48:87:0e:5b:21:fe:b7:fe:ce:4f:8c:2c:cf:ea:d1:
-    0c:59:83:7e:d4:3f:db:0c:09:8d:8d:af:c5:38:8d:
-    96:44:37:7c:a3:4f:79:09:fe:11:cb:cf:20:40:6c:
-    fd:a3:cc:d9:f2:f4:35:79:63:c3:f8:1c:c1:6e:d4:
-    76:2b:67:84:4d:d3:af:81:72:17:ba:9d:98:0c:58:
-    0a:c8:4d:8f:28:95:2b:fa:d9:31:1d:31:ad:c5:87:
-    90:1b:2c:69:42:22:b1:1b:73:4a:22:82:af:b7:5b:
-    82:b4:38:39:3b:f2:47:ef:3d:7d:09:9b:e8:5b:b5:
-    d8:56:1c:16:e7:3a:6e:7d:85:3f:1c:1d:3f:ee:dd:
-    f1:d1
+    0b:61:af:b1:91:bb:df:a5:db:18:88:8a:b8:f5:8a:
+    e4:39:f7:f4:6d:cb:bc:eb:17:39:b6:b0:d8:18:bc:
+    37:24:6e:63:23:b5:a3:ce:70:7b:8a:53:ff:50:e5:
+    80:90:82:05:d6:68:3d:09:1c:ae:1d:f9:1c:20:03:
+    53:2e:4e:e2:26:23:5b:5e:00:97:e2:a2:fd:83:82:
+    8a:09:d3:78:7f:58:22:38:0f:70:82:09:b4:f7:86:
+    c2:48:ad:98:2c:37:86:c0:d9:27:e1:1d:d0:fd:68:
+    93:a1:0d:a3:df:e8:a2:3c:cf:2c:de:aa:99:11:87:
+    de:71:1b:91:67:d4:ce:22:56:27:a3:7d:4d:58:5c:
+    d3:76:80:54:b6:28:ed:60:e7:ba:ef:da:4a:f5:86:
+    b9:f7:7e:c5:94:5f:87:55:d0:5c:6b:8c:ea:4e:82:
+    ca:3d:bc:23:b5:1c:77:4c:bd:57:98:db:1f:ec:af:
+    0d:70:e0:a0:fa:86:d6:ac:cf:2f:a2:55:24:2e:98:
+    60:b0:f5:cf:60:db:bf:97:b8:e2:c0:1f:03:b5:5c:
+    af:ce:fd:5b:2b:97:cd:d5:eb:95:ef:17:bc:19:69:
+    5a:12:1f:28:24:d2:8e:cd:91:8f:90:7c:54:bf:31:
+    75:bd:66:31:eb:61:20:b1:7f:5f:3b:3a:af:48:8d:
+    81
 prime1:
-    00:f2:0c:fe:99:b5:ed:bb:24:f6:79:61:75:f5:a8:
-    9b:56:f9:f3:ee:5b:84:1c:31:00:5e:01:02:b4:50:
-    ea:fb:a8:13:22:73:c2:12:1b:c2:53:55:14:f3:2e:
-    a3:62:f8:82:04:4c:23:09:50:98:c1:ab:45:18:96:
-    c7:a4:e8:29:84:04:ab:24:37:17:45:0b:b3:02:7f:
-    c3:4a:30:3f:ad:69:49:0b:49:c5:89:e0:07:b7:b3:
-    d7:50:19:85:c0:f1:73:60:b4:76:f8:c2:c5:01:7c:
-    09:23:49:57:2a:cc:d7:e1:d6:d9:b4:6b:54:20:61:
-    7f:3a:70:9b:9d:01:12:fa:e7
+    00:c2:f2:79:65:6e:d5:61:bd:e0:6a:fb:67:89:ba:
+    23:fa:db:e4:fc:0f:58:9e:63:37:c4:ad:d8:80:c6:
+    a6:3f:9b:20:a5:70:48:20:f4:37:f3:36:01:8f:47:
+    ff:00:fe:b6:50:6a:56:f4:08:37:0a:0f:7f:28:42:
+    60:f8:01:a9:53:37:29:9c:24:83:14:1c:c3:56:b9:
+    18:33:5a:44:99:fe:b8:ab:45:26:71:b7:c5:1e:56:
+    a1:49:3c:71:5b:b5:c1:7c:bb:64:68:fe:af:24:3d:
+    60:6a:eb:de:d7:58:1d:bd:ff:56:92:5f:05:e6:8f:
+    57:88:5e:71:08:ce:12:e5:ad
 prime2:
-    00:e8:38:1f:fb:1b:f6:4d:e1:be:f0:80:c1:a1:55:
-    2b:d1:db:09:98:cc:70:eb:99:f0:9e:0b:2c:2d:60:
-    20:96:f7:b3:c5:6b:98:22:c5:bf:c3:20:5e:91:be:
-    d1:81:fc:14:36:70:9b:37:9e:6d:c8:6e:84:f6:fa:
-    65:30:64:0e:b0:50:05:85:a8:07:0b:be:4e:de:c1:
-    17:71:39:03:e3:9e:4e:69:5c:51:02:af:97:b8:30:
-    da:95:2e:24:b4:78:76:46:bc:db:a2:27:66:5a:ce:
-    e5:0f:01:82:fe:cb:31:bc:fe:19:6a:e5:73:b6:a5:
-    ad:3a:f3:61:ec:f7:a9:fe:b5
+    00:c2:a8:65:15:66:07:a2:14:75:17:ab:ed:f4:f5:
+    e6:cc:0b:70:6a:ee:a6:d0:3e:69:37:94:e8:3f:41:
+    02:f1:70:98:f4:5a:0d:0e:75:f5:37:4c:68:7a:cb:
+    1a:f2:57:69:5c:5d:b7:73:ce:95:48:92:1a:8a:2c:
+    33:08:a1:a6:3a:e2:7d:16:3b:c2:f7:86:68:da:18:
+    94:e5:9e:32:04:31:a4:07:2d:d4:4c:8c:e5:db:77:
+    72:ef:d9:e8:c2:0d:4e:17:83:7d:09:c5:df:83:35:
+    3b:bc:31:ae:a4:f7:d0:44:f1:98:7d:ad:2d:08:ae:
+    76:11:20:d7:cd:36:81:82:b5
 exponent1:
-    04:5d:93:a1:f6:14:09:92:0b:17:f9:58:05:4c:3b:
-    31:00:65:13:e1:76:aa:83:7f:bc:32:4c:78:30:15:
-    6c:e0:85:27:d3:ea:a6:24:f6:06:46:bc:8f:fe:41:
-    58:21:9f:46:b0:90:d9:34:28:ed:25:47:a3:bf:e4:
-    6d:e6:fa:08:b5:84:d8:ac:5d:b1:13:1a:f1:6a:98:
-    7d:18:0d:ad:f4:fe:2a:43:f4:5a:1e:3e:45:63:ea:
-    f8:38:dd:9e:b3:3c:1f:7c:61:c0:ee:d2:5a:ca:7f:
-    e7:b1:04:ef:72:ae:5a:16:63:ea:cb:1c:c3:50:be:
-    d8:b0:fb:3d:83:ad:71:f5
+    68:16:6f:1a:e9:82:a5:1d:6c:a5:b2:76:25:e3:6d:
+    32:94:16:3f:3f:32:61:df:37:f7:9b:9a:ed:a7:23:
+    3c:f2:e7:0b:6e:58:14:c0:50:df:5b:06:9a:2a:26:
+    cd:b1:32:46:dd:80:6f:eb:b2:f7:7c:2e:b8:a0:38:
+    86:32:dc:e5:c1:9e:45:f0:78:cc:54:4f:38:0e:bc:
+    0d:2f:35:51:c3:df:76:13:05:e3:d1:eb:3d:b7:a3:
+    86:26:ef:9f:b7:fc:07:4d:46:df:88:9c:9b:0c:ea:
+    5e:2c:72:5f:28:7d:38:e5:0c:a4:3a:78:3c:12:6c:
+    fa:32:f2:c7:70:c0:46:41
 exponent2:
-    69:f2:f9:7c:6b:44:94:42:14:08:cc:e6:0b:42:bd:
-    cc:70:80:4f:6b:af:75:7e:f5:ce:55:d0:a1:1f:43:
-    9f:3d:82:92:e7:45:31:50:41:ee:b7:fd:0d:c8:1e:
-    f4:8c:5b:78:7f:26:02:59:51:43:6a:51:56:11:e6:
-    4b:0e:cb:b8:db:b9:b9:42:71:7c:85:26:9c:f1:42:
-    4d:d1:32:9a:0e:67:3e:20:f5:81:21:36:3a:be:67:
-    6c:3a:f2:5a:38:bf:d6:04:62:bc:f7:f6:f6:25:81:
-    52:b8:60:d8:f9:42:47:35:33:c9:96:c8:95:a3:bf:
-    86:ae:f6:95:d4:65:86:25
+    4c:f2:27:d3:07:9b:e8:d3:d1:5d:64:17:12:07:ca:
+    0d:ca:4f:cb:d5:3e:97:7e:b4:34:c6:65:ef:eb:10:
+    f0:c3:a3:92:a3:ae:19:93:43:35:72:bc:b2:1d:6b:
+    2f:74:a2:2f:62:d4:4b:b0:d3:8d:f6:43:0b:6f:61:
+    54:fe:21:29:91:b2:04:81:e7:15:d5:49:c9:3c:82:
+    4f:29:f3:77:78:ef:ef:ee:8b:c7:1e:c3:15:b7:e7:
+    f5:2b:dc:38:28:ee:3f:99:38:6a:0e:8f:c5:db:db:
+    1b:0f:40:8b:f1:71:a0:6f:27:ea:35:f4:61:44:25:
+    63:ab:e9:e2:32:b3:8b:29
 coefficient:
-    28:91:92:b0:3c:bb:1c:58:e9:95:6c:70:fb:66:1d:
-    19:b5:eb:ca:17:83:b9:b6:90:83:9f:18:e4:f2:69:
-    72:e8:20:17:30:0f:dc:9c:4b:8a:9a:38:53:e1:c6:
-    01:ff:bc:1b:2b:22:84:95:48:6f:9e:01:8e:6b:b6:
-    50:f8:42:9d:76:67:e8:34:86:2d:b8:66:32:9d:01:
-    8e:3a:a4:1d:3c:9a:02:85:a5:1d:74:ef:8d:6a:d2:
-    2f:61:2c:e9:17:02:d7:22:9c:ee:8e:4c:cb:de:76:
-    6d:c2:1c:17:af:a3:3c:6a:f2:6a:6a:9c:b5:fb:9b:
-    2f:1e:c9:15:29:97:d2:3d
+    0d:ae:36:95:c9:a2:b3:6a:3d:d4:38:01:ce:e4:10:
+    da:e9:0e:c5:58:dd:0f:cf:9e:ac:cd:fc:68:9b:24:
+    6c:58:76:2b:78:57:ef:03:e5:d9:d6:e8:9a:15:9e:
+    15:c8:21:8c:34:19:9a:7c:e3:bf:dd:a1:c0:dd:ad:
+    50:69:2a:d8:36:60:b2:c0:b3:ab:14:19:f9:4e:8b:
+    b1:f9:2c:5c:28:9c:ce:64:74:07:80:20:15:e1:a1:
+    b6:dc:8f:2a:be:bd:20:f0:62:22:4e:03:a2:aa:a0:
+    fd:46:bf:e1:89:30:ac:1a:09:0a:fe:5b:20:d5:59:
+    72:a1:ce:75:32:a8:70:b4
 -----BEGIN RSA PRIVATE KEY-----
 Proc-Type: 4,ENCRYPTED
-DEK-Info: AES-128-CBC,8F1EB474F99CE22E5ABC5EFE44FF0E3E
+DEK-Info: AES-128-CBC,126A8E3A0DF846B4718A612CDDA959E9
 
-+NQ5qz3FIKH4rcFo1QA0I+hwzIo1POBhLvGBiIK6nhGNneQnCTSq3CgKXtG5gOKI
-t5Ts9gNscN8rxx3iyUk1ldp4eDGf1VxMj1K1Fu8WDclssSqBwSM1QgUBuze41Ei/
-BmLd9wK0u+fGs5mTkcC/VyhOeO2N/4qWpQdsoI5iUf85xfljB330uMeiNJ+hO6mO
-x1NcVuqdKVhgEg+UZ1l6sPZPtiybPrTxVZebWolYp/aKWa2ZF2p9DeI/pSze5tFW
-a64RnKOWopKyDKU2xAprNXd6qG1zuFAYFGwo1bfCeSwDfV928bw3kx6xXJ12BIW8
-GilMF7aKgSc6zlo+vBQt6K5AIkz2Xez3K8KfgQJ1LwNRgWVCA9pL5aQ+wHJJq21A
-+lG/8OYsWPcUhcWgiF8Ydw0nhfSj7+lnCM4PlKfleBkHIXMI4i+s8JDO+3NCvOQE
-ntpYSrzCN1RkdMSmq8OBw1L40PfsEFVQLV1sYQMGa/8Xt/P+QywqivQ4RmGD/7yk
-uuMoazjI7i6Ig1lwTItRR7Wwwx806a722BniTZ1LPtRlRzf0pOQ8Iw2FQgGUcNRO
-b4Y+W1g0f+KdM8DwmIzGx9jmWy9KaFpNF2Zc/rGS8a76h/B2HJEfQxONT+2LOLzs
-FjgfFQhyJGdr43xoum3wnFzKWzCb52kVfoGhXwCJMIXBE1xo6FHBFgXYMFKxTC0N
-eTj7fJ506YJ+924H6jSNC4JsysyFJ7zPOWMKcnBr5bkV7ct9ipozuAlfKdGeS6Ag
-S9l6Y2H+USe99nwptwEhFGk9hjh2tn61UoenwiqZkiMJufBOHn9BmmvfRRB3778s
-/PgltXzDxEu78Wi+0q1XSr1DvvKTH1Co2kdw+9ddliJ4GlAdubZyAIcEDqIHWdgv
-VvNqgd38ckTMWUT6Kc11Of+c3iwuxSRV3GI9kyHRb6zoTKmEfAFGKyUfUuMG1w0c
-v0H42JOulvODObP82dxjDcj8Givm9VhBD9F5K9WaffOAsLKDyGLD9tN8nqjuI2sB
-476Wf0ZvYNpLZlQXUUeHBs6lniq08Kp8eC/FA1VFq5PenPfot/QgarcJEAsM74Kb
-eqMirO3IRJ9wWs49Ti/l2XdzdGjD06LiOo2QBSSNi0UHKZZ1o/GRZN0wvNZIT/ya
-Xea50ONfAoJCUTnvXn7sykONDyPpUb6BpC9P3dE6V6V8vAyGn2koL7QWwQrUK7II
-o+ZDLaaK11XhGYjVUW0RPf2FEjfBq9rLaBhAjHzODx+ZEIhGd78/c1wZ9Fs/XG8q
-9A8rp4Bf8bq5LTlMQ0Bedaq1DFyyD2d1f2ssSpfTwxe07nKms4tFP0nGtvSUjPwf
-zExeYXvpx6q0uShuYbX0PTruM0M73EsXza/RbgxpoUQRP8uC5+Yoxk/3xll021cd
-F6fxfg8qKaGRFAVwP7wJWronZnCdNKmMhzMNvZeVDxrOITqsMmCM53iWJAJKIFFj
-tXXSMqAarWhvjZ41+0/kz4afVjcNFgxfADxrT7sZ4tmLqchsVhfqx7gtU+szQNM8
-sUOPmzOP915hrFplU06/blzJIMYQEHrsKS1MgN6EtiRfw5qiVx8LxFScMs9wca4G
+Su2RyNUrjAnJY2IHpM3y+DcxpOYK80taVjAnDetAAstL5pM74QyQAySPsK7QSepf
+ppVyKtxcMVD0ChmicPxf2YJjJkcPLM0EGQna+r2w85u+rj7+l6m5ULXLaFz5RJap
+pKrGH8lgMKZyBw3sZ36P95jaVnfr6fos+TRWHhWwnrnwbjVcMKRYgrqbHxudydyp
+nWpZmjSyQjTRxG2shI3t5TXjN3XphIuQ/9cKIc8Obte2QHTBh/oU8kyYqsMlP8ZT
+h9tIX6i71PKQxi0U/+JcmupxerM/zdR0A//VWq8lhmudcXMvmlSIj8JIDhcSC9ah
+JyvZyuYsSj5gqFav/NdHCf9OLQMbk9j876RderSMFOKkhNUb1S3xRyepbF0hHisV
+vD8R5kufN0dOPjeghepFf3V6vJvexC3WxwE/txdrhi2KXEs3QRwtryJsN1oiMyrG
+P/QwNw/njA6uPoDXFBhGz/owemW6SwsvrSD/1nruq8nCCDA90HleOq+I6WlySLFs
+gA2Pi9lQ8GgSRw/LkIElOuv7/Xc1IgtzPGBRMajIAeKjOMhl+hwEY6+Z2ncwi8VG
+fydaEeAmX2pOWbxEfi0m+ed6DSfNnGxMmAuEMrCg9nwhkUpwWXgpAs7yBZJksh73
+wb0BDm+nKhAMwWB9Dt7nyDnDsih6EGatOPVS03PSeLt5MB83TlYie0HsUMcHd06o
+8idkXtkYOntBkAu4tcCwQr7Fr5q2rvW5VgGX261BzWZwqTITZs5XVizYj85ppRp7
+n2qrQjViTgK9ZZ52e+1lNQ0J2HVczNirUjCPPt1Pg+ghzmFw1UH8z+ezGH0oYkyw
+tyWJyqdmxl0QM45g6VQuw6yhYkXOVMenxMtFm/LBaxZxJZKhaxpnj5ClVSRZlst1
+WisJfJtH4k35f1JcaSWt3LrSJOLPFJHqgpLusASMEcA6FLT1PErWktPnuLQEFTjh
+6l2nxYR9/X2rxNIVc/IZtGtda8qOGzi13FscPHoTNoC1JUaIiYySXIq26bqli8pr
+bu7xwo+xw31eIhfn0dRMqKltkS7N0FeBTylXKtViLTbuPBaa8a9627xJIuDQm5AD
+JJGyN0sXhkHpGXMNarb3QfpKPUuUWkLJXbDOUXc/9v5trKQF4biF+s0seYiJtec4
+m6QHtUZfonaSS18TK8SXxv3fwuscpJWu7vzRah/Jj5in8cjV9nvdazSuIfrKa1fj
+uvGQ1jsU4Ap9GVPDQI90UzH8Wu7o3c64KLnQIbPxOWvgTWxFJst6w/o/Qf/0bMxZ
+skn/wc1WuiWFk+Yu6Drpp7rNGebJhUKXu6j5rrWnlaw3lHUexPbU9TcV1sfD1K+G
+KIAPt3xayTOXlJMfyquxEPOnCs9eP9wyELFvNIwPtix8QGoDDrm+ojhX0YivF9aX
+AJv3UFPX3yHe6zIUVZoThk9YJIAqp9aem25Xx2CBwFhdihpR0BSf1cgv7Bko23WK
+triO9Zrjk3ySdJ290Xo36imufA6o/P5ledDH/a1zSj1g39DUAv6w5gtHNx4dSUve
+Z2WEvxHIQUGx/KNZeIenrLLBohKBbxNc3ISzDDpOEb7y5Cn7Nfhr6V11QaTkcKRt
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/intermediate-agent-crl.pem
+++ b/spec/fixtures/ssl/intermediate-agent-crl.pem
@@ -3,38 +3,38 @@ Certificate Revocation List (CRL):
         Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA Agent Subauthority
         Last Update: Jan  1 00:00:00 1970 GMT
-        Next Update: Apr 18 18:46:23 2031 GMT
+        Next Update: Jun 15 01:19:37 2031 GMT
         CRL extensions:
             X509v3 Authority Key Identifier: 
-                keyid:30:5C:E0:85:AC:BF:77:41:18:C8:05:24:E3:0A:3E:71:66:1A:95:82
+                keyid:97:84:A5:C2:28:B4:15:97:89:C4:52:2C:69:8F:7B:75:DD:5F:2A:DC
 
             X509v3 CRL Number: 
                 0
 No Revoked Certificates.
     Signature Algorithm: sha256WithRSAEncryption
-         14:7d:d2:53:6f:ce:63:c4:c7:ea:0a:50:9a:31:68:5d:04:9e:
-         d6:57:07:67:54:0c:c7:8a:a3:64:1f:81:eb:71:3f:6e:7d:6b:
-         db:15:38:0d:57:a7:ac:1e:73:93:f5:e2:ff:0e:d1:ed:a2:9f:
-         1c:40:7d:6e:2e:29:7f:aa:e1:8e:46:d1:03:be:6a:3f:c8:b1:
-         dd:3d:a3:0d:f5:6b:b3:ef:23:5d:f6:1c:2a:a7:b7:31:b2:0e:
-         90:79:03:7f:03:24:9e:ad:9e:bf:18:63:b4:87:81:cf:8b:7f:
-         88:e1:6c:fd:c4:3d:46:c3:85:30:74:ca:89:f6:37:e3:dc:c5:
-         4c:50:ee:62:2d:71:e8:dd:ac:46:f8:3f:23:6c:80:3c:e7:be:
-         00:93:a6:6f:e6:0d:86:4e:15:d8:46:cf:0d:cd:61:b2:74:ac:
-         57:9f:79:db:ab:46:de:a7:30:b3:13:a0:44:04:7d:d6:02:a6:
-         94:1a:1e:7e:20:43:2a:69:27:4b:7e:7a:00:8d:ab:39:74:19:
-         f3:b6:b1:89:c8:2d:38:26:92:c4:fd:5c:9a:68:f5:9a:b0:65:
-         7f:e7:a9:04:96:f7:e1:f8:90:79:e4:26:1b:db:cc:93:10:97:
-         ad:23:a4:74:56:31:0a:90:5e:d2:cb:cf:ff:cd:9b:fe:8f:35:
-         96:d0:3a:9a
+         14:7b:e6:cd:e2:be:2a:78:b9:05:94:16:e7:82:79:c9:03:b1:
+         51:8a:0a:0f:8e:44:bf:da:9d:47:72:a9:08:4e:b5:d5:ef:17:
+         54:5d:ba:db:bb:61:e9:5f:b4:8c:49:f7:2b:90:3a:50:00:57:
+         89:00:3d:3c:dd:c2:2d:b2:6c:0d:29:21:4f:4d:68:57:44:bb:
+         36:ba:fe:7f:97:e3:f0:87:7e:73:ba:c5:48:73:13:2c:30:2f:
+         77:86:98:e2:24:93:1a:0c:dc:11:fb:38:48:b6:66:77:a6:d6:
+         d8:c8:dd:23:16:b6:d9:1a:27:14:0f:28:68:8f:38:27:d2:a2:
+         4f:c0:d6:61:f1:61:20:ef:59:4d:5a:20:c3:e7:01:98:36:d5:
+         94:33:b1:8f:15:19:17:1b:d8:60:74:bc:5c:3f:6f:8b:95:f9:
+         fc:77:2c:d6:42:17:0c:0e:4b:db:ed:66:0a:06:25:08:3d:03:
+         6b:56:8b:7b:76:47:6a:c5:3c:97:c0:41:20:43:c8:b2:4b:bf:
+         a0:07:94:58:ad:63:46:89:b2:b7:2a:76:fe:8e:69:d2:7d:51:
+         df:07:bd:c0:14:ce:0d:46:24:ee:de:8b:7b:e4:04:87:be:90:
+         f3:6e:dd:ae:4d:d7:93:d1:dc:3e:f5:4c:e8:1e:24:ca:26:59:
+         ee:ce:48:f3
 -----BEGIN X509 CRL-----
 MIIBnzCBiAIBATANBgkqhkiG9w0BAQsFADAlMSMwIQYDVQQDDBpUZXN0IENBIEFn
-ZW50IFN1YmF1dGhvcml0eRcNNzAwMTAxMDAwMDAwWhcNMzEwNDE4MTg0NjIzWqAv
-MC0wHwYDVR0jBBgwFoAUMFzghay/d0EYyAUk4wo+cWYalYIwCgYDVR0UBAMCAQAw
-DQYJKoZIhvcNAQELBQADggEBABR90lNvzmPEx+oKUJoxaF0EntZXB2dUDMeKo2Qf
-getxP259a9sVOA1Xp6wec5P14v8O0e2inxxAfW4uKX+q4Y5G0QO+aj/Isd09ow31
-a7PvI132HCqntzGyDpB5A38DJJ6tnr8YY7SHgc+Lf4jhbP3EPUbDhTB0yon2N+Pc
-xUxQ7mItcejdrEb4PyNsgDznvgCTpm/mDYZOFdhGzw3NYbJ0rFefedurRt6nMLMT
-oEQEfdYCppQaHn4gQyppJ0t+egCNqzl0GfO2sYnILTgmksT9XJpo9ZqwZX/nqQSW
-9+H4kHnkJhvbzJMQl60jpHRWMQqQXtLLz//Nm/6PNZbQOpo=
+ZW50IFN1YmF1dGhvcml0eRcNNzAwMTAxMDAwMDAwWhcNMzEwNjE1MDExOTM3WqAv
+MC0wHwYDVR0jBBgwFoAUl4Slwii0FZeJxFIsaY97dd1fKtwwCgYDVR0UBAMCAQAw
+DQYJKoZIhvcNAQELBQADggEBABR75s3ivip4uQWUFueCeckDsVGKCg+ORL/anUdy
+qQhOtdXvF1Rdutu7YelftIxJ9yuQOlAAV4kAPTzdwi2ybA0pIU9NaFdEuza6/n+X
+4/CHfnO6xUhzEywwL3eGmOIkkxoM3BH7OEi2Znem1tjI3SMWttkaJxQPKGiPOCfS
+ok/A1mHxYSDvWU1aIMPnAZg21ZQzsY8VGRcb2GB0vFw/b4uV+fx3LNZCFwwOS9vt
+ZgoGJQg9A2tWi3t2R2rFPJfAQSBDyLJLv6AHlFitY0aJsrcqdv6OadJ9Ud8HvcAU
+zg1GJO7ei3vkBIe+kPNu3a5N15PR3D71TOgeJMomWe7OSPM=
 -----END X509 CRL-----

--- a/spec/fixtures/ssl/intermediate-agent.pem
+++ b/spec/fixtures/ssl/intermediate-agent.pem
@@ -1,35 +1,35 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 8 (0x8)
+        Serial Number: 9 (0x9)
         Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Apr 18 18:46:23 2031 GMT
+            Not After : Jun 15 01:19:37 2031 GMT
         Subject: CN=Test CA Agent Subauthority
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:c8:76:0f:6b:12:72:bc:6a:03:90:71:fa:b3:01:
-                    69:bd:d5:d0:64:74:b9:6b:a0:3e:9e:fc:ea:25:c7:
-                    5f:da:c9:95:1e:f8:dc:63:74:f9:3d:ee:28:fe:70:
-                    e9:e8:62:d2:1b:ac:3e:ab:42:a7:2a:95:2b:b4:22:
-                    43:7d:68:1a:c0:39:4f:7a:0c:45:2b:41:4c:de:14:
-                    d2:9e:1f:e5:ce:85:2d:db:d6:7f:25:b0:9b:94:f8:
-                    e4:ed:11:2e:cd:9c:c8:5d:15:bb:11:96:ec:e0:3e:
-                    9a:af:b3:26:50:5d:9c:5f:29:6b:3a:cc:ff:21:07:
-                    e5:13:99:e5:c0:f7:34:ca:7b:49:f4:ba:dc:41:29:
-                    65:db:65:e9:61:7a:f4:17:18:fc:ab:70:a5:de:22:
-                    32:ab:24:63:5c:14:25:48:88:ee:36:33:0b:36:81:
-                    77:d7:ac:1d:75:d6:09:95:54:ef:f2:52:a2:52:15:
-                    58:ce:4e:9e:aa:6f:46:a2:fb:58:30:62:97:4e:80:
-                    87:82:89:f9:22:ab:95:8e:17:bf:64:b5:6f:0e:5f:
-                    54:c3:b0:4a:fa:d3:99:38:00:f7:b1:f6:a9:2c:b1:
-                    c9:ba:3c:07:b7:5c:91:1a:0f:3d:34:74:3f:58:e2:
-                    fa:8d:66:38:a7:a6:af:f2:a7:f2:f1:95:7a:a0:49:
-                    18:19
+                    00:ae:c8:f1:11:5e:bd:b9:e8:60:81:9d:7d:00:b3:
+                    e6:5b:d4:03:e3:46:a0:e2:8b:e9:1f:ed:06:36:c7:
+                    e9:e1:9d:1a:8f:2b:d0:aa:63:00:12:35:44:d4:4d:
+                    d2:d8:69:3f:71:14:f0:0b:21:86:ab:93:37:ee:94:
+                    af:3a:56:35:95:b5:18:88:3b:25:96:dc:7e:b3:ab:
+                    98:58:3b:03:54:90:bf:cf:e5:fc:2a:54:9e:a7:6e:
+                    78:dc:36:cb:0f:20:49:c5:b2:61:76:f5:d2:19:d3:
+                    7a:c2:82:6e:b4:8b:ff:9f:f1:bb:aa:60:b7:8e:6f:
+                    b7:24:f7:39:9f:9b:aa:86:65:8e:67:56:96:79:d3:
+                    10:d8:0e:17:39:35:cb:ef:2d:db:c5:a7:7b:30:68:
+                    68:65:04:a8:8b:ba:23:49:8a:ce:1e:65:9d:9d:02:
+                    3f:5c:4e:1a:3d:ec:af:e4:53:46:c7:9f:17:bd:a2:
+                    0c:81:72:78:89:a0:54:2c:7c:53:99:21:03:5c:b7:
+                    0b:22:56:19:f2:bb:13:5a:35:22:e1:5b:ec:5a:52:
+                    84:f7:e4:69:d9:4f:57:55:c4:e7:40:8c:96:01:e4:
+                    19:03:37:bb:1b:1a:ed:a8:f8:0d:35:83:77:31:9f:
+                    a8:86:de:f8:97:ee:df:14:5e:ba:94:cd:23:38:0b:
+                    6a:f9
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Basic Constraints: critical
@@ -37,45 +37,45 @@ Certificate:
             X509v3 Key Usage: critical
                 Certificate Sign, CRL Sign
             X509v3 Subject Key Identifier: 
-                30:5C:E0:85:AC:BF:77:41:18:C8:05:24:E3:0A:3E:71:66:1A:95:82
+                97:84:A5:C2:28:B4:15:97:89:C4:52:2C:69:8F:7B:75:DD:5F:2A:DC
             Netscape Comment: 
                 Puppet Server Internal Certificate
             X509v3 Authority Key Identifier: 
-                keyid:61:DF:EE:CE:DA:49:6B:5E:F3:EF:94:FE:F9:DC:C7:C0:5A:74:FE:DB
+                keyid:B2:EE:24:88:34:99:18:60:81:9E:2A:D3:F4:5A:66:FA:91:F6:E1:C6
 
     Signature Algorithm: sha256WithRSAEncryption
-         af:6b:69:42:d0:c9:88:83:80:46:fe:d7:0c:dc:cc:81:8a:f9:
-         f0:21:15:53:fa:fa:f2:95:dd:53:17:d6:b5:cc:2d:f8:64:b6:
-         19:62:c7:3e:7e:75:4f:89:b5:00:c2:3d:b2:3c:51:29:31:5b:
-         a0:32:9f:76:5a:1f:36:06:64:47:9b:9a:dd:93:3c:c4:32:7e:
-         3e:f8:19:32:72:ac:ac:e7:fe:a5:06:4a:ee:72:9c:c0:d9:36:
-         72:5a:5f:af:41:c5:9a:4f:0c:ed:22:db:1f:86:b1:f4:ae:54:
-         a1:93:ba:26:b5:93:15:31:ec:a9:d9:2f:94:61:e3:fc:67:69:
-         6b:01:54:02:36:93:d0:73:ae:64:5d:b4:ec:87:65:99:f6:04:
-         7b:b1:d0:51:fc:b3:9e:b1:63:53:c4:cf:38:2c:19:42:69:bd:
-         10:08:a2:92:87:f8:58:7a:9b:cc:cd:f7:41:a2:2f:6a:a1:45:
-         48:70:6e:7a:39:a3:8d:96:ae:ea:65:ea:ab:b6:06:72:0b:f7:
-         76:c0:6e:a0:ad:48:f1:73:7c:22:91:11:eb:88:24:f6:5e:ec:
-         84:5f:65:51:57:43:a6:c6:38:65:d5:c3:7a:f1:4e:b3:54:62:
-         1b:f3:16:30:c3:b3:c6:cf:f1:a6:f8:f2:d8:c6:d0:f7:2a:18:
-         06:f5:a3:ed
+         73:fd:64:e0:87:64:11:b7:31:9e:e2:03:9d:9d:14:71:f1:f6:
+         81:96:78:10:6a:ed:0d:e6:12:57:aa:f8:31:2c:d9:00:83:07:
+         58:14:8c:97:2a:23:09:b0:57:56:68:95:d1:e7:0b:76:0b:82:
+         95:3a:90:15:3d:ae:cb:18:c0:38:2a:11:3d:04:a1:1f:bb:e9:
+         3e:a0:f1:b0:30:78:fb:58:0b:f9:cb:0a:99:2d:2a:a2:50:57:
+         6c:ef:b4:e2:c9:38:88:71:31:61:59:7e:10:c9:c9:51:32:d9:
+         6e:0b:c0:64:c3:40:eb:51:81:26:c3:1a:51:0b:90:ff:44:0e:
+         4f:fe:a7:45:41:00:ea:2a:1e:87:7c:e3:90:8a:2e:19:6c:a4:
+         ec:db:e5:19:b0:79:b2:35:75:08:5a:63:30:29:bb:f3:6a:36:
+         c7:28:9c:1e:88:a6:97:50:82:71:0d:1b:a0:9b:6f:99:33:60:
+         cf:eb:65:60:49:73:6b:81:b6:ee:9c:c7:30:c4:0a:30:43:c1:
+         2c:ef:81:3c:d0:e4:9a:1e:72:eb:ed:37:76:f3:fb:8b:00:09:
+         f6:53:a6:2f:1a:ba:68:32:f2:48:bb:5d:36:bb:31:05:b7:1c:
+         83:d8:ac:c9:af:2c:6f:d5:66:92:e9:f0:3f:1d:c6:fb:fd:37:
+         70:90:65:f5
 -----BEGIN CERTIFICATE-----
-MIIDSjCCAjKgAwIBAgIBCDANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
-IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMxMDQxODE4NDYyM1owJTEjMCEGA1UEAwwa
+MIIDSjCCAjKgAwIBAgIBCTANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMxMDYxNTAxMTkzN1owJTEjMCEGA1UEAwwa
 VGVzdCBDQSBBZ2VudCBTdWJhdXRob3JpdHkwggEiMA0GCSqGSIb3DQEBAQUAA4IB
-DwAwggEKAoIBAQDIdg9rEnK8agOQcfqzAWm91dBkdLlroD6e/Oolx1/ayZUe+Nxj
-dPk97ij+cOnoYtIbrD6rQqcqlSu0IkN9aBrAOU96DEUrQUzeFNKeH+XOhS3b1n8l
-sJuU+OTtES7NnMhdFbsRluzgPpqvsyZQXZxfKWs6zP8hB+UTmeXA9zTKe0n0utxB
-KWXbZelhevQXGPyrcKXeIjKrJGNcFCVIiO42Mws2gXfXrB111gmVVO/yUqJSFVjO
-Tp6qb0ai+1gwYpdOgIeCifkiq5WOF79ktW8OX1TDsEr605k4APex9qksscm6PAe3
-XJEaDz00dD9Y4vqNZjinpq/yp/LxlXqgSRgZAgMBAAGjgZcwgZQwDwYDVR0TAQH/
-BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFDBc4IWsv3dBGMgFJOMK
-PnFmGpWCMDEGCWCGSAGG+EIBDQQkFiJQdXBwZXQgU2VydmVyIEludGVybmFsIENl
-cnRpZmljYXRlMB8GA1UdIwQYMBaAFGHf7s7aSWte8++U/vncx8BadP7bMA0GCSqG
-SIb3DQEBCwUAA4IBAQCva2lC0MmIg4BG/tcM3MyBivnwIRVT+vryld1TF9a1zC34
-ZLYZYsc+fnVPibUAwj2yPFEpMVugMp92Wh82BmRHm5rdkzzEMn4++Bkycqys5/6l
-BkrucpzA2TZyWl+vQcWaTwztItsfhrH0rlShk7omtZMVMeyp2S+UYeP8Z2lrAVQC
-NpPQc65kXbTsh2WZ9gR7sdBR/LOesWNTxM84LBlCab0QCKKSh/hYepvMzfdBoi9q
-oUVIcG56OaONlq7qZeqrtgZyC/d2wG6grUjxc3wikRHriCT2XuyEX2VRV0Omxjhl
-1cN68U6zVGIb8xYww7PGz/Gm+PLYxtD3KhgG9aPt
+DwAwggEKAoIBAQCuyPERXr256GCBnX0As+Zb1APjRqDii+kf7QY2x+nhnRqPK9Cq
+YwASNUTUTdLYaT9xFPALIYarkzfulK86VjWVtRiIOyWW3H6zq5hYOwNUkL/P5fwq
+VJ6nbnjcNssPIEnFsmF29dIZ03rCgm60i/+f8buqYLeOb7ck9zmfm6qGZY5nVpZ5
+0xDYDhc5NcvvLdvFp3swaGhlBKiLuiNJis4eZZ2dAj9cTho97K/kU0bHnxe9ogyB
+cniJoFQsfFOZIQNctwsiVhnyuxNaNSLhW+xaUoT35GnZT1dVxOdAjJYB5BkDN7sb
+Gu2o+A01g3cxn6iG3viX7t8UXrqUzSM4C2r5AgMBAAGjgZcwgZQwDwYDVR0TAQH/
+BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFJeEpcIotBWXicRSLGmP
+e3XdXyrcMDEGCWCGSAGG+EIBDQQkFiJQdXBwZXQgU2VydmVyIEludGVybmFsIENl
+cnRpZmljYXRlMB8GA1UdIwQYMBaAFLLuJIg0mRhggZ4q0/RaZvqR9uHGMA0GCSqG
+SIb3DQEBCwUAA4IBAQBz/WTgh2QRtzGe4gOdnRRx8faBlngQau0N5hJXqvgxLNkA
+gwdYFIyXKiMJsFdWaJXR5wt2C4KVOpAVPa7LGMA4KhE9BKEfu+k+oPGwMHj7WAv5
+ywqZLSqiUFds77TiyTiIcTFhWX4QyclRMtluC8Bkw0DrUYEmwxpRC5D/RA5P/qdF
+QQDqKh6HfOOQii4ZbKTs2+UZsHmyNXUIWmMwKbvzajbHKJweiKaXUIJxDRugm2+Z
+M2DP62VgSXNrgbbunMcwxAowQ8Es74E80OSaHnLr7Td28/uLAAn2U6YvGrpoMvJI
+u102uzEFtxyD2KzJryxv1WaS6fA/Hcb7/TdwkGX1
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/intermediate-crl.pem
+++ b/spec/fixtures/ssl/intermediate-crl.pem
@@ -3,44 +3,44 @@ Certificate Revocation List (CRL):
         Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA Subauthority
         Last Update: Jan  1 00:00:00 1970 GMT
-        Next Update: Apr 18 18:46:23 2031 GMT
+        Next Update: Jun 15 01:19:37 2031 GMT
         CRL extensions:
             X509v3 Authority Key Identifier: 
-                keyid:9A:15:19:07:A0:54:8D:C3:9D:4F:07:C4:05:A1:85:AC:92:D8:B1:E5
+                keyid:59:79:27:C1:94:D7:09:B0:B2:1C:23:44:22:E2:25:25:1B:83:5F:34
 
             X509v3 CRL Number: 
                 0
 Revoked Certificates:
-    Serial Number: 06
-        Revocation Date: Apr 20 18:46:23 2021 GMT
+    Serial Number: 07
+        Revocation Date: Jun 17 01:19:38 2021 GMT
         CRL entry extensions:
             X509v3 CRL Reason Code: 
                 Key Compromise
     Signature Algorithm: sha256WithRSAEncryption
-         42:21:b1:27:84:31:dd:f0:bd:13:1f:70:b4:6e:e3:f5:9e:ec:
-         c4:fd:64:a9:b3:78:c1:8f:26:76:b0:3d:4b:60:5f:be:6d:e7:
-         c1:47:e0:f5:c2:f3:3f:6e:fc:4c:19:f8:41:82:52:9a:f4:02:
-         d6:3a:23:91:21:92:5c:8c:fa:84:79:dc:10:3f:e3:42:45:5a:
-         e6:26:12:67:42:45:c3:76:30:00:05:66:5e:79:cc:0f:d3:90:
-         04:33:72:6c:d5:ae:5e:b4:d1:b1:91:4f:69:f9:b1:7e:c2:33:
-         ae:b6:bb:2e:28:66:b5:0d:03:54:3f:93:40:ac:17:58:e6:d6:
-         c9:7d:3b:96:ec:47:6f:09:a3:a0:ff:b9:77:f9:64:bf:10:30:
-         df:20:d0:95:36:f4:88:d8:c4:c3:da:3e:86:07:e4:1e:11:c2:
-         da:e5:1f:0f:82:3b:40:2e:cf:f8:14:a5:38:2b:b2:c3:80:18:
-         84:e9:d5:90:85:36:00:9d:96:5e:03:ed:ee:2d:d9:5b:57:7f:
-         9e:0d:7d:5b:4e:f9:89:3d:e2:d9:91:db:ae:6e:b0:34:59:30:
-         9c:2e:0a:c8:74:57:10:db:6c:2f:60:70:d6:bb:c7:18:7b:0a:
-         96:3d:77:71:51:11:3f:a3:16:fc:bd:7d:cd:12:a3:98:07:4c:
-         a3:2c:7e:37
+         82:21:ef:06:be:b2:af:42:d5:6a:bf:e3:47:f2:b8:77:fe:76:
+         14:a4:08:51:ae:27:92:4a:fd:20:cb:57:58:1c:ae:f0:15:3b:
+         33:ff:05:5e:77:20:a0:0a:34:2f:c0:d6:15:02:b3:72:7e:58:
+         08:ec:ad:db:b6:4b:a2:89:97:bf:9a:8e:08:c2:0b:ed:82:4d:
+         cf:ee:1a:62:02:df:46:3e:03:55:39:56:64:33:ab:dd:be:54:
+         fa:d9:cd:c8:65:a6:26:09:ef:12:f2:92:d3:aa:7f:88:c4:4c:
+         7e:35:9e:64:11:8c:a2:46:c9:cc:f8:29:56:22:88:0e:94:96:
+         e4:5c:4b:e7:ae:4d:1c:96:80:73:60:e3:69:a3:3a:61:ca:d4:
+         b6:2e:1c:e9:c6:93:e7:8c:5a:ae:b0:c9:92:51:0f:2c:b0:54:
+         43:e7:cf:14:4f:b5:e2:0c:ae:11:19:f2:a4:55:6f:3b:1d:3a:
+         47:d2:ee:0a:71:9b:a5:2d:41:6e:97:8f:02:ff:9f:13:20:c7:
+         6c:67:a5:47:c8:c2:27:a6:8b:66:56:3e:dd:d3:27:f9:8d:21:
+         73:20:c9:f1:e3:70:8f:72:e5:f8:6c:60:7d:c5:71:03:4c:ce:
+         72:8e:78:2d:30:f8:44:1a:4b:41:d3:f5:f4:31:c6:c3:89:cb:
+         88:da:b3:a0
 -----BEGIN X509 CRL-----
 MIIBvTCBpgIBATANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0IENBIFN1
-YmF1dGhvcml0eRcNNzAwMTAxMDAwMDAwWhcNMzEwNDE4MTg0NjIzWjAiMCACAQYX
-DTIxMDQyMDE4NDYyM1owDDAKBgNVHRUEAwoBAaAvMC0wHwYDVR0jBBgwFoAUmhUZ
-B6BUjcOdTwfEBaGFrJLYseUwCgYDVR0UBAMCAQAwDQYJKoZIhvcNAQELBQADggEB
-AEIhsSeEMd3wvRMfcLRu4/We7MT9ZKmzeMGPJnawPUtgX75t58FH4PXC8z9u/EwZ
-+EGCUpr0AtY6I5EhklyM+oR53BA/40JFWuYmEmdCRcN2MAAFZl55zA/TkAQzcmzV
-rl600bGRT2n5sX7CM662uy4oZrUNA1Q/k0CsF1jm1sl9O5bsR28Jo6D/uXf5ZL8Q
-MN8g0JU29IjYxMPaPoYH5B4RwtrlHw+CO0Auz/gUpTgrssOAGITp1ZCFNgCdll4D
-7e4t2VtXf54NfVtO+Yk94tmR265usDRZMJwuCsh0VxDbbC9gcNa7xxh7CpY9d3FR
-ET+jFvy9fc0So5gHTKMsfjc=
+YmF1dGhvcml0eRcNNzAwMTAxMDAwMDAwWhcNMzEwNjE1MDExOTM3WjAiMCACAQcX
+DTIxMDYxNzAxMTkzOFowDDAKBgNVHRUEAwoBAaAvMC0wHwYDVR0jBBgwFoAUWXkn
+wZTXCbCyHCNEIuIlJRuDXzQwCgYDVR0UBAMCAQAwDQYJKoZIhvcNAQELBQADggEB
+AIIh7wa+sq9C1Wq/40fyuHf+dhSkCFGuJ5JK/SDLV1gcrvAVOzP/BV53IKAKNC/A
+1hUCs3J+WAjsrdu2S6KJl7+ajgjCC+2CTc/uGmIC30Y+A1U5VmQzq92+VPrZzchl
+piYJ7xLyktOqf4jETH41nmQRjKJGycz4KVYiiA6UluRcS+euTRyWgHNg42mjOmHK
+1LYuHOnGk+eMWq6wyZJRDyywVEPnzxRPteIMrhEZ8qRVbzsdOkfS7gpxm6UtQW6X
+jwL/nxMgx2xnpUfIwiemi2ZWPt3TJ/mNIXMgyfHjcI9y5fhsYH3FcQNMznKOeC0w
++EQaS0HT9fQxxsOJy4jas6A=
 -----END X509 CRL-----

--- a/spec/fixtures/ssl/intermediate.pem
+++ b/spec/fixtures/ssl/intermediate.pem
@@ -6,30 +6,30 @@ Certificate:
         Issuer: CN=Test CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Apr 18 18:46:23 2031 GMT
+            Not After : Jun 15 01:19:37 2031 GMT
         Subject: CN=Test CA Subauthority
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:cd:ef:ef:31:c5:33:69:3b:ee:25:06:b9:73:a7:
-                    09:e5:c9:9c:0b:39:48:26:fb:88:26:50:2d:8a:52:
-                    29:86:df:7a:12:f0:08:ea:61:52:80:98:9f:a5:45:
-                    26:ad:6d:05:e6:b5:81:e5:91:b3:6b:98:53:09:0a:
-                    e9:05:4b:29:de:3c:64:44:a7:d2:5d:3f:fc:5f:f8:
-                    29:1f:b0:40:e2:74:8a:26:fd:e8:d7:74:a5:78:de:
-                    bf:23:10:73:74:8d:1b:0c:4b:d7:1d:a9:ae:86:14:
-                    05:63:7c:2a:00:38:d6:57:8a:b7:a8:45:80:27:f5:
-                    71:0b:fa:e2:bd:a2:d1:08:8d:fa:cd:9c:f6:ad:89:
-                    76:ea:ab:1c:78:f9:26:5b:a3:18:2a:f7:90:15:ed:
-                    a7:db:50:e9:7d:55:99:7e:05:10:ca:56:11:51:5e:
-                    de:8c:e2:be:2a:8a:34:41:1d:1d:23:92:04:50:05:
-                    c5:5b:b8:7a:45:90:ee:0d:7f:01:b1:ed:d4:dd:c5:
-                    28:ed:7d:4d:6a:70:21:3b:95:5e:e2:31:d7:17:bd:
-                    5b:af:e4:ce:ad:6b:9f:5f:9e:e1:1e:86:ff:83:c1:
-                    88:ec:87:bb:bf:a1:26:22:75:b9:57:31:10:fd:a5:
-                    ca:82:70:6d:c8:a1:a3:f6:3e:76:3d:2e:cd:07:f9:
-                    7b:3f
+                    00:af:36:20:41:45:0b:d1:13:0c:82:fd:b8:e5:ea:
+                    f8:32:6b:5e:f7:a5:1c:7d:21:24:cb:85:bf:cd:f5:
+                    ca:48:85:39:c1:42:a4:65:93:d2:a2:04:f9:c9:19:
+                    10:da:64:0d:be:e3:d0:a5:d3:85:17:79:aa:18:32:
+                    f7:0a:b9:8e:08:de:d8:97:06:28:99:ac:ed:d1:a6:
+                    d4:0a:34:de:3d:33:e3:08:17:c2:22:6c:1d:fc:51:
+                    df:98:e6:de:6e:c6:4b:26:f4:87:44:1e:86:b6:44:
+                    b2:f3:82:9c:9c:2f:5b:66:bf:27:71:49:53:bf:c9:
+                    d2:f5:06:7e:fe:fd:1c:59:ba:aa:a9:05:c8:cb:44:
+                    f5:f5:51:7b:80:1c:59:0e:a5:bf:bb:af:f5:96:68:
+                    26:ca:52:b6:a8:e3:f6:3f:b9:a0:60:09:67:4a:86:
+                    5b:b4:ae:13:d9:39:ca:e0:84:dc:2e:83:51:ce:09:
+                    34:36:30:9c:ff:54:32:a6:b6:5b:a6:41:bd:b3:2b:
+                    5d:1d:eb:79:45:f4:fb:de:47:56:3c:8d:b1:96:34:
+                    2d:ec:9a:66:4c:50:ab:c6:c4:05:3e:8c:27:7c:be:
+                    54:53:5e:ae:20:70:15:12:0f:85:ab:be:18:dd:da:
+                    f5:33:a5:55:6a:c7:d8:36:89:bb:1c:5d:ce:46:45:
+                    ba:7d
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Basic Constraints: critical
@@ -37,45 +37,45 @@ Certificate:
             X509v3 Key Usage: critical
                 Certificate Sign, CRL Sign
             X509v3 Subject Key Identifier: 
-                9A:15:19:07:A0:54:8D:C3:9D:4F:07:C4:05:A1:85:AC:92:D8:B1:E5
+                59:79:27:C1:94:D7:09:B0:B2:1C:23:44:22:E2:25:25:1B:83:5F:34
             Netscape Comment: 
                 Puppet Server Internal Certificate
             X509v3 Authority Key Identifier: 
-                keyid:61:DF:EE:CE:DA:49:6B:5E:F3:EF:94:FE:F9:DC:C7:C0:5A:74:FE:DB
+                keyid:B2:EE:24:88:34:99:18:60:81:9E:2A:D3:F4:5A:66:FA:91:F6:E1:C6
 
     Signature Algorithm: sha256WithRSAEncryption
-         80:38:84:87:30:76:98:4d:35:d8:99:c1:26:f9:4b:bc:aa:e4:
-         e0:6f:b8:b2:0b:ad:22:82:b5:74:98:f2:98:7b:34:92:5e:d8:
-         fa:0f:4f:73:43:b1:5d:d8:69:35:7d:41:1f:ab:bc:6a:14:3f:
-         ff:78:5d:8e:c4:7d:38:5a:14:99:d2:fc:08:08:69:5c:78:9b:
-         5b:a8:bc:bb:92:27:4e:1f:15:48:1c:da:71:f9:ce:ec:3f:55:
-         1b:e5:5d:54:2e:10:b8:b6:57:c7:af:f7:de:7c:c0:76:50:4e:
-         37:a9:3d:26:b8:50:61:89:36:1e:82:92:9d:f5:fd:96:a9:fc:
-         c2:1e:ae:1c:b0:96:03:21:75:7b:9f:56:fa:96:e0:0e:de:df:
-         98:74:65:b8:8d:52:eb:30:7f:aa:4d:d8:38:c2:0b:47:5d:64:
-         c6:52:a2:26:10:f3:5a:d6:04:22:cc:39:8a:30:33:61:6d:6d:
-         67:f2:dd:e6:1f:a0:45:36:ce:db:80:8c:5f:2a:ef:6e:c8:ee:
-         64:20:7f:b1:eb:b1:71:1e:ff:31:00:91:3d:6d:fe:b6:e2:9a:
-         de:7a:fe:e5:59:fc:b5:b7:3f:70:d2:b8:17:99:1a:5b:73:01:
-         c4:17:cc:41:ed:d3:6d:20:56:0b:d7:8f:78:41:10:95:e2:66:
-         ab:f2:2b:4b
+         95:3d:3f:6f:47:83:12:b6:c1:06:dc:86:dc:7b:d3:1b:53:28:
+         cd:d6:38:10:ca:9c:af:bd:da:a2:64:df:6d:36:eb:5c:2b:c9:
+         34:49:6b:d3:0e:22:94:3b:5e:ab:8b:f9:ee:ca:83:1e:94:1b:
+         fe:38:de:a1:f1:7b:54:4b:0a:9a:95:43:03:9c:0c:45:b8:ac:
+         4e:6f:38:76:8a:ac:87:10:e3:0c:f2:58:7b:3c:7c:75:4b:17:
+         52:0f:88:8f:c5:3f:31:b1:09:3c:06:20:00:4a:30:cb:83:1a:
+         fa:eb:32:be:5e:06:57:60:b3:59:40:a9:81:ee:b3:a5:68:f2:
+         30:8a:2f:1f:22:e8:6f:58:e1:32:ae:28:59:39:97:84:bc:a8:
+         10:b8:af:a6:9b:64:e1:a9:78:58:db:ad:0d:b1:00:dd:96:92:
+         45:88:a0:22:f3:2a:e8:e1:27:4d:d0:67:af:a3:01:76:ef:5a:
+         dc:22:c5:3c:78:1b:b1:a5:d3:8f:de:7c:21:29:9a:88:3b:7e:
+         17:f4:5c:c2:b3:cc:b4:fc:f2:49:bb:cd:22:6c:71:ea:6b:1e:
+         b0:6e:bd:5f:2a:0e:31:18:f7:9f:78:98:d7:51:98:0a:cd:da:
+         89:28:f5:22:68:a1:36:1b:80:e7:dc:1c:d8:72:b1:7b:55:5e:
+         90:d8:3b:9b
 -----BEGIN CERTIFICATE-----
 MIIDRDCCAiygAwIBAgIBAzANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
-IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMxMDQxODE4NDYyM1owHzEdMBsGA1UEAwwU
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMxMDYxNTAxMTkzN1owHzEdMBsGA1UEAwwU
 VGVzdCBDQSBTdWJhdXRob3JpdHkwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
-AoIBAQDN7+8xxTNpO+4lBrlzpwnlyZwLOUgm+4gmUC2KUimG33oS8AjqYVKAmJ+l
-RSatbQXmtYHlkbNrmFMJCukFSynePGREp9JdP/xf+CkfsEDidIom/ejXdKV43r8j
-EHN0jRsMS9cdqa6GFAVjfCoAONZXireoRYAn9XEL+uK9otEIjfrNnPatiXbqqxx4
-+SZboxgq95AV7afbUOl9VZl+BRDKVhFRXt6M4r4qijRBHR0jkgRQBcVbuHpFkO4N
-fwGx7dTdxSjtfU1qcCE7lV7iMdcXvVuv5M6ta59fnuEehv+DwYjsh7u/oSYidblX
-MRD9pcqCcG3IoaP2PnY9Ls0H+Xs/AgMBAAGjgZcwgZQwDwYDVR0TAQH/BAUwAwEB
-/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFJoVGQegVI3DnU8HxAWhhayS2LHl
+AoIBAQCvNiBBRQvREwyC/bjl6vgya173pRx9ISTLhb/N9cpIhTnBQqRlk9KiBPnJ
+GRDaZA2+49Cl04UXeaoYMvcKuY4I3tiXBiiZrO3RptQKNN49M+MIF8IibB38Ud+Y
+5t5uxksm9IdEHoa2RLLzgpycL1tmvydxSVO/ydL1Bn7+/RxZuqqpBcjLRPX1UXuA
+HFkOpb+7r/WWaCbKUrao4/Y/uaBgCWdKhlu0rhPZOcrghNwug1HOCTQ2MJz/VDKm
+tlumQb2zK10d63lF9PveR1Y8jbGWNC3smmZMUKvGxAU+jCd8vlRTXq4gcBUSD4Wr
+vhjd2vUzpVVqx9g2ibscXc5GRbp9AgMBAAGjgZcwgZQwDwYDVR0TAQH/BAUwAwEB
+/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFFl5J8GU1wmwshwjRCLiJSUbg180
 MDEGCWCGSAGG+EIBDQQkFiJQdXBwZXQgU2VydmVyIEludGVybmFsIENlcnRpZmlj
-YXRlMB8GA1UdIwQYMBaAFGHf7s7aSWte8++U/vncx8BadP7bMA0GCSqGSIb3DQEB
-CwUAA4IBAQCAOISHMHaYTTXYmcEm+Uu8quTgb7iyC60igrV0mPKYezSSXtj6D09z
-Q7Fd2Gk1fUEfq7xqFD//eF2OxH04WhSZ0vwICGlceJtbqLy7kidOHxVIHNpx+c7s
-P1Ub5V1ULhC4tlfHr/fefMB2UE43qT0muFBhiTYegpKd9f2WqfzCHq4csJYDIXV7
-n1b6luAO3t+YdGW4jVLrMH+qTdg4wgtHXWTGUqImEPNa1gQizDmKMDNhbW1n8t3m
-H6BFNs7bgIxfKu9uyO5kIH+x67FxHv8xAJE9bf624preev7lWfy1tz9w0rgXmRpb
-cwHEF8xB7dNtIFYL1494QRCV4mar8itL
+YXRlMB8GA1UdIwQYMBaAFLLuJIg0mRhggZ4q0/RaZvqR9uHGMA0GCSqGSIb3DQEB
+CwUAA4IBAQCVPT9vR4MStsEG3Ibce9MbUyjN1jgQypyvvdqiZN9tNutcK8k0SWvT
+DiKUO16ri/nuyoMelBv+ON6h8XtUSwqalUMDnAxFuKxObzh2iqyHEOMM8lh7PHx1
+SxdSD4iPxT8xsQk8BiAASjDLgxr66zK+XgZXYLNZQKmB7rOlaPIwii8fIuhvWOEy
+rihZOZeEvKgQuK+mm2ThqXhY260NsQDdlpJFiKAi8yro4SdN0GevowF271rcIsU8
+eBuxpdOP3nwhKZqIO34X9FzCs8y0/PJJu80ibHHqax6wbr1fKg4xGPefeJjXUZgK
+zdqJKPUiaKE2G4Dn3BzYcrF7VV6Q2Dub
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/oid-key.pem
+++ b/spec/fixtures/ssl/oid-key.pem
@@ -1,0 +1,117 @@
+RSA Private-Key: (2048 bit, 2 primes)
+modulus:
+    00:bf:24:ca:22:a8:10:63:f7:0f:23:43:b3:19:fd:
+    42:02:d0:07:12:7f:3b:06:ff:04:3a:b4:d3:8c:bf:
+    c2:21:3a:de:ac:f0:13:ef:00:11:e4:84:f1:f2:08:
+    53:84:aa:74:de:98:ef:05:87:f6:4c:62:cf:8a:c2:
+    0e:c9:02:27:23:35:b9:62:15:1b:51:b0:26:00:e7:
+    7d:be:33:92:a9:a0:48:b6:d9:00:c8:7e:ab:97:28:
+    94:2e:c8:e2:01:57:da:3c:6c:86:02:58:87:69:47:
+    8d:61:2f:7f:0d:e7:a6:83:12:34:f1:17:0d:ca:82:
+    e0:82:91:a2:2d:51:28:1d:d9:f2:01:27:05:ad:30:
+    8c:47:2b:ac:c9:ee:14:a6:0a:4f:a6:e0:3a:c2:93:
+    12:92:84:1f:76:5f:5b:3a:75:7a:08:99:16:77:fd:
+    ba:71:e7:d4:0e:37:5c:ca:3f:80:27:c9:64:87:9a:
+    d3:9e:5d:31:9f:20:c4:0f:65:47:f4:ea:5e:28:70:
+    ed:b9:cf:09:67:ae:fb:c7:99:5f:11:16:e7:99:30:
+    94:01:35:9d:4d:94:a4:55:c5:1b:88:30:25:1b:21:
+    9d:20:0c:91:49:93:92:a7:97:bb:90:4e:8f:27:bf:
+    55:fa:78:2b:6b:40:76:16:ed:44:4d:79:71:75:87:
+    b6:4b
+publicExponent: 65537 (0x10001)
+privateExponent:
+    00:9e:b0:e2:88:c7:53:64:4b:17:6c:45:a6:8a:6b:
+    32:c4:b7:05:48:1c:0d:5b:8f:99:69:4b:fb:5e:9d:
+    4d:84:dd:25:46:1a:c3:d1:e7:12:f3:d0:54:36:87:
+    27:1f:bb:8c:ef:c9:b4:97:b8:fb:89:0b:78:17:51:
+    69:89:04:9a:8d:a6:ea:d4:3d:85:c2:da:25:93:16:
+    9d:d4:ad:68:94:1f:98:7f:05:c6:9a:ae:5f:b3:4d:
+    63:49:3c:4a:36:a7:43:6e:6b:03:0f:2b:84:b0:a9:
+    50:fd:60:bb:71:45:e3:7e:6a:3d:3d:f3:cf:e5:53:
+    a7:25:7f:d7:4f:1c:53:dc:03:44:ec:40:4d:0f:53:
+    cd:3e:a2:93:14:79:e9:4f:b4:bb:f1:a6:a0:29:dd:
+    39:7d:e6:5d:30:35:6f:d1:2f:df:00:d5:19:22:b3:
+    47:cf:ec:ce:35:97:a4:cd:8b:aa:5f:e0:f2:80:58:
+    2b:37:59:58:cd:e4:3d:d9:dd:02:d6:ce:88:91:73:
+    16:05:f2:9b:24:ad:23:d1:be:84:8d:a4:b2:db:14:
+    16:e1:b8:84:2e:b8:59:be:5a:20:83:6d:be:b9:bf:
+    88:d4:2b:79:6a:53:66:d7:56:75:26:2f:dc:f3:97:
+    ec:2e:fb:6e:6c:b3:1a:11:a7:f5:be:ad:1b:5a:cd:
+    86:d1
+prime1:
+    00:fe:af:eb:ab:d3:5d:64:16:81:f5:69:6f:61:24:
+    aa:f5:7b:26:0c:b2:f5:8f:93:33:b7:e4:41:a0:bf:
+    ed:32:80:4e:90:3e:ec:34:07:89:6d:b6:98:39:4b:
+    78:e8:b3:85:4d:f6:4a:29:5c:f9:17:5f:3e:d7:4d:
+    7e:a8:e0:af:af:89:bf:34:c8:98:f1:4d:c9:74:43:
+    44:e2:98:47:6a:e7:c3:39:9b:9c:ab:8c:22:d2:2a:
+    99:c9:78:a8:a6:bc:77:04:8a:8e:56:20:b0:62:19:
+    e2:2e:19:a5:18:76:0f:e4:93:0a:17:f5:57:92:22:
+    8b:43:1e:24:b9:6f:49:fd:17
+prime2:
+    00:c0:21:04:ba:9d:b3:37:75:e4:b7:f4:95:dc:3b:
+    d9:d5:bb:6f:44:7b:99:2a:d4:54:68:7b:18:a3:31:
+    fd:e9:d2:ee:58:00:74:aa:b1:e6:a3:3b:94:96:90:
+    9f:d7:6a:93:aa:c2:9c:72:36:27:1d:89:87:aa:3c:
+    c5:e6:3f:7b:0f:21:19:a1:69:8b:3b:23:5a:33:b9:
+    ce:40:2b:f1:85:55:21:0c:1d:9d:0e:97:71:f3:55:
+    f0:3d:82:e0:52:d9:cb:a4:30:1b:a2:7b:9b:73:93:
+    e7:7f:af:27:b1:a4:1f:10:dc:ba:56:75:9c:5f:b3:
+    d2:08:ae:83:51:33:8b:d8:ed
+exponent1:
+    00:97:d0:13:41:cb:ee:fa:4f:34:4e:2d:f7:f7:46:
+    dd:25:10:b0:20:97:b8:2a:4a:0b:65:0d:09:55:a1:
+    b1:e9:0d:74:47:25:4a:b4:c4:dd:55:69:a7:19:57:
+    f4:8d:79:1c:f7:d8:dc:62:05:8a:71:35:14:07:50:
+    a9:34:4f:22:4a:17:68:c3:34:e3:7d:ca:e9:4f:85:
+    1d:95:98:41:d1:e6:ae:87:33:4b:d3:31:e8:3b:b0:
+    ab:14:dd:f8:61:d3:2b:7a:a8:80:a9:b4:38:8f:71:
+    70:52:1c:75:3d:bc:7a:42:bc:a7:22:9a:db:05:3f:
+    d4:15:40:ed:91:1f:56:52:27
+exponent2:
+    5c:f3:1c:70:94:3e:d2:04:0d:45:19:e5:2e:89:1e:
+    18:12:f7:ff:af:b4:28:4e:55:0f:bf:0d:ea:56:13:
+    3b:7e:3a:a5:04:83:6c:d9:68:75:6c:2b:b4:b3:ff:
+    40:9e:65:16:65:d4:7e:44:c8:a3:b7:97:94:ba:96:
+    1b:90:76:9e:99:2a:e7:36:42:8f:b7:c8:b9:e1:98:
+    70:df:51:97:69:d9:f5:1c:96:91:2a:9f:8c:53:f5:
+    48:2c:fb:0d:da:24:75:28:79:16:20:aa:d2:3d:a9:
+    ef:d1:f3:68:33:b8:7b:d5:ed:a8:4a:79:fe:aa:e6:
+    60:20:dd:92:f9:57:1c:f9
+coefficient:
+    00:c9:d7:2a:ea:1c:8f:85:34:e5:5d:26:23:65:41:
+    71:25:1a:8e:1c:01:52:b3:04:54:fd:71:a3:1b:91:
+    a6:5d:3a:be:16:6f:d7:87:8a:49:aa:5b:92:a1:7e:
+    1d:a1:6a:b0:24:22:0f:f9:39:9f:5a:f9:81:19:ce:
+    7a:d6:b7:8f:e0:3b:59:d2:49:a4:f1:4f:28:9e:0d:
+    bf:15:6d:95:4d:56:8e:1b:7d:84:a2:41:6a:e4:88:
+    98:d9:92:ec:b4:7d:92:7c:f5:39:85:30:e9:52:7e:
+    a4:5f:e7:8e:1c:45:6c:f4:e2:78:0d:26:19:52:9b:
+    87:c3:0e:9c:22:92:4a:9b:e2
+-----BEGIN RSA PRIVATE KEY-----
+MIIEpQIBAAKCAQEAvyTKIqgQY/cPI0OzGf1CAtAHEn87Bv8EOrTTjL/CITrerPAT
+7wAR5ITx8ghThKp03pjvBYf2TGLPisIOyQInIzW5YhUbUbAmAOd9vjOSqaBIttkA
+yH6rlyiULsjiAVfaPGyGAliHaUeNYS9/DeemgxI08RcNyoLggpGiLVEoHdnyAScF
+rTCMRyusye4UpgpPpuA6wpMSkoQfdl9bOnV6CJkWd/26cefUDjdcyj+AJ8lkh5rT
+nl0xnyDED2VH9OpeKHDtuc8JZ677x5lfERbnmTCUATWdTZSkVcUbiDAlGyGdIAyR
+SZOSp5e7kE6PJ79V+ngra0B2Fu1ETXlxdYe2SwIDAQABAoIBAQCesOKIx1NkSxds
+RaaKazLEtwVIHA1bj5lpS/tenU2E3SVGGsPR5xLz0FQ2hycfu4zvybSXuPuJC3gX
+UWmJBJqNpurUPYXC2iWTFp3UrWiUH5h/Bcaarl+zTWNJPEo2p0NuawMPK4SwqVD9
+YLtxReN+aj0988/lU6clf9dPHFPcA0TsQE0PU80+opMUeelPtLvxpqAp3Tl95l0w
+NW/RL98A1Rkis0fP7M41l6TNi6pf4PKAWCs3WVjN5D3Z3QLWzoiRcxYF8pskrSPR
+voSNpLLbFBbhuIQuuFm+WiCDbb65v4jUK3lqU2bXVnUmL9zzl+wu+25ssxoRp/W+
+rRtazYbRAoGBAP6v66vTXWQWgfVpb2EkqvV7Jgyy9Y+TM7fkQaC/7TKATpA+7DQH
+iW22mDlLeOizhU32Silc+RdfPtdNfqjgr6+JvzTImPFNyXRDROKYR2rnwzmbnKuM
+ItIqmcl4qKa8dwSKjlYgsGIZ4i4ZpRh2D+STChf1V5Iii0MeJLlvSf0XAoGBAMAh
+BLqdszd15Lf0ldw72dW7b0R7mSrUVGh7GKMx/enS7lgAdKqx5qM7lJaQn9dqk6rC
+nHI2Jx2Jh6o8xeY/ew8hGaFpizsjWjO5zkAr8YVVIQwdnQ6XcfNV8D2C4FLZy6Qw
+G6J7m3OT53+vJ7GkHxDculZ1nF+z0giug1Ezi9jtAoGBAJfQE0HL7vpPNE4t9/dG
+3SUQsCCXuCpKC2UNCVWhsekNdEclSrTE3VVppxlX9I15HPfY3GIFinE1FAdQqTRP
+IkoXaMM0433K6U+FHZWYQdHmroczS9Mx6DuwqxTd+GHTK3qogKm0OI9xcFIcdT28
+ekK8pyKa2wU/1BVA7ZEfVlInAoGAXPMccJQ+0gQNRRnlLokeGBL3/6+0KE5VD78N
+6lYTO346pQSDbNlodWwrtLP/QJ5lFmXUfkTIo7eXlLqWG5B2npkq5zZCj7fIueGY
+cN9Rl2nZ9RyWkSqfjFP1SCz7DdokdSh5FiCq0j2p79HzaDO4e9XtqEp5/qrmYCDd
+kvlXHPkCgYEAydcq6hyPhTTlXSYjZUFxJRqOHAFSswRU/XGjG5GmXTq+Fm/Xh4pJ
+qluSoX4doWqwJCIP+TmfWvmBGc561reP4DtZ0kmk8U8ong2/FW2VTVaOG32EokFq
+5IiY2ZLstH2SfPU5hTDpUn6kX+eOHEVs9OJ4DSYZUpuHww6cIpJKm+I=
+-----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/oid.pem
+++ b/spec/fixtures/ssl/oid.pem
@@ -1,0 +1,69 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 6 (0x6)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=Test CA Subauthority
+        Validity
+            Not Before: Jan  1 00:00:00 1970 GMT
+            Not After : Jun 15 01:19:37 2031 GMT
+        Subject: CN=oid
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:bf:24:ca:22:a8:10:63:f7:0f:23:43:b3:19:fd:
+                    42:02:d0:07:12:7f:3b:06:ff:04:3a:b4:d3:8c:bf:
+                    c2:21:3a:de:ac:f0:13:ef:00:11:e4:84:f1:f2:08:
+                    53:84:aa:74:de:98:ef:05:87:f6:4c:62:cf:8a:c2:
+                    0e:c9:02:27:23:35:b9:62:15:1b:51:b0:26:00:e7:
+                    7d:be:33:92:a9:a0:48:b6:d9:00:c8:7e:ab:97:28:
+                    94:2e:c8:e2:01:57:da:3c:6c:86:02:58:87:69:47:
+                    8d:61:2f:7f:0d:e7:a6:83:12:34:f1:17:0d:ca:82:
+                    e0:82:91:a2:2d:51:28:1d:d9:f2:01:27:05:ad:30:
+                    8c:47:2b:ac:c9:ee:14:a6:0a:4f:a6:e0:3a:c2:93:
+                    12:92:84:1f:76:5f:5b:3a:75:7a:08:99:16:77:fd:
+                    ba:71:e7:d4:0e:37:5c:ca:3f:80:27:c9:64:87:9a:
+                    d3:9e:5d:31:9f:20:c4:0f:65:47:f4:ea:5e:28:70:
+                    ed:b9:cf:09:67:ae:fb:c7:99:5f:11:16:e7:99:30:
+                    94:01:35:9d:4d:94:a4:55:c5:1b:88:30:25:1b:21:
+                    9d:20:0c:91:49:93:92:a7:97:bb:90:4e:8f:27:bf:
+                    55:fa:78:2b:6b:40:76:16:ed:44:4d:79:71:75:87:
+                    b6:4b
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            1.3.6.1.4.1.34380.1.2.1.1: 
+                ..somevalue
+    Signature Algorithm: sha256WithRSAEncryption
+         6f:40:86:4d:b1:68:6e:1a:a5:52:b1:cb:a0:24:90:2f:20:72:
+         2b:da:cb:25:af:ab:01:8e:fb:94:95:ef:eb:a6:8c:12:a2:3e:
+         dc:9a:fe:c3:70:95:6b:38:04:d5:1b:81:8a:37:5c:c3:eb:85:
+         c7:04:28:ba:f3:33:20:b1:dc:7d:d0:05:6a:eb:25:7a:4f:d4:
+         ae:c5:8b:1f:41:4f:fe:10:a5:b3:55:15:c9:a0:b9:98:33:f2:
+         a3:21:7d:29:34:90:e0:c8:45:d7:ac:27:a7:54:9b:53:9d:5c:
+         cb:52:2e:d5:db:cf:a6:84:c7:4d:50:05:41:6c:59:44:77:bf:
+         de:5f:36:60:7f:50:9e:ed:00:71:63:9e:35:a4:5f:f1:b5:46:
+         8c:c6:3a:e5:ec:05:66:23:d3:a2:05:46:17:0d:24:c1:eb:c5:
+         ff:43:ce:1a:86:2b:e7:d5:a6:73:a5:3a:64:1a:e0:20:97:f9:
+         45:82:12:cc:eb:da:b4:48:a6:8f:67:3d:15:c6:a7:27:12:c6:
+         9a:aa:88:35:6d:21:5d:d5:f9:86:e9:ff:c4:f3:7d:29:ac:2e:
+         ec:d9:8e:c6:ab:40:23:77:7d:ed:7a:76:e3:a9:74:c7:9e:24:
+         87:00:76:7b:fc:e4:98:1e:90:d8:51:dd:8e:b9:ca:90:b7:79:
+         e2:0c:9b:f3
+-----BEGIN CERTIFICATE-----
+MIICxzCCAa+gAwIBAgIBBjANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0
+IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zMTA2MTUwMTE5Mzda
+MA4xDDAKBgNVBAMMA29pZDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+AL8kyiKoEGP3DyNDsxn9QgLQBxJ/Owb/BDq004y/wiE63qzwE+8AEeSE8fIIU4Sq
+dN6Y7wWH9kxiz4rCDskCJyM1uWIVG1GwJgDnfb4zkqmgSLbZAMh+q5colC7I4gFX
+2jxshgJYh2lHjWEvfw3npoMSNPEXDcqC4IKRoi1RKB3Z8gEnBa0wjEcrrMnuFKYK
+T6bgOsKTEpKEH3ZfWzp1egiZFnf9unHn1A43XMo/gCfJZIea055dMZ8gxA9lR/Tq
+Xihw7bnPCWeu+8eZXxEW55kwlAE1nU2UpFXFG4gwJRshnSAMkUmTkqeXu5BOjye/
+Vfp4K2tAdhbtRE15cXWHtksCAwEAAaMfMB0wGwYMKwYBBAGCjEwBAgEBBAsMCXNv
+bWV2YWx1ZTANBgkqhkiG9w0BAQsFAAOCAQEAb0CGTbFobhqlUrHLoCSQLyByK9rL
+Ja+rAY77lJXv66aMEqI+3Jr+w3CVazgE1RuBijdcw+uFxwQouvMzILHcfdAFausl
+ek/UrsWLH0FP/hCls1UVyaC5mDPyoyF9KTSQ4MhF16wnp1SbU51cy1Iu1dvPpoTH
+TVAFQWxZRHe/3l82YH9Qnu0AcWOeNaRf8bVGjMY65ewFZiPTogVGFw0kwevF/0PO
+GoYr59Wmc6U6ZBrgIJf5RYISzOvatEimj2c9FcanJxLGmqqINW0hXdX5hun/xPN9
+Kawu7NmOxqtAI3d97Xp246l0x54khwB2e/zkmB6Q2FHdjrnKkLd54gyb8w==
+-----END CERTIFICATE-----

--- a/spec/fixtures/ssl/pluto-key.pem
+++ b/spec/fixtures/ssl/pluto-key.pem
@@ -1,117 +1,117 @@
 RSA Private-Key: (2048 bit, 2 primes)
 modulus:
-    00:af:60:0e:10:6c:0e:f7:88:5c:38:9b:66:d3:4e:
-    69:ed:ad:d0:d4:31:8f:22:81:e0:94:53:0a:32:74:
-    06:92:ab:48:ad:af:e9:e6:60:d5:83:f2:c3:a5:29:
-    1e:48:d8:91:9c:fd:5e:f6:e9:ea:a3:89:02:45:2c:
-    d8:63:d1:18:ff:67:10:11:6d:0f:32:a6:8a:43:02:
-    f1:5f:0a:95:ef:31:90:0d:af:84:46:4c:3b:7a:dd:
-    aa:07:aa:4d:b0:56:0e:dc:4d:1d:d0:be:d5:13:fd:
-    af:40:69:01:1a:4d:d5:e5:d7:78:65:f9:b4:ca:00:
-    91:e5:45:a0:cb:e8:c0:20:5b:80:fb:db:00:9c:a5:
-    1f:59:8f:e8:9c:21:56:90:a9:30:11:4d:65:84:82:
-    28:de:6e:54:20:79:4a:ec:00:b0:26:08:60:47:ef:
-    3a:bb:24:62:53:bb:e1:28:57:d3:77:2c:56:48:dd:
-    dc:40:dc:7d:b2:1f:1f:c5:0a:d5:0a:9e:73:de:0f:
-    57:9e:e3:d5:cf:2f:58:2a:aa:a8:8f:8b:ad:e9:78:
-    c4:b8:69:0c:c6:8f:5a:9c:f5:24:c3:76:20:e8:cd:
-    98:98:6b:06:89:e1:ad:5e:c0:8e:c5:1e:cf:d5:c5:
-    b1:f2:96:fc:a2:90:1e:4c:c8:7f:7b:f8:8e:dd:9e:
-    aa:17
+    00:a7:b5:af:10:3a:4a:46:00:f7:51:66:8b:1d:35:
+    11:65:e6:1a:50:0a:37:56:ff:93:16:20:cd:35:58:
+    28:c4:6f:06:31:d8:86:77:ed:20:85:55:ad:8a:46:
+    b8:3d:70:51:aa:31:f9:58:ad:a5:d5:4f:ca:d0:3e:
+    10:8f:4f:b9:c6:cc:e8:6e:f2:24:15:26:c3:3a:24:
+    85:d2:e8:f7:63:3a:97:b4:e9:ff:5e:c0:ee:e7:ed:
+    9b:2e:59:87:36:08:8f:e4:df:5a:03:25:a3:35:40:
+    69:a1:e4:a4:f0:c0:28:32:64:ef:ab:2a:f9:cd:ed:
+    d4:0e:bd:46:dd:fc:9d:a3:1f:d6:14:c2:58:1f:0d:
+    9e:85:f4:ce:c9:b1:91:1b:6e:d1:71:4e:ae:8a:c6:
+    65:67:af:27:93:8b:be:80:46:57:9e:a6:8a:5c:0b:
+    18:86:c0:77:b6:57:87:2d:2a:31:fd:34:75:33:58:
+    c3:8b:9c:c1:5b:61:4c:28:94:a9:2a:e1:24:7e:c2:
+    6f:ce:be:fc:98:1b:49:4a:91:b1:2b:73:30:c7:44:
+    ef:d9:f3:af:43:1b:ab:c2:c9:eb:97:a9:9f:6c:6e:
+    b1:12:d3:cb:d0:3e:1d:2d:cc:ee:3e:ea:24:0d:1e:
+    24:f8:3e:bc:8a:4d:85:78:be:c4:e3:97:86:31:6e:
+    d9:07
 publicExponent: 65537 (0x10001)
 privateExponent:
-    00:9a:91:1d:34:2a:18:f2:df:92:f0:2d:3e:ee:23:
-    e1:46:a2:f8:37:dc:ca:1b:8e:be:81:db:c2:53:ff:
-    60:bf:aa:08:ef:53:e8:e1:ac:1c:e3:23:76:7d:bd:
-    84:bc:8d:6b:a1:22:ca:ac:f2:33:64:18:e0:10:59:
-    db:09:f6:83:82:ae:b2:41:b9:8e:38:85:01:bc:d7:
-    fe:26:56:ed:18:98:e5:2e:ba:af:e9:49:4c:ef:18:
-    28:c0:82:bf:e0:17:a9:17:4f:3c:64:fb:9c:4e:f7:
-    3a:9b:99:30:68:9f:8b:52:fc:9a:57:be:42:31:fb:
-    58:9a:ea:c8:32:8f:9b:ad:a7:a2:73:8c:14:d2:1a:
-    4a:cc:1c:25:60:97:ba:bf:c1:37:8c:ff:8d:6b:fd:
-    4d:41:a1:f4:36:03:14:11:39:f1:bb:48:a5:80:35:
-    ca:97:13:af:09:9e:41:e1:65:b2:0a:67:c4:06:ed:
-    96:50:ed:67:17:ae:83:f6:bb:a3:97:cb:2a:c5:16:
-    0b:89:3b:01:a0:93:82:fe:16:c3:c1:88:47:5f:e6:
-    ab:a6:ed:ee:6f:ae:0b:bb:d3:6e:16:d7:d9:43:f3:
-    1d:a6:b0:5e:99:d1:40:30:fc:e6:06:c2:22:8c:6c:
-    f3:be:5d:12:6d:63:50:2e:cd:2e:d8:16:f9:8d:f9:
-    87:59
+    00:a0:5e:d6:f9:d0:93:a7:9f:52:e0:4f:0b:66:31:
+    91:e2:7c:07:db:53:f9:99:42:a9:97:36:64:a4:c7:
+    19:ac:c5:72:0a:06:40:87:bb:84:26:9c:48:67:7a:
+    ba:c1:5d:7f:6a:1d:81:8f:af:f5:6d:26:71:0d:72:
+    dc:08:fe:b6:ea:88:95:17:4a:8b:00:82:e1:9a:de:
+    c3:ed:6c:02:ec:ab:61:d8:89:0e:3e:c0:85:73:d8:
+    bd:54:b4:1d:dc:a8:91:58:cd:cf:d8:44:8c:6d:e6:
+    9b:5c:49:35:04:56:eb:d9:4c:b5:f6:5b:11:27:3f:
+    6e:51:6d:e3:af:70:da:18:da:53:63:47:68:4a:e1:
+    86:7f:89:dc:f2:7e:fd:b5:a7:84:98:30:c3:6b:d5:
+    c6:a1:89:51:af:e9:f6:ca:3e:8c:00:b5:cc:99:90:
+    22:c5:d7:a7:8d:21:bc:58:85:64:ea:5e:00:47:b3:
+    33:f3:df:a9:e3:d8:66:bc:19:83:ad:fa:4f:a5:25:
+    a3:de:bd:8c:65:52:a1:19:92:07:0f:67:27:ab:dc:
+    60:58:8e:88:98:96:3d:ea:30:30:1c:88:2c:6e:d3:
+    e0:db:f2:2e:f4:13:eb:a1:7d:15:de:95:2e:1f:7c:
+    33:fa:ad:79:70:71:05:f4:2c:19:28:5b:f7:e6:54:
+    d4:49
 prime1:
-    00:dc:a8:a5:35:2f:54:5f:9f:32:6a:47:83:5b:f2:
-    22:b6:63:2a:89:09:3e:49:7b:ed:f7:11:c2:3b:45:
-    2e:ae:b9:1c:24:12:8b:7c:a0:3b:91:8a:fc:60:8c:
-    a4:6f:5a:80:1d:74:ab:4f:3c:ff:83:73:10:3d:db:
-    23:ca:a3:e5:77:5f:76:44:06:92:35:a8:b4:ef:c1:
-    74:02:b0:a1:87:75:7f:a3:9b:f0:76:ac:c9:44:23:
-    df:4d:e9:35:2d:7c:07:64:2b:ae:26:b0:4f:f0:67:
-    23:5c:a5:d3:cd:cf:d8:31:b1:9f:b5:13:3e:07:22:
-    b7:70:b0:b0:d0:a0:12:a6:0d
+    00:d1:45:25:20:50:11:d5:b3:c8:67:01:4d:ca:8b:
+    0d:8d:70:78:4d:90:40:16:d0:6b:ac:4e:25:c2:4a:
+    c6:3f:9b:ab:1a:7e:c2:2c:a1:0c:91:de:e0:20:40:
+    a7:fa:bb:07:d3:71:9b:a7:ce:c8:83:d1:7c:8c:b0:
+    24:c7:ff:45:f0:6c:e0:02:47:5c:9a:92:2a:7c:68:
+    08:d8:f7:20:1f:79:e0:90:e1:9a:9b:18:fe:7d:29:
+    19:57:75:4f:e0:89:0b:9d:d9:12:b4:31:78:25:8d:
+    f2:da:2a:f9:1f:f9:53:ec:fa:74:33:fb:28:7c:ed:
+    eb:00:c9:88:0b:55:b0:e1:1b
 prime2:
-    00:cb:76:b6:85:a6:ff:85:e8:f7:f1:ad:0b:86:4c:
-    3b:24:6d:bc:e9:c9:df:90:b1:a3:a8:1b:0b:35:32:
-    dc:26:96:56:b3:f7:c0:70:9f:de:b2:59:10:38:a0:
-    f3:3f:06:2c:0b:85:76:b4:b7:15:60:17:15:2d:74:
-    fc:93:15:7e:31:4d:25:59:2e:76:12:2e:1a:e8:66:
-    d4:81:52:9d:02:bb:f9:e4:c5:42:46:38:11:b5:ca:
-    ed:4b:91:cd:9c:4e:0b:8b:cb:74:86:34:ce:e9:ed:
-    ec:d8:1e:18:7b:29:7d:03:c0:61:27:46:53:6a:e6:
-    0e:1b:8c:5e:35:f6:ba:0b:b3
+    00:cd:28:c0:b4:ac:11:f6:d6:76:10:35:43:1f:ae:
+    cb:ab:65:08:1e:6a:79:e0:ef:ea:5c:fe:11:7e:42:
+    c5:60:b0:aa:c5:26:09:f9:9c:4d:72:10:0b:c2:f4:
+    f3:00:f5:4a:b0:bd:db:24:71:3d:11:c7:4e:39:21:
+    6f:45:95:ad:1d:06:56:d8:4a:a9:f1:4c:a6:ad:57:
+    0e:ae:71:30:7e:02:d4:47:07:49:81:9c:b8:dd:a2:
+    82:3d:e5:d9:ea:52:d3:cf:11:a0:a9:87:95:62:d8:
+    39:b3:a0:14:67:b3:d9:6e:eb:0c:2a:79:8e:d0:d3:
+    a9:67:58:d2:39:97:82:12:85
 exponent1:
-    46:52:60:c4:40:5f:2d:52:38:e8:f1:fd:85:11:f7:
-    ca:14:74:7b:d3:bc:4c:02:f8:e5:a2:7d:3a:12:64:
-    3c:3e:b6:1f:30:e1:cf:47:e9:74:0a:cd:3f:9f:d2:
-    cf:c2:11:ce:51:5e:3f:14:7b:81:d2:eb:bc:2a:d8:
-    8f:3e:08:65:30:c1:2a:10:c6:0b:df:c6:3a:1a:76:
-    f4:5c:82:3d:ff:4e:3c:3f:f8:34:7a:00:72:7c:d4:
-    2f:aa:40:ce:4c:16:b6:ef:cc:c2:7b:b2:1e:35:60:
-    69:a8:57:85:e1:d5:4e:91:03:0a:dc:25:0a:75:1f:
-    ed:04:02:75:9a:6e:17:09
+    7d:39:12:ee:32:fb:79:15:0b:66:17:b1:a4:f1:70:
+    3a:a2:82:5a:67:66:f2:3f:e5:2e:45:d4:f2:5e:2c:
+    23:03:d3:6f:17:4a:b9:c9:e4:eb:a4:a2:18:aa:97:
+    d9:c0:f0:fd:e5:8d:6e:ec:9d:af:c3:3a:f4:34:b2:
+    cd:ba:42:ef:8b:36:c0:26:53:93:6a:c3:61:8e:1f:
+    3d:35:23:53:b2:6a:5e:47:a1:6c:0d:98:ba:ec:4c:
+    ed:b8:95:03:96:fe:0c:86:48:5a:ea:ff:29:f9:b6:
+    c8:35:ce:bd:03:44:e5:19:39:4f:a1:8a:a8:b6:f5:
+    58:93:3f:85:08:d1:be:e1
 exponent2:
-    66:df:6f:09:c4:96:0d:ae:ed:2e:54:c0:2e:f6:fc:
-    30:3f:0b:f5:69:0c:90:ac:40:83:0e:a9:6c:0c:7b:
-    23:47:80:2f:1e:65:3e:8c:96:9c:b6:4b:6d:56:73:
-    a6:ba:08:2b:0b:20:29:df:27:ff:9d:ac:27:7f:ae:
-    f4:ef:39:0e:d4:62:bd:e4:af:ee:21:41:99:9f:e4:
-    72:3e:c3:04:4e:e6:da:b4:a1:fd:be:fb:b5:5f:14:
-    fb:d0:8c:95:2b:20:cb:5d:e3:5c:b7:f6:a6:70:95:
-    ff:ef:b7:91:0e:39:17:5c:7d:c2:cd:db:ff:80:b2:
-    41:5b:87:86:e1:68:cf:e1
+    00:82:e4:8e:56:77:36:1a:eb:67:76:1d:d5:4e:a0:
+    82:17:3f:25:77:ea:6d:0a:43:67:9e:9f:06:e0:2c:
+    8f:ab:89:eb:da:4e:d3:ac:6a:b9:ca:9d:4c:33:bd:
+    7e:50:cd:2f:33:26:5e:6b:98:c7:e2:d0:eb:2a:6e:
+    17:85:28:e2:c3:12:e9:53:a4:07:5b:09:91:8a:24:
+    72:1c:7f:e0:f5:74:ae:a5:06:94:32:5a:a0:63:df:
+    ac:02:fb:e4:15:a9:74:b3:b7:46:6f:03:2f:1f:5a:
+    5f:2e:28:62:fc:6a:f5:bd:db:be:ee:56:91:f4:d0:
+    26:53:e6:8a:71:ee:25:31:d5
 coefficient:
-    00:8c:38:5e:33:4c:b2:94:37:37:37:69:4a:84:f5:
-    29:01:d5:e1:88:0b:4b:88:a1:d6:af:ca:f0:77:1e:
-    ba:20:70:83:30:b6:d8:ad:fd:f5:28:e9:49:6c:8c:
-    28:75:bc:c4:e1:64:2e:65:43:ec:50:00:fa:03:5f:
-    c6:93:99:b6:32:c8:c7:b3:06:23:8b:0c:5c:91:68:
-    6e:dc:75:94:e1:57:fb:f0:f4:47:8a:52:53:1b:a9:
-    b4:44:a7:7f:aa:df:6d:30:85:35:da:7a:ab:3f:1a:
-    97:6b:31:7f:2e:00:c4:92:4a:eb:5f:39:25:8a:a7:
-    9b:f4:1b:0b:86:cb:da:b3:e1
+    72:cc:12:f1:eb:3b:5b:d1:93:65:c7:39:51:e5:0e:
+    5f:bb:80:f0:44:1f:b5:b8:76:0b:ad:1c:8c:50:b8:
+    83:67:a1:2f:e1:fe:3c:b1:c6:22:48:39:18:ff:39:
+    59:c4:12:7c:03:20:50:f2:1f:64:b7:4d:50:19:45:
+    cc:65:f5:ae:ee:45:1a:74:bb:f3:85:53:4e:cb:5d:
+    a7:59:ad:ca:24:d0:35:a5:7c:b1:2f:b8:33:bf:0d:
+    ae:66:62:67:69:99:f0:a7:b3:f8:8f:6e:50:2b:ba:
+    49:95:88:80:c9:7f:31:f5:20:c9:1d:45:29:5b:c0:
+    b4:cd:6e:94:ab:3b:89:6e
 -----BEGIN RSA PRIVATE KEY-----
-MIIEpAIBAAKCAQEAr2AOEGwO94hcOJtm005p7a3Q1DGPIoHglFMKMnQGkqtIra/p
-5mDVg/LDpSkeSNiRnP1e9unqo4kCRSzYY9EY/2cQEW0PMqaKQwLxXwqV7zGQDa+E
-Rkw7et2qB6pNsFYO3E0d0L7VE/2vQGkBGk3V5dd4Zfm0ygCR5UWgy+jAIFuA+9sA
-nKUfWY/onCFWkKkwEU1lhIIo3m5UIHlK7ACwJghgR+86uyRiU7vhKFfTdyxWSN3c
-QNx9sh8fxQrVCp5z3g9XnuPVzy9YKqqoj4ut6XjEuGkMxo9anPUkw3Yg6M2YmGsG
-ieGtXsCOxR7P1cWx8pb8opAeTMh/e/iO3Z6qFwIDAQABAoIBAQCakR00Khjy35Lw
-LT7uI+FGovg33Mobjr6B28JT/2C/qgjvU+jhrBzjI3Z9vYS8jWuhIsqs8jNkGOAQ
-WdsJ9oOCrrJBuY44hQG81/4mVu0YmOUuuq/pSUzvGCjAgr/gF6kXTzxk+5xO9zqb
-mTBon4tS/JpXvkIx+1ia6sgyj5utp6JzjBTSGkrMHCVgl7q/wTeM/41r/U1BofQ2
-AxQROfG7SKWANcqXE68JnkHhZbIKZ8QG7ZZQ7WcXroP2u6OXyyrFFguJOwGgk4L+
-FsPBiEdf5qum7e5vrgu7024W19lD8x2msF6Z0UAw/OYGwiKMbPO+XRJtY1AuzS7Y
-FvmN+YdZAoGBANyopTUvVF+fMmpHg1vyIrZjKokJPkl77fcRwjtFLq65HCQSi3yg
-O5GK/GCMpG9agB10q088/4NzED3bI8qj5XdfdkQGkjWotO/BdAKwoYd1f6Ob8Has
-yUQj303pNS18B2QrriawT/BnI1yl083P2DGxn7UTPgcit3CwsNCgEqYNAoGBAMt2
-toWm/4Xo9/GtC4ZMOyRtvOnJ35Cxo6gbCzUy3CaWVrP3wHCf3rJZEDig8z8GLAuF
-drS3FWAXFS10/JMVfjFNJVkudhIuGuhm1IFSnQK7+eTFQkY4EbXK7UuRzZxOC4vL
-dIY0zunt7NgeGHspfQPAYSdGU2rmDhuMXjX2uguzAoGARlJgxEBfLVI46PH9hRH3
-yhR0e9O8TAL45aJ9OhJkPD62HzDhz0fpdArNP5/Sz8IRzlFePxR7gdLrvCrYjz4I
-ZTDBKhDGC9/GOhp29FyCPf9OPD/4NHoAcnzUL6pAzkwWtu/MwnuyHjVgaahXheHV
-TpEDCtwlCnUf7QQCdZpuFwkCgYBm328JxJYNru0uVMAu9vwwPwv1aQyQrECDDqls
-DHsjR4AvHmU+jJactkttVnOmuggrCyAp3yf/nawnf6707zkO1GK95K/uIUGZn+Ry
-PsMETubatKH9vvu1XxT70IyVKyDLXeNct/amcJX/77eRDjkXXH3Czdv/gLJBW4eG
-4WjP4QKBgQCMOF4zTLKUNzc3aUqE9SkB1eGIC0uIodavyvB3HrogcIMwttit/fUo
-6UlsjCh1vMThZC5lQ+xQAPoDX8aTmbYyyMezBiOLDFyRaG7cdZThV/vw9EeKUlMb
-qbREp3+q320whTXaeqs/GpdrMX8uAMSSSutfOSWKp5v0GwuGy9qz4Q==
+MIIEpAIBAAKCAQEAp7WvEDpKRgD3UWaLHTURZeYaUAo3Vv+TFiDNNVgoxG8GMdiG
+d+0ghVWtika4PXBRqjH5WK2l1U/K0D4Qj0+5xszobvIkFSbDOiSF0uj3YzqXtOn/
+XsDu5+2bLlmHNgiP5N9aAyWjNUBpoeSk8MAoMmTvqyr5ze3UDr1G3fydox/WFMJY
+Hw2ehfTOybGRG27RcU6uisZlZ68nk4u+gEZXnqaKXAsYhsB3tleHLSox/TR1M1jD
+i5zBW2FMKJSpKuEkfsJvzr78mBtJSpGxK3Mwx0Tv2fOvQxurwsnrl6mfbG6xEtPL
+0D4dLczuPuokDR4k+D68ik2FeL7E45eGMW7ZBwIDAQABAoIBAQCgXtb50JOnn1Lg
+TwtmMZHifAfbU/mZQqmXNmSkxxmsxXIKBkCHu4QmnEhnerrBXX9qHYGPr/VtJnEN
+ctwI/rbqiJUXSosAguGa3sPtbALsq2HYiQ4+wIVz2L1UtB3cqJFYzc/YRIxt5ptc
+STUEVuvZTLX2WxEnP25RbeOvcNoY2lNjR2hK4YZ/idzyfv21p4SYMMNr1cahiVGv
+6fbKPowAtcyZkCLF16eNIbxYhWTqXgBHszPz36nj2Ga8GYOt+k+lJaPevYxlUqEZ
+kgcPZyer3GBYjoiYlj3qMDAciCxu0+Db8i70E+uhfRXelS4ffDP6rXlwcQX0LBko
+W/fmVNRJAoGBANFFJSBQEdWzyGcBTcqLDY1weE2QQBbQa6xOJcJKxj+bqxp+wiyh
+DJHe4CBAp/q7B9Nxm6fOyIPRfIywJMf/RfBs4AJHXJqSKnxoCNj3IB954JDhmpsY
+/n0pGVd1T+CJC53ZErQxeCWN8toq+R/5U+z6dDP7KHzt6wDJiAtVsOEbAoGBAM0o
+wLSsEfbWdhA1Qx+uy6tlCB5qeeDv6lz+EX5CxWCwqsUmCfmcTXIQC8L08wD1SrC9
+2yRxPRHHTjkhb0WVrR0GVthKqfFMpq1XDq5xMH4C1EcHSYGcuN2igj3l2epS088R
+oKmHlWLYObOgFGez2W7rDCp5jtDTqWdY0jmXghKFAoGAfTkS7jL7eRULZhexpPFw
+OqKCWmdm8j/lLkXU8l4sIwPTbxdKucnk66SiGKqX2cDw/eWNbuydr8M69DSyzbpC
+74s2wCZTk2rDYY4fPTUjU7JqXkehbA2YuuxM7biVA5b+DIZIWur/Kfm2yDXOvQNE
+5Rk5T6GKqLb1WJM/hQjRvuECgYEAguSOVnc2Gutndh3VTqCCFz8ld+ptCkNnnp8G
+4CyPq4nr2k7TrGq5yp1MM71+UM0vMyZea5jH4tDrKm4XhSjiwxLpU6QHWwmRiiRy
+HH/g9XSupQaUMlqgY9+sAvvkFal0s7dGbwMvH1pfLihi/Gr1vdu+7laR9NAmU+aK
+ce4lMdUCgYByzBLx6ztb0ZNlxzlR5Q5fu4DwRB+1uHYLrRyMULiDZ6Ev4f48scYi
+SDkY/zlZxBJ8AyBQ8h9kt01QGUXMZfWu7kUadLvzhVNOy12nWa3KJNA1pXyxL7gz
+vw2uZmJnaZnwp7P4j25QK7pJlYiAyX8x9SDJHUUpW8C0zW6UqzuJbg==
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/pluto.pem
+++ b/spec/fixtures/ssl/pluto.pem
@@ -1,66 +1,66 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 9 (0x9)
+        Serial Number: 10 (0xa)
         Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA Agent Subauthority
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Apr 18 18:46:23 2031 GMT
+            Not After : Jun 15 01:19:37 2031 GMT
         Subject: CN=pluto
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:af:60:0e:10:6c:0e:f7:88:5c:38:9b:66:d3:4e:
-                    69:ed:ad:d0:d4:31:8f:22:81:e0:94:53:0a:32:74:
-                    06:92:ab:48:ad:af:e9:e6:60:d5:83:f2:c3:a5:29:
-                    1e:48:d8:91:9c:fd:5e:f6:e9:ea:a3:89:02:45:2c:
-                    d8:63:d1:18:ff:67:10:11:6d:0f:32:a6:8a:43:02:
-                    f1:5f:0a:95:ef:31:90:0d:af:84:46:4c:3b:7a:dd:
-                    aa:07:aa:4d:b0:56:0e:dc:4d:1d:d0:be:d5:13:fd:
-                    af:40:69:01:1a:4d:d5:e5:d7:78:65:f9:b4:ca:00:
-                    91:e5:45:a0:cb:e8:c0:20:5b:80:fb:db:00:9c:a5:
-                    1f:59:8f:e8:9c:21:56:90:a9:30:11:4d:65:84:82:
-                    28:de:6e:54:20:79:4a:ec:00:b0:26:08:60:47:ef:
-                    3a:bb:24:62:53:bb:e1:28:57:d3:77:2c:56:48:dd:
-                    dc:40:dc:7d:b2:1f:1f:c5:0a:d5:0a:9e:73:de:0f:
-                    57:9e:e3:d5:cf:2f:58:2a:aa:a8:8f:8b:ad:e9:78:
-                    c4:b8:69:0c:c6:8f:5a:9c:f5:24:c3:76:20:e8:cd:
-                    98:98:6b:06:89:e1:ad:5e:c0:8e:c5:1e:cf:d5:c5:
-                    b1:f2:96:fc:a2:90:1e:4c:c8:7f:7b:f8:8e:dd:9e:
-                    aa:17
+                    00:a7:b5:af:10:3a:4a:46:00:f7:51:66:8b:1d:35:
+                    11:65:e6:1a:50:0a:37:56:ff:93:16:20:cd:35:58:
+                    28:c4:6f:06:31:d8:86:77:ed:20:85:55:ad:8a:46:
+                    b8:3d:70:51:aa:31:f9:58:ad:a5:d5:4f:ca:d0:3e:
+                    10:8f:4f:b9:c6:cc:e8:6e:f2:24:15:26:c3:3a:24:
+                    85:d2:e8:f7:63:3a:97:b4:e9:ff:5e:c0:ee:e7:ed:
+                    9b:2e:59:87:36:08:8f:e4:df:5a:03:25:a3:35:40:
+                    69:a1:e4:a4:f0:c0:28:32:64:ef:ab:2a:f9:cd:ed:
+                    d4:0e:bd:46:dd:fc:9d:a3:1f:d6:14:c2:58:1f:0d:
+                    9e:85:f4:ce:c9:b1:91:1b:6e:d1:71:4e:ae:8a:c6:
+                    65:67:af:27:93:8b:be:80:46:57:9e:a6:8a:5c:0b:
+                    18:86:c0:77:b6:57:87:2d:2a:31:fd:34:75:33:58:
+                    c3:8b:9c:c1:5b:61:4c:28:94:a9:2a:e1:24:7e:c2:
+                    6f:ce:be:fc:98:1b:49:4a:91:b1:2b:73:30:c7:44:
+                    ef:d9:f3:af:43:1b:ab:c2:c9:eb:97:a9:9f:6c:6e:
+                    b1:12:d3:cb:d0:3e:1d:2d:cc:ee:3e:ea:24:0d:1e:
+                    24:f8:3e:bc:8a:4d:85:78:be:c4:e3:97:86:31:6e:
+                    d9:07
                 Exponent: 65537 (0x10001)
     Signature Algorithm: sha256WithRSAEncryption
-         0a:2a:22:ca:3c:6e:fb:29:47:7f:f3:28:ff:2f:7f:4e:ce:66:
-         43:a2:ef:40:eb:22:9e:95:d0:06:31:0f:a6:cb:20:bf:e5:e5:
-         5b:7f:32:d3:6d:d4:b5:0b:b0:69:eb:f5:73:ea:64:8e:8f:9d:
-         84:56:a5:dd:f7:ea:6e:20:ae:3a:9d:9c:1e:0e:ca:52:14:8b:
-         a2:60:99:24:10:72:33:40:57:16:ee:c5:19:40:31:9e:07:88:
-         06:24:45:07:b1:19:9f:b7:88:c6:64:04:83:b4:8e:a3:b6:70:
-         ee:46:10:d8:42:0d:ad:50:41:0f:2b:89:0b:c7:98:e9:9a:59:
-         21:2b:a1:0d:d0:24:a0:e1:56:1e:c7:83:be:0e:bd:64:dc:5d:
-         19:c3:92:5a:f6:57:70:a5:7d:b9:0a:5f:d6:18:90:d0:3e:6d:
-         e1:ae:8f:bb:e8:f7:c7:16:cd:31:89:5a:9f:93:0b:9e:03:8b:
-         66:7f:b5:06:72:a3:86:24:25:33:8a:08:64:15:45:91:ef:a6:
-         53:1d:5a:0a:b6:03:b8:3d:73:b5:ad:dc:69:6f:24:d0:ec:b6:
-         5e:1a:f0:0f:b1:69:47:1a:71:e3:43:1e:e4:c2:8f:54:61:e1:
-         17:ce:44:a9:3f:6a:55:a1:db:5e:d8:4d:c8:36:22:22:f8:ca:
-         67:b8:85:42
+         21:81:c6:f9:ce:10:12:5a:52:73:52:90:7f:7d:f0:1c:7a:48:
+         91:6e:f7:5d:f2:6b:10:b1:6d:d1:19:62:40:7e:bb:3f:23:0d:
+         7f:6c:5a:51:b4:07:80:17:f2:6d:2e:44:a4:f2:07:3c:1e:ce:
+         85:4e:bc:3c:69:ce:94:b5:4e:03:66:8e:21:68:15:c8:8d:06:
+         79:ab:ff:ac:0d:03:8a:02:06:1f:8c:09:87:64:ee:75:37:eb:
+         db:54:79:0f:03:7b:dd:c2:c3:c3:4b:fc:76:72:8c:b5:ae:f3:
+         ea:6e:c5:b1:ff:96:0e:05:fc:0f:16:88:bd:2e:e5:04:3b:a4:
+         fd:ed:1f:fb:b2:14:ab:30:d8:f9:44:5c:bb:8b:bc:86:c7:d7:
+         59:e8:f4:b0:9e:28:24:f4:93:14:97:27:73:a5:8e:8a:3b:09:
+         cb:76:fc:02:9e:72:3f:f5:12:ce:84:82:d4:7e:d5:b9:32:ff:
+         af:cf:0e:7a:97:29:4e:c3:e7:1c:e5:c1:61:bb:85:5a:47:c1:
+         6d:ac:e4:a8:a1:68:d7:bc:aa:e6:16:08:5a:4e:dc:8b:7d:0d:
+         53:6f:c1:8b:bd:a0:57:70:b5:1c:a8:27:8a:1a:93:18:3d:72:
+         0d:97:49:63:88:f9:af:51:9e:87:2d:8f:98:b2:cb:42:b6:ee:
+         44:18:8d:93
 -----BEGIN CERTIFICATE-----
-MIICrjCCAZagAwIBAgIBCTANBgkqhkiG9w0BAQsFADAlMSMwIQYDVQQDDBpUZXN0
-IENBIEFnZW50IFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zMTA0MTgx
-ODQ2MjNaMBAxDjAMBgNVBAMMBXBsdXRvMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
-MIIBCgKCAQEAr2AOEGwO94hcOJtm005p7a3Q1DGPIoHglFMKMnQGkqtIra/p5mDV
-g/LDpSkeSNiRnP1e9unqo4kCRSzYY9EY/2cQEW0PMqaKQwLxXwqV7zGQDa+ERkw7
-et2qB6pNsFYO3E0d0L7VE/2vQGkBGk3V5dd4Zfm0ygCR5UWgy+jAIFuA+9sAnKUf
-WY/onCFWkKkwEU1lhIIo3m5UIHlK7ACwJghgR+86uyRiU7vhKFfTdyxWSN3cQNx9
-sh8fxQrVCp5z3g9XnuPVzy9YKqqoj4ut6XjEuGkMxo9anPUkw3Yg6M2YmGsGieGt
-XsCOxR7P1cWx8pb8opAeTMh/e/iO3Z6qFwIDAQABMA0GCSqGSIb3DQEBCwUAA4IB
-AQAKKiLKPG77KUd/8yj/L39OzmZDou9A6yKeldAGMQ+myyC/5eVbfzLTbdS1C7Bp
-6/Vz6mSOj52EVqXd9+puIK46nZweDspSFIuiYJkkEHIzQFcW7sUZQDGeB4gGJEUH
-sRmft4jGZASDtI6jtnDuRhDYQg2tUEEPK4kLx5jpmlkhK6EN0CSg4VYex4O+Dr1k
-3F0Zw5Ja9ldwpX25Cl/WGJDQPm3hro+76PfHFs0xiVqfkwueA4tmf7UGcqOGJCUz
-ighkFUWR76ZTHVoKtgO4PXO1rdxpbyTQ7LZeGvAPsWlHGnHjQx7kwo9UYeEXzkSp
-P2pVodte2E3INiIi+MpnuIVC
+MIICrjCCAZagAwIBAgIBCjANBgkqhkiG9w0BAQsFADAlMSMwIQYDVQQDDBpUZXN0
+IENBIEFnZW50IFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zMTA2MTUw
+MTE5MzdaMBAxDjAMBgNVBAMMBXBsdXRvMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+MIIBCgKCAQEAp7WvEDpKRgD3UWaLHTURZeYaUAo3Vv+TFiDNNVgoxG8GMdiGd+0g
+hVWtika4PXBRqjH5WK2l1U/K0D4Qj0+5xszobvIkFSbDOiSF0uj3YzqXtOn/XsDu
+5+2bLlmHNgiP5N9aAyWjNUBpoeSk8MAoMmTvqyr5ze3UDr1G3fydox/WFMJYHw2e
+hfTOybGRG27RcU6uisZlZ68nk4u+gEZXnqaKXAsYhsB3tleHLSox/TR1M1jDi5zB
+W2FMKJSpKuEkfsJvzr78mBtJSpGxK3Mwx0Tv2fOvQxurwsnrl6mfbG6xEtPL0D4d
+LczuPuokDR4k+D68ik2FeL7E45eGMW7ZBwIDAQABMA0GCSqGSIb3DQEBCwUAA4IB
+AQAhgcb5zhASWlJzUpB/ffAcekiRbvdd8msQsW3RGWJAfrs/Iw1/bFpRtAeAF/Jt
+LkSk8gc8Hs6FTrw8ac6UtU4DZo4haBXIjQZ5q/+sDQOKAgYfjAmHZO51N+vbVHkP
+A3vdwsPDS/x2coy1rvPqbsWx/5YOBfwPFoi9LuUEO6T97R/7shSrMNj5RFy7i7yG
+x9dZ6PSwnigk9JMUlydzpY6KOwnLdvwCnnI/9RLOhILUftW5Mv+vzw56lylOw+cc
+5cFhu4VaR8FtrOSooWjXvKrmFghaTtyLfQ1Tb8GLvaBXcLUcqCeKGpMYPXINl0lj
+iPmvUZ6HLY+YsstCtu5EGI2T
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/request-key.pem
+++ b/spec/fixtures/ssl/request-key.pem
@@ -1,117 +1,117 @@
 RSA Private-Key: (2048 bit, 2 primes)
 modulus:
-    00:c2:a5:41:96:ca:af:a4:6e:84:61:33:30:0c:87:
-    17:ae:a9:35:16:d0:4a:db:c1:23:e0:33:1d:2d:d6:
-    76:d0:f6:79:d3:69:6e:2c:5a:c0:04:c8:27:e0:75:
-    86:03:43:61:61:71:33:1a:9f:30:c5:77:78:10:2c:
-    93:95:dc:4b:b0:14:19:78:63:f0:de:cd:5a:20:fe:
-    7f:8e:96:60:ab:94:5a:df:26:fb:d2:34:d4:73:7a:
-    ca:bf:73:bb:e4:60:ac:15:dc:f7:37:40:cb:4c:ad:
-    d2:4c:f7:5f:ee:dd:b4:c4:cb:91:6d:5d:7d:18:ca:
-    99:85:4e:bd:55:6f:f4:de:61:d1:ee:45:63:21:22:
-    00:7e:8b:85:18:35:09:02:f0:61:58:af:e0:cc:21:
-    0f:cd:c8:10:df:e9:2f:b7:f1:b9:2b:88:da:9a:90:
-    91:ea:bc:55:cd:d6:42:90:fe:06:9a:0d:c2:44:d1:
-    7c:0a:86:72:3e:d0:f4:05:62:e6:fa:e0:74:51:2b:
-    36:3e:c9:98:fa:0a:be:5f:ac:c7:fd:bf:4b:81:de:
-    f1:b7:c5:43:73:02:66:98:1f:89:60:48:f9:53:a4:
-    75:c9:68:ab:00:3d:e9:4d:2c:84:9f:a7:a5:71:14:
-    89:fb:f5:d9:fa:0a:7e:9e:c8:b4:32:65:a1:05:52:
-    18:39
+    00:a8:02:d7:77:d2:93:b5:c3:7f:1b:4f:6f:cf:ba:
+    3b:ab:2c:07:de:7f:ce:ea:8e:21:54:29:39:7a:b7:
+    53:19:e1:1a:98:52:86:e9:22:ef:b4:30:b7:0a:d1:
+    52:40:cd:de:50:31:6e:93:f3:b2:03:8b:aa:23:d7:
+    86:23:fa:f3:8e:bc:af:a7:4a:86:3d:4f:58:d3:6c:
+    d6:6c:81:78:70:9c:6a:88:c0:e9:86:c6:76:1c:73:
+    53:ab:9f:47:01:4a:68:44:99:1e:15:ef:56:b6:1a:
+    2b:3d:28:a9:3e:b5:64:cf:8f:90:d7:e8:1a:70:52:
+    72:2c:d9:2e:a4:78:d9:4d:45:12:98:d1:a2:03:16:
+    d4:5a:eb:22:39:f5:4b:39:41:df:02:77:dd:62:0d:
+    1b:71:c1:8d:0a:b7:d9:a2:57:b6:0a:56:75:7f:6a:
+    cd:cc:3a:b5:06:db:80:55:36:03:89:65:a4:d3:82:
+    cf:b0:d3:d1:fd:07:ee:ab:27:07:95:c5:8b:e4:a8:
+    36:50:ac:83:17:ff:ff:05:6c:6e:fa:cb:46:4b:31:
+    14:db:c3:6b:aa:97:32:f5:a3:65:83:39:da:df:d9:
+    43:7f:01:62:d0:dc:09:4a:0a:aa:44:ff:42:6c:24:
+    e5:09:9a:c3:59:18:aa:30:60:38:bc:0a:93:4a:3c:
+    7d:55
 publicExponent: 65537 (0x10001)
 privateExponent:
-    7e:21:60:53:3a:9c:7e:cd:2e:f3:5d:9c:31:42:09:
-    52:a1:4b:49:b1:48:11:07:23:1c:51:83:03:05:0a:
-    91:76:66:93:5c:aa:8c:0b:72:8a:a6:b9:50:76:57:
-    95:1d:c0:a8:c8:15:f9:96:56:a0:5f:3e:6a:1c:b8:
-    b6:4f:be:ac:27:1a:2a:2d:79:14:a7:b5:53:d4:17:
-    0c:6a:dd:d1:d1:9c:e1:25:fd:e0:c5:63:36:41:c7:
-    c8:30:52:fd:36:b7:cc:a3:17:7f:b2:79:0b:03:48:
-    57:9f:a5:86:c0:1c:37:ba:42:4e:c0:5a:24:0a:85:
-    59:21:21:07:90:38:f9:30:ff:ff:b9:30:c7:e3:27:
-    df:a9:51:39:df:6a:a7:7a:c1:45:fe:36:09:bb:36:
-    f4:88:db:4e:ae:80:b0:89:3a:3a:d6:5c:72:02:61:
-    93:63:0a:9f:49:f9:6b:dd:70:7e:ae:16:ba:12:63:
-    7c:a4:94:25:9d:7b:54:cd:b3:2d:7d:f9:91:89:98:
-    66:5b:e6:1d:f7:95:56:cd:94:be:a8:72:ed:26:f6:
-    6c:23:6d:5e:10:7c:99:55:8f:a5:b8:2f:1e:81:d8:
-    53:2e:92:5b:24:2b:58:62:db:fd:f3:d0:c7:66:70:
-    f0:4a:cc:67:1d:ff:9b:82:17:81:eb:69:a9:bc:c0:
-    01
+    00:93:e1:b4:70:26:6c:97:5f:95:40:9f:a2:06:10:
+    a1:36:a0:51:e8:d9:4c:72:8e:59:ed:af:3f:85:b1:
+    59:36:fd:39:20:7b:fb:7d:b7:9f:8f:56:15:b7:32:
+    d9:98:6a:dc:54:6f:be:2a:02:25:5d:13:90:d5:6d:
+    7e:07:ab:7a:b7:d7:83:30:d7:da:e2:9a:35:d0:1b:
+    0b:7d:84:54:53:a2:89:ef:07:06:45:f7:e7:bc:51:
+    12:83:8c:75:be:40:15:18:d4:41:74:03:2f:aa:a7:
+    cc:09:50:01:f0:4d:4f:87:96:91:62:49:4d:04:32:
+    bd:86:96:3f:84:cb:4e:51:c0:9d:d0:0d:5f:a1:5c:
+    44:bf:cb:31:1f:ee:ed:6c:4b:32:7b:c7:f3:42:80:
+    7a:08:71:09:2b:39:ac:a3:54:5e:15:fc:f1:de:2c:
+    25:79:75:f0:23:51:52:0f:1d:1b:09:79:ca:04:3b:
+    20:4e:e4:36:00:66:9b:a2:42:7b:ac:9d:e2:7a:a6:
+    13:84:21:6f:36:e5:28:b4:14:8c:eb:b9:7e:b1:b5:
+    b2:3b:55:04:8c:da:a7:47:85:be:3f:67:b3:bc:93:
+    be:31:c6:33:ac:12:5c:7e:ca:fb:7b:77:7d:22:2d:
+    87:53:ee:85:7f:99:43:17:b1:4d:b1:f9:3e:ed:7e:
+    5f:bd
 prime1:
-    00:f1:e5:23:22:8d:ab:e3:30:c5:59:14:b9:72:c6:
-    7a:7f:66:f8:22:92:af:83:18:3f:39:4d:ac:16:77:
-    b0:35:fb:a6:e3:22:6e:fe:60:a4:02:7f:8c:94:98:
-    5b:e7:f6:31:ad:90:ce:40:81:a5:b5:a3:5c:3a:e9:
-    e4:c1:44:87:4f:dd:b1:fa:f4:42:40:11:df:01:80:
-    72:ab:a9:26:ad:5d:3f:8b:ba:42:f9:31:61:93:3f:
-    7d:f3:e9:c6:61:52:f2:8b:05:c5:9b:ca:3a:f1:f3:
-    fb:02:c6:83:6c:f0:86:25:2a:ee:e2:45:8c:90:b8:
-    a8:a5:a1:b3:d8:41:0b:32:01
+    00:db:dc:17:0e:0f:25:c6:46:0a:a3:6f:b6:d2:44:
+    e7:39:75:d0:77:8d:29:77:63:76:11:2b:7e:8c:63:
+    dc:4a:57:e6:12:7a:b2:4b:c6:cc:cf:b9:41:e1:af:
+    e2:63:a3:33:68:3a:d0:47:c3:13:71:74:ba:c4:6d:
+    f0:2b:ef:96:6a:48:0e:79:b7:dc:71:dd:c9:0c:b6:
+    ca:55:36:46:b6:36:e1:dd:af:4e:b4:c7:10:72:39:
+    85:12:d4:63:65:10:14:35:a3:db:72:f1:6b:e6:15:
+    ab:61:e6:07:ec:17:a3:50:94:35:ac:2a:5b:13:97:
+    82:26:eb:97:59:31:46:22:57
 prime2:
-    00:cd:fe:ce:7b:b1:5c:69:87:a2:ea:18:74:e1:66:
-    99:a9:21:95:6e:5d:69:58:ea:df:3c:bf:c6:9d:5e:
-    31:19:74:4f:4b:c9:a3:41:2f:74:09:50:b8:34:b9:
-    3f:bd:4c:51:0a:80:b1:ea:a4:d2:d7:e3:9d:39:da:
-    68:53:68:f0:dc:ca:d6:5d:9a:69:2e:12:80:72:c8:
-    e1:a5:3d:0e:2d:fc:ba:c4:b5:6d:1c:43:e8:5f:ef:
-    14:28:d1:3e:e1:a6:44:a5:b3:51:d0:de:d4:9b:80:
-    5c:cf:82:4a:4d:38:26:da:8a:4e:b8:b6:55:86:5a:
-    0b:fa:30:b5:c3:e9:c7:f6:39
+    00:c3:a0:e9:48:a4:9b:16:8a:37:14:37:c4:41:75:
+    28:24:f8:6a:d9:f4:bc:9a:4d:3c:ba:c7:29:89:f7:
+    c0:3b:9c:60:ca:ec:20:37:f8:e3:f0:ea:7c:8c:c1:
+    35:8f:c7:37:4f:bc:ad:e0:ae:9e:bf:47:5e:2c:e0:
+    35:73:94:7f:21:ff:f8:af:4b:ae:af:14:f6:16:a4:
+    c2:21:02:52:92:8f:28:53:95:be:6e:cc:d7:e8:77:
+    6e:db:c5:f9:03:55:b8:96:ce:a5:16:f0:39:f8:71:
+    dc:8f:0f:69:9e:86:fa:d7:d9:b4:8e:db:d8:a0:13:
+    a1:96:96:03:1c:e2:4d:ca:33
 exponent1:
-    0f:ad:e2:91:22:cd:b9:74:37:d6:86:59:5e:ef:2e:
-    91:83:83:21:fa:90:15:d7:44:81:da:5f:05:35:cc:
-    de:32:e9:a6:5f:5d:02:70:11:31:78:43:0c:7e:b3:
-    b6:5d:66:ea:f1:2f:ed:4e:7a:07:44:07:7e:6a:1a:
-    c1:cc:47:59:0d:ed:b3:6e:91:bc:c5:6b:c7:15:24:
-    59:ac:25:2d:a7:95:ae:e0:eb:e6:6b:24:ff:fe:65:
-    93:a1:db:92:03:66:65:4c:82:7a:8e:a9:33:75:b5:
-    17:80:f6:93:e1:23:50:d5:6f:96:8b:1b:89:65:ee:
-    c8:8d:aa:b2:a1:c4:b0:01
+    02:d5:b2:a2:66:c5:98:e9:dc:47:41:30:7d:43:90:
+    2b:a8:7e:38:9c:64:55:7a:bd:d1:f8:da:97:da:cd:
+    c3:53:a0:ce:ca:30:34:53:ea:de:1e:c8:5f:ad:91:
+    e0:b1:00:ff:ae:0a:73:72:6b:74:c2:09:8a:70:d4:
+    70:ec:94:e6:e7:e8:ef:de:d4:03:cf:d5:40:c9:b6:
+    90:24:b4:02:b3:70:74:18:47:8e:83:26:8e:22:79:
+    b9:c5:6d:46:a7:4f:6b:65:a2:75:b7:f1:29:35:4c:
+    51:65:d2:e2:53:67:b2:a9:46:8b:e2:bb:eb:e3:bf:
+    34:db:42:c7:4e:a0:55:df
 exponent2:
-    00:8c:35:55:d7:8d:25:e8:52:40:c9:f3:71:82:85:
-    b2:2b:13:47:c1:81:e5:15:77:70:10:ca:3b:66:9b:
-    58:f2:09:5f:7b:a7:37:ee:43:5d:48:85:df:8b:4b:
-    57:9e:01:d6:db:3e:33:5b:11:6a:cd:35:08:ab:fb:
-    03:ad:5a:2d:2f:2b:04:73:5b:89:21:a9:c8:31:d8:
-    96:f5:40:34:69:8a:ae:98:fb:1f:d3:f0:48:b7:1b:
-    64:6e:4f:d5:ec:02:9e:90:e6:17:d7:02:04:55:ff:
-    2d:ac:b3:f2:dc:d2:4e:67:cb:61:bf:89:a3:76:b9:
-    cd:93:32:1a:55:c9:c6:a7:c9
+    36:33:a9:2f:15:5c:5a:fc:64:92:57:79:2a:e1:b9:
+    03:b5:48:75:a7:17:72:71:1f:f8:68:22:1c:35:e6:
+    af:1d:7e:bb:fa:7c:5a:c5:bc:f2:0d:26:01:21:af:
+    23:6d:00:e8:38:d0:bc:45:e5:79:fd:de:1b:f4:eb:
+    1a:60:f4:70:89:29:6f:f8:3a:28:0c:58:ba:a1:5f:
+    a0:21:b2:9b:24:ca:f9:8d:ad:bb:a9:49:d1:00:f6:
+    58:32:1b:f2:4e:97:dc:40:d9:00:e8:02:47:d1:d4:
+    58:56:de:de:ab:6b:68:ce:ca:f6:21:f7:7d:32:b3:
+    3c:b3:c7:9d:03:1e:a6:7d
 coefficient:
-    00:a0:ae:da:e7:29:9d:f3:04:c0:53:97:42:96:bb:
-    74:11:5b:8c:4f:7d:7d:08:16:06:a0:61:cc:34:ca:
-    c4:97:43:eb:1d:c3:8e:29:b6:33:5e:8a:ea:5c:32:
-    b9:b5:3c:fe:11:9d:6e:b3:87:0f:ae:02:66:cc:7a:
-    0c:f3:96:6b:59:9a:bd:fd:bd:6b:dc:aa:ca:a7:ef:
-    ec:b9:91:5f:be:19:82:80:db:34:d3:56:67:b0:ec:
-    be:81:0c:01:4e:53:23:b7:af:86:1f:eb:9d:35:6f:
-    58:a4:34:f1:df:14:e7:f3:a1:3b:6a:7d:5c:d6:a3:
-    b8:9f:5f:f3:51:95:eb:11:6b
+    6f:16:3f:5d:96:b8:bd:b8:3f:7c:a8:a5:4d:66:13:
+    77:47:73:d9:11:be:67:d0:81:0c:4c:b3:e7:cb:33:
+    ba:49:42:dc:8e:44:2d:b6:ca:52:05:48:c1:27:36:
+    88:d1:dc:cb:ba:d2:b0:99:30:a2:19:f9:47:ae:38:
+    de:26:ae:44:76:0f:c4:f2:1c:b4:0d:d4:74:96:f5:
+    f4:e8:23:1d:c5:e9:d9:47:7f:ce:83:c4:58:1f:99:
+    42:c5:ac:65:26:99:df:ec:b0:e9:0a:78:e1:09:5f:
+    16:44:a0:4b:30:a1:d5:3a:c4:f7:9c:28:b0:e9:89:
+    3c:15:13:eb:85:ed:5d:66
 -----BEGIN RSA PRIVATE KEY-----
-MIIEpAIBAAKCAQEAwqVBlsqvpG6EYTMwDIcXrqk1FtBK28Ej4DMdLdZ20PZ502lu
-LFrABMgn4HWGA0NhYXEzGp8wxXd4ECyTldxLsBQZeGPw3s1aIP5/jpZgq5Ra3yb7
-0jTUc3rKv3O75GCsFdz3N0DLTK3STPdf7t20xMuRbV19GMqZhU69VW/03mHR7kVj
-ISIAfouFGDUJAvBhWK/gzCEPzcgQ3+kvt/G5K4jampCR6rxVzdZCkP4Gmg3CRNF8
-CoZyPtD0BWLm+uB0USs2PsmY+gq+X6zH/b9Lgd7xt8VDcwJmmB+JYEj5U6R1yWir
-AD3pTSyEn6elcRSJ+/XZ+gp+nsi0MmWhBVIYOQIDAQABAoIBAH4hYFM6nH7NLvNd
-nDFCCVKhS0mxSBEHIxxRgwMFCpF2ZpNcqowLcoqmuVB2V5UdwKjIFfmWVqBfPmoc
-uLZPvqwnGioteRSntVPUFwxq3dHRnOEl/eDFYzZBx8gwUv02t8yjF3+yeQsDSFef
-pYbAHDe6Qk7AWiQKhVkhIQeQOPkw//+5MMfjJ9+pUTnfaqd6wUX+Ngm7NvSI206u
-gLCJOjrWXHICYZNjCp9J+WvdcH6uFroSY3yklCWde1TNsy19+ZGJmGZb5h33lVbN
-lL6ocu0m9mwjbV4QfJlVj6W4Lx6B2FMuklskK1hi2/3z0MdmcPBKzGcd/5uCF4Hr
-aam8wAECgYEA8eUjIo2r4zDFWRS5csZ6f2b4IpKvgxg/OU2sFnewNfum4yJu/mCk
-An+MlJhb5/YxrZDOQIGltaNcOunkwUSHT92x+vRCQBHfAYByq6kmrV0/i7pC+TFh
-kz998+nGYVLyiwXFm8o68fP7AsaDbPCGJSru4kWMkLiopaGz2EELMgECgYEAzf7O
-e7FcaYei6hh04WaZqSGVbl1pWOrfPL/GnV4xGXRPS8mjQS90CVC4NLk/vUxRCoCx
-6qTS1+OdOdpoU2jw3MrWXZppLhKAcsjhpT0OLfy6xLVtHEPoX+8UKNE+4aZEpbNR
-0N7Um4Bcz4JKTTgm2opOuLZVhloL+jC1w+nH9jkCgYAPreKRIs25dDfWhlle7y6R
-g4Mh+pAV10SB2l8FNczeMummX10CcBExeEMMfrO2XWbq8S/tTnoHRAd+ahrBzEdZ
-De2zbpG8xWvHFSRZrCUtp5Wu4OvmayT//mWToduSA2ZlTIJ6jqkzdbUXgPaT4SNQ
-1W+WixuJZe7IjaqyocSwAQKBgQCMNVXXjSXoUkDJ83GChbIrE0fBgeUVd3AQyjtm
-m1jyCV97pzfuQ11Ihd+LS1eeAdbbPjNbEWrNNQir+wOtWi0vKwRzW4khqcgx2Jb1
-QDRpiq6Y+x/T8Ei3G2RuT9XsAp6Q5hfXAgRV/y2ss/Lc0k5ny2G/iaN2uc2TMhpV
-ycanyQKBgQCgrtrnKZ3zBMBTl0KWu3QRW4xPfX0IFgagYcw0ysSXQ+sdw44ptjNe
-iupcMrm1PP4RnW6zhw+uAmbMegzzlmtZmr39vWvcqsqn7+y5kV++GYKA2zTTVmew
-7L6BDAFOUyO3r4Yf6501b1ikNPHfFOfzoTtqfVzWo7ifX/NRlesRaw==
+MIIEowIBAAKCAQEAqALXd9KTtcN/G09vz7o7qywH3n/O6o4hVCk5erdTGeEamFKG
+6SLvtDC3CtFSQM3eUDFuk/OyA4uqI9eGI/rzjryvp0qGPU9Y02zWbIF4cJxqiMDp
+hsZ2HHNTq59HAUpoRJkeFe9WthorPSipPrVkz4+Q1+gacFJyLNkupHjZTUUSmNGi
+AxbUWusiOfVLOUHfAnfdYg0bccGNCrfZole2ClZ1f2rNzDq1BtuAVTYDiWWk04LP
+sNPR/QfuqycHlcWL5Kg2UKyDF///BWxu+stGSzEU28Nrqpcy9aNlgzna39lDfwFi
+0NwJSgqqRP9CbCTlCZrDWRiqMGA4vAqTSjx9VQIDAQABAoIBAQCT4bRwJmyXX5VA
+n6IGEKE2oFHo2Uxyjlntrz+FsVk2/Tkge/t9t5+PVhW3MtmYatxUb74qAiVdE5DV
+bX4Hq3q314Mw19rimjXQGwt9hFRToonvBwZF9+e8URKDjHW+QBUY1EF0Ay+qp8wJ
+UAHwTU+HlpFiSU0EMr2Glj+Ey05RwJ3QDV+hXES/yzEf7u1sSzJ7x/NCgHoIcQkr
+OayjVF4V/PHeLCV5dfAjUVIPHRsJecoEOyBO5DYAZpuiQnusneJ6phOEIW825Si0
+FIzruX6xtbI7VQSM2qdHhb4/Z7O8k74xxjOsElx+yvt7d30iLYdT7oV/mUMXsU2x
++T7tfl+9AoGBANvcFw4PJcZGCqNvttJE5zl10HeNKXdjdhErfoxj3EpX5hJ6skvG
+zM+5QeGv4mOjM2g60EfDE3F0usRt8CvvlmpIDnm33HHdyQy2ylU2RrY24d2vTrTH
+EHI5hRLUY2UQFDWj23Lxa+YVq2HmB+wXo1CUNawqWxOXgibrl1kxRiJXAoGBAMOg
+6UikmxaKNxQ3xEF1KCT4atn0vJpNPLrHKYn3wDucYMrsIDf44/DqfIzBNY/HN0+8
+reCunr9HXizgNXOUfyH/+K9Lrq8U9hakwiECUpKPKFOVvm7M1+h3btvF+QNVuJbO
+pRbwOfhx3I8PaZ6G+tfZtI7b2KAToZaWAxziTcozAoGAAtWyombFmOncR0EwfUOQ
+K6h+OJxkVXq90fjal9rNw1OgzsowNFPq3h7IX62R4LEA/64Kc3JrdMIJinDUcOyU
+5ufo797UA8/VQMm2kCS0ArNwdBhHjoMmjiJ5ucVtRqdPa2WidbfxKTVMUWXS4lNn
+sqlGi+K76+O/NNtCx06gVd8CgYA2M6kvFVxa/GSSV3kq4bkDtUh1pxdycR/4aCIc
+NeavHX67+nxaxbzyDSYBIa8jbQDoONC8ReV5/d4b9OsaYPRwiSlv+DooDFi6oV+g
+IbKbJMr5ja27qUnRAPZYMhvyTpfcQNkA6AJH0dRYVt7eq2tozsr2Ifd9MrM8s8ed
+Ax6mfQKBgG8WP12WuL24P3yopU1mE3dHc9kRvmfQgQxMs+fLM7pJQtyORC22ylIF
+SMEnNojR3Mu60rCZMKIZ+UeuON4mrkR2D8TyHLQN1HSW9fToIx3F6dlHf86DxFgf
+mULFrGUmmd/ssOkKeOEJXxZEoEswodU6xPecKLDpiTwVE+uF7V1m
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/request.pem
+++ b/spec/fixtures/ssl/request.pem
@@ -6,55 +6,55 @@ Certificate Request:
             Public Key Algorithm: rsaEncryption
                 RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:c2:a5:41:96:ca:af:a4:6e:84:61:33:30:0c:87:
-                    17:ae:a9:35:16:d0:4a:db:c1:23:e0:33:1d:2d:d6:
-                    76:d0:f6:79:d3:69:6e:2c:5a:c0:04:c8:27:e0:75:
-                    86:03:43:61:61:71:33:1a:9f:30:c5:77:78:10:2c:
-                    93:95:dc:4b:b0:14:19:78:63:f0:de:cd:5a:20:fe:
-                    7f:8e:96:60:ab:94:5a:df:26:fb:d2:34:d4:73:7a:
-                    ca:bf:73:bb:e4:60:ac:15:dc:f7:37:40:cb:4c:ad:
-                    d2:4c:f7:5f:ee:dd:b4:c4:cb:91:6d:5d:7d:18:ca:
-                    99:85:4e:bd:55:6f:f4:de:61:d1:ee:45:63:21:22:
-                    00:7e:8b:85:18:35:09:02:f0:61:58:af:e0:cc:21:
-                    0f:cd:c8:10:df:e9:2f:b7:f1:b9:2b:88:da:9a:90:
-                    91:ea:bc:55:cd:d6:42:90:fe:06:9a:0d:c2:44:d1:
-                    7c:0a:86:72:3e:d0:f4:05:62:e6:fa:e0:74:51:2b:
-                    36:3e:c9:98:fa:0a:be:5f:ac:c7:fd:bf:4b:81:de:
-                    f1:b7:c5:43:73:02:66:98:1f:89:60:48:f9:53:a4:
-                    75:c9:68:ab:00:3d:e9:4d:2c:84:9f:a7:a5:71:14:
-                    89:fb:f5:d9:fa:0a:7e:9e:c8:b4:32:65:a1:05:52:
-                    18:39
+                    00:a8:02:d7:77:d2:93:b5:c3:7f:1b:4f:6f:cf:ba:
+                    3b:ab:2c:07:de:7f:ce:ea:8e:21:54:29:39:7a:b7:
+                    53:19:e1:1a:98:52:86:e9:22:ef:b4:30:b7:0a:d1:
+                    52:40:cd:de:50:31:6e:93:f3:b2:03:8b:aa:23:d7:
+                    86:23:fa:f3:8e:bc:af:a7:4a:86:3d:4f:58:d3:6c:
+                    d6:6c:81:78:70:9c:6a:88:c0:e9:86:c6:76:1c:73:
+                    53:ab:9f:47:01:4a:68:44:99:1e:15:ef:56:b6:1a:
+                    2b:3d:28:a9:3e:b5:64:cf:8f:90:d7:e8:1a:70:52:
+                    72:2c:d9:2e:a4:78:d9:4d:45:12:98:d1:a2:03:16:
+                    d4:5a:eb:22:39:f5:4b:39:41:df:02:77:dd:62:0d:
+                    1b:71:c1:8d:0a:b7:d9:a2:57:b6:0a:56:75:7f:6a:
+                    cd:cc:3a:b5:06:db:80:55:36:03:89:65:a4:d3:82:
+                    cf:b0:d3:d1:fd:07:ee:ab:27:07:95:c5:8b:e4:a8:
+                    36:50:ac:83:17:ff:ff:05:6c:6e:fa:cb:46:4b:31:
+                    14:db:c3:6b:aa:97:32:f5:a3:65:83:39:da:df:d9:
+                    43:7f:01:62:d0:dc:09:4a:0a:aa:44:ff:42:6c:24:
+                    e5:09:9a:c3:59:18:aa:30:60:38:bc:0a:93:4a:3c:
+                    7d:55
                 Exponent: 65537 (0x10001)
         Attributes:
             a0:00
     Signature Algorithm: sha256WithRSAEncryption
-         2c:83:d0:c6:69:03:58:68:79:15:b8:ad:5a:ba:d5:c6:05:d1:
-         6a:f0:e3:48:c4:c0:6d:ce:d1:a7:b6:4a:61:b8:56:de:e5:98:
-         a2:32:56:88:cc:a5:2a:7e:8e:22:0c:c5:27:b6:20:78:68:98:
-         00:56:48:5f:54:9c:c4:a5:4c:79:26:72:81:20:c6:c1:ad:80:
-         b8:80:0e:27:0a:ec:ae:57:1d:33:bf:8c:4f:1b:d5:86:d2:8d:
-         32:9a:c5:e2:37:f6:24:86:fa:1d:e0:8e:80:e4:99:e3:27:32:
-         4f:94:4c:b2:4d:28:5e:86:37:02:1c:b6:b3:86:7e:fd:10:63:
-         88:eb:fc:24:60:be:cb:6f:ff:9a:95:5a:1f:fd:de:bb:1e:1e:
-         ab:da:56:36:40:1a:3a:4b:08:79:74:eb:16:b8:b1:f9:5a:92:
-         25:f0:60:78:39:53:86:9e:a7:cc:81:70:17:50:4f:28:fa:d2:
-         b9:69:aa:a2:44:e6:6d:3c:9c:bf:6b:d2:00:fd:56:f9:3b:f0:
-         8e:83:12:2a:bc:c9:12:13:1c:81:f8:03:03:05:9a:24:6d:e0:
-         cc:b7:20:9e:d2:01:21:24:4d:71:09:f6:5e:28:9e:11:6b:21:
-         78:ea:01:2d:f0:27:f4:ce:f4:7d:43:cc:91:49:78:d1:37:e4:
-         48:74:32:ef
+         7f:17:53:8b:56:b0:49:60:90:10:48:a0:76:88:39:65:6a:33:
+         90:42:6b:1d:51:b1:8d:df:67:c0:02:ae:03:16:19:8b:dc:f5:
+         e4:ef:99:a6:a7:97:cc:3c:cc:e0:ce:dd:14:a1:b7:f7:a5:a0:
+         04:67:e0:63:b7:4a:8f:5b:c7:d9:ef:b8:4a:a0:77:ad:52:de:
+         cf:05:c4:f5:29:5c:e1:7e:3c:f1:a5:6f:da:56:66:50:45:2e:
+         49:d7:23:71:2a:4c:0a:9f:b3:6f:b8:ad:77:ad:08:e9:be:3c:
+         14:8d:5e:48:44:40:b4:0f:00:1d:7d:ed:60:2d:fa:f5:c7:e8:
+         5e:d0:8b:3d:da:0c:11:bc:bd:5f:37:93:7b:0a:20:03:0d:ce:
+         e3:2c:c7:de:67:ae:07:d8:48:67:69:ad:1a:6e:03:31:23:f2:
+         ca:05:d9:45:e9:8c:ce:e2:f7:e5:7d:da:50:0a:50:31:0b:3e:
+         85:e7:11:6a:c4:00:8f:ea:c2:74:06:2b:c3:58:61:5a:8c:54:
+         b4:7a:70:3d:a0:50:5a:35:79:35:32:0f:a6:90:4c:1a:74:ac:
+         a7:f1:44:2a:29:06:68:c9:47:90:73:d6:1d:bc:7a:d8:48:39:
+         25:8b:2e:a0:3a:32:ca:6f:b0:08:5c:2d:cb:54:2a:5c:39:94:
+         45:01:95:3a
 -----BEGIN CERTIFICATE REQUEST-----
 MIICVzCCAT8CAQIwEjEQMA4GA1UEAwwHcGVuZGluZzCCASIwDQYJKoZIhvcNAQEB
-BQADggEPADCCAQoCggEBAMKlQZbKr6RuhGEzMAyHF66pNRbQStvBI+AzHS3WdtD2
-edNpbixawATIJ+B1hgNDYWFxMxqfMMV3eBAsk5XcS7AUGXhj8N7NWiD+f46WYKuU
-Wt8m+9I01HN6yr9zu+RgrBXc9zdAy0yt0kz3X+7dtMTLkW1dfRjKmYVOvVVv9N5h
-0e5FYyEiAH6LhRg1CQLwYViv4MwhD83IEN/pL7fxuSuI2pqQkeq8Vc3WQpD+BpoN
-wkTRfAqGcj7Q9AVi5vrgdFErNj7JmPoKvl+sx/2/S4He8bfFQ3MCZpgfiWBI+VOk
-dcloqwA96U0shJ+npXEUifv12foKfp7ItDJloQVSGDkCAwEAAaAAMA0GCSqGSIb3
-DQEBCwUAA4IBAQAsg9DGaQNYaHkVuK1autXGBdFq8ONIxMBtztGntkphuFbe5Zii
-MlaIzKUqfo4iDMUntiB4aJgAVkhfVJzEpUx5JnKBIMbBrYC4gA4nCuyuVx0zv4xP
-G9WG0o0ymsXiN/Ykhvod4I6A5JnjJzJPlEyyTShehjcCHLazhn79EGOI6/wkYL7L
-b/+alVof/d67Hh6r2lY2QBo6Swh5dOsWuLH5WpIl8GB4OVOGnqfMgXAXUE8o+tK5
-aaqiROZtPJy/a9IA/Vb5O/COgxIqvMkSExyB+AMDBZokbeDMtyCe0gEhJE1xCfZe
-KJ4RayF46gEt8Cf0zvR9Q8yRSXjRN+RIdDLv
+BQADggEPADCCAQoCggEBAKgC13fSk7XDfxtPb8+6O6ssB95/zuqOIVQpOXq3Uxnh
+GphShuki77QwtwrRUkDN3lAxbpPzsgOLqiPXhiP68468r6dKhj1PWNNs1myBeHCc
+aojA6YbGdhxzU6ufRwFKaESZHhXvVrYaKz0oqT61ZM+PkNfoGnBScizZLqR42U1F
+EpjRogMW1FrrIjn1SzlB3wJ33WING3HBjQq32aJXtgpWdX9qzcw6tQbbgFU2A4ll
+pNOCz7DT0f0H7qsnB5XFi+SoNlCsgxf//wVsbvrLRksxFNvDa6qXMvWjZYM52t/Z
+Q38BYtDcCUoKqkT/Qmwk5Qmaw1kYqjBgOLwKk0o8fVUCAwEAAaAAMA0GCSqGSIb3
+DQEBCwUAA4IBAQB/F1OLVrBJYJAQSKB2iDllajOQQmsdUbGN32fAAq4DFhmL3PXk
+75mmp5fMPMzgzt0Uobf3paAEZ+Bjt0qPW8fZ77hKoHetUt7PBcT1KVzhfjzxpW/a
+VmZQRS5J1yNxKkwKn7NvuK13rQjpvjwUjV5IREC0DwAdfe1gLfr1x+he0Is92gwR
+vL1fN5N7CiADDc7jLMfeZ64H2Ehnaa0abgMxI/LKBdlF6YzO4vflfdpQClAxCz6F
+5xFqxACP6sJ0BivDWGFajFS0enA9oFBaNXk1Mg+mkEwadKyn8UQqKQZoyUeQc9Yd
+vHrYSDkliy6gOjLKb7AIXC3LVCpcOZRFAZU6
 -----END CERTIFICATE REQUEST-----

--- a/spec/fixtures/ssl/revoked-key.pem
+++ b/spec/fixtures/ssl/revoked-key.pem
@@ -1,117 +1,117 @@
 RSA Private-Key: (2048 bit, 2 primes)
 modulus:
-    00:d6:7b:d8:19:56:82:ff:86:58:15:2b:40:db:c9:
-    88:55:c4:af:51:81:f9:89:e4:8b:fa:93:42:98:63:
-    74:9c:ed:71:4a:16:1c:ef:95:2e:89:dc:28:83:91:
-    d1:f7:31:66:a8:9c:7d:7b:0c:dc:62:9f:97:84:13:
-    a7:35:ab:c3:8f:41:4b:d1:0c:13:fe:f4:17:83:ae:
-    00:28:6c:c6:d9:46:1c:4f:8d:ba:40:ab:52:8a:bc:
-    47:53:41:9d:ea:4d:eb:eb:3f:c7:de:bc:3c:d8:16:
-    35:0d:16:da:45:c2:50:90:12:6a:4e:f3:f2:ff:c7:
-    b2:24:5e:18:ca:3d:ca:a2:be:e3:24:89:f9:58:70:
-    d5:d1:a7:d1:01:78:20:6a:15:ab:96:75:2c:7e:f1:
-    72:1b:3c:56:53:4e:11:d7:93:5e:44:31:59:ce:4c:
-    8a:f6:cd:61:30:16:e1:50:18:25:3c:f9:22:a9:7c:
-    fb:38:78:f1:b9:0a:45:68:9c:f7:2f:c7:f8:d6:36:
-    6c:00:34:24:f7:69:0d:38:d1:03:e9:48:79:79:01:
-    ba:63:74:f0:9e:f6:b9:74:78:b3:94:48:61:9e:26:
-    22:02:9e:f7:88:78:08:13:7e:71:75:39:b1:2d:e5:
-    6a:ed:06:e3:10:36:c0:c2:8b:3e:dd:07:4a:c5:51:
-    96:1b
+    00:dd:c1:e0:87:23:e8:91:3c:90:ab:fe:9c:ac:69:
+    08:e1:7d:ba:10:ac:b7:7d:eb:47:ae:25:ff:6d:ab:
+    f4:d2:47:2f:bd:16:c9:21:09:e2:1e:e1:9a:aa:24:
+    0c:7a:8e:f9:bf:72:56:0d:b7:f8:0e:b6:5b:01:d1:
+    96:3d:e4:41:d9:71:57:d3:34:d9:85:c2:86:ef:29:
+    54:7d:f7:6a:3a:90:9c:00:f4:4e:77:2e:e1:32:2f:
+    c5:14:8e:ab:db:ec:36:ec:b1:aa:12:b6:27:76:e3:
+    df:88:08:40:e5:4e:6b:fa:20:dd:28:68:21:50:fd:
+    1c:a0:10:53:39:21:96:81:88:cd:4b:9a:e6:b1:d1:
+    3c:29:30:0e:ed:d8:e7:c6:29:c7:72:2c:f8:51:fe:
+    ce:1f:72:65:0d:03:a3:ab:5e:ba:90:3f:09:f7:df:
+    f5:37:e4:4d:d6:4d:2d:28:6a:d5:e2:c6:9d:7b:41:
+    f8:b7:5f:44:3e:27:61:ad:ac:9d:60:5b:02:b2:ff:
+    76:6b:83:75:e6:64:8d:ee:3e:68:17:0e:b9:18:c6:
+    47:e0:ca:77:9a:e2:6e:6e:71:64:7f:a2:fa:fb:33:
+    74:42:8f:8d:c1:43:69:4d:6e:a3:96:57:26:54:7d:
+    52:45:d8:6b:7e:5d:4a:20:f1:89:a5:70:a7:3c:2e:
+    98:25
 publicExponent: 65537 (0x10001)
 privateExponent:
-    00:84:6a:cf:3e:cd:6f:70:ec:73:43:16:82:23:6f:
-    67:f1:73:cd:bd:67:9e:35:28:d9:d6:e8:c5:ab:a9:
-    73:5c:53:27:a7:52:c1:a8:94:94:b7:de:29:51:19:
-    5c:e4:dd:26:01:21:24:43:2c:ec:7f:23:02:7b:33:
-    5a:ff:42:bd:28:9b:6a:80:74:91:7f:cd:19:1b:5d:
-    f8:90:fc:9f:43:93:0a:75:7f:0d:a7:51:5e:53:72:
-    ec:22:15:97:b6:09:47:86:e4:c8:b3:d5:c9:46:ab:
-    67:33:5e:91:81:91:f7:05:0b:a9:80:77:11:e6:22:
-    56:f4:26:f7:ed:1c:7b:17:3f:db:22:a3:b6:1f:28:
-    4e:e6:2f:c6:6c:22:b5:4d:48:61:00:30:c5:ff:ce:
-    ea:2c:02:96:c9:5b:9e:f3:98:bf:14:95:19:f7:2e:
-    de:92:7c:6c:47:0e:4f:cf:4b:a9:42:4c:4e:b1:22:
-    13:bd:99:19:6b:75:07:a2:72:de:1d:96:92:62:d1:
-    00:f4:4c:f7:3b:90:0f:1a:cf:e1:50:ad:a2:50:8b:
-    63:9b:95:78:5f:36:02:a4:c2:19:41:07:23:a8:8a:
-    23:53:6d:52:54:b8:13:38:bb:de:12:e9:39:50:00:
-    4b:d3:2d:61:b3:9e:80:f4:1f:9d:59:82:f8:43:6b:
-    83:89
+    12:cb:05:6e:2e:7a:dd:24:16:d6:9c:a3:46:71:38:
+    51:73:c8:3a:f5:88:2f:61:ab:17:75:1c:ea:7c:72:
+    29:07:e3:61:d0:f6:86:98:41:d3:80:27:0d:58:34:
+    be:86:33:60:28:1e:66:d7:3a:6c:74:c3:cd:a9:a7:
+    63:e3:5e:39:41:43:c2:20:6e:76:c9:7f:89:f1:24:
+    b9:f0:27:ce:82:c6:d5:c5:de:88:77:2e:9a:84:35:
+    dd:82:21:ca:67:80:58:1a:ce:60:fb:92:e8:9e:73:
+    29:22:19:ed:d4:f1:8d:a7:0f:57:07:4c:1b:82:f7:
+    d4:10:ce:1c:bf:5d:f3:e8:2d:a5:72:95:c5:58:d1:
+    2c:70:2a:bc:84:4c:3c:29:19:6d:ac:5d:a4:10:99:
+    af:b2:ef:db:79:dd:76:80:ac:46:fb:48:57:ad:7e:
+    a3:ab:a7:81:03:3f:d3:ba:e4:17:78:ba:f3:dd:5c:
+    41:8f:4f:4d:9b:8d:eb:1d:5d:1a:61:a5:f5:31:62:
+    3e:f3:f3:f9:3b:2f:ee:1c:31:8b:f0:af:8b:1d:27:
+    b2:ed:71:3b:32:cc:09:b2:12:7f:a3:4c:ff:d8:8d:
+    47:54:47:af:fc:3d:4a:62:cf:fe:4c:2b:ff:1e:22:
+    5d:1c:50:a7:a8:b1:c3:58:1e:6e:90:5c:c8:e6:75:
+    81
 prime1:
-    00:f2:48:d3:f1:ef:bc:6b:57:fa:ce:ab:28:32:b8:
-    52:2b:4b:c1:ef:3a:54:85:ea:74:86:08:de:e7:54:
-    ae:04:ff:18:72:65:6e:03:94:8b:f4:61:11:ee:b0:
-    ec:16:75:4c:b6:cc:24:e3:d8:f1:54:2e:00:f8:7f:
-    93:b9:4e:7a:3a:38:e3:b5:d1:5a:f5:1d:fe:11:b0:
-    0a:1e:f6:f8:1d:38:e6:1a:4e:e2:cc:c3:da:c4:32:
-    c8:c3:4c:3a:d3:7d:93:36:19:23:f9:f3:81:78:02:
-    ec:6c:a7:44:f3:9a:7f:6c:cc:bb:06:cb:63:ad:40:
-    99:9b:02:e7:6d:c3:b4:ee:b7
+    00:f6:70:7b:5d:e7:a9:74:f9:b5:e1:fc:2b:ab:81:
+    3e:24:25:9a:8f:92:8f:63:ae:bd:10:41:a2:40:4b:
+    f5:9f:b6:97:74:48:b0:d1:d7:68:4c:9f:d0:a0:97:
+    35:e4:76:38:03:28:0b:db:de:68:2b:fd:12:0b:4e:
+    b5:34:81:d6:18:73:4f:e5:b3:11:67:ec:b2:24:b7:
+    34:60:d0:d2:96:05:d3:f0:d2:dc:3b:49:d8:a5:83:
+    98:0f:cd:04:ad:68:c3:60:7a:69:b7:97:22:32:3e:
+    af:f9:25:c6:9d:8f:44:1e:e2:14:12:81:56:f0:10:
+    eb:9d:db:d8:93:71:c9:d3:f1
 prime2:
-    00:e2:a0:21:41:67:62:d0:b1:46:20:7f:b8:dd:de:
-    d3:c0:ec:f7:44:53:4a:d7:6e:8f:45:11:ec:ac:a5:
-    34:07:2a:ea:27:f0:0f:9f:49:07:8f:1e:0d:b1:4f:
-    4f:07:c3:74:c3:17:e2:3b:32:fb:56:6c:57:3f:dd:
-    fd:fe:b3:89:1a:fc:ca:39:ae:e0:9a:ee:89:2d:6f:
-    d1:12:e3:e8:4f:c2:77:74:a1:e9:38:4e:99:ef:fc:
-    d3:2f:ca:b9:41:51:8a:5c:a1:b8:8d:f8:d0:86:54:
-    1c:85:0f:e9:f8:6d:c9:50:f8:4e:d0:e1:4d:f8:43:
-    fa:ad:ae:fc:02:58:a4:6f:bd
+    00:e6:5c:43:cc:a4:3d:6a:f1:19:0c:bd:5c:13:c7:
+    4d:48:17:7b:7c:8c:42:cf:2f:81:15:13:34:ba:1a:
+    43:d3:6c:10:e4:5d:e2:3d:98:9c:ad:33:68:df:f3:
+    42:69:10:84:88:f7:78:d9:82:6c:39:1f:4d:c6:e6:
+    24:d8:e3:00:6d:aa:be:6e:df:6e:53:0f:66:36:44:
+    c4:e7:a6:01:58:a4:a9:03:ce:8b:dd:b4:52:2f:96:
+    f4:6c:ad:ed:17:ae:c2:70:86:b7:59:e2:c8:03:38:
+    68:74:5e:1e:ab:d5:71:2e:72:4d:11:ea:10:84:d5:
+    c4:63:22:fa:49:04:0b:6b:75
 exponent1:
-    00:9e:1f:d1:d3:90:77:14:47:b3:34:b6:97:e1:a2:
-    52:5e:57:6f:16:c6:a6:eb:4f:7d:05:0d:3d:0d:15:
-    43:0d:97:bf:48:c9:d1:e7:1c:47:cb:12:9f:35:7c:
-    da:58:3d:ed:f7:4f:7c:b4:07:9e:59:26:3d:13:f1:
-    8f:63:dd:48:00:3f:a8:bd:bd:08:f3:f8:c3:1c:a0:
-    1b:ba:e1:cc:44:a6:21:e7:01:9d:1b:ae:a7:54:6d:
-    20:81:f5:7a:5f:15:11:c2:b8:dd:b5:ff:aa:7b:bc:
-    cc:b8:8c:e2:7f:6a:51:c7:9c:46:63:c4:d2:24:fc:
-    88:43:96:bd:9b:f1:a2:60:39
+    00:d1:3a:34:73:48:90:e5:80:70:7c:59:d5:55:b9:
+    d7:e1:66:8f:af:df:75:9f:e3:26:1f:5c:29:fd:be:
+    bf:de:06:6e:d5:ca:35:5d:23:2e:29:07:f2:5f:b5:
+    a1:8a:c3:17:d1:0e:39:eb:45:0b:5a:75:74:d1:66:
+    d4:8f:ac:bf:f1:68:4d:68:2e:3c:d3:e7:f0:63:1d:
+    ab:f9:9a:b1:7f:af:98:fe:38:77:c4:5a:70:f6:2d:
+    20:78:21:cf:1b:ce:fb:39:b9:14:72:4b:7d:3b:fd:
+    5e:f7:ff:ab:7d:ef:b9:9d:22:c2:79:e7:97:c1:20:
+    0c:7a:ac:c1:56:85:60:1e:71
 exponent2:
-    0b:92:e7:ff:e2:1a:ce:d3:ae:e4:2c:01:b1:fb:16:
-    4f:6d:0a:b7:c7:95:33:e9:66:91:bd:77:9b:dd:98:
-    09:a1:ac:71:bb:b5:e0:89:a7:44:2c:e1:c0:23:6f:
-    c2:d2:bd:9c:d5:14:6d:b7:8d:d4:7d:15:fb:a2:07:
-    bd:c1:47:88:44:4e:c3:a1:65:c1:23:db:87:a1:85:
-    48:f4:b0:c1:9a:09:e5:bf:fb:1c:30:0f:76:8d:2f:
-    ef:e9:e7:8a:29:72:ea:86:2b:d9:bc:52:51:f9:eb:
-    b6:f3:f8:1c:02:e7:5c:26:42:48:32:a9:7b:bb:65:
-    0b:07:bb:c1:16:eb:d6:f5
+    32:fb:28:66:19:d3:1d:df:cd:d3:6b:f4:fc:cb:96:
+    e6:e5:8b:86:bc:e3:ec:46:6f:22:e2:e5:40:6a:9f:
+    a8:22:ba:7a:4f:ec:ca:05:04:67:b0:80:fd:4f:30:
+    db:5f:b4:75:3b:8f:9b:53:a9:ef:da:65:b4:27:2a:
+    f0:75:0c:9b:38:b6:7c:83:26:3f:6b:a1:0b:51:9c:
+    e2:47:72:f4:d3:3c:34:83:79:a0:cf:4f:81:08:bf:
+    7f:6d:de:92:e7:32:51:04:ff:7e:fd:19:96:dc:dd:
+    01:23:f3:55:c4:1f:10:50:6b:8e:13:67:24:7e:ca:
+    bf:c5:f5:ee:42:de:e4:21
 coefficient:
-    60:07:2c:02:1e:90:75:6a:7c:c1:75:62:d0:76:dc:
-    02:31:69:ed:2a:74:14:a2:c8:c0:18:85:8c:48:16:
-    c5:ed:75:14:dd:f1:2d:ac:aa:37:16:b9:f8:21:07:
-    27:75:ee:ab:a3:de:d4:fd:76:ea:a9:ee:5f:4c:9e:
-    6c:e2:ee:50:7e:18:cd:d3:39:48:f6:ae:88:6c:a4:
-    ab:cc:4b:28:90:60:43:d0:1a:bc:8c:62:a5:d8:f5:
-    37:ac:a5:51:2b:e8:9a:d2:ce:89:15:65:2c:54:23:
-    9a:40:6d:fe:9c:4d:c8:bc:2a:1f:1b:2d:fc:b5:b5:
-    a0:af:ec:16:ab:5f:47:7e
+    7c:cc:19:27:a1:44:22:5b:0f:07:53:6c:2f:e0:b6:
+    8b:a6:24:d0:42:57:b0:c9:5f:dd:0d:f9:3a:9d:34:
+    60:f2:a2:83:20:2f:fa:73:58:df:1c:3d:92:43:47:
+    f3:fb:cc:53:10:1f:be:76:3f:cb:e8:09:52:7a:1c:
+    46:fc:02:5f:64:6f:76:6d:f5:c8:cf:64:15:48:d2:
+    d3:e9:e6:ba:c2:f6:01:60:fc:79:b8:cc:4b:d5:2e:
+    0b:49:f0:29:52:27:f2:78:b1:79:07:a5:2a:b8:78:
+    a1:6a:5d:a3:6d:79:a7:ab:a5:5f:07:d8:02:49:79:
+    d8:ee:73:16:d2:f3:1c:7c
 -----BEGIN RSA PRIVATE KEY-----
-MIIEpAIBAAKCAQEA1nvYGVaC/4ZYFStA28mIVcSvUYH5ieSL+pNCmGN0nO1xShYc
-75Uuidwog5HR9zFmqJx9ewzcYp+XhBOnNavDj0FL0QwT/vQXg64AKGzG2UYcT426
-QKtSirxHU0Gd6k3r6z/H3rw82BY1DRbaRcJQkBJqTvPy/8eyJF4Yyj3Kor7jJIn5
-WHDV0afRAXggahWrlnUsfvFyGzxWU04R15NeRDFZzkyK9s1hMBbhUBglPPkiqXz7
-OHjxuQpFaJz3L8f41jZsADQk92kNONED6Uh5eQG6Y3Twnva5dHizlEhhniYiAp73
-iHgIE35xdTmxLeVq7QbjEDbAwos+3QdKxVGWGwIDAQABAoIBAQCEas8+zW9w7HND
-FoIjb2fxc829Z541KNnW6MWrqXNcUyenUsGolJS33ilRGVzk3SYBISRDLOx/IwJ7
-M1r/Qr0om2qAdJF/zRkbXfiQ/J9Dkwp1fw2nUV5TcuwiFZe2CUeG5Miz1clGq2cz
-XpGBkfcFC6mAdxHmIlb0JvftHHsXP9sio7YfKE7mL8ZsIrVNSGEAMMX/zuosApbJ
-W57zmL8UlRn3Lt6SfGxHDk/PS6lCTE6xIhO9mRlrdQeict4dlpJi0QD0TPc7kA8a
-z+FQraJQi2OblXhfNgKkwhlBByOoiiNTbVJUuBM4u94S6TlQAEvTLWGznoD0H51Z
-gvhDa4OJAoGBAPJI0/HvvGtX+s6rKDK4UitLwe86VIXqdIYI3udUrgT/GHJlbgOU
-i/RhEe6w7BZ1TLbMJOPY8VQuAPh/k7lOejo447XRWvUd/hGwCh72+B045hpO4szD
-2sQyyMNMOtN9kzYZI/nzgXgC7GynRPOaf2zMuwbLY61AmZsC523DtO63AoGBAOKg
-IUFnYtCxRiB/uN3e08Ds90RTStduj0UR7KylNAcq6ifwD59JB48eDbFPTwfDdMMX
-4jsy+1ZsVz/d/f6ziRr8yjmu4JruiS1v0RLj6E/Cd3Sh6ThOme/80y/KuUFRilyh
-uI340IZUHIUP6fhtyVD4TtDhTfhD+q2u/AJYpG+9AoGBAJ4f0dOQdxRHszS2l+Gi
-Ul5XbxbGputPfQUNPQ0VQw2Xv0jJ0eccR8sSnzV82lg97fdPfLQHnlkmPRPxj2Pd
-SAA/qL29CPP4wxygG7rhzESmIecBnRuup1RtIIH1el8VEcK43bX/qnu8zLiM4n9q
-UcecRmPE0iT8iEOWvZvxomA5AoGAC5Ln/+IaztOu5CwBsfsWT20Kt8eVM+lmkb13
-m92YCaGscbu14ImnRCzhwCNvwtK9nNUUbbeN1H0V+6IHvcFHiEROw6FlwSPbh6GF
-SPSwwZoJ5b/7HDAPdo0v7+nniily6oYr2bxSUfnrtvP4HALnXCZCSDKpe7tlCwe7
-wRbr1vUCgYBgBywCHpB1anzBdWLQdtwCMWntKnQUosjAGIWMSBbF7XUU3fEtrKo3
-Frn4IQcnde6ro97U/Xbqqe5fTJ5s4u5QfhjN0zlI9q6IbKSrzEsokGBD0Bq8jGKl
-2PU3rKVRK+ia0s6JFWUsVCOaQG3+nE3IvCofGy38tbWgr+wWq19Hfg==
+MIIEowIBAAKCAQEA3cHghyPokTyQq/6crGkI4X26EKy3fetHriX/bav00kcvvRbJ
+IQniHuGaqiQMeo75v3JWDbf4DrZbAdGWPeRB2XFX0zTZhcKG7ylUffdqOpCcAPRO
+dy7hMi/FFI6r2+w27LGqErYnduPfiAhA5U5r+iDdKGghUP0coBBTOSGWgYjNS5rm
+sdE8KTAO7djnxinHciz4Uf7OH3JlDQOjq166kD8J99/1N+RN1k0tKGrV4sade0H4
+t19EPidhraydYFsCsv92a4N15mSN7j5oFw65GMZH4Mp3muJubnFkf6L6+zN0Qo+N
+wUNpTW6jllcmVH1SRdhrfl1KIPGJpXCnPC6YJQIDAQABAoIBABLLBW4uet0kFtac
+o0ZxOFFzyDr1iC9hqxd1HOp8cikH42HQ9oaYQdOAJw1YNL6GM2AoHmbXOmx0w82p
+p2PjXjlBQ8IgbnbJf4nxJLnwJ86CxtXF3oh3LpqENd2CIcpngFgazmD7kuiecyki
+Ge3U8Y2nD1cHTBuC99QQzhy/XfPoLaVylcVY0SxwKryETDwpGW2sXaQQma+y79t5
+3XaArEb7SFetfqOrp4EDP9O65Bd4uvPdXEGPT02bjesdXRphpfUxYj7z8/k7L+4c
+MYvwr4sdJ7LtcTsyzAmyEn+jTP/YjUdUR6/8PUpiz/5MK/8eIl0cUKeoscNYHm6Q
+XMjmdYECgYEA9nB7XeepdPm14fwrq4E+JCWaj5KPY669EEGiQEv1n7aXdEiw0ddo
+TJ/QoJc15HY4AygL295oK/0SC061NIHWGHNP5bMRZ+yyJLc0YNDSlgXT8NLcO0nY
+pYOYD80ErWjDYHppt5ciMj6v+SXGnY9EHuIUEoFW8BDrndvYk3HJ0/ECgYEA5lxD
+zKQ9avEZDL1cE8dNSBd7fIxCzy+BFRM0uhpD02wQ5F3iPZicrTNo3/NCaRCEiPd4
+2YJsOR9NxuYk2OMAbaq+bt9uUw9mNkTE56YBWKSpA86L3bRSL5b0bK3tF67CcIa3
+WeLIAzhodF4eq9VxLnJNEeoQhNXEYyL6SQQLa3UCgYEA0To0c0iQ5YBwfFnVVbnX
+4WaPr991n+MmH1wp/b6/3gZu1co1XSMuKQfyX7WhisMX0Q4560ULWnV00WbUj6y/
+8WhNaC480+fwYx2r+Zqxf6+Y/jh3xFpw9i0geCHPG877ObkUckt9O/1e9/+rfe+5
+nSLCeeeXwSAMeqzBVoVgHnECgYAy+yhmGdMd383Ta/T8y5bm5YuGvOPsRm8i4uVA
+ap+oIrp6T+zKBQRnsID9TzDbX7R1O4+bU6nv2mW0JyrwdQybOLZ8gyY/a6ELUZzi
+R3L00zw0g3mgz0+BCL9/bd6S5zJRBP9+/RmW3N0BI/NVxB8QUGuOE2ckfsq/xfXu
+Qt7kIQKBgHzMGSehRCJbDwdTbC/gtoumJNBCV7DJX90N+TqdNGDyooMgL/pzWN8c
+PZJDR/P7zFMQH752P8voCVJ6HEb8Al9kb3Zt9cjPZBVI0tPp5rrC9gFg/Hm4zEvV
+LgtJ8ClSJ/J4sXkHpSq4eKFqXaNteaerpV8H2AJJedjucxbS8xx8
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/revoked.pem
+++ b/spec/fixtures/ssl/revoked.pem
@@ -1,66 +1,66 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 6 (0x6)
+        Serial Number: 7 (0x7)
         Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA Subauthority
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Apr 18 18:46:23 2031 GMT
+            Not After : Jun 15 01:19:37 2031 GMT
         Subject: CN=revoked
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:d6:7b:d8:19:56:82:ff:86:58:15:2b:40:db:c9:
-                    88:55:c4:af:51:81:f9:89:e4:8b:fa:93:42:98:63:
-                    74:9c:ed:71:4a:16:1c:ef:95:2e:89:dc:28:83:91:
-                    d1:f7:31:66:a8:9c:7d:7b:0c:dc:62:9f:97:84:13:
-                    a7:35:ab:c3:8f:41:4b:d1:0c:13:fe:f4:17:83:ae:
-                    00:28:6c:c6:d9:46:1c:4f:8d:ba:40:ab:52:8a:bc:
-                    47:53:41:9d:ea:4d:eb:eb:3f:c7:de:bc:3c:d8:16:
-                    35:0d:16:da:45:c2:50:90:12:6a:4e:f3:f2:ff:c7:
-                    b2:24:5e:18:ca:3d:ca:a2:be:e3:24:89:f9:58:70:
-                    d5:d1:a7:d1:01:78:20:6a:15:ab:96:75:2c:7e:f1:
-                    72:1b:3c:56:53:4e:11:d7:93:5e:44:31:59:ce:4c:
-                    8a:f6:cd:61:30:16:e1:50:18:25:3c:f9:22:a9:7c:
-                    fb:38:78:f1:b9:0a:45:68:9c:f7:2f:c7:f8:d6:36:
-                    6c:00:34:24:f7:69:0d:38:d1:03:e9:48:79:79:01:
-                    ba:63:74:f0:9e:f6:b9:74:78:b3:94:48:61:9e:26:
-                    22:02:9e:f7:88:78:08:13:7e:71:75:39:b1:2d:e5:
-                    6a:ed:06:e3:10:36:c0:c2:8b:3e:dd:07:4a:c5:51:
-                    96:1b
+                    00:dd:c1:e0:87:23:e8:91:3c:90:ab:fe:9c:ac:69:
+                    08:e1:7d:ba:10:ac:b7:7d:eb:47:ae:25:ff:6d:ab:
+                    f4:d2:47:2f:bd:16:c9:21:09:e2:1e:e1:9a:aa:24:
+                    0c:7a:8e:f9:bf:72:56:0d:b7:f8:0e:b6:5b:01:d1:
+                    96:3d:e4:41:d9:71:57:d3:34:d9:85:c2:86:ef:29:
+                    54:7d:f7:6a:3a:90:9c:00:f4:4e:77:2e:e1:32:2f:
+                    c5:14:8e:ab:db:ec:36:ec:b1:aa:12:b6:27:76:e3:
+                    df:88:08:40:e5:4e:6b:fa:20:dd:28:68:21:50:fd:
+                    1c:a0:10:53:39:21:96:81:88:cd:4b:9a:e6:b1:d1:
+                    3c:29:30:0e:ed:d8:e7:c6:29:c7:72:2c:f8:51:fe:
+                    ce:1f:72:65:0d:03:a3:ab:5e:ba:90:3f:09:f7:df:
+                    f5:37:e4:4d:d6:4d:2d:28:6a:d5:e2:c6:9d:7b:41:
+                    f8:b7:5f:44:3e:27:61:ad:ac:9d:60:5b:02:b2:ff:
+                    76:6b:83:75:e6:64:8d:ee:3e:68:17:0e:b9:18:c6:
+                    47:e0:ca:77:9a:e2:6e:6e:71:64:7f:a2:fa:fb:33:
+                    74:42:8f:8d:c1:43:69:4d:6e:a3:96:57:26:54:7d:
+                    52:45:d8:6b:7e:5d:4a:20:f1:89:a5:70:a7:3c:2e:
+                    98:25
                 Exponent: 65537 (0x10001)
     Signature Algorithm: sha256WithRSAEncryption
-         8c:38:83:61:c1:4c:2f:c0:8a:fd:0b:4b:8e:fc:fd:28:cd:5d:
-         45:45:73:bb:c0:82:d1:41:4b:8c:c2:ae:62:91:dc:42:50:6b:
-         bb:b0:27:4c:90:f3:91:c2:1a:46:bb:31:3c:de:e5:cc:3c:da:
-         94:6c:40:86:7f:38:36:e5:a0:22:77:fc:9a:06:e7:b5:cc:35:
-         70:ff:06:4e:20:38:98:9d:03:85:73:26:35:3a:7e:9d:13:89:
-         94:52:10:8a:c0:c4:c0:f3:56:8e:47:88:f5:1e:c8:fc:68:e6:
-         70:28:b9:0d:5b:f3:6d:3c:b4:94:2f:38:40:61:77:33:c6:f2:
-         25:7d:6b:d4:0c:75:05:15:89:ed:d4:1f:55:10:80:0a:b9:71:
-         20:f3:73:84:d1:a4:3c:21:1c:64:b9:cf:bd:e1:21:24:dc:cf:
-         2d:7e:d8:08:d5:1e:d6:6c:7d:bb:8f:66:5d:2b:29:a8:41:52:
-         e4:30:3f:43:22:a4:06:94:f5:2d:3b:3b:e5:9b:f1:24:dc:5e:
-         ad:ed:fe:cc:ec:f5:99:de:4a:f2:13:de:c7:94:29:18:e4:21:
-         5e:f5:21:ec:0c:dd:2f:1f:5c:c5:9c:f9:c3:72:8b:cd:63:b1:
-         e3:2c:f3:04:db:73:43:ed:6e:59:f1:86:8b:f3:90:63:74:cf:
-         74:80:8a:32
+         45:2e:85:90:41:98:ce:10:47:80:a0:94:f7:54:cc:d0:92:03:
+         77:6d:e8:e4:0c:da:8c:a1:50:c4:7a:02:24:5f:96:aa:5b:e5:
+         8e:1f:a1:e6:31:8f:eb:d9:98:c0:a3:25:93:c0:0d:cd:ea:02:
+         17:65:cf:10:bd:31:34:09:bd:eb:98:09:d4:09:68:94:41:df:
+         69:4f:a8:cc:f5:b2:3a:c8:22:9c:24:2a:24:6f:64:65:c6:85:
+         f3:3b:65:14:b6:14:ca:17:56:9e:71:9f:9c:13:6a:8b:e5:37:
+         15:f1:53:93:89:2f:17:0c:49:d7:76:a5:a9:5d:e3:6f:09:b2:
+         8d:59:1b:3c:17:7d:e8:29:bc:bf:27:1b:eb:20:7e:38:b0:ce:
+         55:5a:e3:47:08:1e:66:d5:aa:f6:50:10:c9:33:0d:0d:41:79:
+         14:f4:95:2f:81:be:84:37:88:5a:d5:08:3a:a5:e8:79:0b:e3:
+         e0:24:68:b0:b3:5d:95:3e:a5:4c:a9:7a:f5:d1:3c:cb:2b:a0:
+         85:19:b2:6d:8f:11:5f:09:d7:10:51:fb:70:64:b2:79:29:b5:
+         56:21:a0:1d:04:5f:94:02:40:98:b7:43:d9:21:7a:5c:b2:9b:
+         50:37:58:bf:76:e8:d4:c5:13:f4:b2:a3:4b:e7:b6:3f:91:a6:
+         a8:ab:6c:07
 -----BEGIN CERTIFICATE-----
-MIICqjCCAZKgAwIBAgIBBjANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0
-IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zMTA0MTgxODQ2MjNa
+MIICqjCCAZKgAwIBAgIBBzANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0
+IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zMTA2MTUwMTE5Mzda
 MBIxEDAOBgNVBAMMB3Jldm9rZWQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
-AoIBAQDWe9gZVoL/hlgVK0DbyYhVxK9RgfmJ5Iv6k0KYY3Sc7XFKFhzvlS6J3CiD
-kdH3MWaonH17DNxin5eEE6c1q8OPQUvRDBP+9BeDrgAobMbZRhxPjbpAq1KKvEdT
-QZ3qTevrP8fevDzYFjUNFtpFwlCQEmpO8/L/x7IkXhjKPcqivuMkiflYcNXRp9EB
-eCBqFauWdSx+8XIbPFZTThHXk15EMVnOTIr2zWEwFuFQGCU8+SKpfPs4ePG5CkVo
-nPcvx/jWNmwANCT3aQ040QPpSHl5AbpjdPCe9rl0eLOUSGGeJiICnveIeAgTfnF1
-ObEt5WrtBuMQNsDCiz7dB0rFUZYbAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAIw4
-g2HBTC/Aiv0LS478/SjNXUVFc7vAgtFBS4zCrmKR3EJQa7uwJ0yQ85HCGka7MTze
-5cw82pRsQIZ/ODbloCJ3/JoG57XMNXD/Bk4gOJidA4VzJjU6fp0TiZRSEIrAxMDz
-Vo5HiPUeyPxo5nAouQ1b8208tJQvOEBhdzPG8iV9a9QMdQUVie3UH1UQgAq5cSDz
-c4TRpDwhHGS5z73hISTczy1+2AjVHtZsfbuPZl0rKahBUuQwP0MipAaU9S07O+Wb
-8STcXq3t/szs9ZneSvIT3seUKRjkIV71IewM3S8fXMWc+cNyi81jseMs8wTbc0Pt
-blnxhovzkGN0z3SAijI=
+AoIBAQDdweCHI+iRPJCr/pysaQjhfboQrLd960euJf9tq/TSRy+9FskhCeIe4Zqq
+JAx6jvm/clYNt/gOtlsB0ZY95EHZcVfTNNmFwobvKVR992o6kJwA9E53LuEyL8UU
+jqvb7DbssaoStid249+ICEDlTmv6IN0oaCFQ/RygEFM5IZaBiM1Lmuax0TwpMA7t
+2OfGKcdyLPhR/s4fcmUNA6OrXrqQPwn33/U35E3WTS0oatXixp17Qfi3X0Q+J2Gt
+rJ1gWwKy/3Zrg3XmZI3uPmgXDrkYxkfgynea4m5ucWR/ovr7M3RCj43BQ2lNbqOW
+VyZUfVJF2Gt+XUog8YmlcKc8LpglAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAEUu
+hZBBmM4QR4CglPdUzNCSA3dt6OQM2oyhUMR6AiRflqpb5Y4foeYxj+vZmMCjJZPA
+Dc3qAhdlzxC9MTQJveuYCdQJaJRB32lPqMz1sjrIIpwkKiRvZGXGhfM7ZRS2FMoX
+Vp5xn5wTaovlNxXxU5OJLxcMSdd2pald428Jso1ZGzwXfegpvL8nG+sgfjiwzlVa
+40cIHmbVqvZQEMkzDQ1BeRT0lS+BvoQ3iFrVCDql6HkL4+AkaLCzXZU+pUypevXR
+PMsroIUZsm2PEV8J1xBR+3BksnkptVYhoB0EX5QCQJi3Q9khelyym1A3WL926NTF
+E/Syo0vntj+RpqirbAc=
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/signed-key.pem
+++ b/spec/fixtures/ssl/signed-key.pem
@@ -1,117 +1,117 @@
 RSA Private-Key: (2048 bit, 2 primes)
 modulus:
-    00:db:90:d7:cf:fe:81:bc:51:d1:a1:d2:d9:0f:c2:
-    21:16:06:3d:12:87:7c:e9:45:97:28:f4:33:12:51:
-    d2:b3:31:be:13:5d:28:a8:b5:fb:8f:0e:ce:3e:bb:
-    42:7a:3f:ba:35:e9:58:2a:fb:61:38:c0:6b:37:9f:
-    3f:de:b9:64:5b:c3:08:21:64:d7:c2:af:0a:ac:21:
-    0b:ed:c1:8a:71:fe:05:27:eb:4b:31:ba:79:62:e5:
-    41:ef:dd:66:85:76:28:bb:03:08:c7:35:26:85:c2:
-    f8:3b:1f:67:45:39:73:ce:d8:5d:df:4a:0b:4e:8c:
-    85:29:02:98:04:95:e9:d3:f6:d1:9f:6c:25:ce:a3:
-    81:4c:c7:4d:b5:ce:43:12:d9:b2:f1:68:c8:fd:a3:
-    57:16:f5:7a:42:85:fe:19:b5:ee:e8:3f:da:27:85:
-    82:c9:ec:d6:63:bf:cd:4b:75:1e:a0:c5:8f:ce:90:
-    b8:ca:25:ba:45:52:6d:e4:ea:6d:e5:1d:41:8e:4f:
-    33:4a:97:23:8e:c1:98:d4:60:a7:1e:1c:28:31:0d:
-    05:c8:a2:d2:d7:7a:d9:c3:46:26:a1:e7:ef:67:e7:
-    6b:ce:97:8a:37:0b:d7:e2:28:b0:33:85:b0:89:6b:
-    38:83:ae:a3:02:a7:d2:1a:87:f0:88:a6:a3:1a:db:
-    97:53
+    00:94:3b:fc:18:7e:09:d6:93:10:9a:d7:df:84:49:
+    74:7d:9a:0e:91:ff:31:ca:9f:c0:c0:cf:4a:6b:1e:
+    be:77:b0:82:9f:a6:17:fc:f3:99:f1:e5:ed:c4:d3:
+    e1:f4:e8:ee:d2:70:3b:98:b1:21:55:9a:9e:6d:89:
+    f1:82:ba:82:43:00:af:e6:05:7e:0f:a1:50:ff:ec:
+    77:88:28:92:a2:f0:f9:29:1d:cb:86:ca:63:a9:c7:
+    9e:01:99:6e:56:c8:39:f1:c6:33:b9:b4:96:b2:05:
+    5e:e1:f7:1c:55:58:23:ec:bd:bb:4d:a0:54:3c:09:
+    d0:c9:83:27:9b:3c:f5:50:8c:1e:54:22:b3:0a:0f:
+    97:c1:68:d5:07:b7:0d:b9:16:d6:f8:d0:2c:87:25:
+    5e:53:65:31:d5:d6:94:ab:8b:77:29:a2:78:4e:c7:
+    cf:66:f2:79:f2:66:ca:ce:c9:9a:04:a2:0d:47:6f:
+    a0:1c:cc:39:7d:f2:01:73:3d:9c:56:0f:15:f6:06:
+    92:98:19:9b:52:ed:43:f8:84:6c:1f:96:0b:dd:8e:
+    c7:0f:dc:13:08:7b:1a:07:c1:ac:de:ba:dc:ce:1b:
+    a8:c5:c5:d5:c8:6c:32:6a:e2:2c:aa:e2:56:ba:55:
+    b4:3c:2b:7f:87:99:3e:d0:0c:47:ba:6e:60:86:2b:
+    3d:51
 publicExponent: 65537 (0x10001)
 privateExponent:
-    00:9d:74:93:af:8f:1e:4e:84:86:46:fc:43:b9:2f:
-    48:36:d9:26:76:e1:3e:cc:b2:a1:22:37:6d:60:97:
-    d8:f7:b4:96:50:a0:a0:05:cc:eb:a7:bd:c0:5d:f0:
-    40:4e:16:e1:5c:c4:07:fc:5a:e5:6f:a3:5d:c0:37:
-    ad:bf:f5:47:69:1e:c5:f7:dc:af:75:e7:bd:49:8f:
-    31:54:c1:54:9d:46:c3:3f:cb:56:d3:44:9c:c4:35:
-    10:42:09:8d:f9:eb:b0:6d:dc:51:31:3a:86:73:aa:
-    4c:05:6a:11:ce:ec:d2:85:e5:57:fc:46:c7:30:ff:
-    48:87:0e:5b:21:fe:b7:fe:ce:4f:8c:2c:cf:ea:d1:
-    0c:59:83:7e:d4:3f:db:0c:09:8d:8d:af:c5:38:8d:
-    96:44:37:7c:a3:4f:79:09:fe:11:cb:cf:20:40:6c:
-    fd:a3:cc:d9:f2:f4:35:79:63:c3:f8:1c:c1:6e:d4:
-    76:2b:67:84:4d:d3:af:81:72:17:ba:9d:98:0c:58:
-    0a:c8:4d:8f:28:95:2b:fa:d9:31:1d:31:ad:c5:87:
-    90:1b:2c:69:42:22:b1:1b:73:4a:22:82:af:b7:5b:
-    82:b4:38:39:3b:f2:47:ef:3d:7d:09:9b:e8:5b:b5:
-    d8:56:1c:16:e7:3a:6e:7d:85:3f:1c:1d:3f:ee:dd:
-    f1:d1
+    0b:61:af:b1:91:bb:df:a5:db:18:88:8a:b8:f5:8a:
+    e4:39:f7:f4:6d:cb:bc:eb:17:39:b6:b0:d8:18:bc:
+    37:24:6e:63:23:b5:a3:ce:70:7b:8a:53:ff:50:e5:
+    80:90:82:05:d6:68:3d:09:1c:ae:1d:f9:1c:20:03:
+    53:2e:4e:e2:26:23:5b:5e:00:97:e2:a2:fd:83:82:
+    8a:09:d3:78:7f:58:22:38:0f:70:82:09:b4:f7:86:
+    c2:48:ad:98:2c:37:86:c0:d9:27:e1:1d:d0:fd:68:
+    93:a1:0d:a3:df:e8:a2:3c:cf:2c:de:aa:99:11:87:
+    de:71:1b:91:67:d4:ce:22:56:27:a3:7d:4d:58:5c:
+    d3:76:80:54:b6:28:ed:60:e7:ba:ef:da:4a:f5:86:
+    b9:f7:7e:c5:94:5f:87:55:d0:5c:6b:8c:ea:4e:82:
+    ca:3d:bc:23:b5:1c:77:4c:bd:57:98:db:1f:ec:af:
+    0d:70:e0:a0:fa:86:d6:ac:cf:2f:a2:55:24:2e:98:
+    60:b0:f5:cf:60:db:bf:97:b8:e2:c0:1f:03:b5:5c:
+    af:ce:fd:5b:2b:97:cd:d5:eb:95:ef:17:bc:19:69:
+    5a:12:1f:28:24:d2:8e:cd:91:8f:90:7c:54:bf:31:
+    75:bd:66:31:eb:61:20:b1:7f:5f:3b:3a:af:48:8d:
+    81
 prime1:
-    00:f2:0c:fe:99:b5:ed:bb:24:f6:79:61:75:f5:a8:
-    9b:56:f9:f3:ee:5b:84:1c:31:00:5e:01:02:b4:50:
-    ea:fb:a8:13:22:73:c2:12:1b:c2:53:55:14:f3:2e:
-    a3:62:f8:82:04:4c:23:09:50:98:c1:ab:45:18:96:
-    c7:a4:e8:29:84:04:ab:24:37:17:45:0b:b3:02:7f:
-    c3:4a:30:3f:ad:69:49:0b:49:c5:89:e0:07:b7:b3:
-    d7:50:19:85:c0:f1:73:60:b4:76:f8:c2:c5:01:7c:
-    09:23:49:57:2a:cc:d7:e1:d6:d9:b4:6b:54:20:61:
-    7f:3a:70:9b:9d:01:12:fa:e7
+    00:c2:f2:79:65:6e:d5:61:bd:e0:6a:fb:67:89:ba:
+    23:fa:db:e4:fc:0f:58:9e:63:37:c4:ad:d8:80:c6:
+    a6:3f:9b:20:a5:70:48:20:f4:37:f3:36:01:8f:47:
+    ff:00:fe:b6:50:6a:56:f4:08:37:0a:0f:7f:28:42:
+    60:f8:01:a9:53:37:29:9c:24:83:14:1c:c3:56:b9:
+    18:33:5a:44:99:fe:b8:ab:45:26:71:b7:c5:1e:56:
+    a1:49:3c:71:5b:b5:c1:7c:bb:64:68:fe:af:24:3d:
+    60:6a:eb:de:d7:58:1d:bd:ff:56:92:5f:05:e6:8f:
+    57:88:5e:71:08:ce:12:e5:ad
 prime2:
-    00:e8:38:1f:fb:1b:f6:4d:e1:be:f0:80:c1:a1:55:
-    2b:d1:db:09:98:cc:70:eb:99:f0:9e:0b:2c:2d:60:
-    20:96:f7:b3:c5:6b:98:22:c5:bf:c3:20:5e:91:be:
-    d1:81:fc:14:36:70:9b:37:9e:6d:c8:6e:84:f6:fa:
-    65:30:64:0e:b0:50:05:85:a8:07:0b:be:4e:de:c1:
-    17:71:39:03:e3:9e:4e:69:5c:51:02:af:97:b8:30:
-    da:95:2e:24:b4:78:76:46:bc:db:a2:27:66:5a:ce:
-    e5:0f:01:82:fe:cb:31:bc:fe:19:6a:e5:73:b6:a5:
-    ad:3a:f3:61:ec:f7:a9:fe:b5
+    00:c2:a8:65:15:66:07:a2:14:75:17:ab:ed:f4:f5:
+    e6:cc:0b:70:6a:ee:a6:d0:3e:69:37:94:e8:3f:41:
+    02:f1:70:98:f4:5a:0d:0e:75:f5:37:4c:68:7a:cb:
+    1a:f2:57:69:5c:5d:b7:73:ce:95:48:92:1a:8a:2c:
+    33:08:a1:a6:3a:e2:7d:16:3b:c2:f7:86:68:da:18:
+    94:e5:9e:32:04:31:a4:07:2d:d4:4c:8c:e5:db:77:
+    72:ef:d9:e8:c2:0d:4e:17:83:7d:09:c5:df:83:35:
+    3b:bc:31:ae:a4:f7:d0:44:f1:98:7d:ad:2d:08:ae:
+    76:11:20:d7:cd:36:81:82:b5
 exponent1:
-    04:5d:93:a1:f6:14:09:92:0b:17:f9:58:05:4c:3b:
-    31:00:65:13:e1:76:aa:83:7f:bc:32:4c:78:30:15:
-    6c:e0:85:27:d3:ea:a6:24:f6:06:46:bc:8f:fe:41:
-    58:21:9f:46:b0:90:d9:34:28:ed:25:47:a3:bf:e4:
-    6d:e6:fa:08:b5:84:d8:ac:5d:b1:13:1a:f1:6a:98:
-    7d:18:0d:ad:f4:fe:2a:43:f4:5a:1e:3e:45:63:ea:
-    f8:38:dd:9e:b3:3c:1f:7c:61:c0:ee:d2:5a:ca:7f:
-    e7:b1:04:ef:72:ae:5a:16:63:ea:cb:1c:c3:50:be:
-    d8:b0:fb:3d:83:ad:71:f5
+    68:16:6f:1a:e9:82:a5:1d:6c:a5:b2:76:25:e3:6d:
+    32:94:16:3f:3f:32:61:df:37:f7:9b:9a:ed:a7:23:
+    3c:f2:e7:0b:6e:58:14:c0:50:df:5b:06:9a:2a:26:
+    cd:b1:32:46:dd:80:6f:eb:b2:f7:7c:2e:b8:a0:38:
+    86:32:dc:e5:c1:9e:45:f0:78:cc:54:4f:38:0e:bc:
+    0d:2f:35:51:c3:df:76:13:05:e3:d1:eb:3d:b7:a3:
+    86:26:ef:9f:b7:fc:07:4d:46:df:88:9c:9b:0c:ea:
+    5e:2c:72:5f:28:7d:38:e5:0c:a4:3a:78:3c:12:6c:
+    fa:32:f2:c7:70:c0:46:41
 exponent2:
-    69:f2:f9:7c:6b:44:94:42:14:08:cc:e6:0b:42:bd:
-    cc:70:80:4f:6b:af:75:7e:f5:ce:55:d0:a1:1f:43:
-    9f:3d:82:92:e7:45:31:50:41:ee:b7:fd:0d:c8:1e:
-    f4:8c:5b:78:7f:26:02:59:51:43:6a:51:56:11:e6:
-    4b:0e:cb:b8:db:b9:b9:42:71:7c:85:26:9c:f1:42:
-    4d:d1:32:9a:0e:67:3e:20:f5:81:21:36:3a:be:67:
-    6c:3a:f2:5a:38:bf:d6:04:62:bc:f7:f6:f6:25:81:
-    52:b8:60:d8:f9:42:47:35:33:c9:96:c8:95:a3:bf:
-    86:ae:f6:95:d4:65:86:25
+    4c:f2:27:d3:07:9b:e8:d3:d1:5d:64:17:12:07:ca:
+    0d:ca:4f:cb:d5:3e:97:7e:b4:34:c6:65:ef:eb:10:
+    f0:c3:a3:92:a3:ae:19:93:43:35:72:bc:b2:1d:6b:
+    2f:74:a2:2f:62:d4:4b:b0:d3:8d:f6:43:0b:6f:61:
+    54:fe:21:29:91:b2:04:81:e7:15:d5:49:c9:3c:82:
+    4f:29:f3:77:78:ef:ef:ee:8b:c7:1e:c3:15:b7:e7:
+    f5:2b:dc:38:28:ee:3f:99:38:6a:0e:8f:c5:db:db:
+    1b:0f:40:8b:f1:71:a0:6f:27:ea:35:f4:61:44:25:
+    63:ab:e9:e2:32:b3:8b:29
 coefficient:
-    28:91:92:b0:3c:bb:1c:58:e9:95:6c:70:fb:66:1d:
-    19:b5:eb:ca:17:83:b9:b6:90:83:9f:18:e4:f2:69:
-    72:e8:20:17:30:0f:dc:9c:4b:8a:9a:38:53:e1:c6:
-    01:ff:bc:1b:2b:22:84:95:48:6f:9e:01:8e:6b:b6:
-    50:f8:42:9d:76:67:e8:34:86:2d:b8:66:32:9d:01:
-    8e:3a:a4:1d:3c:9a:02:85:a5:1d:74:ef:8d:6a:d2:
-    2f:61:2c:e9:17:02:d7:22:9c:ee:8e:4c:cb:de:76:
-    6d:c2:1c:17:af:a3:3c:6a:f2:6a:6a:9c:b5:fb:9b:
-    2f:1e:c9:15:29:97:d2:3d
+    0d:ae:36:95:c9:a2:b3:6a:3d:d4:38:01:ce:e4:10:
+    da:e9:0e:c5:58:dd:0f:cf:9e:ac:cd:fc:68:9b:24:
+    6c:58:76:2b:78:57:ef:03:e5:d9:d6:e8:9a:15:9e:
+    15:c8:21:8c:34:19:9a:7c:e3:bf:dd:a1:c0:dd:ad:
+    50:69:2a:d8:36:60:b2:c0:b3:ab:14:19:f9:4e:8b:
+    b1:f9:2c:5c:28:9c:ce:64:74:07:80:20:15:e1:a1:
+    b6:dc:8f:2a:be:bd:20:f0:62:22:4e:03:a2:aa:a0:
+    fd:46:bf:e1:89:30:ac:1a:09:0a:fe:5b:20:d5:59:
+    72:a1:ce:75:32:a8:70:b4
 -----BEGIN RSA PRIVATE KEY-----
-MIIEowIBAAKCAQEA25DXz/6BvFHRodLZD8IhFgY9Eod86UWXKPQzElHSszG+E10o
-qLX7jw7OPrtCej+6NelYKvthOMBrN58/3rlkW8MIIWTXwq8KrCEL7cGKcf4FJ+tL
-Mbp5YuVB791mhXYouwMIxzUmhcL4Ox9nRTlzzthd30oLToyFKQKYBJXp0/bRn2wl
-zqOBTMdNtc5DEtmy8WjI/aNXFvV6QoX+GbXu6D/aJ4WCyezWY7/NS3UeoMWPzpC4
-yiW6RVJt5Opt5R1Bjk8zSpcjjsGY1GCnHhwoMQ0FyKLS13rZw0YmoefvZ+drzpeK
-NwvX4iiwM4WwiWs4g66jAqfSGofwiKajGtuXUwIDAQABAoIBAQCddJOvjx5OhIZG
-/EO5L0g22SZ24T7MsqEiN21gl9j3tJZQoKAFzOunvcBd8EBOFuFcxAf8WuVvo13A
-N62/9UdpHsX33K91571JjzFUwVSdRsM/y1bTRJzENRBCCY3567Bt3FExOoZzqkwF
-ahHO7NKF5Vf8Rscw/0iHDlsh/rf+zk+MLM/q0QxZg37UP9sMCY2Nr8U4jZZEN3yj
-T3kJ/hHLzyBAbP2jzNny9DV5Y8P4HMFu1HYrZ4RN06+Bche6nZgMWArITY8olSv6
-2TEdMa3Fh5AbLGlCIrEbc0oigq+3W4K0ODk78kfvPX0Jm+hbtdhWHBbnOm59hT8c
-HT/u3fHRAoGBAPIM/pm17bsk9nlhdfWom1b58+5bhBwxAF4BArRQ6vuoEyJzwhIb
-wlNVFPMuo2L4ggRMIwlQmMGrRRiWx6ToKYQEqyQ3F0ULswJ/w0owP61pSQtJxYng
-B7ez11AZhcDxc2C0dvjCxQF8CSNJVyrM1+HW2bRrVCBhfzpwm50BEvrnAoGBAOg4
-H/sb9k3hvvCAwaFVK9HbCZjMcOuZ8J4LLC1gIJb3s8VrmCLFv8MgXpG+0YH8FDZw
-mzeebchuhPb6ZTBkDrBQBYWoBwu+Tt7BF3E5A+OeTmlcUQKvl7gw2pUuJLR4dka8
-26InZlrO5Q8Bgv7LMbz+GWrlc7alrTrzYez3qf61AoGABF2TofYUCZILF/lYBUw7
-MQBlE+F2qoN/vDJMeDAVbOCFJ9PqpiT2Bka8j/5BWCGfRrCQ2TQo7SVHo7/kbeb6
-CLWE2KxdsRMa8WqYfRgNrfT+KkP0Wh4+RWPq+DjdnrM8H3xhwO7SWsp/57EE73Ku
-WhZj6sscw1C+2LD7PYOtcfUCgYBp8vl8a0SUQhQIzOYLQr3McIBPa691fvXOVdCh
-H0OfPYKS50UxUEHut/0NyB70jFt4fyYCWVFDalFWEeZLDsu427m5QnF8hSac8UJN
-0TKaDmc+IPWBITY6vmdsOvJaOL/WBGK89/b2JYFSuGDY+UJHNTPJlsiVo7+GrvaV
-1GWGJQKBgCiRkrA8uxxY6ZVscPtmHRm168oXg7m2kIOfGOTyaXLoIBcwD9ycS4qa
-OFPhxgH/vBsrIoSVSG+eAY5rtlD4Qp12Z+g0hi24ZjKdAY46pB08mgKFpR10741q
-0i9hLOkXAtcinO6OTMvedm3CHBevozxq8mpqnLX7my8eyRUpl9I9
+MIIEogIBAAKCAQEAlDv8GH4J1pMQmtffhEl0fZoOkf8xyp/AwM9Kax6+d7CCn6YX
+/POZ8eXtxNPh9Oju0nA7mLEhVZqebYnxgrqCQwCv5gV+D6FQ/+x3iCiSovD5KR3L
+hspjqceeAZluVsg58cYzubSWsgVe4fccVVgj7L27TaBUPAnQyYMnmzz1UIweVCKz
+Cg+XwWjVB7cNuRbW+NAshyVeU2Ux1daUq4t3KaJ4TsfPZvJ58mbKzsmaBKINR2+g
+HMw5ffIBcz2cVg8V9gaSmBmbUu1D+IRsH5YL3Y7HD9wTCHsaB8Gs3rrczhuoxcXV
+yGwyauIsquJWulW0PCt/h5k+0AxHum5ghis9UQIDAQABAoIBAAthr7GRu9+l2xiI
+irj1iuQ59/Rty7zrFzm2sNgYvDckbmMjtaPOcHuKU/9Q5YCQggXWaD0JHK4d+Rwg
+A1MuTuImI1teAJfiov2DgooJ03h/WCI4D3CCCbT3hsJIrZgsN4bA2SfhHdD9aJOh
+DaPf6KI8zyzeqpkRh95xG5Fn1M4iViejfU1YXNN2gFS2KO1g57rv2kr1hrn3fsWU
+X4dV0FxrjOpOgso9vCO1HHdMvVeY2x/srw1w4KD6htaszy+iVSQumGCw9c9g27+X
+uOLAHwO1XK/O/Vsrl83V65XvF7wZaVoSHygk0o7NkY+QfFS/MXW9ZjHrYSCxf187
+Oq9IjYECgYEAwvJ5ZW7VYb3gavtniboj+tvk/A9YnmM3xK3YgMamP5sgpXBIIPQ3
+8zYBj0f/AP62UGpW9Ag3Cg9/KEJg+AGpUzcpnCSDFBzDVrkYM1pEmf64q0UmcbfF
+HlahSTxxW7XBfLtkaP6vJD1gauve11gdvf9Wkl8F5o9XiF5xCM4S5a0CgYEAwqhl
+FWYHohR1F6vt9PXmzAtwau6m0D5pN5ToP0EC8XCY9FoNDnX1N0xoessa8ldpXF23
+c86VSJIaiiwzCKGmOuJ9FjvC94Zo2hiU5Z4yBDGkBy3UTIzl23dy79nowg1OF4N9
+CcXfgzU7vDGupPfQRPGYfa0tCK52ESDXzTaBgrUCgYBoFm8a6YKlHWylsnYl420y
+lBY/PzJh3zf3m5rtpyM88ucLblgUwFDfWwaaKibNsTJG3YBv67L3fC64oDiGMtzl
+wZ5F8HjMVE84DrwNLzVRw992EwXj0es9t6OGJu+ft/wHTUbfiJybDOpeLHJfKH04
+5QykOng8Emz6MvLHcMBGQQKBgEzyJ9MHm+jT0V1kFxIHyg3KT8vVPpd+tDTGZe/r
+EPDDo5KjrhmTQzVyvLIday90oi9i1Euw0432QwtvYVT+ISmRsgSB5xXVSck8gk8p
+83d47+/ui8cewxW35/Ur3Dgo7j+ZOGoOj8Xb2xsPQIvxcaBvJ+o19GFEJWOr6eIy
+s4spAoGADa42lcmis2o91DgBzuQQ2ukOxVjdD8+erM38aJskbFh2K3hX7wPl2dbo
+mhWeFcghjDQZmnzjv92hwN2tUGkq2DZgssCzqxQZ+U6LsfksXCiczmR0B4AgFeGh
+ttyPKr69IPBiIk4Doqqg/Ua/4YkwrBoJCv5bINVZcqHOdTKocLQ=
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/signed.pem
+++ b/spec/fixtures/ssl/signed.pem
@@ -6,61 +6,61 @@ Certificate:
         Issuer: CN=Test CA Subauthority
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Apr 18 18:46:23 2031 GMT
+            Not After : Jun 15 01:19:37 2031 GMT
         Subject: CN=signed
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:db:90:d7:cf:fe:81:bc:51:d1:a1:d2:d9:0f:c2:
-                    21:16:06:3d:12:87:7c:e9:45:97:28:f4:33:12:51:
-                    d2:b3:31:be:13:5d:28:a8:b5:fb:8f:0e:ce:3e:bb:
-                    42:7a:3f:ba:35:e9:58:2a:fb:61:38:c0:6b:37:9f:
-                    3f:de:b9:64:5b:c3:08:21:64:d7:c2:af:0a:ac:21:
-                    0b:ed:c1:8a:71:fe:05:27:eb:4b:31:ba:79:62:e5:
-                    41:ef:dd:66:85:76:28:bb:03:08:c7:35:26:85:c2:
-                    f8:3b:1f:67:45:39:73:ce:d8:5d:df:4a:0b:4e:8c:
-                    85:29:02:98:04:95:e9:d3:f6:d1:9f:6c:25:ce:a3:
-                    81:4c:c7:4d:b5:ce:43:12:d9:b2:f1:68:c8:fd:a3:
-                    57:16:f5:7a:42:85:fe:19:b5:ee:e8:3f:da:27:85:
-                    82:c9:ec:d6:63:bf:cd:4b:75:1e:a0:c5:8f:ce:90:
-                    b8:ca:25:ba:45:52:6d:e4:ea:6d:e5:1d:41:8e:4f:
-                    33:4a:97:23:8e:c1:98:d4:60:a7:1e:1c:28:31:0d:
-                    05:c8:a2:d2:d7:7a:d9:c3:46:26:a1:e7:ef:67:e7:
-                    6b:ce:97:8a:37:0b:d7:e2:28:b0:33:85:b0:89:6b:
-                    38:83:ae:a3:02:a7:d2:1a:87:f0:88:a6:a3:1a:db:
-                    97:53
+                    00:94:3b:fc:18:7e:09:d6:93:10:9a:d7:df:84:49:
+                    74:7d:9a:0e:91:ff:31:ca:9f:c0:c0:cf:4a:6b:1e:
+                    be:77:b0:82:9f:a6:17:fc:f3:99:f1:e5:ed:c4:d3:
+                    e1:f4:e8:ee:d2:70:3b:98:b1:21:55:9a:9e:6d:89:
+                    f1:82:ba:82:43:00:af:e6:05:7e:0f:a1:50:ff:ec:
+                    77:88:28:92:a2:f0:f9:29:1d:cb:86:ca:63:a9:c7:
+                    9e:01:99:6e:56:c8:39:f1:c6:33:b9:b4:96:b2:05:
+                    5e:e1:f7:1c:55:58:23:ec:bd:bb:4d:a0:54:3c:09:
+                    d0:c9:83:27:9b:3c:f5:50:8c:1e:54:22:b3:0a:0f:
+                    97:c1:68:d5:07:b7:0d:b9:16:d6:f8:d0:2c:87:25:
+                    5e:53:65:31:d5:d6:94:ab:8b:77:29:a2:78:4e:c7:
+                    cf:66:f2:79:f2:66:ca:ce:c9:9a:04:a2:0d:47:6f:
+                    a0:1c:cc:39:7d:f2:01:73:3d:9c:56:0f:15:f6:06:
+                    92:98:19:9b:52:ed:43:f8:84:6c:1f:96:0b:dd:8e:
+                    c7:0f:dc:13:08:7b:1a:07:c1:ac:de:ba:dc:ce:1b:
+                    a8:c5:c5:d5:c8:6c:32:6a:e2:2c:aa:e2:56:ba:55:
+                    b4:3c:2b:7f:87:99:3e:d0:0c:47:ba:6e:60:86:2b:
+                    3d:51
                 Exponent: 65537 (0x10001)
     Signature Algorithm: sha256WithRSAEncryption
-         53:37:9e:35:1c:d7:55:72:4c:2f:1b:47:52:0a:cf:ca:39:8f:
-         c7:4d:8e:07:89:7e:cd:f8:9d:44:f5:81:a6:de:89:1a:c0:4d:
-         d7:bd:92:da:84:3b:e3:47:ac:11:c3:98:65:08:65:bf:b8:9b:
-         2f:24:c1:73:2e:55:03:fc:79:c9:91:07:34:15:1e:14:ec:60:
-         5f:d1:82:7a:35:aa:06:74:59:48:35:b6:cd:05:b7:2f:4d:f0:
-         08:c3:06:3b:cd:52:02:2e:b6:a4:b8:41:26:b3:49:85:85:e8:
-         eb:c0:9e:3d:94:16:3b:23:93:b7:3e:32:d2:f6:7f:8d:30:fd:
-         c2:f8:7c:3b:b1:62:c6:a4:dc:4b:d2:5c:b2:4c:83:7e:b5:dc:
-         75:bf:36:d3:1b:f2:ab:37:2d:6b:30:8a:fc:c1:d8:e3:32:a2:
-         4a:d1:bc:2d:9b:a4:91:62:cd:06:b6:8c:5d:51:89:21:87:61:
-         02:d4:b8:41:6e:80:e5:3e:3b:2e:47:df:fc:2a:35:19:00:36:
-         28:ba:ef:8c:00:4d:38:0e:f9:1a:a5:a9:d0:9b:ec:66:5a:54:
-         40:f8:39:bc:32:f4:55:a7:9e:93:82:90:0a:8c:cf:51:76:a9:
-         fb:03:1d:9e:eb:92:90:b2:bd:a5:2a:98:a2:23:a0:ac:5d:f0:
-         34:e3:e3:2a
+         0a:bb:98:88:03:a0:98:98:74:30:d6:fd:27:ee:e9:52:51:14:
+         c8:27:d9:4c:e6:83:c6:ca:dc:7f:c1:9e:81:ab:6f:d2:1c:f5:
+         e9:ec:39:d5:24:2f:9b:43:15:47:6a:be:f4:fa:65:ad:08:ac:
+         be:5b:f9:3e:c1:4b:74:d6:d5:72:23:74:5e:87:b2:df:e2:f8:
+         e3:94:07:14:a5:5c:a6:69:0c:48:1d:ac:bd:2d:85:e2:5c:41:
+         9d:02:29:13:d1:30:05:2c:d2:f7:15:91:e5:70:de:5e:16:f1:
+         1c:c6:62:d3:2b:92:2a:69:40:74:23:60:e6:ce:6c:65:3a:22:
+         1b:66:c7:53:c9:07:95:29:fd:8f:d0:02:e4:a2:e4:72:2e:38:
+         54:3d:60:ad:6e:35:83:cc:f8:9d:db:fd:e9:68:21:42:db:7a:
+         58:db:c3:bc:bc:e9:a7:d4:6b:b9:b0:24:eb:e2:9d:d7:4d:61:
+         a7:0c:57:0c:f1:12:2f:48:a7:1b:e6:f9:37:32:10:56:5a:78:
+         4f:3e:9b:1b:6d:db:01:11:13:31:68:2c:ce:a5:41:c5:36:3d:
+         1a:29:3b:15:cd:09:51:82:07:7a:f2:98:0d:bd:dd:2e:02:8d:
+         18:39:2a:ee:5b:9b:c8:49:71:3a:2b:38:07:c0:3a:03:cf:67:
+         b4:ff:c9:97
 -----BEGIN CERTIFICATE-----
 MIICqTCCAZGgAwIBAgIBBDANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0
-IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zMTA0MTgxODQ2MjNa
+IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zMTA2MTUwMTE5Mzda
 MBExDzANBgNVBAMMBnNpZ25lZDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC
-ggEBANuQ18/+gbxR0aHS2Q/CIRYGPRKHfOlFlyj0MxJR0rMxvhNdKKi1+48Ozj67
-Qno/ujXpWCr7YTjAazefP965ZFvDCCFk18KvCqwhC+3BinH+BSfrSzG6eWLlQe/d
-ZoV2KLsDCMc1JoXC+DsfZ0U5c87YXd9KC06MhSkCmASV6dP20Z9sJc6jgUzHTbXO
-QxLZsvFoyP2jVxb1ekKF/hm17ug/2ieFgsns1mO/zUt1HqDFj86QuMolukVSbeTq
-beUdQY5PM0qXI47BmNRgpx4cKDENBcii0td62cNGJqHn72fna86XijcL1+IosDOF
-sIlrOIOuowKn0hqH8Iimoxrbl1MCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAUzee
-NRzXVXJMLxtHUgrPyjmPx02OB4l+zfidRPWBpt6JGsBN172S2oQ740esEcOYZQhl
-v7ibLyTBcy5VA/x5yZEHNBUeFOxgX9GCejWqBnRZSDW2zQW3L03wCMMGO81SAi62
-pLhBJrNJhYXo68CePZQWOyOTtz4y0vZ/jTD9wvh8O7FixqTcS9JcskyDfrXcdb82
-0xvyqzctazCK/MHY4zKiStG8LZukkWLNBraMXVGJIYdhAtS4QW6A5T47Lkff/Co1
-GQA2KLrvjABNOA75GqWp0JvsZlpUQPg5vDL0Vaeek4KQCozPUXap+wMdnuuSkLK9
-pSqYoiOgrF3wNOPjKg==
+ggEBAJQ7/Bh+CdaTEJrX34RJdH2aDpH/McqfwMDPSmsevnewgp+mF/zzmfHl7cTT
+4fTo7tJwO5ixIVWanm2J8YK6gkMAr+YFfg+hUP/sd4gokqLw+Skdy4bKY6nHngGZ
+blbIOfHGM7m0lrIFXuH3HFVYI+y9u02gVDwJ0MmDJ5s89VCMHlQiswoPl8Fo1Qe3
+DbkW1vjQLIclXlNlMdXWlKuLdymieE7Hz2byefJmys7JmgSiDUdvoBzMOX3yAXM9
+nFYPFfYGkpgZm1LtQ/iEbB+WC92Oxw/cEwh7GgfBrN663M4bqMXF1chsMmriLKri
+VrpVtDwrf4eZPtAMR7puYIYrPVECAwEAATANBgkqhkiG9w0BAQsFAAOCAQEACruY
+iAOgmJh0MNb9J+7pUlEUyCfZTOaDxsrcf8Gegatv0hz16ew51SQvm0MVR2q+9Ppl
+rQisvlv5PsFLdNbVciN0Xoey3+L445QHFKVcpmkMSB2svS2F4lxBnQIpE9EwBSzS
+9xWR5XDeXhbxHMZi0yuSKmlAdCNg5s5sZToiG2bHU8kHlSn9j9AC5KLkci44VD1g
+rW41g8z4ndv96WghQtt6WNvDvLzpp9RrubAk6+Kd101hpwxXDPESL0inG+b5NzIQ
+Vlp4Tz6bG23bARETMWgszqVBxTY9Gik7Fc0JUYIHevKYDb3dLgKNGDkq7lubyElx
+Ois4B8A6A89ntP/Jlw==
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/tampered-cert.pem
+++ b/spec/fixtures/ssl/tampered-cert.pem
@@ -1,66 +1,66 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 11 (0xb)
+        Serial Number: 12 (0xc)
         Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA Subauthority
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Apr 18 18:46:23 2031 GMT
+            Not After : Jun 15 01:19:37 2031 GMT
         Subject: CN=signed
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:cb:ce:cb:7b:df:9b:4a:d7:f5:72:a6:a7:a0:04:
-                    d9:8b:16:b9:47:9f:50:27:d8:0a:bf:cb:47:d3:54:
-                    ae:bc:68:54:78:cf:fb:cd:2f:ae:b0:9b:48:c1:9f:
-                    3b:87:d6:86:ad:99:fb:ff:4a:dd:2f:cc:3a:bc:6f:
-                    bd:02:65:6f:87:de:f6:9b:8b:96:1a:2c:4d:30:89:
-                    8b:e4:87:56:b0:5b:83:d7:98:5a:b9:9c:77:15:75:
-                    50:ed:7d:07:fe:2b:83:3d:43:13:6f:fd:78:71:d1:
-                    e6:47:52:8e:b8:d1:ac:88:f4:d9:76:3e:b1:df:d9:
-                    0c:de:5f:a8:21:51:62:35:d0:00:d0:a8:72:73:f3:
-                    b0:8b:c6:94:fe:b2:11:96:d3:de:ba:11:9f:69:1f:
-                    15:e5:2f:8c:ce:8c:aa:ec:7d:f3:57:d6:db:9e:f8:
-                    5f:1f:43:e2:42:1b:31:a5:46:e3:ac:c0:f8:4f:e1:
-                    6a:f5:39:2e:d3:1a:a4:3b:36:72:f5:9f:eb:33:cb:
-                    3d:8a:26:aa:92:ca:67:83:9d:40:b1:10:3c:be:15:
-                    1c:7a:49:74:b8:48:0c:55:e3:8c:ce:25:e3:c4:65:
-                    3f:cb:f9:fa:09:b7:2f:c7:6e:b5:ba:35:56:b2:92:
-                    7a:be:69:1b:aa:08:31:24:80:f1:68:6d:76:b1:d0:
-                    5b:83
+                    00:e5:d1:41:c2:76:00:ff:d2:26:73:88:6b:06:e8:
+                    4e:6e:f6:76:b0:94:bf:71:b4:26:1b:1d:05:e9:ea:
+                    b2:e9:8b:cf:81:8d:93:3e:82:27:a0:ef:61:b6:78:
+                    e3:5a:70:58:b0:56:ed:2f:3c:fd:80:67:e7:a7:49:
+                    39:c0:3f:a8:f1:15:86:e3:b6:9b:d8:5d:af:e3:9c:
+                    b1:e3:dc:4a:81:60:60:f8:7d:ef:01:4e:84:5c:64:
+                    64:35:bb:52:8f:d9:d0:c4:74:90:a4:27:ab:0d:2e:
+                    df:1c:1d:9e:62:43:4e:f5:e4:04:a7:9e:45:6d:61:
+                    11:e5:ff:9d:fe:8a:5e:55:19:96:ed:de:a4:a0:f5:
+                    44:ea:14:06:af:8b:eb:62:c6:f5:78:27:36:3b:e6:
+                    9d:fc:65:b3:57:5a:52:b1:e9:f6:4a:13:a4:fa:8a:
+                    dc:60:8a:a3:8e:15:db:24:8c:61:03:62:ea:6a:a4:
+                    b6:47:82:8d:34:48:5b:0e:bb:0f:5d:3e:9d:05:38:
+                    f8:6c:da:01:45:66:19:bc:a9:a1:5d:f5:42:1d:12:
+                    5e:b1:93:12:db:87:19:06:35:b6:39:18:b9:d1:c8:
+                    dc:9e:3f:d6:28:b1:07:cf:e0:af:bc:19:bd:50:e2:
+                    0f:f6:36:77:a9:84:b7:08:92:f4:47:9a:f5:ea:73:
+                    46:c5
                 Exponent: 65537 (0x10001)
     Signature Algorithm: sha256WithRSAEncryption
-         78:3c:51:49:d1:81:dd:c9:e0:14:bf:ff:86:44:5b:b6:50:a5:
-         ca:8e:27:cc:2a:2d:1e:97:2b:6a:de:04:e7:f6:b3:d1:61:bb:
-         63:c9:2b:60:0e:ec:f6:bd:7f:84:77:85:62:b8:b8:bf:a0:63:
-         85:56:b5:8b:7b:8a:01:f5:31:f2:5d:82:df:ef:2b:69:a5:bd:
-         c0:d8:61:7f:28:e9:cb:7f:18:af:77:8e:af:f3:53:dd:bc:aa:
-         cb:74:8f:e8:f2:26:e7:d9:8b:bc:de:58:b6:b8:da:e2:1d:03:
-         ca:7a:3e:b0:1c:9d:05:9c:04:11:84:94:f4:df:36:04:61:8d:
-         88:f7:ce:3d:9a:96:7c:1b:10:d3:85:e5:84:ab:59:b1:b6:5b:
-         96:7e:93:c6:fb:87:a4:00:c1:8a:e3:6b:47:4b:fd:c1:4e:1a:
-         1c:f7:73:e3:69:eb:4a:71:c9:7a:11:4a:ec:3a:d0:d2:fc:a4:
-         41:38:27:cd:51:92:8c:1a:c4:a3:61:21:eb:e1:24:5d:5b:08:
-         da:6c:0d:04:37:c3:7c:26:fd:22:c1:38:ff:d9:1e:01:f6:a2:
-         8a:37:de:bb:e2:59:6e:2d:40:e2:81:83:3a:2e:6d:1b:99:be:
-         1e:4b:4f:f8:c1:ee:97:81:59:39:b8:6a:3b:aa:99:5f:2c:86:
-         65:47:bc:10
+         4c:37:72:d9:ee:d3:8a:75:a6:f8:36:01:50:95:e6:75:a7:b0:
+         67:14:a6:88:ab:e3:a3:ea:c4:5c:20:2b:12:e4:8a:fb:9d:88:
+         33:1e:17:dc:91:bc:4a:dc:45:b9:ac:88:67:db:ba:12:ec:4d:
+         9b:b1:58:87:ef:af:b6:be:1a:4b:44:0e:7c:70:68:50:90:93:
+         db:a2:ee:73:2b:75:cc:27:8f:60:11:15:c6:19:7b:12:d3:43:
+         68:63:02:d3:2c:10:37:2a:f1:fe:6f:46:45:d4:81:15:0b:93:
+         0d:ae:6f:23:4f:71:e8:42:45:f7:3d:f8:56:66:79:91:06:3b:
+         01:71:f6:1f:dd:e7:59:a1:c5:48:35:a4:80:b6:40:14:20:47:
+         85:21:92:3a:83:19:ba:bd:b5:ab:ab:92:c6:a7:f2:f0:e6:d6:
+         00:fd:ec:91:34:46:72:bf:57:ec:c0:d8:68:4c:19:89:6d:4f:
+         a2:51:e8:a6:6f:b1:a1:ff:b0:55:46:b7:cc:51:39:38:ba:c2:
+         22:b2:57:19:02:f4:00:92:bc:ad:2b:e3:43:2b:1a:f2:36:55:
+         1f:c7:97:4b:0f:65:8e:33:00:e8:ed:44:56:82:b5:8b:57:dc:
+         bd:a6:c5:61:86:49:9a:82:a5:e5:8c:01:62:9d:18:cb:9e:05:
+         d3:03:51:50
 -----BEGIN CERTIFICATE-----
-MIICqTCCAZGgAwIBAgIBCzANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0
-IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zMTA0MTgxODQ2MjNa
+MIICqTCCAZGgAwIBAgIBDDANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0
+IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zMTA2MTUwMTE5Mzda
 MBExDzANBgNVBAMMBnNpZ25lZDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC
-ggEBAMvOy3vfm0rX9XKmp6AE2YsWuUefUCfYCr/LR9NUrrxoVHjP+80vrrCbSMGf
-O4fWhq2Z+/9K3S/MOrxvvQJlb4fe9puLlhosTTCJi+SHVrBbg9eYWrmcdxV1UO19
-B/4rgz1DE2/9eHHR5kdSjrjRrIj02XY+sd/ZDN5fqCFRYjXQANCocnPzsIvGlP6y
-EZbT3roRn2kfFeUvjM6Mqux981fW2574Xx9D4kIbMaVG46zA+E/havU5LtMapDs2
-cvWf6zPLPYomqpLKZ4OdQLEQPL4VHHpJdLhIDFXjjM4l48RlP8v5+gm3L8dutbo1
-VrKSer5pG6oIMSSA8WhtdrHQW4MCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAeDxR
-SdGB3cngFL//hkRbtlClyo4nzCotHpcrat4E5/az0WG7Y8krYA7s9r1/hHeFYri4
-v6BjhVa1i3uKAfUx8l2C3+8raaW9wNhhfyjpy38Yr3eOr/NT3byqy3SP6PIm59mL
-vN5Ytrja4h0Dyno+sBydBZwEEYSU9N82BGGNiPfOPZqWfBsQ04XlhKtZsbZbln6T
-xvuHpADBiuNrR0v9wU4aHPdz42nrSnHJehFK7DrQ0vykQTgnzVGSjBrEo2Eh6+Ek
-XVsI2mwNBDfDfCb9IsE4/9keAfaiijfeu+JZbi1A4oGDOi5tG5m+HktP+MHul4FZ
-ObhqO6qZXyyGZUe8EA==
+ggEBAOXRQcJ2AP/SJnOIawboTm72drCUv3G0JhsdBenqsumLz4GNkz6CJ6DvYbZ4
+41pwWLBW7S88/YBn56dJOcA/qPEVhuO2m9hdr+OcsePcSoFgYPh97wFOhFxkZDW7
+Uo/Z0MR0kKQnqw0u3xwdnmJDTvXkBKeeRW1hEeX/nf6KXlUZlu3epKD1ROoUBq+L
+62LG9XgnNjvmnfxls1daUrHp9koTpPqK3GCKo44V2ySMYQNi6mqktkeCjTRIWw67
+D10+nQU4+GzaAUVmGbypoV31Qh0SXrGTEtuHGQY1tjkYudHI3J4/1iixB8/gr7wZ
+vVDiD/Y2d6mEtwiS9Eea9epzRsUCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEATDdy
+2e7TinWm+DYBUJXmdaewZxSmiKvjo+rEXCArEuSK+52IMx4X3JG8StxFuayIZ9u6
+EuxNm7FYh++vtr4aS0QOfHBoUJCT26Lucyt1zCePYBEVxhl7EtNDaGMC0ywQNyrx
+/m9GRdSBFQuTDa5vI09x6EJF9z34VmZ5kQY7AXH2H93nWaHFSDWkgLZAFCBHhSGS
+OoMZur21q6uSxqfy8ObWAP3skTRGcr9X7MDYaEwZiW1PolHopm+xof+wVUa3zFE5
+OLrCIrJXGQL0AJK8rSvjQysa8jZVH8eXSw9ljjMA6O1EVoK1i1fcvabFYYZJmoKl
+5YwBYp0Yy54F0wNRUA==
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/tampered-csr.pem
+++ b/spec/fixtures/ssl/tampered-csr.pem
@@ -6,55 +6,55 @@ Certificate Request:
             Public Key Algorithm: rsaEncryption
                 RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:a8:3e:27:31:e2:33:8e:51:90:06:55:5b:ee:bc:
-                    8b:a2:b3:53:74:7d:06:6d:43:cf:12:57:46:fc:56:
-                    79:f0:cd:af:d1:dc:19:b3:3c:54:39:85:b4:6a:1e:
-                    a3:0f:f4:ee:e7:8f:1c:c9:99:79:5d:92:b5:7e:a6:
-                    49:1a:ec:e5:f4:12:8e:6d:57:9a:86:29:b2:38:42:
-                    1e:a9:c7:73:b1:a9:e3:9c:fc:5c:f9:51:a5:47:ce:
-                    45:af:21:20:d8:45:40:fe:a2:bf:5e:77:34:eb:6f:
-                    17:bc:fd:06:33:2a:6f:64:6c:61:03:76:ad:dd:e4:
-                    11:02:3f:48:b2:39:94:cc:da:30:41:36:8e:be:24:
-                    74:b2:45:60:ba:59:0e:b5:1d:fd:0f:e8:97:47:61:
-                    c4:9d:88:ef:09:69:01:d7:7e:cd:1b:ad:ff:d2:19:
-                    7d:c8:35:cf:72:55:cd:1e:68:58:8a:b2:78:9c:76:
-                    b2:2c:8e:34:3d:91:9c:c2:d8:fd:21:b3:bd:72:43:
-                    85:dd:6e:4e:0a:47:92:0f:e4:f9:e6:43:20:f6:25:
-                    22:7e:e3:94:70:a8:02:2e:f6:0b:e1:2d:22:bf:94:
-                    00:4e:31:23:83:79:00:70:28:a0:b6:32:1b:ee:c8:
-                    d4:ff:16:d7:1a:17:41:38:c0:5c:ed:18:de:d7:1a:
-                    f4:01
+                    00:d1:3e:20:3f:c0:5e:64:78:1f:f6:a8:60:c7:c8:
+                    0d:7b:a7:c9:c1:f5:7e:c2:76:b7:cc:0f:c2:77:e4:
+                    ba:3d:41:81:dc:b3:a1:9a:de:83:6c:80:29:78:17:
+                    b9:cf:2b:0e:b5:5e:74:04:e5:c6:ad:66:4a:cf:6f:
+                    f8:ec:1c:41:c9:c0:4a:28:74:17:1f:85:1f:11:d2:
+                    5a:36:c0:bd:08:a3:72:ba:00:1e:d7:f8:fd:44:23:
+                    21:b7:ba:67:7c:fc:c1:5c:ac:fe:ce:d7:72:8b:17:
+                    3a:2b:0f:a0:d6:d3:2f:ed:6d:28:e9:00:f7:a4:4d:
+                    4a:cd:42:e3:fe:6f:44:7a:cd:69:bb:50:90:51:4d:
+                    83:ad:04:5d:91:48:2b:7a:86:29:4d:19:5a:03:98:
+                    8c:e9:12:61:99:db:6b:c6:ca:f7:e5:e0:c5:0c:63:
+                    fb:d9:d0:f7:7e:ea:e2:38:e5:8e:13:7e:63:6b:7f:
+                    26:ff:5e:da:a5:bc:0a:b7:80:c9:58:3e:f5:28:5c:
+                    dc:a2:62:56:80:64:30:67:ab:f7:d1:d3:b4:51:61:
+                    51:14:a1:8b:82:ae:35:f9:cd:8b:7e:3b:b1:0d:3c:
+                    6b:7b:aa:50:53:3b:3f:44:1c:51:3b:91:01:d2:c3:
+                    38:31:1a:26:89:ba:8e:58:76:66:fb:4d:02:ff:e6:
+                    dd:1d
                 Exponent: 65537 (0x10001)
         Attributes:
             a0:00
     Signature Algorithm: sha256WithRSAEncryption
-         17:09:e2:b8:c6:d5:1e:44:60:86:bf:8b:7c:b9:7a:43:55:76:
-         38:32:fa:9d:ad:0a:6b:ea:56:9e:4d:45:5d:58:ae:08:93:20:
-         d6:79:99:20:7e:88:6a:bb:14:b6:62:a3:e1:2a:82:a6:2e:9d:
-         1a:9e:7a:86:36:d0:a6:b2:b6:43:24:7f:4f:b9:4a:e3:50:e4:
-         c6:d6:ac:85:ce:a8:e6:07:d1:44:b3:b8:e8:b4:54:79:68:4f:
-         36:29:b3:f8:e2:d0:05:40:d9:ca:05:6b:16:56:c9:6f:9f:63:
-         ff:99:fc:e0:69:b7:e3:cd:93:4c:1d:29:8c:23:40:bd:0b:eb:
-         fd:2d:88:fc:28:4e:77:76:6b:2c:85:ca:5c:61:31:9e:50:f0:
-         7e:41:ab:c3:5e:73:e5:1c:3e:03:52:5a:07:12:d9:b8:6d:5e:
-         af:f4:6a:5c:e6:f5:01:8a:66:6e:bc:4a:f0:fb:b3:0a:48:5a:
-         6d:e6:ef:aa:ea:22:12:6b:c5:70:28:ac:8e:57:9e:54:9a:27:
-         6a:37:d7:8f:d8:0e:7d:c8:38:1d:de:d6:e0:3a:c6:81:2d:f9:
-         bb:f4:ae:4e:ad:c2:b2:e3:90:8f:e0:24:98:b3:ea:ef:0d:95:
-         2e:3c:e3:65:b4:d8:e3:99:10:80:4f:35:61:df:7d:77:c3:4f:
-         ab:ff:5b:ed
+         10:3f:46:8b:31:46:fb:0d:a1:00:4a:1e:3c:27:16:92:29:b7:
+         73:a1:2e:69:a0:a3:1b:dc:4c:9f:63:81:ee:02:9b:78:bf:46:
+         94:f4:2a:80:03:5a:da:15:51:91:bc:16:27:61:c7:2f:17:15:
+         c8:af:6e:87:26:bb:1e:8e:32:92:f8:45:1e:86:f6:f1:eb:17:
+         02:11:75:6e:e8:9f:cd:05:d7:43:35:bd:17:42:ef:df:f9:55:
+         cc:a3:3f:4c:dd:f1:9b:2f:10:55:a4:d4:cf:9c:e5:af:85:6a:
+         98:eb:7d:83:e7:68:af:32:7f:d9:90:d7:ed:62:07:6e:47:13:
+         e1:6f:a2:6c:1a:4e:47:7a:f8:10:a9:4e:45:0c:64:39:b5:8d:
+         6f:ff:e6:b0:76:b0:b3:79:4b:a1:fa:26:96:63:7c:c5:58:c9:
+         f9:46:bc:ab:0d:a8:be:e5:c0:29:f8:d1:ca:bc:ca:0b:8e:90:
+         8d:68:50:92:79:30:51:da:58:68:b2:16:1d:e0:1c:e1:1e:f4:
+         4b:aa:8e:14:ac:fc:33:59:c4:23:2f:85:6d:6e:76:cf:fe:04:
+         3d:45:d1:62:e4:68:c5:ff:25:f3:6e:cb:10:21:cc:13:84:e9:
+         e5:53:c2:ca:b5:34:43:38:14:ec:b8:66:3d:69:1c:bc:cb:82:
+         b5:d0:84:ac
 -----BEGIN CERTIFICATE REQUEST-----
 MIICVjCCAT4CAQIwETEPMA0GA1UEAwwGc2lnbmVkMIIBIjANBgkqhkiG9w0BAQEF
-AAOCAQ8AMIIBCgKCAQEAqD4nMeIzjlGQBlVb7ryLorNTdH0GbUPPEldG/FZ58M2v
-0dwZszxUOYW0ah6jD/Tu548cyZl5XZK1fqZJGuzl9BKObVeahimyOEIeqcdzsanj
-nPxc+VGlR85FryEg2EVA/qK/Xnc0628XvP0GMypvZGxhA3at3eQRAj9IsjmUzNow
-QTaOviR0skVgulkOtR39D+iXR2HEnYjvCWkB137NG63/0hl9yDXPclXNHmhYirJ4
-nHayLI40PZGcwtj9IbO9ckOF3W5OCkeSD+T55kMg9iUifuOUcKgCLvYL4S0iv5QA
-TjEjg3kAcCigtjIb7sjU/xbXGhdBOMBc7Rje1xr0AQIDAQABoAAwDQYJKoZIhvcN
-AQELBQADggEBABcJ4rjG1R5EYIa/i3y5ekNVdjgy+p2tCmvqVp5NRV1YrgiTINZ5
-mSB+iGq7FLZio+EqgqYunRqeeoY20KaytkMkf0+5SuNQ5MbWrIXOqOYH0USzuOi0
-VHloTzYps/ji0AVA2coFaxZWyW+fY/+Z/OBpt+PNk0wdKYwjQL0L6/0tiPwoTnd2
-ayyFylxhMZ5Q8H5Bq8Nec+UcPgNSWgcS2bhtXq/0alzm9QGKZm68SvD7swpIWm3m
-76rqIhJrxXAorI5XnlSaJ2o314/YDn3IOB3e1uA6xoEt+bv0rk6twrLjkI/gJJiz
-6u8NlS4842W02OOZEIBPNWHffXfDT6v/W+0=
+AAOCAQ8AMIIBCgKCAQEA0T4gP8BeZHgf9qhgx8gNe6fJwfV+wna3zA/Cd+S6PUGB
+3LOhmt6DbIApeBe5zysOtV50BOXGrWZKz2/47BxBycBKKHQXH4UfEdJaNsC9CKNy
+ugAe1/j9RCMht7pnfPzBXKz+ztdyixc6Kw+g1tMv7W0o6QD3pE1KzULj/m9Ees1p
+u1CQUU2DrQRdkUgreoYpTRlaA5iM6RJhmdtrxsr35eDFDGP72dD3furiOOWOE35j
+a38m/17apbwKt4DJWD71KFzcomJWgGQwZ6v30dO0UWFRFKGLgq41+c2LfjuxDTxr
+e6pQUzs/RBxRO5EB0sM4MRomibqOWHZm+00C/+bdHQIDAQABoAAwDQYJKoZIhvcN
+AQELBQADggEBABA/RosxRvsNoQBKHjwnFpIpt3OhLmmgoxvcTJ9jge4Cm3i/RpT0
+KoADWtoVUZG8Fidhxy8XFcivbocmux6OMpL4RR6G9vHrFwIRdW7on80F10M1vRdC
+79/5VcyjP0zd8ZsvEFWk1M+c5a+FapjrfYPnaK8yf9mQ1+1iB25HE+FvomwaTkd6
++BCpTkUMZDm1jW//5rB2sLN5S6H6JpZjfMVYyflGvKsNqL7lwCn40cq8yguOkI1o
+UJJ5MFHaWGiyFh3gHOEe9EuqjhSs/DNZxCMvhW1uds/+BD1F0WLkaMX/JfNuyxAh
+zBOE6eVTwsq1NEM4FOy4Zj1pHLzLgrXQhKw=
 -----END CERTIFICATE REQUEST-----

--- a/spec/fixtures/ssl/trusted_oid_mapping.yaml
+++ b/spec/fixtures/ssl/trusted_oid_mapping.yaml
@@ -1,0 +1,5 @@
+---
+oid_mapping:
+  '1.3.6.1.4.1.34380.1.2.1.1':
+    shortname : 'myshortname'
+    longname  : 'Long name'

--- a/spec/fixtures/ssl/unknown-127.0.0.1-key.pem
+++ b/spec/fixtures/ssl/unknown-127.0.0.1-key.pem
@@ -1,117 +1,117 @@
 RSA Private-Key: (2048 bit, 2 primes)
 modulus:
-    00:c3:c8:2b:f4:88:83:50:13:f7:3d:f8:b6:b8:7b:
-    d0:58:7e:88:9c:a5:c2:30:72:36:9d:9a:d1:73:79:
-    c1:6d:06:3f:3b:f3:10:b6:87:3d:55:a4:e2:a9:c1:
-    48:d4:fd:30:8f:36:46:2f:96:bc:a5:e4:35:d9:89:
-    b2:8b:8b:90:ab:9a:b1:f9:ed:fa:67:3e:ea:27:42:
-    59:67:bb:69:18:e6:d7:0d:1a:0e:ad:c2:58:62:24:
-    05:6e:18:39:db:09:7d:96:a5:c9:c7:56:ba:68:e0:
-    06:27:37:15:e9:5c:f3:bf:b0:29:9b:0d:c7:ea:54:
-    a7:41:3f:11:11:db:23:3b:23:33:3e:c7:9c:d7:82:
-    99:23:df:c2:5a:4d:90:2f:73:64:92:bc:b8:f5:b5:
-    3f:56:e2:5d:95:e2:a8:3f:fa:ed:96:af:b8:3d:63:
-    fd:cd:24:2d:27:32:c8:41:7e:38:e8:02:3e:87:ce:
-    ab:f2:40:4d:a2:ec:42:ea:b5:14:ff:9d:ca:4b:d9:
-    de:84:4d:45:b7:d9:d9:56:7b:e3:7d:af:de:19:76:
-    91:cb:72:e9:b0:02:ca:8b:75:f8:54:23:ae:03:ab:
-    ec:48:ba:d6:c9:1a:0b:5b:7d:f9:f1:d7:9a:1a:83:
-    89:b9:f7:e7:ea:2c:11:2f:0f:c4:63:78:ff:5b:80:
-    be:0f
+    00:b4:5f:1a:9d:71:c7:2d:1b:5d:b7:3a:5d:c7:3c:
+    e9:8f:f4:b3:0d:fa:03:91:f1:60:70:e6:6e:8c:e9:
+    bc:12:6e:ef:f0:fb:e1:7b:7f:bf:54:00:8a:4d:96:
+    8c:6b:2c:ad:a9:2a:33:ee:20:ec:ea:18:c2:d0:26:
+    43:d9:5d:2f:15:3a:72:42:b7:28:18:23:9d:ed:6f:
+    fe:f1:6b:66:d4:eb:f8:13:22:ce:48:f8:b3:58:75:
+    2c:ca:4f:30:24:45:a2:9d:bc:bc:3a:da:47:28:82:
+    07:0f:b2:8d:17:17:68:db:89:cc:2c:de:3e:44:d0:
+    d0:09:a8:6c:f6:2d:d9:16:18:8c:35:de:36:ac:83:
+    fe:4f:cb:20:44:f0:0b:7a:a7:64:12:b1:aa:5d:74:
+    87:95:0e:38:42:4f:68:7e:48:66:31:5f:aa:43:ae:
+    25:db:f0:56:73:89:72:11:fe:13:7c:09:e0:50:3a:
+    d3:53:95:90:a7:e6:7d:59:f5:dc:6c:00:a7:de:7c:
+    b4:23:b5:b7:3e:27:83:c3:89:68:df:0b:1e:8e:df:
+    b9:e7:9b:ff:19:ed:c7:22:b1:e1:66:78:10:12:c8:
+    f9:e8:e6:a7:02:29:8f:a1:33:a0:be:68:90:b3:eb:
+    3c:8e:cd:ef:51:de:5f:ae:4d:2d:50:bd:9d:51:2d:
+    9a:8d
 publicExponent: 65537 (0x10001)
 privateExponent:
-    3e:63:47:3e:81:51:f6:ee:a5:d6:e5:ae:b4:53:20:
-    2d:53:05:0d:85:f4:bf:a3:65:ac:0b:6d:bb:32:8d:
-    64:c4:9c:d9:e9:b6:e5:b3:6a:e4:23:ca:e6:f5:64:
-    d4:1a:6a:a2:f8:54:9d:4d:97:87:f5:95:03:61:51:
-    b8:0e:1d:67:d1:bf:ed:38:dc:96:92:01:e3:c8:cc:
-    dc:b5:67:e4:3b:8b:43:ed:8d:c7:e9:2a:68:fb:b9:
-    8f:3f:c1:0f:ff:92:39:b3:52:fd:66:b1:b8:41:cb:
-    34:2b:e5:9b:9b:b7:40:da:4e:27:ce:d8:69:df:d7:
-    fc:7e:b0:5d:d4:4b:01:c8:c3:18:1f:fa:ac:46:45:
-    1f:3a:87:82:49:56:30:3a:6b:88:61:1c:62:a8:b4:
-    e9:c3:9b:ac:78:e4:86:f0:96:71:11:54:b5:0b:c7:
-    28:c0:0b:d0:b5:ce:9a:2e:db:e6:e4:75:52:1a:72:
-    09:6c:b4:5c:d0:ff:0e:87:ec:74:59:2b:21:12:39:
-    ce:d3:45:89:91:75:1a:4b:20:59:d3:bd:ba:92:78:
-    f8:58:c8:db:48:30:d6:43:72:24:4a:2d:de:18:09:
-    66:2c:27:eb:b9:ab:16:66:d0:85:6e:b5:d0:89:80:
-    95:fc:e1:7f:6e:c0:52:1b:15:d3:3c:4f:ce:81:b8:
-    a1
+    00:ec:bb:e6:32:bf:22:ac:11:3e:ef:3d:ab:d7:d4:
+    1a:b8:d6:72:2b:e5:f8:c9:94:05:00:29:70:ef:81:
+    d7:56:5a:44:92:06:05:ec:11:bf:0c:81:a9:04:2c:
+    94:20:16:83:d7:83:8c:a4:fe:91:f4:ae:8b:02:a7:
+    36:66:13:e7:b7:f4:fe:02:92:62:0d:4c:b1:fa:f1:
+    03:ab:d9:4b:1e:2a:97:6e:86:40:39:86:31:dd:e7:
+    ec:e1:9b:0d:94:8d:d0:e1:36:d5:d6:68:a6:fc:83:
+    ac:c0:ed:98:40:b6:78:e9:ab:f2:4e:f1:62:c8:ef:
+    48:1d:64:f1:9e:2a:8e:c2:6f:41:75:a5:47:35:97:
+    e3:43:9d:ac:87:4d:fe:48:a6:b4:ae:cb:2f:19:9e:
+    1f:1e:37:1b:8c:87:62:c6:f6:0d:05:60:b9:45:d6:
+    62:ab:0d:0d:ed:34:e9:ba:4e:ea:1d:84:6a:77:4c:
+    ad:eb:c9:90:ca:a7:7a:8c:79:f2:85:2e:63:98:2d:
+    40:c3:46:fc:96:17:39:ac:ad:bb:e6:9d:d3:8d:79:
+    74:3f:72:f8:47:d7:8f:ae:54:f7:e5:66:32:42:0d:
+    34:bb:77:ee:fc:a7:23:f7:0d:72:15:49:f1:a3:f2:
+    40:e9:48:20:5a:59:26:a3:c1:7c:90:87:78:78:ae:
+    c1
 prime1:
-    00:e1:7c:e4:10:00:3d:05:88:93:5a:ca:02:58:6e:
-    71:08:7e:a6:5e:04:19:13:43:4f:8f:30:b7:9b:04:
-    07:8b:1a:ac:a6:d8:21:aa:4b:60:5b:29:ae:47:bb:
-    d1:c0:e2:13:bb:85:d1:c6:72:82:8a:8f:59:24:5c:
-    64:11:36:84:61:55:6b:7d:b7:1b:34:93:7f:c5:1a:
-    dc:99:10:b4:0d:6b:69:f7:d6:63:32:8a:c7:56:e3:
-    ea:36:60:2a:3c:83:98:e3:e7:99:22:c3:cd:93:80:
-    e9:72:a9:37:f8:b4:2a:5c:1c:17:0c:14:ae:4d:d3:
-    cc:63:bf:ec:53:be:95:28:83
+    00:da:16:0f:12:2c:5b:07:2c:d8:de:91:ad:e7:72:
+    23:56:aa:e8:9c:a9:c3:ba:31:da:a1:a3:78:54:3e:
+    4f:94:ca:f7:bd:f7:91:54:4e:67:14:e0:15:cd:2a:
+    da:ae:e4:7f:b3:43:03:31:e1:6d:5c:85:4c:55:e9:
+    1c:e8:7c:48:1b:ef:b6:37:5d:35:bb:48:a9:23:a1:
+    53:7e:57:cf:47:cc:d9:7e:1a:49:ce:33:b9:cf:48:
+    5e:3f:6c:dd:df:5f:66:80:5f:31:5f:fa:8b:57:38:
+    62:08:68:6e:ad:97:56:fd:07:29:f0:2c:10:ec:5f:
+    68:48:4e:76:43:8d:d1:04:27
 prime2:
-    00:de:46:3d:58:07:8e:b7:61:d6:1a:9f:0a:d4:fb:
-    98:8c:c8:5f:74:26:42:01:95:74:6f:f5:05:f8:7e:
-    d1:56:cb:59:8a:3b:6d:9e:9e:5c:5a:af:31:40:bb:
-    0d:6e:18:da:9a:12:1f:5d:62:ba:b3:38:61:b2:26:
-    7a:43:86:58:85:85:71:6e:91:1e:02:14:22:64:e5:
-    13:9c:ef:a7:a1:a1:0d:96:70:fe:a3:23:a6:7d:23:
-    01:c6:45:69:f2:73:fd:2b:9b:5d:0e:63:b7:5f:c7:
-    23:d0:bb:52:11:e3:e1:6d:2b:5e:70:1a:eb:28:80:
-    24:a2:82:ab:dd:ef:5f:e6:85
+    00:d3:ba:8d:0e:84:11:45:b8:a8:66:29:5e:b2:0f:
+    a4:d2:7b:f9:ea:bc:39:03:af:22:a7:8f:e1:08:96:
+    90:91:69:e3:8b:cd:35:75:bd:34:22:5a:df:31:e7:
+    bb:48:d7:35:f6:35:0d:9d:77:e5:8c:13:32:54:3d:
+    12:7a:cb:d0:3c:1a:88:e3:ad:b7:08:40:dc:fe:c9:
+    e7:20:f1:a2:24:57:e3:f1:58:d2:c9:7c:71:0a:80:
+    80:da:2e:a7:d5:88:87:74:5e:87:0e:4d:44:37:f0:
+    4a:6c:cd:cc:26:f9:9d:78:c7:fe:a2:79:40:1d:38:
+    de:b4:00:be:2e:55:87:d8:2b
 exponent1:
-    28:e9:93:2b:c0:0f:52:58:b4:7b:cd:99:5d:58:34:
-    94:18:fe:b0:a2:47:b6:72:09:16:6e:fd:71:57:ea:
-    d2:77:75:8a:14:3f:0f:79:fb:b2:ae:be:5b:6f:9d:
-    a0:44:a4:d5:ea:72:e4:71:d4:73:b5:8c:b4:07:3b:
-    74:d0:12:76:e2:9b:cd:44:92:e0:18:3f:1f:91:3f:
-    23:5a:9f:80:ab:d3:9f:4f:3b:d2:68:d1:c0:57:3c:
-    20:bf:94:0a:44:ca:51:d7:ac:b6:5d:16:88:c3:e4:
-    17:94:d2:7e:02:9a:88:f9:e3:c8:a2:5b:f9:ed:0a:
-    f1:b2:59:fb:db:e1:8e:67
+    29:6a:93:06:22:82:4f:04:87:53:0d:5b:77:5e:c7:
+    b3:47:d5:d1:1a:b4:5f:01:e4:c1:59:a8:1a:67:92:
+    f9:70:ea:47:9b:62:70:1e:4b:99:3d:4d:26:9f:82:
+    d4:3f:f4:b8:78:7b:7c:d7:90:cb:47:4d:4d:eb:6d:
+    60:01:6a:38:53:f7:c8:df:dc:ba:6a:7c:24:96:18:
+    a3:1f:cd:ef:96:c9:9f:17:22:f9:13:fd:af:8d:d0:
+    c8:3e:c6:8c:0b:34:0e:21:05:e1:72:55:50:05:17:
+    28:fd:9c:37:3f:4c:77:d5:0a:73:e0:0a:7e:b9:47:
+    b6:a3:9f:f6:08:52:af:75
 exponent2:
-    00:99:7a:bc:be:fd:30:f1:b5:6f:c6:a0:0d:35:b5:
-    a8:c7:85:50:4b:fe:62:d3:7f:24:90:6e:0b:3a:64:
-    2f:1e:94:79:76:76:c4:a1:a3:4d:b8:1c:82:90:e4:
-    d8:48:2e:87:3b:9d:c9:e4:8c:d8:c8:09:e5:83:c3:
-    07:e7:7a:6b:c3:7e:ba:2d:93:ac:b9:d8:b7:4b:1d:
-    d6:a6:25:e1:85:3c:95:0a:4d:69:b6:b2:56:32:d0:
-    2a:58:82:f3:be:43:93:0c:3a:52:4e:2e:52:9f:a2:
-    fd:3b:13:2d:7f:46:f0:10:96:c2:b5:fc:10:66:bd:
-    dd:0e:0d:d6:a8:ff:b2:23:95
+    00:8c:47:74:3f:a2:d6:c2:c7:e6:a2:d1:54:11:4b:
+    76:1b:92:d2:71:68:c5:a9:a0:36:a8:a8:16:23:97:
+    86:2f:21:e6:05:f1:2f:33:53:e9:1f:bd:ef:54:e4:
+    40:dc:b0:e1:ea:bf:19:c7:33:f1:dd:4d:b6:b1:c3:
+    48:e4:1c:f7:59:6b:07:39:3a:16:23:9c:be:0e:fd:
+    7c:6a:02:4e:38:20:17:41:07:65:98:e3:1f:0e:23:
+    37:bb:d6:df:92:05:84:21:60:a3:c0:a1:06:ca:bd:
+    24:c2:53:d3:a8:1b:07:ef:47:2a:79:41:36:6e:66:
+    08:7f:60:62:a0:d6:40:4b:c3
 coefficient:
-    00:ba:b1:87:cb:c7:3d:32:91:59:87:c0:9b:2f:54:
-    d3:a1:ef:98:87:51:8e:2e:2f:6c:de:5c:cc:cb:b9:
-    29:b5:7e:7a:cc:75:d1:a0:91:55:c7:c5:ac:6f:ad:
-    bb:c7:58:76:ee:8d:b0:cb:40:fb:6c:b8:c4:ec:b6:
-    a8:24:c5:74:ea:b6:19:79:e8:da:71:0d:e4:ba:ab:
-    cc:8c:50:9d:51:91:ec:81:17:20:46:bf:e6:49:e0:
-    e8:8e:bd:ed:64:32:9e:66:67:92:3e:7f:c7:65:8d:
-    68:ae:b8:6f:e8:37:8a:ac:ec:d0:94:14:09:a7:a9:
-    90:47:d0:e7:bf:10:36:d7:91
+    03:04:c6:62:fd:21:9b:5b:d4:95:ea:6c:fd:7d:56:
+    28:09:97:19:ba:b2:12:0d:6c:6f:0b:0d:ed:41:59:
+    c4:6b:5d:67:3d:72:b9:f1:0b:2b:2d:e2:8c:d5:6d:
+    b0:ad:bc:55:32:77:87:60:b7:64:99:58:49:ed:3d:
+    bc:cd:6a:05:51:d3:e0:00:a7:b2:fc:fa:c7:fe:fa:
+    92:69:2e:b2:84:80:56:c7:27:bb:ff:8a:7f:7e:d4:
+    38:b9:75:c3:f3:f5:ec:d6:57:1a:c8:ff:de:35:5e:
+    93:50:20:7c:b4:71:1a:5a:43:3a:20:58:58:e1:58:
+    f0:fb:78:e1:ab:98:c7:ca
 -----BEGIN RSA PRIVATE KEY-----
-MIIEpAIBAAKCAQEAw8gr9IiDUBP3Pfi2uHvQWH6InKXCMHI2nZrRc3nBbQY/O/MQ
-toc9VaTiqcFI1P0wjzZGL5a8peQ12Ymyi4uQq5qx+e36Zz7qJ0JZZ7tpGObXDRoO
-rcJYYiQFbhg52wl9lqXJx1a6aOAGJzcV6Vzzv7Apmw3H6lSnQT8REdsjOyMzPsec
-14KZI9/CWk2QL3Nkkry49bU/VuJdleKoP/rtlq+4PWP9zSQtJzLIQX446AI+h86r
-8kBNouxC6rUU/53KS9nehE1Ft9nZVnvjfa/eGXaRy3LpsALKi3X4VCOuA6vsSLrW
-yRoLW3358deaGoOJuffn6iwRLw/EY3j/W4C+DwIDAQABAoIBAD5jRz6BUfbupdbl
-rrRTIC1TBQ2F9L+jZawLbbsyjWTEnNnptuWzauQjyub1ZNQaaqL4VJ1Nl4f1lQNh
-UbgOHWfRv+043JaSAePIzNy1Z+Q7i0PtjcfpKmj7uY8/wQ//kjmzUv1msbhByzQr
-5Zubt0DaTifO2Gnf1/x+sF3USwHIwxgf+qxGRR86h4JJVjA6a4hhHGKotOnDm6x4
-5IbwlnERVLULxyjAC9C1zpou2+bkdVIacglstFzQ/w6H7HRZKyESOc7TRYmRdRpL
-IFnTvbqSePhYyNtIMNZDciRKLd4YCWYsJ+u5qxZm0IVutdCJgJX84X9uwFIbFdM8
-T86BuKECgYEA4XzkEAA9BYiTWsoCWG5xCH6mXgQZE0NPjzC3mwQHixqsptghqktg
-WymuR7vRwOITu4XRxnKCio9ZJFxkETaEYVVrfbcbNJN/xRrcmRC0DWtp99ZjMorH
-VuPqNmAqPIOY4+eZIsPNk4Dpcqk3+LQqXBwXDBSuTdPMY7/sU76VKIMCgYEA3kY9
-WAeOt2HWGp8K1PuYjMhfdCZCAZV0b/UF+H7RVstZijttnp5cWq8xQLsNbhjamhIf
-XWK6szhhsiZ6Q4ZYhYVxbpEeAhQiZOUTnO+noaENlnD+oyOmfSMBxkVp8nP9K5td
-DmO3X8cj0LtSEePhbStecBrrKIAkooKr3e9f5oUCgYAo6ZMrwA9SWLR7zZldWDSU
-GP6woke2cgkWbv1xV+rSd3WKFD8Pefuyrr5bb52gRKTV6nLkcdRztYy0Bzt00BJ2
-4pvNRJLgGD8fkT8jWp+Aq9OfTzvSaNHAVzwgv5QKRMpR16y2XRaIw+QXlNJ+ApqI
-+ePIolv57Qrxsln72+GOZwKBgQCZery+/TDxtW/GoA01tajHhVBL/mLTfySQbgs6
-ZC8elHl2dsSho024HIKQ5NhILoc7ncnkjNjICeWDwwfnemvDfrotk6y52LdLHdam
-JeGFPJUKTWm2slYy0CpYgvO+Q5MMOlJOLlKfov07Ey1/RvAQlsK1/BBmvd0ODdao
-/7IjlQKBgQC6sYfLxz0ykVmHwJsvVNOh75iHUY4uL2zeXMzLuSm1fnrMddGgkVXH
-xaxvrbvHWHbujbDLQPtsuMTstqgkxXTqthl56NpxDeS6q8yMUJ1RkeyBFyBGv+ZJ
-4OiOve1kMp5mZ5I+f8dljWiuuG/oN4qs7NCUFAmnqZBH0Oe/EDbXkQ==
+MIIEowIBAAKCAQEAtF8anXHHLRtdtzpdxzzpj/SzDfoDkfFgcOZujOm8Em7v8Pvh
+e3+/VACKTZaMayytqSoz7iDs6hjC0CZD2V0vFTpyQrcoGCOd7W/+8Wtm1Ov4EyLO
+SPizWHUsyk8wJEWinby8OtpHKIIHD7KNFxdo24nMLN4+RNDQCahs9i3ZFhiMNd42
+rIP+T8sgRPALeqdkErGqXXSHlQ44Qk9ofkhmMV+qQ64l2/BWc4lyEf4TfAngUDrT
+U5WQp+Z9WfXcbACn3ny0I7W3PieDw4lo3wsejt+555v/Ge3HIrHhZngQEsj56Oan
+AimPoTOgvmiQs+s8js3vUd5frk0tUL2dUS2ajQIDAQABAoIBAADsu+YyvyKsET7v
+PavX1Bq41nIr5fjJlAUAKXDvgddWWkSSBgXsEb8MgakELJQgFoPXg4yk/pH0rosC
+pzZmE+e39P4CkmINTLH68QOr2UseKpduhkA5hjHd5+zhmw2UjdDhNtXWaKb8g6zA
+7ZhAtnjpq/JO8WLI70gdZPGeKo7Cb0F1pUc1l+NDnayHTf5IprSuyy8Znh8eNxuM
+h2LG9g0FYLlF1mKrDQ3tNOm6TuodhGp3TK3ryZDKp3qMefKFLmOYLUDDRvyWFzms
+rbvmndONeXQ/cvhH14+uVPflZjJCDTS7d+78pyP3DXIVSfGj8kDpSCBaWSajwXyQ
+h3h4rsECgYEA2hYPEixbByzY3pGt53IjVqronKnDujHaoaN4VD5PlMr3vfeRVE5n
+FOAVzSraruR/s0MDMeFtXIVMVekc6HxIG++2N101u0ipI6FTflfPR8zZfhpJzjO5
+z0heP2zd319mgF8xX/qLVzhiCGhurZdW/Qcp8CwQ7F9oSE52Q43RBCcCgYEA07qN
+DoQRRbioZilesg+k0nv56rw5A68ip4/hCJaQkWnji801db00IlrfMee7SNc19jUN
+nXfljBMyVD0SesvQPBqI4623CEDc/snnIPGiJFfj8VjSyXxxCoCA2i6n1YiHdF6H
+Dk1EN/BKbM3MJvmdeMf+onlAHTjetAC+LlWH2CsCgYApapMGIoJPBIdTDVt3Xsez
+R9XRGrRfAeTBWagaZ5L5cOpHm2JwHkuZPU0mn4LUP/S4eHt815DLR01N621gAWo4
+U/fI39y6anwklhijH83vlsmfFyL5E/2vjdDIPsaMCzQOIQXhclVQBRco/Zw3P0x3
+1Qpz4Ap+uUe2o5/2CFKvdQKBgQCMR3Q/otbCx+ai0VQRS3YbktJxaMWpoDaoqBYj
+l4YvIeYF8S8zU+kfve9U5EDcsOHqvxnHM/HdTbaxw0jkHPdZawc5OhYjnL4O/Xxq
+Ak44IBdBB2WY4x8OIze71t+SBYQhYKPAoQbKvSTCU9OoGwfvRyp5QTZuZgh/YGKg
+1kBLwwKBgAMExmL9IZtb1JXqbP19VigJlxm6shINbG8LDe1BWcRrXWc9crnxCyst
+4ozVbbCtvFUyd4dgt2SZWEntPbzNagVR0+AAp7L8+sf++pJpLrKEgFbHJ7v/in9+
+1Di5dcPz9ezWVxrI/941XpNQIHy0cRpaQzogWFjhWPD7eOGrmMfK
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/unknown-127.0.0.1.pem
+++ b/spec/fixtures/ssl/unknown-127.0.0.1.pem
@@ -6,64 +6,64 @@ Certificate:
         Issuer: CN=Unknown CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Apr 18 18:46:23 2031 GMT
+            Not After : Jun 15 01:19:37 2031 GMT
         Subject: CN=127.0.0.1
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:c3:c8:2b:f4:88:83:50:13:f7:3d:f8:b6:b8:7b:
-                    d0:58:7e:88:9c:a5:c2:30:72:36:9d:9a:d1:73:79:
-                    c1:6d:06:3f:3b:f3:10:b6:87:3d:55:a4:e2:a9:c1:
-                    48:d4:fd:30:8f:36:46:2f:96:bc:a5:e4:35:d9:89:
-                    b2:8b:8b:90:ab:9a:b1:f9:ed:fa:67:3e:ea:27:42:
-                    59:67:bb:69:18:e6:d7:0d:1a:0e:ad:c2:58:62:24:
-                    05:6e:18:39:db:09:7d:96:a5:c9:c7:56:ba:68:e0:
-                    06:27:37:15:e9:5c:f3:bf:b0:29:9b:0d:c7:ea:54:
-                    a7:41:3f:11:11:db:23:3b:23:33:3e:c7:9c:d7:82:
-                    99:23:df:c2:5a:4d:90:2f:73:64:92:bc:b8:f5:b5:
-                    3f:56:e2:5d:95:e2:a8:3f:fa:ed:96:af:b8:3d:63:
-                    fd:cd:24:2d:27:32:c8:41:7e:38:e8:02:3e:87:ce:
-                    ab:f2:40:4d:a2:ec:42:ea:b5:14:ff:9d:ca:4b:d9:
-                    de:84:4d:45:b7:d9:d9:56:7b:e3:7d:af:de:19:76:
-                    91:cb:72:e9:b0:02:ca:8b:75:f8:54:23:ae:03:ab:
-                    ec:48:ba:d6:c9:1a:0b:5b:7d:f9:f1:d7:9a:1a:83:
-                    89:b9:f7:e7:ea:2c:11:2f:0f:c4:63:78:ff:5b:80:
-                    be:0f
+                    00:b4:5f:1a:9d:71:c7:2d:1b:5d:b7:3a:5d:c7:3c:
+                    e9:8f:f4:b3:0d:fa:03:91:f1:60:70:e6:6e:8c:e9:
+                    bc:12:6e:ef:f0:fb:e1:7b:7f:bf:54:00:8a:4d:96:
+                    8c:6b:2c:ad:a9:2a:33:ee:20:ec:ea:18:c2:d0:26:
+                    43:d9:5d:2f:15:3a:72:42:b7:28:18:23:9d:ed:6f:
+                    fe:f1:6b:66:d4:eb:f8:13:22:ce:48:f8:b3:58:75:
+                    2c:ca:4f:30:24:45:a2:9d:bc:bc:3a:da:47:28:82:
+                    07:0f:b2:8d:17:17:68:db:89:cc:2c:de:3e:44:d0:
+                    d0:09:a8:6c:f6:2d:d9:16:18:8c:35:de:36:ac:83:
+                    fe:4f:cb:20:44:f0:0b:7a:a7:64:12:b1:aa:5d:74:
+                    87:95:0e:38:42:4f:68:7e:48:66:31:5f:aa:43:ae:
+                    25:db:f0:56:73:89:72:11:fe:13:7c:09:e0:50:3a:
+                    d3:53:95:90:a7:e6:7d:59:f5:dc:6c:00:a7:de:7c:
+                    b4:23:b5:b7:3e:27:83:c3:89:68:df:0b:1e:8e:df:
+                    b9:e7:9b:ff:19:ed:c7:22:b1:e1:66:78:10:12:c8:
+                    f9:e8:e6:a7:02:29:8f:a1:33:a0:be:68:90:b3:eb:
+                    3c:8e:cd:ef:51:de:5f:ae:4d:2d:50:bd:9d:51:2d:
+                    9a:8d
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Subject Alternative Name: 
                 DNS:127.0.0.1, DNS:127.0.0.2
     Signature Algorithm: sha256WithRSAEncryption
-         c5:f2:04:d3:b9:16:b1:fa:4a:2f:b8:0c:30:ef:ce:bd:2e:4f:
-         25:b6:aa:6f:c8:ae:1a:b4:e7:e6:86:51:28:34:53:ff:58:07:
-         68:d8:a0:ce:79:c7:2f:71:2c:55:1c:67:82:05:7d:f4:ce:d8:
-         b7:d7:71:67:03:e8:a2:38:34:16:83:8c:df:c3:27:80:e2:f9:
-         12:83:a0:49:e1:f3:5f:1d:c0:e2:68:91:77:f0:1d:a6:63:8b:
-         1d:96:ee:46:ec:41:cd:3c:55:63:a9:4b:5c:68:d6:44:67:47:
-         43:4a:21:8b:13:a2:10:06:5c:0f:1b:d5:e7:4d:b3:72:aa:bd:
-         cc:ac:e7:cf:8b:89:51:3c:d0:d3:0e:75:37:91:a0:e4:73:5b:
-         74:80:7d:64:a3:ee:4d:69:7d:97:15:35:1a:a9:a8:2a:f6:12:
-         d1:b7:73:ad:f1:ca:d9:9b:96:d6:66:ac:14:e5:88:2d:7e:ce:
-         20:61:94:4a:18:41:27:8e:2d:ad:45:d7:2e:ff:a8:d6:2c:a2:
-         01:54:28:16:15:84:5e:94:2d:56:a2:90:b3:31:40:3a:a8:04:
-         8d:42:55:45:10:7a:fe:19:4d:d9:b4:ef:95:2e:cf:6e:28:3f:
-         cb:12:7d:aa:34:96:60:b2:29:7e:6c:c3:bd:3b:f7:4c:6e:31:
-         25:60:b5:96
+         41:9d:8f:0b:f2:ab:e2:9e:c1:90:3d:ae:b2:63:2d:94:bb:18:
+         86:84:df:a1:ef:c4:06:70:41:73:59:71:67:f5:0e:58:14:2b:
+         0f:43:65:7b:f0:12:aa:24:f4:4e:33:e7:43:e5:0b:ed:8c:51:
+         5d:9e:a6:51:68:76:3f:e0:4c:f1:09:90:6e:9b:96:ae:03:c5:
+         e1:ca:b8:5c:d8:c5:cd:d5:e8:38:2e:59:78:10:3a:43:b0:3c:
+         07:e5:f3:66:2a:6a:29:9d:81:74:27:a1:86:2a:cc:7f:0a:c4:
+         c4:96:71:b1:08:ba:07:9d:90:28:01:8a:7f:fe:f8:db:f0:fa:
+         45:0b:ed:c5:81:84:96:aa:ce:49:90:99:ca:b2:d2:af:0a:ff:
+         02:a4:4e:fa:5c:5e:d4:60:42:d1:d2:fc:17:b5:aa:c0:e5:8b:
+         d4:e2:26:ee:d2:dc:6a:74:35:c5:67:f3:a7:9a:ed:9d:e2:c2:
+         d0:27:88:12:d2:2f:b1:42:67:bd:17:48:1f:cd:6d:9a:00:ff:
+         0d:ff:02:24:fd:8f:57:1e:d4:87:3e:5d:71:f0:b6:58:6a:46:
+         56:48:aa:94:09:85:a7:54:99:58:8e:a6:a8:ad:43:76:8a:63:
+         e0:45:78:2e:8b:3c:f2:46:e9:a5:0c:0c:2c:8f:57:ac:cf:8d:
+         90:93:26:87
 -----BEGIN CERTIFICATE-----
 MIICxzCCAa+gAwIBAgIBATANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDDApVbmtu
-b3duIENBMB4XDTcwMDEwMTAwMDAwMFoXDTMxMDQxODE4NDYyM1owFDESMBAGA1UE
-AwwJMTI3LjAuMC4xMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAw8gr
-9IiDUBP3Pfi2uHvQWH6InKXCMHI2nZrRc3nBbQY/O/MQtoc9VaTiqcFI1P0wjzZG
-L5a8peQ12Ymyi4uQq5qx+e36Zz7qJ0JZZ7tpGObXDRoOrcJYYiQFbhg52wl9lqXJ
-x1a6aOAGJzcV6Vzzv7Apmw3H6lSnQT8REdsjOyMzPsec14KZI9/CWk2QL3Nkkry4
-9bU/VuJdleKoP/rtlq+4PWP9zSQtJzLIQX446AI+h86r8kBNouxC6rUU/53KS9ne
-hE1Ft9nZVnvjfa/eGXaRy3LpsALKi3X4VCOuA6vsSLrWyRoLW3358deaGoOJuffn
-6iwRLw/EY3j/W4C+DwIDAQABoyMwITAfBgNVHREEGDAWggkxMjcuMC4wLjGCCTEy
-Ny4wLjAuMjANBgkqhkiG9w0BAQsFAAOCAQEAxfIE07kWsfpKL7gMMO/OvS5PJbaq
-b8iuGrTn5oZRKDRT/1gHaNigznnHL3EsVRxnggV99M7Yt9dxZwPoojg0FoOM38Mn
-gOL5EoOgSeHzXx3A4miRd/AdpmOLHZbuRuxBzTxVY6lLXGjWRGdHQ0ohixOiEAZc
-DxvV502zcqq9zKznz4uJUTzQ0w51N5Gg5HNbdIB9ZKPuTWl9lxU1GqmoKvYS0bdz
-rfHK2ZuW1masFOWILX7OIGGUShhBJ44trUXXLv+o1iyiAVQoFhWEXpQtVqKQszFA
-OqgEjUJVRRB6/hlN2bTvlS7Pbig/yxJ9qjSWYLIpfmzDvTv3TG4xJWC1lg==
+b3duIENBMB4XDTcwMDEwMTAwMDAwMFoXDTMxMDYxNTAxMTkzN1owFDESMBAGA1UE
+AwwJMTI3LjAuMC4xMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtF8a
+nXHHLRtdtzpdxzzpj/SzDfoDkfFgcOZujOm8Em7v8Pvhe3+/VACKTZaMayytqSoz
+7iDs6hjC0CZD2V0vFTpyQrcoGCOd7W/+8Wtm1Ov4EyLOSPizWHUsyk8wJEWinby8
+OtpHKIIHD7KNFxdo24nMLN4+RNDQCahs9i3ZFhiMNd42rIP+T8sgRPALeqdkErGq
+XXSHlQ44Qk9ofkhmMV+qQ64l2/BWc4lyEf4TfAngUDrTU5WQp+Z9WfXcbACn3ny0
+I7W3PieDw4lo3wsejt+555v/Ge3HIrHhZngQEsj56OanAimPoTOgvmiQs+s8js3v
+Ud5frk0tUL2dUS2ajQIDAQABoyMwITAfBgNVHREEGDAWggkxMjcuMC4wLjGCCTEy
+Ny4wLjAuMjANBgkqhkiG9w0BAQsFAAOCAQEAQZ2PC/Kr4p7BkD2usmMtlLsYhoTf
+oe/EBnBBc1lxZ/UOWBQrD0Nle/ASqiT0TjPnQ+UL7YxRXZ6mUWh2P+BM8QmQbpuW
+rgPF4cq4XNjFzdXoOC5ZeBA6Q7A8B+XzZipqKZ2BdCehhirMfwrExJZxsQi6B52Q
+KAGKf/742/D6RQvtxYGElqrOSZCZyrLSrwr/AqRO+lxe1GBC0dL8F7WqwOWL1OIm
+7tLcanQ1xWfzp5rtneLC0CeIEtIvsUJnvRdIH81tmgD/Df8CJP2PVx7Uhz5dcfC2
+WGpGVkiqlAmFp1SZWI6mqK1Ddopj4EV4Los88kbppQwMLI9XrM+NkJMmhw==
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/unknown-ca-key.pem
+++ b/spec/fixtures/ssl/unknown-ca-key.pem
@@ -1,117 +1,117 @@
 RSA Private-Key: (2048 bit, 2 primes)
 modulus:
-    00:ea:16:4c:26:71:56:ac:35:bb:2b:f6:1b:18:58:
-    16:0f:1c:39:3f:4d:02:e4:b2:a7:8b:bd:fe:99:57:
-    f2:a5:a8:15:01:79:0d:1d:f6:d9:12:db:d5:26:a2:
-    f6:58:af:4b:2c:aa:46:7a:53:63:9f:1f:1a:9e:1c:
-    fc:9a:8e:20:c8:c8:c8:db:4d:50:8d:4e:19:83:a1:
-    9d:54:49:26:7b:3a:e0:77:1d:7d:88:01:80:46:32:
-    70:47:16:08:71:de:12:94:67:fd:71:1f:41:56:93:
-    15:91:68:bd:05:3b:67:96:1f:7a:4d:d5:1e:b6:ac:
-    41:1f:f0:ce:d3:2d:96:d9:7c:ad:cd:be:b3:32:66:
-    18:03:2c:83:98:f1:e8:96:6f:85:0f:e1:1f:93:d0:
-    f9:09:43:8c:b1:ea:43:26:32:a5:c6:d2:32:75:2d:
-    ed:72:9d:bf:3a:bb:f3:4e:d0:0c:ac:ba:6b:fd:7f:
-    66:d8:12:40:4e:49:e7:d4:ec:70:03:71:37:cb:5e:
-    cc:d3:4f:f3:d2:cc:e2:39:eb:79:6c:71:e5:d1:0e:
-    45:4c:7a:3d:6f:39:e8:16:e7:de:60:eb:01:e7:80:
-    4e:42:1d:1c:33:0a:eb:f9:10:2c:5c:ed:0c:58:0b:
-    8c:fd:6d:f4:19:49:8a:a2:81:ab:04:b0:cb:7a:61:
-    1f:d3
+    00:b4:79:b0:16:e7:9b:22:20:17:4b:36:87:eb:38:
+    03:1f:df:88:00:1b:37:40:5e:1f:1d:89:1f:3e:f4:
+    fa:69:90:9c:d8:68:df:c8:71:07:07:4e:01:1d:f0:
+    a8:9a:67:94:af:47:f2:b8:60:f5:ca:fb:bb:ac:7c:
+    23:58:59:bc:95:b0:ad:b2:c7:a0:28:e1:4f:1e:c4:
+    ef:5f:2b:a3:4e:f2:6a:95:c8:4f:f5:af:bc:fa:36:
+    10:f9:a9:62:7a:04:d5:01:cd:9b:ba:97:32:4c:99:
+    e5:88:fc:05:84:34:f5:4a:f2:f1:ec:04:c7:c7:63:
+    28:eb:9e:ee:91:cd:95:8b:60:9e:5f:51:a1:2b:5a:
+    cd:02:b2:a7:52:6c:d1:8a:ab:b1:c4:52:cd:10:ce:
+    9e:56:24:6c:63:84:2c:15:6c:c0:62:ea:c2:d9:04:
+    88:e2:e2:0f:ff:ce:87:51:eb:77:50:83:33:1c:c7:
+    88:5b:08:d4:3a:22:2f:13:a6:89:f7:4b:a0:2e:30:
+    c1:12:7a:bb:37:1f:aa:87:56:44:2f:5a:63:4b:b2:
+    36:f6:29:5e:b8:67:52:6f:63:2a:ad:3d:c3:a5:45:
+    af:97:e9:85:9e:76:1e:51:9c:68:36:58:32:ad:cf:
+    3e:4d:f0:92:e2:ad:d6:f0:e1:5d:af:08:ca:2a:82:
+    0e:a3
 publicExponent: 65537 (0x10001)
 privateExponent:
-    00:b5:87:11:0a:86:bd:d5:d1:dd:12:1c:49:aa:b9:
-    34:72:07:4b:05:a1:ac:ea:b8:f8:60:cf:b7:8e:26:
-    bb:8e:67:27:d2:fa:92:87:78:13:a2:22:43:cb:30:
-    78:a5:11:5a:d4:8a:3f:19:41:6d:71:c9:e7:14:52:
-    1a:39:a8:9a:17:da:4c:98:73:fe:51:76:0d:27:1c:
-    bf:2a:cb:87:41:ec:c8:80:d6:a7:b0:3e:a9:c0:c6:
-    00:77:bf:c8:50:b5:0b:e7:76:34:fd:f2:64:f2:c4:
-    20:e7:a0:37:64:c5:4a:71:0a:7c:07:bb:8b:93:d1:
-    44:b7:86:40:7d:57:4f:31:db:98:22:21:d5:f3:b0:
-    57:4e:f6:c9:a4:08:43:3d:d8:ce:59:aa:a7:1f:da:
-    93:40:11:cf:8c:14:9d:f3:10:9f:cf:0a:d0:cf:2b:
-    b6:ea:e5:3c:92:9f:c2:6f:24:86:71:15:61:49:7b:
-    77:48:c1:d2:13:67:1a:f7:c0:89:3d:3d:87:cf:6e:
-    5c:e4:46:28:fe:33:89:3c:09:fc:50:3c:b7:a9:25:
-    3c:f2:a5:a0:e1:e0:9c:d1:4a:3e:11:5b:10:1a:33:
-    29:c7:ca:0b:ac:bf:c2:be:90:27:1f:ef:d7:d2:ca:
-    5f:37:b3:b3:b9:3a:35:87:be:ca:c3:f7:59:03:f7:
-    7e:f1
+    00:9b:ce:8e:a2:47:93:5b:b3:be:c8:75:2c:84:7a:
+    97:df:f5:78:11:37:6d:cc:c9:35:2d:a7:8a:ed:2c:
+    4b:df:c5:34:53:74:be:f5:e9:f6:7a:6c:f2:73:e9:
+    a7:75:9d:c4:f4:4a:36:16:cd:c6:85:56:2c:a0:ed:
+    8f:0a:20:76:b9:f8:8d:0c:d2:60:c7:ca:34:27:49:
+    37:aa:bf:1e:be:f2:73:e8:19:c6:46:42:50:f0:e6:
+    aa:63:0f:c3:ef:b9:aa:37:63:4d:75:9a:40:97:77:
+    29:7d:c8:ad:ee:84:55:dc:3d:bf:73:d6:70:af:07:
+    41:75:a1:81:2f:29:00:59:11:3e:98:49:12:ec:e9:
+    9d:ca:ca:71:1e:bc:2f:9f:13:9c:5c:01:54:6d:69:
+    6b:85:6f:2a:2f:96:a5:38:37:e3:0c:7d:9f:6c:12:
+    a4:13:1b:bf:cb:35:16:88:a6:c6:47:6f:0b:61:22:
+    c2:de:00:7a:b1:70:f6:1e:01:99:70:87:1d:23:21:
+    0f:bf:41:59:16:75:40:8e:7c:50:73:bb:ce:17:7c:
+    07:ec:f2:83:12:95:4e:6a:ac:79:89:8f:32:58:61:
+    af:55:df:30:1d:3a:d1:f3:fa:ee:74:27:73:62:f8:
+    c4:e2:b2:e3:a5:64:e4:6b:4b:86:13:44:00:3d:51:
+    45:d9
 prime1:
-    00:f7:83:23:4b:6f:82:af:b6:7a:0f:1f:1a:05:21:
-    d1:a1:84:d1:07:24:db:dd:64:9f:16:84:eb:c4:bf:
-    ec:cf:2f:69:92:21:b8:88:05:24:8c:bc:c1:db:d0:
-    38:53:bf:43:dc:5b:5e:42:7b:ad:de:d6:3a:04:9e:
-    a5:a7:f0:0b:2e:4e:2a:20:6f:95:7d:f0:be:ff:12:
-    c6:f4:d2:ca:39:e1:a5:c9:34:58:3b:3d:40:c1:88:
-    63:c3:cc:87:02:25:70:88:58:df:ec:b6:d6:0c:9e:
-    15:2d:57:e1:34:e9:2e:ac:51:cf:c4:83:dd:b6:11:
-    44:23:b8:95:50:6c:40:ae:ed
+    00:da:9b:01:67:9b:20:66:3b:69:da:ce:9e:ac:fa:
+    03:84:8e:da:fb:04:8d:9b:f0:ff:c9:55:a4:26:c4:
+    b8:e3:1c:47:7d:fb:f5:2e:f6:50:22:75:63:ac:b7:
+    2d:f0:d5:75:0f:04:d5:e6:ee:75:9c:15:9f:e4:5c:
+    76:2c:0b:df:7f:9d:5f:16:3a:8a:82:36:6b:c9:fc:
+    49:e1:83:fe:cf:85:e1:fc:80:60:06:33:b2:e6:54:
+    6c:ba:29:6e:e4:3a:ee:d7:e6:0a:d6:bd:27:5d:40:
+    e0:89:97:89:2a:3e:cf:a5:ec:ae:5f:db:df:3e:e8:
+    c4:b0:9a:77:96:4d:a1:5e:5d
 prime2:
-    00:f2:1d:4d:7f:ee:9e:a5:0f:c9:73:a5:4d:fe:7c:
-    0a:94:8e:c6:77:c8:ec:53:e0:03:f5:65:42:39:40:
-    26:02:46:8f:05:3d:b9:ba:f2:29:8a:b4:3c:60:37:
-    85:ee:e0:ba:e2:35:69:be:84:95:53:f3:fd:b8:b9:
-    5b:51:76:10:2a:f8:b2:54:58:ab:e5:89:18:46:df:
-    08:c0:4f:57:56:cc:1c:f2:53:e6:b6:91:c0:bd:9c:
-    c6:a8:8c:bf:a0:d4:b6:86:37:50:f9:69:78:95:bd:
-    83:6f:5e:64:1a:b7:75:31:2c:a2:c5:c9:b7:b7:80:
-    c4:61:ac:fd:f7:c7:88:71:bf
+    00:d3:58:ea:f8:aa:9b:e0:95:aa:81:27:f4:1a:5e:
+    ae:60:bf:0f:37:be:b8:64:78:d4:ce:47:7e:21:82:
+    49:a7:f6:ff:15:62:1c:87:e8:c2:d5:d2:9b:d2:21:
+    87:36:36:66:bc:03:23:8f:5e:09:2b:4f:a2:8a:7f:
+    ea:c8:ea:fb:21:54:4a:ba:b8:14:74:59:50:fa:31:
+    cf:31:c3:22:32:4a:db:05:b6:3c:f5:9f:6b:cd:3c:
+    6b:1b:48:b0:b5:13:5d:c7:b6:13:4e:09:85:e2:db:
+    38:ac:ee:27:42:d8:49:47:9e:0c:59:95:97:e7:c2:
+    78:0a:65:c9:ee:29:e8:50:ff
 exponent1:
-    3c:63:9c:9a:ed:2c:1f:9f:10:0c:dc:73:c6:c8:c7:
-    92:f7:0a:e1:09:57:33:9f:37:49:91:48:cd:0a:5e:
-    c6:f6:34:75:d9:10:62:ef:8e:49:60:4c:94:4b:2b:
-    53:13:99:85:0c:2d:e5:5e:b3:bf:68:d9:63:03:2a:
-    3b:dd:4f:7d:0e:c9:2c:7c:cd:26:9b:34:9e:9b:80:
-    3b:7f:aa:a3:90:b0:98:74:d3:0a:31:19:b9:9e:83:
-    68:e4:60:14:5f:fa:22:ea:3c:48:4f:1b:ce:9c:4b:
-    62:72:cc:99:d2:42:f6:fc:47:0b:15:79:64:d0:b5:
-    a5:59:85:e4:c7:64:c8:c9
+    50:f7:12:19:1e:72:6c:8a:da:d4:e8:ac:0a:62:fb:
+    04:90:a8:78:4a:22:6c:bc:60:f0:5f:e0:d1:5f:11:
+    1f:44:ad:11:f3:4c:c7:1d:01:67:11:d5:5d:f5:e6:
+    75:09:8a:36:8a:d2:f2:9a:25:43:2f:1b:2e:48:34:
+    98:71:b9:50:99:a7:cb:22:d9:84:0a:c5:f7:64:92:
+    b4:8c:df:c6:5a:ce:ed:67:5a:a9:51:62:94:3e:76:
+    9a:a8:97:e2:be:15:12:2f:a8:9a:0a:2a:d7:36:1d:
+    33:b8:c5:5b:b9:31:cd:41:90:ff:fd:fe:7c:5d:57:
+    e4:15:01:ef:d0:46:d1:1d
 exponent2:
-    00:d5:ba:32:58:d5:cf:6c:0c:94:9c:26:f7:c3:c7:
-    c2:1b:44:32:45:39:b4:0d:92:ba:4b:dd:38:69:8b:
-    8c:42:04:01:6a:f2:03:4b:d9:4b:fc:aa:80:85:bb:
-    5d:da:f2:bd:66:c5:19:f4:d9:db:6c:81:fd:9f:1c:
-    d9:54:fe:f0:e4:ce:27:b6:37:94:7f:0a:d7:c8:70:
-    48:ac:63:1d:c9:7c:63:ad:33:8d:7d:eb:0a:87:17:
-    a7:72:d0:d4:b4:e8:31:bc:27:86:ae:b5:81:82:46:
-    0a:89:bc:7c:87:ed:1d:61:ec:72:40:41:82:91:55:
-    f5:85:f8:0d:35:b7:09:66:c7
+    00:91:f0:d9:b8:c2:df:06:b3:72:dc:e3:00:fd:e0:
+    99:9b:76:f3:84:33:ef:d2:79:59:c1:e3:be:66:57:
+    38:93:82:cc:dc:30:36:b1:66:fa:7b:7a:86:5d:11:
+    07:f4:58:96:92:87:bc:5b:78:bc:ee:2a:7c:7c:15:
+    1e:c4:84:f6:cb:2a:10:bc:64:f6:c2:ed:16:2c:de:
+    8e:4b:b7:8a:7a:9e:14:26:1a:94:77:ac:11:5d:d4:
+    b5:c5:4e:69:af:70:63:16:d0:54:fe:53:37:1f:d2:
+    ef:8d:02:9b:1b:de:8c:a3:a6:b0:b2:7f:c9:38:a1:
+    a2:10:d3:ff:1f:b5:d2:95:73
 coefficient:
-    3d:9b:b0:01:4b:43:c3:bf:50:86:d8:c8:52:d4:4d:
-    7a:05:40:2d:20:50:d4:4a:a9:33:a3:b8:d1:fc:6b:
-    eb:be:c9:df:44:f7:70:51:05:d8:58:d2:a0:d8:e0:
-    36:fc:56:43:25:0f:2a:b6:41:a2:25:99:01:8b:d5:
-    93:f4:d6:04:ae:4f:40:44:f6:f2:85:a8:9f:35:99:
-    63:9d:ef:f9:f5:3e:5d:07:3c:96:23:a6:26:8c:28:
-    d1:60:cd:13:18:3b:41:e9:30:31:83:50:73:91:ba:
-    5a:a3:69:d1:6e:a8:40:f2:72:df:e8:88:73:9c:a7:
-    ce:e7:9f:11:97:e5:04:6d
+    00:bb:0a:77:ec:98:3c:fe:92:2b:66:06:7a:2a:80:
+    a6:41:bb:d8:60:7e:fa:90:41:f3:4d:e4:4e:95:1e:
+    48:19:33:49:9a:24:09:6c:17:98:ce:72:09:ad:96:
+    43:3a:16:6c:16:cd:38:39:13:58:3e:dc:89:98:08:
+    38:d3:e5:d8:c1:34:8c:71:a9:88:a1:79:23:af:ad:
+    94:04:7a:ca:20:82:76:af:84:2a:43:c4:d6:96:b0:
+    c8:f7:e6:be:4c:e8:d8:7c:bb:79:7a:c8:d9:32:72:
+    81:63:9f:2c:45:33:e3:6a:6a:42:3d:d6:19:b4:0d:
+    0d:15:1b:44:67:47:ef:b6:2e
 -----BEGIN RSA PRIVATE KEY-----
-MIIEpAIBAAKCAQEA6hZMJnFWrDW7K/YbGFgWDxw5P00C5LKni73+mVfypagVAXkN
-HfbZEtvVJqL2WK9LLKpGelNjnx8anhz8mo4gyMjI201QjU4Zg6GdVEkmezrgdx19
-iAGARjJwRxYIcd4SlGf9cR9BVpMVkWi9BTtnlh96TdUetqxBH/DO0y2W2Xytzb6z
-MmYYAyyDmPHolm+FD+Efk9D5CUOMsepDJjKlxtIydS3tcp2/OrvzTtAMrLpr/X9m
-2BJATknn1OxwA3E3y17M00/z0sziOet5bHHl0Q5FTHo9bznoFufeYOsB54BOQh0c
-Mwrr+RAsXO0MWAuM/W30GUmKooGrBLDLemEf0wIDAQABAoIBAQC1hxEKhr3V0d0S
-HEmquTRyB0sFoazquPhgz7eOJruOZyfS+pKHeBOiIkPLMHilEVrUij8ZQW1xyecU
-Uho5qJoX2kyYc/5Rdg0nHL8qy4dB7MiA1qewPqnAxgB3v8hQtQvndjT98mTyxCDn
-oDdkxUpxCnwHu4uT0US3hkB9V08x25giIdXzsFdO9smkCEM92M5Zqqcf2pNAEc+M
-FJ3zEJ/PCtDPK7bq5TySn8JvJIZxFWFJe3dIwdITZxr3wIk9PYfPblzkRij+M4k8
-CfxQPLepJTzypaDh4JzRSj4RWxAaMynHygusv8K+kCcf79fSyl83s7O5OjWHvsrD
-91kD937xAoGBAPeDI0tvgq+2eg8fGgUh0aGE0Qck291knxaE68S/7M8vaZIhuIgF
-JIy8wdvQOFO/Q9xbXkJ7rd7WOgSepafwCy5OKiBvlX3wvv8SxvTSyjnhpck0WDs9
-QMGIY8PMhwIlcIhY3+y21gyeFS1X4TTpLqxRz8SD3bYRRCO4lVBsQK7tAoGBAPId
-TX/unqUPyXOlTf58CpSOxnfI7FPgA/VlQjlAJgJGjwU9ubryKYq0PGA3he7guuI1
-ab6ElVPz/bi5W1F2ECr4slRYq+WJGEbfCMBPV1bMHPJT5raRwL2cxqiMv6DUtoY3
-UPlpeJW9g29eZBq3dTEsosXJt7eAxGGs/ffHiHG/AoGAPGOcmu0sH58QDNxzxsjH
-kvcK4QlXM583SZFIzQpexvY0ddkQYu+OSWBMlEsrUxOZhQwt5V6zv2jZYwMqO91P
-fQ7JLHzNJps0npuAO3+qo5CwmHTTCjEZuZ6DaORgFF/6Iuo8SE8bzpxLYnLMmdJC
-9vxHCxV5ZNC1pVmF5MdkyMkCgYEA1boyWNXPbAyUnCb3w8fCG0QyRTm0DZK6S904
-aYuMQgQBavIDS9lL/KqAhbtd2vK9ZsUZ9NnbbIH9nxzZVP7w5M4ntjeUfwrXyHBI
-rGMdyXxjrTONfesKhxenctDUtOgxvCeGrrWBgkYKibx8h+0dYexyQEGCkVX1hfgN
-NbcJZscCgYA9m7ABS0PDv1CG2MhS1E16BUAtIFDUSqkzo7jR/GvrvsnfRPdwUQXY
-WNKg2OA2/FZDJQ8qtkGiJZkBi9WT9NYErk9ARPbyhaifNZljne/59T5dBzyWI6Ym
-jCjRYM0TGDtB6TAxg1Bzkbpao2nRbqhA8nLf6IhznKfO558Rl+UEbQ==
+MIIEpQIBAAKCAQEAtHmwFuebIiAXSzaH6zgDH9+IABs3QF4fHYkfPvT6aZCc2Gjf
+yHEHB04BHfCommeUr0fyuGD1yvu7rHwjWFm8lbCtssegKOFPHsTvXyujTvJqlchP
+9a+8+jYQ+aliegTVAc2bupcyTJnliPwFhDT1SvLx7ATHx2Mo657ukc2Vi2CeX1Gh
+K1rNArKnUmzRiquxxFLNEM6eViRsY4QsFWzAYurC2QSI4uIP/86HUet3UIMzHMeI
+WwjUOiIvE6aJ90ugLjDBEnq7Nx+qh1ZEL1pjS7I29ileuGdSb2MqrT3DpUWvl+mF
+nnYeUZxoNlgyrc8+TfCS4q3W8OFdrwjKKoIOowIDAQABAoIBAQCbzo6iR5Nbs77I
+dSyEepff9XgRN23MyTUtp4rtLEvfxTRTdL716fZ6bPJz6ad1ncT0SjYWzcaFViyg
+7Y8KIHa5+I0M0mDHyjQnSTeqvx6+8nPoGcZGQlDw5qpjD8Pvuao3Y011mkCXdyl9
+yK3uhFXcPb9z1nCvB0F1oYEvKQBZET6YSRLs6Z3KynEevC+fE5xcAVRtaWuFbyov
+lqU4N+MMfZ9sEqQTG7/LNRaIpsZHbwthIsLeAHqxcPYeAZlwhx0jIQ+/QVkWdUCO
+fFBzu84XfAfs8oMSlU5qrHmJjzJYYa9V3zAdOtHz+u50J3Ni+MTisuOlZORrS4YT
+RAA9UUXZAoGBANqbAWebIGY7adrOnqz6A4SO2vsEjZvw/8lVpCbEuOMcR3379S72
+UCJ1Y6y3LfDVdQ8E1ebudZwVn+RcdiwL33+dXxY6ioI2a8n8SeGD/s+F4fyAYAYz
+suZUbLopbuQ67tfmCta9J11A4ImXiSo+z6Xsrl/b3z7oxLCad5ZNoV5dAoGBANNY
+6viqm+CVqoEn9BpermC/Dze+uGR41M5HfiGCSaf2/xViHIfowtXSm9IhhzY2ZrwD
+I49eCStPoop/6sjq+yFUSrq4FHRZUPoxzzHDIjJK2wW2PPWfa808axtIsLUTXce2
+E04JheLbOKzuJ0LYSUeeDFmVl+fCeAplye4p6FD/AoGAUPcSGR5ybIra1OisCmL7
+BJCoeEoibLxg8F/g0V8RH0StEfNMxx0BZxHVXfXmdQmKNorS8polQy8bLkg0mHG5
+UJmnyyLZhArF92SStIzfxlrO7WdaqVFilD52mqiX4r4VEi+omgoq1zYdM7jFW7kx
+zUGQ//3+fF1X5BUB79BG0R0CgYEAkfDZuMLfBrNy3OMA/eCZm3bzhDPv0nlZweO+
+Zlc4k4LM3DA2sWb6e3qGXREH9FiWkoe8W3i87ip8fBUexIT2yyoQvGT2wu0WLN6O
+S7eKep4UJhqUd6wRXdS1xU5pr3BjFtBU/lM3H9LvjQKbG96Mo6awsn/JOKGiENP/
+H7XSlXMCgYEAuwp37Jg8/pIrZgZ6KoCmQbvYYH76kEHzTeROlR5IGTNJmiQJbBeY
+znIJrZZDOhZsFs04ORNYPtyJmAg40+XYwTSMcamIoXkjr62UBHrKIIJ2r4QqQ8TW
+lrDI9+a+TOjYfLt5esjZMnKBY58sRTPjampCPdYZtA0NFRtEZ0fvti4=
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/unknown-ca.pem
+++ b/spec/fixtures/ssl/unknown-ca.pem
@@ -6,30 +6,30 @@ Certificate:
         Issuer: CN=Unknown CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Apr 18 18:46:23 2031 GMT
+            Not After : Jun 15 01:19:37 2031 GMT
         Subject: CN=Unknown CA
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:ea:16:4c:26:71:56:ac:35:bb:2b:f6:1b:18:58:
-                    16:0f:1c:39:3f:4d:02:e4:b2:a7:8b:bd:fe:99:57:
-                    f2:a5:a8:15:01:79:0d:1d:f6:d9:12:db:d5:26:a2:
-                    f6:58:af:4b:2c:aa:46:7a:53:63:9f:1f:1a:9e:1c:
-                    fc:9a:8e:20:c8:c8:c8:db:4d:50:8d:4e:19:83:a1:
-                    9d:54:49:26:7b:3a:e0:77:1d:7d:88:01:80:46:32:
-                    70:47:16:08:71:de:12:94:67:fd:71:1f:41:56:93:
-                    15:91:68:bd:05:3b:67:96:1f:7a:4d:d5:1e:b6:ac:
-                    41:1f:f0:ce:d3:2d:96:d9:7c:ad:cd:be:b3:32:66:
-                    18:03:2c:83:98:f1:e8:96:6f:85:0f:e1:1f:93:d0:
-                    f9:09:43:8c:b1:ea:43:26:32:a5:c6:d2:32:75:2d:
-                    ed:72:9d:bf:3a:bb:f3:4e:d0:0c:ac:ba:6b:fd:7f:
-                    66:d8:12:40:4e:49:e7:d4:ec:70:03:71:37:cb:5e:
-                    cc:d3:4f:f3:d2:cc:e2:39:eb:79:6c:71:e5:d1:0e:
-                    45:4c:7a:3d:6f:39:e8:16:e7:de:60:eb:01:e7:80:
-                    4e:42:1d:1c:33:0a:eb:f9:10:2c:5c:ed:0c:58:0b:
-                    8c:fd:6d:f4:19:49:8a:a2:81:ab:04:b0:cb:7a:61:
-                    1f:d3
+                    00:b4:79:b0:16:e7:9b:22:20:17:4b:36:87:eb:38:
+                    03:1f:df:88:00:1b:37:40:5e:1f:1d:89:1f:3e:f4:
+                    fa:69:90:9c:d8:68:df:c8:71:07:07:4e:01:1d:f0:
+                    a8:9a:67:94:af:47:f2:b8:60:f5:ca:fb:bb:ac:7c:
+                    23:58:59:bc:95:b0:ad:b2:c7:a0:28:e1:4f:1e:c4:
+                    ef:5f:2b:a3:4e:f2:6a:95:c8:4f:f5:af:bc:fa:36:
+                    10:f9:a9:62:7a:04:d5:01:cd:9b:ba:97:32:4c:99:
+                    e5:88:fc:05:84:34:f5:4a:f2:f1:ec:04:c7:c7:63:
+                    28:eb:9e:ee:91:cd:95:8b:60:9e:5f:51:a1:2b:5a:
+                    cd:02:b2:a7:52:6c:d1:8a:ab:b1:c4:52:cd:10:ce:
+                    9e:56:24:6c:63:84:2c:15:6c:c0:62:ea:c2:d9:04:
+                    88:e2:e2:0f:ff:ce:87:51:eb:77:50:83:33:1c:c7:
+                    88:5b:08:d4:3a:22:2f:13:a6:89:f7:4b:a0:2e:30:
+                    c1:12:7a:bb:37:1f:aa:87:56:44:2f:5a:63:4b:b2:
+                    36:f6:29:5e:b8:67:52:6f:63:2a:ad:3d:c3:a5:45:
+                    af:97:e9:85:9e:76:1e:51:9c:68:36:58:32:ad:cf:
+                    3e:4d:f0:92:e2:ad:d6:f0:e1:5d:af:08:ca:2a:82:
+                    0e:a3
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Basic Constraints: critical
@@ -37,45 +37,45 @@ Certificate:
             X509v3 Key Usage: critical
                 Certificate Sign, CRL Sign
             X509v3 Subject Key Identifier: 
-                16:C5:98:B8:84:0B:0A:43:CB:5A:D2:E0:55:C0:64:AB:89:F8:50:FD
+                D0:CD:40:49:88:F6:74:BB:B4:D7:05:37:74:33:B1:C2:27:73:81:CB
             Netscape Comment: 
                 Puppet Server Internal Certificate
             X509v3 Authority Key Identifier: 
-                keyid:16:C5:98:B8:84:0B:0A:43:CB:5A:D2:E0:55:C0:64:AB:89:F8:50:FD
+                keyid:D0:CD:40:49:88:F6:74:BB:B4:D7:05:37:74:33:B1:C2:27:73:81:CB
 
     Signature Algorithm: sha256WithRSAEncryption
-         7d:0b:a0:2e:d4:fb:6b:29:04:d6:86:4e:89:94:4c:b5:d4:f7:
-         79:5a:38:95:51:9a:80:03:82:93:c8:a7:4e:93:4a:4b:41:1a:
-         85:f3:46:57:e1:70:50:ad:bb:4e:b9:d6:0c:00:e5:9e:4c:f7:
-         26:3b:88:61:27:ad:fa:39:a7:36:e1:62:87:7a:dc:7d:f9:f6:
-         c1:ee:bc:db:f7:65:a1:b0:2a:06:ae:4b:cb:99:82:f5:8e:38:
-         51:ac:c9:92:33:b9:7b:50:8b:c6:72:36:d3:f2:73:7d:58:13:
-         00:21:4d:c6:70:9d:eb:70:58:bf:dc:34:94:7e:bc:ef:17:2d:
-         9d:00:bd:55:f9:48:11:c0:8f:88:ea:a8:7c:5d:fb:88:fd:8c:
-         b4:00:1d:61:a7:4b:2a:90:ef:96:c1:28:2a:a0:95:ad:bb:b3:
-         af:3a:d5:93:1c:54:d7:c5:5b:26:a3:24:87:df:bd:68:74:fa:
-         e6:07:4e:13:b9:5f:54:19:ae:da:00:8c:ca:d6:ff:b7:94:6b:
-         4f:ff:71:ca:2b:7d:ee:7e:32:ff:03:3e:60:a4:30:d4:7d:9c:
-         ab:97:0e:f7:80:ee:69:c0:28:a8:ec:6b:89:05:38:64:34:e8:
-         b2:e9:f3:a1:85:e7:3d:e1:64:3c:86:e4:fd:44:4f:3b:2a:f8:
-         d2:b4:93:22
+         51:79:86:29:27:07:e5:fc:59:83:2d:15:ae:5f:c4:bc:0a:71:
+         2c:71:74:20:14:ce:47:8f:cf:79:03:76:bd:df:c9:e9:7f:12:
+         b2:4e:5a:c5:4f:e1:0b:c3:17:44:92:37:af:10:08:75:9a:d9:
+         c5:0d:66:e9:24:2b:ec:00:aa:de:2f:ce:df:04:fa:49:d9:bd:
+         bd:5e:7b:e4:e7:1e:9e:20:d3:85:70:b4:95:b5:1d:2e:fa:0c:
+         b4:47:5a:38:ec:b0:bd:7e:34:5f:4d:9d:1f:81:81:8a:6c:a6:
+         94:fb:f8:41:d6:a3:e4:64:3a:b7:12:4f:9e:4e:60:4a:12:a9:
+         d1:87:a5:a8:31:91:16:96:50:73:87:64:46:f1:f2:f9:99:80:
+         a2:89:e9:99:57:48:8a:56:08:d7:8d:a9:1d:69:7c:8f:73:e5:
+         53:2d:28:ee:70:d7:f8:fe:41:25:3e:4c:6c:de:31:3f:9e:7d:
+         c4:f0:67:e9:fc:a3:02:c7:39:19:f5:6f:59:6a:ca:bb:8c:c8:
+         e6:01:43:ad:95:67:3f:c0:d6:35:18:b1:6e:9f:e1:ce:c7:be:
+         35:f0:7b:65:e7:79:82:c3:b6:f7:48:28:98:d0:5c:3c:97:f3:
+         69:b3:5e:c3:a0:c5:82:02:6f:20:d0:1b:cd:43:b0:85:7e:4f:
+         71:b9:f3:8f
 -----BEGIN CERTIFICATE-----
 MIIDPTCCAiWgAwIBAgIBADANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDDApVbmtu
-b3duIENBMB4XDTcwMDEwMTAwMDAwMFoXDTMxMDQxODE4NDYyM1owFTETMBEGA1UE
-AwwKVW5rbm93biBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOoW
-TCZxVqw1uyv2GxhYFg8cOT9NAuSyp4u9/plX8qWoFQF5DR322RLb1Sai9livSyyq
-RnpTY58fGp4c/JqOIMjIyNtNUI1OGYOhnVRJJns64HcdfYgBgEYycEcWCHHeEpRn
-/XEfQVaTFZFovQU7Z5Yfek3VHrasQR/wztMtltl8rc2+szJmGAMsg5jx6JZvhQ/h
-H5PQ+QlDjLHqQyYypcbSMnUt7XKdvzq7807QDKy6a/1/ZtgSQE5J59TscANxN8te
-zNNP89LM4jnreWxx5dEORUx6PW856Bbn3mDrAeeATkIdHDMK6/kQLFztDFgLjP1t
-9BlJiqKBqwSwy3phH9MCAwEAAaOBlzCBlDAPBgNVHRMBAf8EBTADAQH/MA4GA1Ud
-DwEB/wQEAwIBBjAdBgNVHQ4EFgQUFsWYuIQLCkPLWtLgVcBkq4n4UP0wMQYJYIZI
+b3duIENBMB4XDTcwMDEwMTAwMDAwMFoXDTMxMDYxNTAxMTkzN1owFTETMBEGA1UE
+AwwKVW5rbm93biBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALR5
+sBbnmyIgF0s2h+s4Ax/fiAAbN0BeHx2JHz70+mmQnNho38hxBwdOAR3wqJpnlK9H
+8rhg9cr7u6x8I1hZvJWwrbLHoCjhTx7E718ro07yapXIT/WvvPo2EPmpYnoE1QHN
+m7qXMkyZ5Yj8BYQ09Ury8ewEx8djKOue7pHNlYtgnl9RoStazQKyp1Js0YqrscRS
+zRDOnlYkbGOELBVswGLqwtkEiOLiD//Oh1Hrd1CDMxzHiFsI1DoiLxOmifdLoC4w
+wRJ6uzcfqodWRC9aY0uyNvYpXrhnUm9jKq09w6VFr5fphZ52HlGcaDZYMq3PPk3w
+kuKt1vDhXa8IyiqCDqMCAwEAAaOBlzCBlDAPBgNVHRMBAf8EBTADAQH/MA4GA1Ud
+DwEB/wQEAwIBBjAdBgNVHQ4EFgQU0M1ASYj2dLu01wU3dDOxwidzgcswMQYJYIZI
 AYb4QgENBCQWIlB1cHBldCBTZXJ2ZXIgSW50ZXJuYWwgQ2VydGlmaWNhdGUwHwYD
-VR0jBBgwFoAUFsWYuIQLCkPLWtLgVcBkq4n4UP0wDQYJKoZIhvcNAQELBQADggEB
-AH0LoC7U+2spBNaGTomUTLXU93laOJVRmoADgpPIp06TSktBGoXzRlfhcFCtu065
-1gwA5Z5M9yY7iGEnrfo5pzbhYod63H359sHuvNv3ZaGwKgauS8uZgvWOOFGsyZIz
-uXtQi8ZyNtPyc31YEwAhTcZwnetwWL/cNJR+vO8XLZ0AvVX5SBHAj4jqqHxd+4j9
-jLQAHWGnSyqQ75bBKCqgla27s6861ZMcVNfFWyajJIffvWh0+uYHThO5X1QZrtoA
-jMrW/7eUa0//ccorfe5+Mv8DPmCkMNR9nKuXDveA7mnAKKjsa4kFOGQ06LLp86GF
-5z3hZDyG5P1ETzsq+NK0kyI=
+VR0jBBgwFoAU0M1ASYj2dLu01wU3dDOxwidzgcswDQYJKoZIhvcNAQELBQADggEB
+AFF5hiknB+X8WYMtFa5fxLwKcSxxdCAUzkePz3kDdr3fyel/ErJOWsVP4QvDF0SS
+N68QCHWa2cUNZukkK+wAqt4vzt8E+knZvb1ee+TnHp4g04VwtJW1HS76DLRHWjjs
+sL1+NF9NnR+BgYpsppT7+EHWo+RkOrcST55OYEoSqdGHpagxkRaWUHOHZEbx8vmZ
+gKKJ6ZlXSIpWCNeNqR1pfI9z5VMtKO5w1/j+QSU+TGzeMT+efcTwZ+n8owLHORn1
+b1lqyruMyOYBQ62VZz/A1jUYsW6f4c7HvjXwe2XneYLDtvdIKJjQXDyX82mzXsOg
+xYICbyDQG81DsIV+T3G5848=
 -----END CERTIFICATE-----

--- a/spec/integration/application/ssl_spec.rb
+++ b/spec/integration/application/ssl_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe "puppet ssl", unless: Puppet::Util::Platform.jruby? do
+  context "print" do
+    it 'translates custom oids to their long name' do
+      basedir = File.expand_path("#{__FILE__}/../../../fixtures/ssl")
+      # registering custom oids changes global state, so shell out
+      output =
+        %x{puppet ssl show \
+           --certname oid \
+           --localcacert #{basedir}/ca.pem \
+           --hostcrl #{basedir}/crl.pem \
+           --hostprivkey #{basedir}/oid-key.pem \
+           --hostcert #{basedir}/oid.pem \
+           --trusted_oid_mapping_file #{basedir}/trusted_oid_mapping.yaml 2>&1
+        }
+      expect(output).to match(/Long name:/)
+    end
+  end
+end

--- a/spec/lib/puppet/test_ca.rb
+++ b/spec/lib/puppet/test_ca.rb
@@ -46,6 +46,11 @@ module Puppet
         ext = ef.create_extension(["subjectAltName", opts[:subject_alt_names], false])
         cert.add_extension(ext)
       end
+      if exts = opts[:extensions]
+        exts.each do |e|
+          cert.add_extension(OpenSSL::X509::Extension.new(*e))
+        end
+      end
       cert.sign(issuer_key, @digest)
       { private_key: key, cert: cert }
     end

--- a/tasks/generate_cert_fixtures.rake
+++ b/tasks/generate_cert_fixtures.rake
@@ -40,6 +40,7 @@ task(:gen_cert_fixtures) do
   # 127.0.0.1.pem                     |   +- /CN=127.0.0.1 (with dns alt names)
   # tampered-cert.pem                 |   +- /CN=signed (with different public key)
   # ec.pem                            |   +- /CN=ec (with EC private key)
+  # oid.pem                           |   +- /CN=oid (with custom oid)
   #                                   |
   #                                   + /CN=Test CA Agent Subauthority
   #                                   |  |
@@ -49,7 +50,7 @@ task(:gen_cert_fixtures) do
   #
   # bad-basic-constraints.pem        /CN=Test CA (bad isCA constraint)
   #
-  # unknown-ca.pemm                  /CN=Unknown CA
+  # unknown-ca.pem                   /CN=Unknown CA
   #                                   |
   # unknown-127.0.0.1.pem             +- /CN=127.0.0.1
   #
@@ -102,6 +103,14 @@ task(:gen_cert_fixtures) do
   signed = ca.create_cert('127.0.0.1', ca.ca_cert, ca.key, subject_alt_names: 'DNS:127.0.0.1,DNS:127.0.0.2')
   save(dir, '127.0.0.1.pem', signed[:cert])
   save(dir, '127.0.0.1-key.pem', signed[:private_key])
+
+  # Create an SSL cert with extensions containing custom oids
+  extensions = [
+    ['1.3.6.1.4.1.34380.1.2.1.1', OpenSSL::ASN1::UTF8String.new('somevalue'), false],
+  ]
+  oid = ca.create_cert('oid', inter[:cert], inter[:private_key], extensions: extensions)
+  save(dir, 'oid.pem', oid[:cert])
+  save(dir, 'oid-key.pem', oid[:private_key])
 
   # Create a leaf/entity key and cert for host "revoked", issued by "Test CA Subauthority"
   # and revoke the cert


### PR DESCRIPTION
Commit 68a10c6b allowed `puppet cert print` to translate custom oids into their
respective long name. This functionality was lost during the move to `puppet ssl
show` and this commit readds it.

Prior to this commit, we would see:

    $ puppet ssl show | grep -A2 X509v3
        X509v3 extensions:
            1.3.6.1.4.1.34380.1.2.1.1:
                ..somevalue

With this commit, the custom oid is translated to its long name:

        X509v3 extensions:
            Long name:
                ..somevalue