### PR TITLE
(PUP-7785) Ensure `keylength` setting is treated as an int

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1197,6 +1197,7 @@ EOT
     },
     :keylength => {
       :default    => 4096,
+      :type       => :integer,
       :desc       => "The bit length of keys.",
     },
     :cert_inventory => {


### PR DESCRIPTION
A recent change to the way numerical settings are munged made it
necessary to specify the type of a setting that should be converted to a
number, rather than automatically converting all strings that look like
numbers. This commit adds the `integer` type to the `keylength` setting,
to ensure it is converted to an int and not passed as a string.