### PR TITLE
(maint) Provide types for possible integer settings defaults

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -2025,7 +2025,8 @@ EOT
       :desc     => "The LDAP server.",
     },
     :ldapport => {
-      :default  => "389",
+      :default  => 389,
+      :type     => :port,
       :desc     => "The LDAP port.",
     },
 

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -478,6 +478,7 @@ module Puppet
     },
     :maximum_uid => {
         :default  => 4294967290,
+        :type     => :integer,
         :desc     => "The maximum allowed UID.  Some platforms use negative UIDs
           but then ship with tools that do not know how to handle signed ints,
           so the UIDs show up as huge numbers that can then not be fed back into
@@ -615,6 +616,7 @@ module Puppet
     },
     :http_proxy_port => {
       :default    => 3128,
+      :type       => :port,
       :desc       => "The HTTP proxy port to use for outgoing connections",
     },
     :http_proxy_user => {
@@ -2023,7 +2025,7 @@ EOT
       :desc     => "The LDAP server.",
     },
     :ldapport => {
-      :default  => 389,
+      :default  => "389",
       :desc     => "The LDAP port.",
     },
 
@@ -2107,6 +2109,7 @@ EOT
   settings.define_settings(:parser,
    :max_errors => {
      :default => 10,
+     :type => :integer,
      :desc => <<-'EOT'
        Sets the max number of logged/displayed parser validation errors in case
        multiple errors have been detected. A value of 0 is the same as a value of 1; a
@@ -2115,6 +2118,7 @@ EOT
    },
    :max_warnings => {
      :default => 10,
+     :type => :integer,
      :desc => <<-'EOT'
        Sets the max number of logged/displayed parser validation warnings in
        case multiple warnings have been detected. A value of 0 blocks logging of
@@ -2123,6 +2127,7 @@ EOT
      },
   :max_deprecations => {
     :default => 10,
+    :type => :integer,
     :desc => <<-'EOT'
       Sets the max number of logged/displayed parser validation deprecation
       warnings in case multiple deprecation warnings have been detected. A value of 0

--- a/spec/unit/util/ldap/connection_spec.rb
+++ b/spec/unit/util/ldap/connection_spec.rb
@@ -29,7 +29,7 @@ describe Puppet::Util::Ldap::Connection do
     allow(LDAP::Conn).to receive(:new).and_return(@ldapconn)
     allow(LDAP::SSLConn).to receive(:new).and_return(@ldapconn)
 
-    @connection = Puppet::Util::Ldap::Connection.new("host", "port")
+    @connection = Puppet::Util::Ldap::Connection.new("host", 1234)
   end
 
 
@@ -39,31 +39,31 @@ describe Puppet::Util::Ldap::Connection do
     end
 
     it "should allow specification of a user and password" do
-      expect { Puppet::Util::Ldap::Connection.new("myhost", "myport", :user => "blah", :password => "boo") }.not_to raise_error
+      expect { Puppet::Util::Ldap::Connection.new("myhost", 1234, :user => "blah", :password => "boo") }.not_to raise_error
     end
 
     it "should allow specification of ssl" do
-      expect { Puppet::Util::Ldap::Connection.new("myhost", "myport", :ssl => :tsl) }.not_to raise_error
+      expect { Puppet::Util::Ldap::Connection.new("myhost", 1234, :ssl => :tsl) }.not_to raise_error
     end
 
     it "should support requiring a new connection" do
-      expect { Puppet::Util::Ldap::Connection.new("myhost", "myport", :reset => true) }.not_to raise_error
+      expect { Puppet::Util::Ldap::Connection.new("myhost", 1234, :reset => true) }.not_to raise_error
     end
 
     it "should fail if ldap is unavailable" do
       expect(Puppet.features).to receive(:ldap?).and_return(false)
 
-      expect { Puppet::Util::Ldap::Connection.new("host", "port") }.to raise_error(Puppet::Error)
+      expect { Puppet::Util::Ldap::Connection.new("host", 1234) }.to raise_error(Puppet::Error)
     end
 
     it "should use neither ssl nor tls by default" do
-      expect(LDAP::Conn).to receive(:new).with("host", "port").and_return(@ldapconn)
+      expect(LDAP::Conn).to receive(:new).with("host", 1234).and_return(@ldapconn)
 
       @connection.start
     end
 
     it "should use LDAP::SSLConn if ssl is requested" do
-      expect(LDAP::SSLConn).to receive(:new).with("host", "port").and_return(@ldapconn)
+      expect(LDAP::SSLConn).to receive(:new).with("host", 1234).and_return(@ldapconn)
 
       @connection.ssl = true
 
@@ -71,7 +71,7 @@ describe Puppet::Util::Ldap::Connection do
     end
 
     it "should use LDAP::SSLConn and tls if tls is requested" do
-      expect(LDAP::SSLConn).to receive(:new).with("host", "port", true).and_return(@ldapconn)
+      expect(LDAP::SSLConn).to receive(:new).with("host", 1234, true).and_return(@ldapconn)
 
       @connection.ssl = :tls
 
@@ -121,8 +121,8 @@ describe Puppet::Util::Ldap::Connection do
     end
 
     it "should use the :ldapport setting to determine the port" do
-      Puppet[:ldapport] = "456"
-      expect(Puppet::Util::Ldap::Connection).to receive(:new).with(anything, "456", anything)
+      Puppet[:ldapport] = 456
+      expect(Puppet::Util::Ldap::Connection).to receive(:new).with(anything, 456, anything)
       Puppet::Util::Ldap::Connection.instance
     end
 

--- a/spec/unit/util/ldap/manager_spec.rb
+++ b/spec/unit/util/ldap/manager_spec.rb
@@ -245,8 +245,8 @@ describe Puppet::Util::Ldap::Manager, :if => Puppet.features.ldap? do
     end
 
     it "should open the connection with its port set to the :ldapport" do
-      Puppet[:ldapport] = "28"
-      expect(Puppet::Util::Ldap::Connection).to receive(:new).with(anything, "28", anything).and_return(@conn)
+      Puppet[:ldapport] = 28
+      expect(Puppet::Util::Ldap::Connection).to receive(:new).with(anything, 28, anything).and_return(@conn)
 
       @manager.connect { |c| }
     end


### PR DESCRIPTION
The change in eeb61d1c6 allowed settings to be strings containing digits
and to remain strings (helpful for numeric certnames for example).

However, several settings depended on the automatic conversion of
strings that contain digits to Integer. This adds type specification
to any defaults that match / \d+,/ in the defaults.rb.

All are given the type `:integer` unless the setting contains the word
"port" in which case they gain the type `:port`.

A notable exception being the ldapport setting, which depends on being a
string and now is explicitly a string in the defaults.

Additional searches for ttl & priority didn't reveal any defaults that
needed changing. Nor did a search for strings containing wholy digits.