### PR TITLE
(PUP-10641) Provide useful error message if module name is invalid

### DIFF
--- a/lib/puppet/module_tool/applications/installer.rb
+++ b/lib/puppet/module_tool/applications/installer.rb
@@ -59,6 +59,10 @@ module Puppet::ModuleTool
         results = { :action => :install, :module_name => name, :module_version => version }
 
         begin
+          if !@local_tarball && name !~ /-/
+            raise InvalidModuleNameError.new(module_name: @name, suggestion: "puppetlabs-#{@name}", action: :install)
+          end
+
           installed_module = installed_modules[name]
           if installed_module
             unless forced?

--- a/lib/puppet/module_tool/errors/shared.rb
+++ b/lib/puppet/module_tool/errors/shared.rb
@@ -127,6 +127,23 @@ module Puppet::ModuleTool::Errors
     end
   end
 
+  class InvalidModuleNameError < ModuleToolError
+    def initialize(options)
+      @module_name = options[:module_name]
+      @suggestion = options[:suggestion]
+      @action = options[:action]
+      super _("Could not %{action} '%{module_name}', did you mean '%{suggestion}'?") % { action: @action, module_name: @module_name, suggestion: @suggestion }
+    end
+
+    def multiline
+      message = []
+      message << _("Could not %{action} module '%{module_name}'") % { action: @action, module_name: @module_name }
+      message << _("  The name '%{module_name}' is invalid") % { module_name: @module_name }
+      message << _("    Did you mean `puppet module %{action} %{suggestion}`?") % { action: @action, suggestion: @suggestion }
+      message.join("\n")
+    end
+  end
+
   class NotInstalledError < ModuleToolError
     def initialize(options)
       @module_name = options[:module_name]

--- a/spec/unit/module_tool/applications/installer_spec.rb
+++ b/spec/unit/module_tool/applications/installer_spec.rb
@@ -66,6 +66,18 @@ describe Puppet::ModuleTool::Applications::Installer, :unless => RUBY_PLATFORM =
       graph_should_include 'pmtacceptance-stdlib', nil => v('4.1.0')
     end
 
+    it 'reports a meaningful error if the name is invalid' do
+      app = installer('ntp', install_dir, options)
+      results = app.run
+      expect(results).to include :result => :failure
+      expect(results[:error][:oneline]).to eq("Could not install 'ntp', did you mean 'puppetlabs-ntp'?")
+      expect(results[:error][:multiline]).to eq(<<~END.chomp)
+        Could not install module 'ntp'
+          The name 'ntp' is invalid
+            Did you mean `puppet module install puppetlabs-ntp`?
+      END
+    end
+
     context 'with a tarball file' do
       let(:module) { fixtures('stdlib.tgz') }
 


### PR DESCRIPTION
The 'puppet module install' command requires a fully qualified module name in
the form 'author-module' or 'author/module' or an absolute or relative path to a
tarball. If it's not a tarball, provide a helpful error if author is missing.