### PR TITLE
(maint) Update tests to match more strict settings behavior

### DIFF
--- a/spec/integration/indirector/facts/facter_spec.rb
+++ b/spec/integration/indirector/facts/facter_spec.rb
@@ -127,7 +127,7 @@ describe Puppet::Node::Facts::Facter do
       it "prefers agent_specified_environment from agent if set in multiple sections" do
         set_puppet_conf(Puppet[:confdir], <<~CONF)
         [main]
-        serverport=baz
+        serverport=80
 
         [agent]
         environment=bar

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -277,7 +277,7 @@ describe Puppet::Settings do
 
     it "should retrieve numeric settings from the CLI" do
       @settings.handlearg("--myval", "12")
-      expect(@settings.set_by_cli(:myval)).to eq(12)
+      expect(@settings.set_by_cli(:myval)).to eq("12")
       expect(@settings.set_by_cli?(:myval)).to be true
     end
 


### PR DESCRIPTION
Prior to eeb61d1c64, puppet automatically coerced settings whose values were all
digits to an integer. Puppet no longer does that, instead it stores the value
that was set, and converts the value when it is looked up, based on the
settings' type, e.g. :integer, :enum, etc.

The facter_spec change is because `serverport` is a `:port` setting so trying to
set it to "baz" is invalid. It's not a breaking change, because running `puppet
agent -t --serverport baz` would never have worked.

The setting_spec change is because we no longer coerce the string to an integer.

Also 6.x doesn't have this issue, because the `integer` and `port` type were added in 7.0