### PR TITLE
(PUP-11131) Honor explicitly configured "purge_ssh_keys: false"

### DIFF
--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -695,7 +695,7 @@ module Puppet
     end
 
     def generate
-      if !self[:purge_ssh_keys].empty?
+      if !self[:purge_ssh_keys].empty? && self[:purge_ssh_keys] != :false
         return [] if self[:ensure] == :present && !provider.exists? 
         if Puppet::Type.type(:ssh_authorized_key).nil?
           warning _("Ssh_authorized_key type is not available. Cannot purge SSH keys.")


### PR DESCRIPTION
this makes an explicitly configured "purge_ssh_keys: false" in type
"user" bypass the whole purging mechanism as expected