### PR TITLE
(PUP-3634) User resource password run with chpasswd

### DIFF
--- a/acceptance/tests/resource/user/should_create_modify_with_password.rb
+++ b/acceptance/tests/resource/user/should_create_modify_with_password.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+test_name 'should create a user with password and modify the password' do
+
+  tag 'audit:high',
+      'audit:acceptance' # Could be done as integration tests, but would
+  # require changing the system running the test
+  # in ways that might require special permissions
+  # or be harmful to the system running the test
+  
+  require 'puppet/acceptance/common_utils'
+  extend Puppet::Acceptance::ManifestUtils
+
+  name = "pl#{rand(999_999).to_i}"
+  initial_password = 'test1'
+  modified_password = 'test2'
+
+  agents.each do |agent|
+    teardown { agent.user_absent(name) }
+
+    step 'ensure the user does not exist' do
+      user_manifest = resource_manifest('user', name, { ensure: 'absent', provider: 'useradd' } )
+      apply_manifest_on(agent, user_manifest) do |result|
+        skip_test 'Useradd provider not present on this host' if result.stderr =~ /Provider useradd is not functional on this host/
+      end
+    end
+
+    step 'create the user with password' do
+      apply_manifest_on(agent, <<-MANIFEST, catch_failures: true)
+          user { '#{name}':
+            ensure => present,
+            password => '#{initial_password}',
+          }
+        MANIFEST
+    end
+
+    step 'verify the password was set correctly' do
+      on(agent, puppet('resource', 'user', name), acceptable_exit_codes: 0) do
+        assert_match(/password\s*=>\s*'#{initial_password}'/, stdout, 'Password was not set correctly')
+      end
+    end
+
+    step 'modify the user with a different password' do
+      apply_manifest_on(agent, <<-MANIFEST, catch_failures: true)
+	    user { '#{name}':
+	      ensure => present,
+	      password => '#{modified_password}',
+	    }
+	MANIFEST
+    end
+
+    step 'verify the password was set correctly' do
+      on(agent, "puppet resource user #{name}", acceptable_exit_codes: 0) do
+        assert_match(/password\s*=>\s*'#{modified_password}'/, stdout, 'Password was not changed correctly')
+      end
+    end
+
+    step 'Verify idempotency when setting the same password' do
+      apply_manifest_on(agent, <<-MANIFEST, expect_changes: false)
+	    user { '#{name}':
+	      ensure => present,
+	      password => '#{modified_password}',
+	    }
+	MANIFEST
+    end
+  end
+end

--- a/spec/unit/provider/user/useradd_spec.rb
+++ b/spec/unit/provider/user/useradd_spec.rb
@@ -13,6 +13,7 @@ describe Puppet::Type.type(:user).provider(:useradd) do
     allow(described_class).to receive(:command).with(:localmodify).and_return('/usr/sbin/lusermod')
     allow(described_class).to receive(:command).with(:delete).and_return('/usr/sbin/userdel')
     allow(described_class).to receive(:command).with(:localdelete).and_return('/usr/sbin/luserdel')
+    allow(described_class).to receive(:command).with(:chpasswd).and_return('/usr/sbin/chpasswd')
   end
 
   let(:resource) do
@@ -62,7 +63,7 @@ describe Puppet::Type.type(:user).provider(:useradd) do
         :provider   => provider,
       )
       resource2[:ensure] = :present
-      expect(provider).to receive(:execute).with(kind_of(Array), hash_including(sensitive: true))
+      expect(provider).to receive(:execute).with(kind_of(Array), hash_including(sensitive: true)).twice
       provider.create
     end
 
@@ -208,7 +209,7 @@ describe Puppet::Type.type(:user).provider(:useradd) do
     end
 
     it "should call execute with sensitive if sensitive data is changed" do
-      expect(provider).to receive(:execute).with(kind_of(Array), hash_including(sensitive: true))
+      expect(provider).to receive(:execute).with(kind_of(Array), hash_including(sensitive: true)).and_return('')
       provider.password = 'bird bird bird'
     end
   end


### PR DESCRIPTION
When managing passwords with useradd provider, the password hash appears
for a quick time when listing running processes (ps, top, strace)

Now the password is set via the chpasswd command that uses stdin to
receive the password from a temporary file. This way it won't appear on
the process list.