### PR TITLE
(PUP-5704) Let exec control shell invocation

### DIFF
--- a/lib/puppet/provider/exec.rb
+++ b/lib/puppet/provider/exec.rb
@@ -97,6 +97,20 @@ class Puppet::Provider::Exec < Puppet::Provider
     end
   end
 
+  # Splits a string into an array of tokens
+  # Tokens are delimited by a space and can be wrapped around quoutes
+  #
+  # splitcmd("ls -al \"b c\"")
+  # => ["ls", "-al", "b c"]
+  #
+  # splitcmd("ls -al bc")
+  # => ["ls", "-al", "bc"]
+  def splitcmd(command)
+    return command unless command.respond_to?(:split)
+
+    command.split(/\G\s*(?>([^\s'"]+)|'([^']*)'|"((?:[^"])*)")(\s|\z)?/m) - ['', ' ']
+  end
+
   def validatecmd(command)
     exe = extractexe(command)
     # if we're not fully qualified, require a path

--- a/lib/puppet/provider/exec/posix.rb
+++ b/lib/puppet/provider/exec/posix.rb
@@ -2,14 +2,13 @@ require 'puppet/provider/exec'
 
 Puppet::Type.type(:exec).provide :posix, :parent => Puppet::Provider::Exec do
   has_feature :umask
-  has_feature :supports_pass_through_shell
 
   confine :feature => :posix
   defaultfor :feature => :posix
 
   desc <<-EOT
     Executes the command through the standard shell.
-    Use `pass_through_shell => false` to execute external binaries directly,
+    Use `use_shell => false` to execute external binaries directly,
     without passing through a shell or performing any interpolation.
     This is a safer and more predictable way to execute most commands,
     but prevents the use of globbing and shell built-ins
@@ -43,7 +42,7 @@ Puppet::Type.type(:exec).provide :posix, :parent => Puppet::Provider::Exec do
   end
 
   def run(command, check = false)
-   command = command.split if command.respond_to?(:split) && !resource[:pass_through_shell]
+    command = splitcmd(command) unless resource[:use_shell]
 
     if resource[:umask]
       Puppet::Util::withumask(resource[:umask]) { super(command, check) }

--- a/lib/puppet/provider/exec/posix.rb
+++ b/lib/puppet/provider/exec/posix.rb
@@ -2,14 +2,18 @@ require 'puppet/provider/exec'
 
 Puppet::Type.type(:exec).provide :posix, :parent => Puppet::Provider::Exec do
   has_feature :umask
+  has_feature :supports_pass_through_shell
+
   confine :feature => :posix
   defaultfor :feature => :posix
 
   desc <<-EOT
-    Executes external binaries directly, without passing through a shell or
-    performing any interpolation. This is a safer and more predictable way
-    to execute most commands, but prevents the use of globbing and shell
-    built-ins (including control logic like "for" and "if" statements).
+    Executes the command through the standard shell.
+    Use `pass_through_shell => false` to execute external binaries directly,
+    without passing through a shell or performing any interpolation.
+    This is a safer and more predictable way to execute most commands,
+    but prevents the use of globbing and shell built-ins
+    (including control logic like "for" and "if" statements).
   EOT
 
   # Verify that we have the executable
@@ -39,6 +43,8 @@ Puppet::Type.type(:exec).provide :posix, :parent => Puppet::Provider::Exec do
   end
 
   def run(command, check = false)
+   command = command.split if command.respond_to?(:split) && !resource[:pass_through_shell]
+
     if resource[:umask]
       Puppet::Util::withumask(resource[:umask]) { super(command, check) }
     else

--- a/lib/puppet/type/exec.rb
+++ b/lib/puppet/type/exec.rb
@@ -67,8 +67,6 @@ module Puppet
       files. If Puppet is managing the user that an exec should run as, the
       exec resource autorequires that user."
 
-    feature :supports_pass_through_shell, "The provider can execute external binaries through the standard shell"
-
     # Create a new check mechanism.  It's basically a parameter that
     # provides one extra 'check' method.
     def self.newcheck(name, options = {}, &block)
@@ -209,7 +207,11 @@ module Puppet
       end
     end
 
-    newparam(:pass_through_shell, :boolean => true, :parent => Puppet::Parameter::Boolean, :required_features => :supports_pass_through_shell) do
+    newparam(:use_shell, :boolean => true, :parent => Puppet::Parameter::Boolean) do
+      desc "A boolean flag that controls shell invocation.
+      By default, the provider executes commands through the standard shell.
+      It is recommended to set this parameter to `false` to execute external binaries directly"
+
       defaultto(:true)
 
       newvalues(:true, :false)

--- a/lib/puppet/type/exec.rb
+++ b/lib/puppet/type/exec.rb
@@ -1,3 +1,5 @@
+require_relative '../../puppet/parameter/boolean'
+
 module Puppet
   Type.newtype(:exec) do
     include Puppet::Util::Execution
@@ -64,6 +66,8 @@ module Puppet
       file used in an exec's command, the exec resource autorequires those
       files. If Puppet is managing the user that an exec should run as, the
       exec resource autorequires that user."
+
+    feature :supports_pass_through_shell, "The provider can execute external binaries through the standard shell"
 
     # Create a new check mechanism.  It's basically a parameter that
     # provides one extra 'check' method.
@@ -203,6 +207,12 @@ module Puppet
       validate do |command|
         raise ArgumentError, _("Command must be a String, got value of class %{klass}") % { klass: command.class } unless command.is_a? String
       end
+    end
+
+    newparam(:pass_through_shell, :boolean => true, :parent => Puppet::Parameter::Boolean, :required_features => :supports_pass_through_shell) do
+      defaultto(:true)
+
+      newvalues(:true, :false)
     end
 
     newparam(:path) do

--- a/spec/unit/provider/exec/posix_spec.rb
+++ b/spec/unit/provider/exec/posix_spec.rb
@@ -98,15 +98,17 @@ describe Puppet::Type.type(:exec).provider(:posix), :if => Puppet.features.posix
       provider.run("#{command} bar --sillyarg=true --blah")
     end
 
-    it 'splits the command when pass_trough_shell is false' do
-      provider.resource[:path] = ['/bogus/bin']
-      provider.resource[:pass_through_shell] = false
-      command = make_exe
-      split_command = command.split
+    context 'when use_shell is false' do
+      it 'splits the command' do
+        provider.resource[:path] = ['/bogus/bin']
+        provider.resource[:use_shell] = false
+        command = make_exe
+        split_command = command.split
 
-      expect(Puppet::Util::Execution).to receive(:execute).with([*split_command, 'bar', '--sillyarg=true', '--blah'], instance_of(Hash)).and_return(Puppet::Util::Execution::ProcessOutput.new('', 0))
+        expect(Puppet::Util::Execution).to receive(:execute).with([*split_command, 'bar', '--sillyarg=true', '--blah'], instance_of(Hash)).and_return(Puppet::Util::Execution::ProcessOutput.new('', 0))
 
-      provider.run("#{command} bar --sillyarg=true --blah")
+        provider.run("#{command} bar --sillyarg=true --blah")
+      end
     end
 
     it "should fail if quoted command doesn't exist" do

--- a/spec/unit/provider/exec/posix_spec.rb
+++ b/spec/unit/provider/exec/posix_spec.rb
@@ -98,6 +98,17 @@ describe Puppet::Type.type(:exec).provider(:posix), :if => Puppet.features.posix
       provider.run("#{command} bar --sillyarg=true --blah")
     end
 
+    it 'splits the command when pass_trough_shell is false' do
+      provider.resource[:path] = ['/bogus/bin']
+      provider.resource[:pass_through_shell] = false
+      command = make_exe
+      split_command = command.split
+
+      expect(Puppet::Util::Execution).to receive(:execute).with([*split_command, 'bar', '--sillyarg=true', '--blah'], instance_of(Hash)).and_return(Puppet::Util::Execution::ProcessOutput.new('', 0))
+
+      provider.run("#{command} bar --sillyarg=true --blah")
+    end
+
     it "should fail if quoted command doesn't exist" do
       provider.resource[:path] = ['/bogus/bin']
       command = "/foo bar --sillyarg=true --blah"

--- a/spec/unit/provider/exec_spec.rb
+++ b/spec/unit/provider/exec_spec.rb
@@ -241,4 +241,20 @@ describe Puppet::Provider::Exec do
       end
     end
   end
+
+  describe "#splitcmd" do
+    {
+      'ls -a dir'                   => ['ls', '-a', 'dir'],
+      'ls -a "dir wrapped"'         => ['ls', '-a', 'dir wrapped'],
+      'ls -a          "dir spaced"' => ['ls', '-a', 'dir spaced'],
+      'ls -a $special'              => ['ls', '-a', '$special'],
+      'ls -a | pipe'                => ['ls', '-a', '|', 'pipe'],
+      'ls -a \escaped'              => ['ls', '-a', '\escaped'],
+      'ls -a \ escaped'             => ['ls', '-a', '\\', 'escaped']
+    }.each do |command, result|
+      it "splits command: #{command} correctly" do
+        expect(subject.splitcmd(command)).to eql(result)
+      end
+    end
+  end
 end


### PR DESCRIPTION
The posix implementation of the exec provider relies
on `Puppet::Util::Execution` which passes the command
string to `Kernel.exec`[0]. By default, the command
line is passed to the standard shell. To avoid this,
a new parameter was added `use_shell`,
which defaults to `true` and can be set to false.
The command is split as `cmdname, arg1, ...`
before passing it to `exec`.

[0] https://www.rubydoc.info/stdlib/core/Kernel:exec




TODO: rebase after review