### PR TITLE
(maint) remove clear_if_expired from get_conf

### DIFF
--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -465,7 +465,6 @@ module Puppet::Environments
     # @!macro loader_get_conf
     def get_conf(name)
       name = name.to_sym
-      clear_if_expired(name, @cache[name])
       @loader.get_conf(name)
     end
 


### PR DESCRIPTION
There is an issue due to the cache normalization,
before the fix in https://github.com/puppetlabs/puppet/pull/8655 we were caching the environment
as a string, but we would try to delete the environment as a symbol.
After that fix, everything is stored as a symbol and get_conf
https://github.com/puppetlabs/puppet/blob/main/lib/puppet/environments.rb#L468 would remove the cached entry,
forcing a reload of the environment on the next call.

```
passing:
get_conf: :production
clear_if_expired for :production
cache -> {"production"=>...}


failing:
get_conf: :production
clear_if_expired for :production
cache -> {:production=>...}
...
get_conf: :production
```