### PR TITLE
(maint) remove deprecated --[no-]tests install option

### DIFF
--- a/install.rb
+++ b/install.rb
@@ -159,10 +159,6 @@ def prepare_installation
     opts.on('--[no-]ri', 'Prevents the creation of RI output.', 'Default off on mswin32.') do |onri|
       InstallOptions.ri = onri
     end
-    opts.on('--[no-]tests', 'Prevents the execution of unit tests.', 'Default off.') do |ontest|
-      InstallOptions.tests = ontest
-      warn "The tests flag is no longer functional in Puppet and is deprecated as of Dec 19, 2012. It will be removed in a future version of Puppet."
-    end
     opts.on('--[no-]configs', 'Prevents the installation of config files', 'Default off.') do |ontest|
       InstallOptions.configs = ontest
     end


### PR DESCRIPTION
fbd859fd02d176137cc9102854be50c04f2912a2 deprecated this parameter back in 2012. That's a long enough deprecation period for packagers to migrate and can be safely removed by now.