### PR TITLE
(maint) Fix typo in environment spec - main

### DIFF
--- a/spec/integration/indirector/facts/facter_spec.rb
+++ b/spec/integration/indirector/facts/facter_spec.rb
@@ -127,7 +127,7 @@ describe Puppet::Node::Facts::Facter do
       it "prefers agent_specified_environment from agent if set in multiple sections" do
         set_puppet_conf(Puppet[:confdir], <<~CONF)
         [main]
-        serverport=80
+        environment=baz
 
         [agent]
         environment=bar


### PR DESCRIPTION
Spec test should have set `environment` not `serverport`.