### PR TITLE
(PUP-11088) Warn if fact limits are exceeded

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1689,6 +1689,31 @@ EOT
         new configurations, where you want to fix the broken configuration
         rather than reverting to a known-good one.",
     },
+    :fact_name_length_soft_limit => {
+      :default    => 2560,
+      :type       => :integer,
+      :desc       => "The soft limit for the length of a fact name.",
+    },
+    :fact_value_length_soft_limit => {
+      :default    => 4096,
+      :type       => :integer,
+      :desc       => "The soft limit for the length of a fact value.",
+    },
+    :top_level_facts_soft_limit => {
+      :default    => 512,
+      :type       => :integer,
+      :desc       => "The soft limit for the number of top level facts.",
+    },
+    :number_of_facts_soft_limit => {
+      :default    => 2048,
+      :type       => :integer,
+      :desc       => "The soft limit for the total number of facts.",
+    },
+    :payload_soft_limit => {
+      :default    => 16 * 1024 * 1024,
+      :type       => :integer,
+      :desc       => "The soft limit for the size of the payload.",
+    },
     :use_cached_catalog => {
       :default    => false,
       :type       => :boolean,


### PR DESCRIPTION
Puppet doesn't warn the user when the facts exceed certain limits. This pull request 
adds checks that compare the current sizes and lengths of the facts with a series of limits.
Options for the user to change the values for these limits were also added.

The limits implemented so far are the following:

1. `fact_name_length_soft_limit` - The soft limit for the length of a fact name
2. `fact_value_length_soft_limit` - The soft limit for the length of a fact value
3. `top_level_facts_soft_limit` - The soft limit for the number of top level facts
4. `number_of_facts_soft_limit` - The soft limit for the total number of facts.
5. `payload_soft_limit` - The soft limit for the size of the fact hash after its encoded

Brief explanation on how we check each limit:

1. To check the length of the **fact name** we have to take in consideration the way it is stored in puppetdb. In the case of structured facts such as `{‘a’ => {‘b’ => ‘c’}}`, we use the full path of the fact name, so we will check the sizes of **‘a’** and **‘ab’,** and in the case where have arrays such as `{‘a’ => {‘b’ => [‘c’, ‘d’]}}`, we do the same thing described above but we also add the index of each value in the array to the names, so we would check the following sizes : **‘a’,** **‘ab0’** and **‘ab1’.**
2. To check the length of a **fact value**, when we end up to a value that’s not an array or a hash, we know that this is a value and we check the bytesize and compare it to the set limits
3. To check the **number of top level facts**, we count the number of keys in the fact hash
4. To check the **total number of facts**, we increment a counter each time we check a fact name
5. To check the **size of the payload**, we compare the bytesize of the encoded fact hash to the set limits.

