### PR TITLE
(PUP-10967) Debug logs clean up when resolving account SID on Windows

### DIFF
--- a/lib/puppet/util/windows/sid.rb
+++ b/lib/puppet/util/windows/sid.rb
@@ -75,7 +75,9 @@ module Puppet::Util::Windows
           raw_sid_bytes = sid_ptr.read_array_of_uchar(get_length_sid(sid_ptr))
         end
       rescue => e
-        Puppet.debug("Could not retrieve raw SID bytes from '#{name}': #{e.message}")
+        # Avoid debug logs pollution with valid account names
+        # https://docs.microsoft.com/en-us/windows/win32/api/sddl/nf-sddl-convertstringsidtosidw#return-value
+        Puppet.debug("Could not retrieve raw SID bytes from '#{name}': #{e.message}") unless e.code == ERROR_INVALID_SID_STRUCTURE
       end
 
       raw_sid_bytes ? Principal.lookup_account_sid(raw_sid_bytes) : Principal.lookup_account_name(name)


### PR DESCRIPTION
This commit simply restricts the `Could not retrieve raw SID bytes from` debug log to when an actual SID is passed to `ConvertStringSidToSidW`. The order in which the `Puppet::Util::Windows::SID.name_to_principal` method checks and tries to convert the input (be it an account name, domain qualified account name or SID) to a `Puppet::Util::Windows::SID::Principal` object made it print error messages to debug when it was actually succeeding in the end. Since every Puppet Agent run needs information about at least the currently logged on user, this was creating unnecessary noise in the debug logs.

Before fix:
```sh-session
➜ bundle exec puppet resource user 'Luchi' --debug
...
Debug: Facter: fact "operatingsystem" has resolved to: windows
...
Debug: Could not retrieve raw SID bytes from 'Luchi': Failed to convert string SID: Luchi:  The security ID structure is invalid.
Debug: Could not retrieve raw SID bytes from 'SYSTEM': Failed to convert string SID: SYSTEM:  The security ID structure is invalid.
Debug: Could not retrieve raw SID bytes from 'Luchi': Failed to convert string SID: Luchi:  The security ID structure is invalid.
Debug: Could not retrieve raw SID bytes from 'Luchi': Failed to convert string SID: Luchi:  The security ID structure is invalid.
user { 'Luchi':
  ensure   => 'present',
  provider => 'windows_adsi',
  uid      => 'S-1-5-21-654025930-916225823-201077790-1003',
}

➜ bundle exec irb
irb(main):001:0> require 'puppet'
=> true

irb(main):002:0> Puppet[:log_level] = 'debug'
=> "debug"

irb(main):003:0> Puppet::Util::Log.newdestination(:console)
=> #<Puppet::Util::Log::DestConsole:0x000001b2c3fd2a88>

irb(main):004:0> Puppet::Util::Windows::SID.name_to_principal('S-1-5-21-654025930-916225823-201077790-1003')
=> #<Puppet::Util::Windows::SID::Principal:0x000001b2c57cbd88 @account="Luchi", @sid_bytes=[1, 5, 0, 0, 0, 0, 0, 5, 21, 0, 0, 0, 202, 164, 251, 38, 31, 127, 156, 54, 30, 52, 252, 11, 235, 3, 0, 0], @sid="S-1-5-21-654025930-916225823-201077790-1003", @domain="STURDY-ACIDITY", @account_type=:SidTypeUser, @domain_account="STURDY-ACIDITY\\Luchi">

irb(main):005:0> Puppet::Util::Windows::SID.name_to_principal('Luchi')
Debug: Could not retrieve raw SID bytes from 'Luchi': Failed to convert string SID: Luchi:  The security ID structure is invalid.
=> #<Puppet::Util::Windows::SID::Principal:0x000001e85ae98b50 @account="Luchi", @sid_bytes=[1, 5, 0, 0, 0, 0, 0, 5, 21, 0, 0, 0, 202, 164, 251, 38, 31, 127, 156, 54, 30, 52, 252, 11, 235, 3, 0, 0], @sid="S-1-5-21-654025930-916225823-201077790-1003", @domain="STURDY-ACIDITY", @account_type=:SidTypeUser, @domain_account="STURDY-ACIDITY\\Luchi">

irb(main):006:0> Puppet::Util::Windows::SID.name_to_principal('S-1-5-21-INVALID-SID')
Debug: Could not retrieve raw SID bytes from 'S-1-5-21-INVALID-SID': Failed to convert string SID: S-1-5-21-INVALID-SID:  The security ID structure is invalid.
Debug: Failed to call LookupAccountNameW with account: S-1-5-21-INVALID-SID:  No mapping between account names and security IDs was done.
=> nil
```


With fix:
```sh-session
➜ bundle exec puppet resource user 'Luchi' --debug
...
Debug: Facter: fact "operatingsystem" has resolved to: windows
user { 'Luchi':
  ensure   => 'present',
  provider => 'windows_adsi',
  uid      => 'S-1-5-21-654025930-916225823-201077790-1003',
}

➜ bundle exec irb
irb(main):001:0> require 'puppet'
=> true

irb(main):002:0> Puppet[:log_level] = 'debug'
=> "debug"

irb(main):003:0> Puppet::Util::Log.newdestination(:console)
=> #<Puppet::Util::Log::DestConsole:0x000001a753baaaa8>

irb(main):004:0> Puppet::Util::Windows::SID.name_to_principal('S-1-5-21-654025930-916225823-201077790-1003')
=> #<Puppet::Util::Windows::SID::Principal:0x000001a753642f70 @account="Luchi", @sid_bytes=[1, 5, 0, 0, 0, 0, 0, 5, 21, 0, 0, 0, 202, 164, 251, 38, 31, 127, 156, 54, 30, 52, 252, 11, 235, 3, 0, 0], @sid="S-1-5-21-654025930-916225823-201077790-1003", @domain="STURDY-ACIDITY", @account_type=:SidTypeUser, @domain_account="STURDY-ACIDITY\\Luchi">

irb(main):005:0> Puppet::Util::Windows::SID.name_to_principal('Luchi')
=> #<Puppet::Util::Windows::SID::Principal:0x000001a7527f33c0 @account="Luchi", @sid_bytes=[1, 5, 0, 0, 0, 0, 0, 5, 21, 0, 0, 0, 202, 164, 251, 38, 31, 127, 156, 54, 30, 52, 252, 11, 235, 3, 0, 0], @sid="S-1-5-21-654025930-916225823-201077790-1003", @domain="STURDY-ACIDITY", @account_type=:SidTypeUser, @domain_account="STURDY-ACIDITY\\Luchi">

irb(main):006:0> Puppet::Util::Windows::SID.name_to_principal('S-1-5-21-INVALID-SID')
Debug: Failed to call LookupAccountNameW with account: S-1-5-21-INVALID-SID:  No mapping between account names and security IDs was done.
=> nil

```
Useful info:
https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes--1300-1699-
https://docs.microsoft.com/en-us/windows/win32/api/sddl/nf-sddl-convertstringsidtosidw#return-value