### PR TITLE
(PUP-10955) Normalize environment name to symbol before caching

### DIFF
--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -379,6 +379,7 @@ module Puppet::Environments
       # This strategy favors smaller memory footprint over environment
       # retrieval time.
       clear_all_expired
+      name = name.to_sym
       result = @cache[name]
       if result
         Puppet.debug {"Found in cache '#{name}' #{result.label}"}
@@ -413,6 +414,7 @@ module Puppet::Environments
     # Clears the cache of the environment with the given name.
     # (The intention is that this could be used from a MANUAL cache eviction command (TBD)
     def clear(name)
+      name = name.to_sym
       entry = @cache[name]
       clear_entry(name, entry) if entry
     end
@@ -462,6 +464,7 @@ module Puppet::Environments
     #
     # @!macro loader_get_conf
     def get_conf(name)
+      name = name.to_sym
       clear_if_expired(name, @cache[name])
       @loader.get_conf(name)
     end

--- a/spec/unit/environments_spec.rb
+++ b/spec/unit/environments_spec.rb
@@ -607,6 +607,51 @@ config_version=$vardir/random/scripts
         cached.get(:cached)
       end
 
+      it "normalizes environment name to symbol" do
+        env = Puppet::Node::Environment.create(:cached, [])
+        mocked_loader = double('loader')
+
+        expect(mocked_loader).not_to receive(:get).with('cached')
+        expect(mocked_loader).to receive(:get).with(:cached).and_return(env).once
+        expect(mocked_loader).to receive(:get_conf).with(:cached).and_return(Puppet::Settings::EnvironmentConf.static_for(env, 20)).once
+
+        cached = Puppet::Environments::Cached.new(mocked_loader)
+        cached.get('cached')
+        cached.get(:cached)
+      end
+
+      it "caches environment name as symbol and only once" do
+        mocked_loader = double('loader')
+
+        env = Puppet::Node::Environment.create(:cached, [])
+        allow(mocked_loader).to receive(:get).with(:cached).and_return(env)
+        allow(mocked_loader).to receive(:get_conf).with(:cached).and_return(Puppet::Settings::EnvironmentConf.static_for(env, 20))
+
+        cached = Puppet::Environments::Cached.new(mocked_loader)
+        cached.get(:cached)
+        cached.get('cached')
+
+        expect(cached.instance_variable_get(:@cache).keys).to eq([:cached])
+      end
+
+      it "is able to cache multiple environments" do
+        mocked_loader = double('loader')
+
+        env1 = Puppet::Node::Environment.create(:env1, [])
+        allow(mocked_loader).to receive(:get).with(:env1).and_return(env1)
+        allow(mocked_loader).to receive(:get_conf).with(:env1).and_return(Puppet::Settings::EnvironmentConf.static_for(env1, 20))
+
+        env2 = Puppet::Node::Environment.create(:env2, [])
+        allow(mocked_loader).to receive(:get).with(:env2).and_return(env2)
+        allow(mocked_loader).to receive(:get_conf).with(:env2).and_return(Puppet::Settings::EnvironmentConf.static_for(env2, 20))
+
+        cached = Puppet::Environments::Cached.new(mocked_loader)
+        cached.get('env1')
+        cached.get('env2')
+
+        expect(cached.instance_variable_get(:@cache).keys).to eq([:env1, :env2])
+      end
+
       it "returns nil if env not found" do
         cached_loader_from(:filesystem => [directory_tree], :directory => directory_tree.children.first) do |loader|
           expect(loader.get(:doesnotexist)).to be_nil
@@ -659,6 +704,17 @@ config_version=$vardir/random/scripts
         cached = Puppet::Environments::Cached.new(mocked_loader)
 
         cached.get_conf(:cached)
+        cached.get_conf(:cached)
+      end
+
+      it "normalizes environment name to symbol" do
+        env = Puppet::Node::Environment.create(:cached, [])
+        mocked_loader = double('loader')
+        expect(mocked_loader).to receive(:get_conf).with(:cached).and_return(Puppet::Settings::EnvironmentConf.static_for(env, 20)).twice
+
+        cached = Puppet::Environments::Cached.new(mocked_loader)
+
+        cached.get_conf('cached')
         cached.get_conf(:cached)
       end
 
@@ -762,6 +818,14 @@ config_version=$vardir/random/scripts
       it "evicts an environment" do
         with_environment_loaded(service) do |cached|
           cached.clear(:an_environment)
+        end
+
+        expect(service.evicted_envs).to eq([:an_environment])
+      end
+
+      it "normalizes environment name to symbol" do
+        with_environment_loaded(service) do |cached|
+          cached.clear('an_environment')
         end
 
         expect(service.evicted_envs).to eq([:an_environment])

--- a/spec/unit/functions/logging_spec.rb
+++ b/spec/unit/functions/logging_spec.rb
@@ -6,6 +6,7 @@ describe 'the log function' do
 
   def collect_logs(code)
     Puppet[:code] = code
+    Puppet[:environment_timeout] = 10
     node = Puppet::Node.new('logtest')
     compiler = Puppet::Parser::Compiler.new(node)
     node.environment.check_for_reparse


### PR DESCRIPTION
The `Puppet::Environments::Cached.get` method says it accepts Strings or Symbols. This commit normalizes the environment name before caching and getting the environment to avoid duplicated environments in cache (as String and as Symbol).
### Script used for checking:
```ruby
require 'puppet'
Puppet.initialize_settings
Puppet[:log_level] = 'debug'
Puppet::Util::Log.newdestination(:console)

Puppet::ApplicationSupport.push_application_context(Puppet::Util::RunMode[:user])

envs = Puppet.lookup(:environments)
pp envs.instance_variable_get(:@cache).keys

envs.get!('production')
pp envs.instance_variable_get(:@cache).keys

envs.get!(:production)
pp envs.instance_variable_get(:@cache).keys
```
### Output before fix:
```sh-session
➜ bundle exec ruby script.rb
Debug: Caching environment 'production' (ttl = 1 sec)
["production"]
Debug: Found in cache 'production' (ttl = 1 sec)
["production"]
Debug: Caching environment 'production' (ttl = 1 sec)
["production", :production]
```

### Output after fix:
```sh-session
➜  bundle exec ruby script.rb
Debug: Caching environment 'production' (ttl = 1 sec)
[:production]
Debug: Found in cache 'production' (ttl = 1 sec)
[:production]
Debug: Found in cache 'production' (ttl = 1 sec)
[:production]
```
### Useful note for testing with above script:
If you are receiving a debug log such as `Debug: Path to /Users/luchian.nemes/.puppetlabs/etc/code/environments/production does not exist, using default environment.conf`, you might not be reproducing the issue due to `environment_timeout` being set to `0` in that `environment.conf` file (also confirmed by `Debug: Found in cache 'production' (ttl = 0 sec)` logs). Puppet will consider that environment expired and will remove it before getting another one (see [here](https://github.com/puppetlabs/puppet/blob/bfc2471a1a2c457df68317b1529528ba4aaf72b5/lib/puppet/environments.rb#L381)). 