### PR TITLE
(PUP-11123) make Function unwrap more tolerant

### DIFF
--- a/lib/puppet/functions/unwrap.rb
+++ b/lib/puppet/functions/unwrap.rb
@@ -1,4 +1,5 @@
 # Unwraps a Sensitive value and returns the wrapped object.
+# Returns the Value itself, if it is not Sensitive.
 #
 # @example Usage of unwrap
 #
@@ -28,13 +29,27 @@
 # @since 4.0.0
 #
 Puppet::Functions.create_function(:unwrap) do
-  dispatch :unwrap do
+  dispatch :from_sensitive do
     param 'Sensitive', :arg
     optional_block_param
   end
 
-  def unwrap(arg)
+  dispatch :from_any do
+    param 'Any', :arg
+    optional_block_param
+  end
+
+  def from_sensitive(arg)
     unwrapped = arg.unwrap
+    if block_given?
+      yield(unwrapped)
+    else
+      unwrapped
+    end
+  end
+
+  def from_any(arg)
+    unwrapped = arg
     if block_given?
       yield(unwrapped)
     else

--- a/spec/unit/functions/unwrap_spec.rb
+++ b/spec/unit/functions/unwrap_spec.rb
@@ -15,6 +15,14 @@ describe 'the unwrap function' do
     expect(eval_and_collect_notices(code)).to eq(['unwrapped value is 12345'])
   end
 
+  it 'just returns a non-sensitive value' do
+    code = <<-CODE
+      $non_sensitive = "12345"
+      notice("value is still ${non_sensitive.unwrap}")
+    CODE
+    expect(eval_and_collect_notices(code)).to eq(['value is still 12345'])
+  end
+
   it 'unwraps a sensitive value when given a code block' do
     code = <<-CODE
       $sensitive = Sensitive.new("12345")


### PR DESCRIPTION
- as there is no Function `unwrap_if_necessary()` we make the Function `unwrap()`
  more tolerant and let it return a non-sensitive Value just like it is