### PR TITLE
(PUP-5704) allow array commands in exec resource

### DIFF
--- a/acceptance/tests/resource/exec/accept_array_commands.rb
+++ b/acceptance/tests/resource/exec/accept_array_commands.rb
@@ -1,0 +1,23 @@
+test_name "Be able to execute array commands" do
+  tag 'audit:high',
+      'audit:acceptance'
+
+  agents.each do |agent|
+    if agent.platform =~ /windows/
+      cmd = ['C:\Windows\System32\cmd.exe', '/c', 'echo', '*']
+    else
+      cmd = ['/bin/echo', '*']
+    end
+
+    exec_manifest = <<~MANIFEST
+      exec { "test exec":
+        command => #{cmd},
+        logoutput => true,
+      }
+    MANIFEST
+
+    apply_manifest_on(agent, exec_manifest) do |output|
+      assert_match('Notice: /Stage[main]/Main/Exec[test exec]/returns: *', output.stdout)
+    end
+  end
+end

--- a/lib/puppet/provider/exec/posix.rb
+++ b/lib/puppet/provider/exec/posix.rb
@@ -6,10 +6,22 @@ Puppet::Type.type(:exec).provide :posix, :parent => Puppet::Provider::Exec do
   defaultfor :feature => :posix
 
   desc <<-EOT
-    Executes external binaries directly, without passing through a shell or
-    performing any interpolation. This is a safer and more predictable way
-    to execute most commands, but prevents the use of globbing and shell
-    built-ins (including control logic like "for" and "if" statements).
+    Executes external binaries by invoking Ruby's `Kernel.exec`.
+    When the command is a string, it will be executed directly,
+    without a shell, if it follows these rules:
+     - no meta characters
+     - no shell reserved word and no special built-in
+
+    When the command is an Array of Strings, passed as `[cmdname, arg1, ...]`
+    it will be executed directly(the first element is taken as a command name
+    and the rest are passed as parameters to command with no shell expansion)
+    This is a safer and more predictable way to execute most commands,
+    but prevents the use of globbing and shell built-ins (including control
+    logic like "for" and "if" statements).
+
+    If the use of globbing and shell built-ins is desired, please check
+    the `shell` provider
+
   EOT
 
   # Verify that we have the executable

--- a/spec/integration/type/exec_spec.rb
+++ b/spec/integration/type/exec_spec.rb
@@ -7,70 +7,95 @@ describe Puppet::Type.type(:exec), unless: Puppet::Util::Platform.jruby? do
 
   let(:catalog) { Puppet::Resource::Catalog.new }
   let(:path) { tmpfile('exec_provider') }
-  let(:command) { "ruby -e 'File.open(\"#{path}\", \"w\") { |f| f.print \"foo\" }'" }
 
   before :each do
     catalog.host_config = false
   end
 
-  it "should execute the command" do
-    exec = described_class.new :command => command, :path => ENV['PATH']
+  shared_examples_for 'a valid exec resource' do
+    it "should execute the command" do
+      exec = described_class.new :command => command, :path => ENV['PATH']
 
-    catalog.add_resource exec
-    catalog.apply
+      catalog.add_resource exec
+      catalog.apply
 
-    expect(File.read(path)).to eq('foo')
+      expect(File.read(path)).to eq('foo')
+    end
+
+    it "should not execute the command if onlyif returns non-zero" do
+      exec = described_class.new(
+        :command => command,
+        :onlyif => "ruby -e 'exit 44'",
+        :path => ENV['PATH']
+      )
+
+      catalog.add_resource exec
+      catalog.apply
+
+      expect(Puppet::FileSystem.exist?(path)).to be_falsey
+    end
+
+    it "should execute the command if onlyif returns zero" do
+      exec = described_class.new(
+        :command => command,
+        :onlyif => "ruby -e 'exit 0'",
+        :path => ENV['PATH']
+      )
+
+      catalog.add_resource exec
+      catalog.apply
+
+      expect(File.read(path)).to eq('foo')
+    end
+
+    it "should execute the command if unless returns non-zero" do
+      exec = described_class.new(
+        :command => command,
+        :unless => "ruby -e 'exit 45'",
+        :path => ENV['PATH']
+      )
+
+      catalog.add_resource exec
+      catalog.apply
+
+      expect(File.read(path)).to eq('foo')
+    end
+
+    it "should not execute the command if unless returns zero" do
+      exec = described_class.new(
+        :command => command,
+        :unless => "ruby -e 'exit 0'",
+        :path => ENV['PATH']
+      )
+
+      catalog.add_resource exec
+      catalog.apply
+
+      expect(Puppet::FileSystem.exist?(path)).to be_falsey
+    end
   end
 
-  it "should not execute the command if onlyif returns non-zero" do
-    exec = described_class.new(
-      :command => command,
-      :onlyif => "ruby -e 'exit 44'",
-      :path => ENV['PATH']
-    )
+  context 'when command is a string' do
+    let(:command) { "ruby -e 'File.open(\"#{path}\", \"w\") { |f| f.print \"foo\" }'" }
 
-    catalog.add_resource exec
-    catalog.apply
-
-    expect(Puppet::FileSystem.exist?(path)).to be_falsey
+    it_behaves_like 'a valid exec resource'
   end
 
-  it "should execute the command if onlyif returns zero" do
-    exec = described_class.new(
-      :command => command,
-      :onlyif => "ruby -e 'exit 0'",
-      :path => ENV['PATH']
-    )
+  context 'when command is an array' do
+    let(:command) { ['ruby', '-e', "File.open(\"#{path}\", \"w\") { |f| f.print \"foo\" }"] }
 
-    catalog.add_resource exec
-    catalog.apply
+    it_behaves_like 'a valid exec resource'
 
-    expect(File.read(path)).to eq('foo')
-  end
+    context 'when is invalid' do
+      let(:command) { [ "ruby -e 'puts 1'" ] }
 
-  it "should execute the command if unless returns non-zero" do
-    exec = described_class.new(
-      :command => command,
-      :unless => "ruby -e 'exit 45'",
-      :path => ENV['PATH']
-    )
+      it 'logs error' do
+        exec = described_class.new :command => command, :path => ENV['PATH']
+        catalog.add_resource exec
+        logs = catalog.apply.report.logs
 
-    catalog.add_resource exec
-    catalog.apply
-
-    expect(File.read(path)).to eq('foo')
-  end
-
-  it "should not execute the command if unless returns zero" do
-    exec = described_class.new(
-      :command => command,
-      :unless => "ruby -e 'exit 0'",
-      :path => ENV['PATH']
-    )
-
-    catalog.add_resource exec
-    catalog.apply
-
-    expect(Puppet::FileSystem.exist?(path)).to be_falsey
+        expect(logs[0].message).to eql("Could not find command 'ruby -e 'puts 1''")
+      end
+    end
   end
 end


### PR DESCRIPTION
This change updates the exec resource to accept arrays as command. 
The new behavior is enabled for the following parameters: `:comand`, `:onlyif`, `:unless`, `:refresh`.

```
Changing the command to accept an array:

command: "/bin/echo *"         # executes through shell
command: ["/bin/echo *"]       # non-existing command "bin/echo *"
command: ["/bin/echo *", "*"]  # non-existing command "bin/echo *"
command: ["/bin/echo", "*"]    # executes directly

onlyif/unless: '/bin/echo *'                                  # executes one command through shell
onlyif/unless: ['/bin/echo', '*']            				  # this is handled as two separated commands: '/bin/echo'(1), '*'(2)
onlyif/unless: ['/bin/echo *', '/bin/echo $SHELL']            # executes two commands through shell
onlyif/unless: [["/bin/echo", "*"]]                           # executes one command directly
onlyif/unless: [["/bin/echo", "*"], ["/bin/echo", "$SHELL"]]  # executes two commands directly
```