### PR TITLE
(PUP-9570) Short-circuit compilation if the agent's current env doesn't match the server specified env

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -571,6 +571,7 @@ class Puppet::Configurer
           # don't update cache until after environment converges
           :ignore_cache_save => true,
           :environment       => Puppet::Node::Environment.remote(@environment),
+          :check_environment => true,
           :fail_on_404       => true,
           :facts_for_catalog => facts
         )

--- a/lib/puppet/http/service/compiler.rb
+++ b/lib/puppet/http/service/compiler.rb
@@ -69,6 +69,10 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
   # @param [String] environment The name of the environment we are operating in
   # @param [String] configured_environment Optional, the name of the configured
   #   environment. If unset, `environment` is used.
+  # @param [Boolean] check_environment If true, request that the server check if
+  #   our `environment` matches the server-specified environment. If they do not
+  #   match, then the server may return an empty catalog in the server-specified
+  #   environment.
   # @param [String] transaction_uuid An agent generated transaction uuid, used
   #   for connecting catalogs and reports.
   # @param [String] job_uuid A unique job identifier defined when the orchestrator
@@ -85,7 +89,7 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
   #   containing the request response and the deserialized catalog returned by
   #   the server
   #
-  def post_catalog(name, facts:, environment:, configured_environment: nil, transaction_uuid: nil, job_uuid: nil, static_catalog: true, checksum_type: Puppet[:supported_checksum_types])
+  def post_catalog(name, facts:, environment:, configured_environment: nil, check_environment: false, transaction_uuid: nil, job_uuid: nil, static_catalog: true, checksum_type: Puppet[:supported_checksum_types])
     if Puppet[:preferred_serialization_format] == "pson"
       formatter = Puppet::Network::FormatHandler.format_for(:pson)
       # must use 'pson' instead of 'text/pson'
@@ -103,6 +107,7 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
       facts: Puppet::Util.uri_query_encode(facts_as_string),
       environment: environment,
       configured_environment: configured_environment || environment,
+      check_environment: !!check_environment,
       transaction_uuid: transaction_uuid,
       job_uuid: job_uuid,
       static_catalog: static_catalog,

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -53,6 +53,14 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
     node.trusted_data = Puppet.lookup(:trusted_information) { Puppet::Context::TrustedInformation.local(node) }.to_h
 
     if node.environment
+      # If the requested environment doesn't match the server specified environment,
+      # as determined by the node terminus, and the request wants us to check for an
+      # environment mismatch, then return an empty catalog with the server-specified
+      # enviroment.
+      if request.remote? && request.options[:check_environment] && node.environment != request.environment
+        return Puppet::Resource::Catalog.new(node.name, node.environment)
+      end
+
       node.environment.with_text_domain do
         envs = Puppet.lookup(:environments)
         envs.guard(node.environment.name)

--- a/lib/puppet/indirector/catalog/rest.rb
+++ b/lib/puppet/indirector/catalog/rest.rb
@@ -20,6 +20,7 @@ class Puppet::Resource::Catalog::Rest < Puppet::Indirector::REST
       facts: request.options[:facts_for_catalog],
       environment: request.environment.to_s,
       configured_environment: request.options[:configured_environment],
+      check_environment: request.options[:check_environment],
       transaction_uuid: request.options[:transaction_uuid],
       job_uuid: request.options[:job_id],
       static_catalog: request.options[:static_catalog],

--- a/spec/fixtures/integration/application/agent/lib/facter/agent_spec_role.rb
+++ b/spec/fixtures/integration/application/agent/lib/facter/agent_spec_role.rb
@@ -1,0 +1,3 @@
+Facter.add(:agent_spec_role) do
+  setcode { 'web' }
+end

--- a/spec/lib/puppet_spec/puppetserver.rb
+++ b/spec/lib/puppet_spec/puppetserver.rb
@@ -38,6 +38,12 @@ class PuppetSpec::Puppetserver
     end
   end
 
+  class FileContentServlet < WEBrick::HTTPServlet::AbstractServlet
+    def do_GET request, response
+      response.status = 404
+    end
+  end
+
   class ReportServlet < WEBrick::HTTPServlet::AbstractServlet
     def do_PUT request, response
       response['Content-Type'] = 'application/json'
@@ -115,6 +121,7 @@ class PuppetSpec::Puppetserver
     register_mount('/puppet/v3/catalog', mounts[:catalog], CatalogServlet)
     register_mount('/puppet/v3/file_metadata', mounts[:file_metadata], FileMetadataServlet)
     register_mount('/puppet/v3/file_metadatas', mounts[:file_metadatas], FileMetadatasServlet)
+    register_mount('/puppet/v3/file_content', mounts[:file_content], FileContentServlet)
     register_mount('/puppet/v3/static_file_content', mounts[:static_file_content], StaticFileContentServlet)
     register_mount('/puppet/v3/report', mounts[:report], ReportServlet)
     register_mount('/puppet/v3/file_bucket_file', mounts[:filebucket], FilebucketServlet)

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -565,7 +565,7 @@ describe Puppet::Configurer do
   end
 
   def expects_new_catalog_only(catalog)
-    expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(ignore_cache: true)).and_return(catalog)
+    expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(ignore_cache: true, check_environment: true)).and_return(catalog)
     expect(Puppet::Resource::Catalog.indirection).not_to receive(:find).with(anything, hash_including(ignore_terminus: true))
   end
 
@@ -582,7 +582,7 @@ describe Puppet::Configurer do
   def expects_fallback_to_new_catalog(catalog)
     expects_pluginsync
     expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(ignore_terminus: true)).and_return(nil)
-    expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(ignore_cache: true)).and_return(catalog)
+    expect(Puppet::Resource::Catalog.indirection).to receive(:find).with(anything, hash_including(ignore_cache: true, check_environment: true)).and_return(catalog)
   end
 
   def expects_neither_new_or_cached_catalog

--- a/spec/unit/http/service/compiler_spec.rb
+++ b/spec/unit/http/service/compiler_spec.rb
@@ -96,6 +96,14 @@ describe Puppet::HTTP::Service::Compiler do
       subject.post_catalog(certname, environment: 'production', facts: facts, configured_environment: 'agent_specified')
     end
 
+    it 'includes check_environment' do
+      stub_request(:post, uri)
+        .with(body: hash_including('check_environment' => 'false'))
+        .to_return(**catalog_response)
+
+      subject.post_catalog(certname, environment: 'production', facts: facts)
+    end
+
     it 'includes transaction_uuid' do
       uuid = "ec3d2844-b236-4287-b0ad-632fbb4d1ff0"
 

--- a/spec/unit/indirector/catalog/compiler_spec.rb
+++ b/spec/unit/indirector/catalog/compiler_spec.rb
@@ -11,6 +11,9 @@ def set_facts(fact_hash)
 end
 
 describe Puppet::Resource::Catalog::Compiler do
+  include Matchers::Resource
+  include PuppetSpec::Files
+
   let(:compiler) { described_class.new }
   let(:node_name) { "foo" }
   let(:node) { Puppet::Node.new(node_name)}
@@ -248,6 +251,33 @@ describe Puppet::Resource::Catalog::Compiler do
       end
 
       compiler.find(@request)
+    end
+
+    context 'when checking agent and server specified environments' do
+      before :each do
+        FileUtils.mkdir_p(File.join(Puppet[:environmentpath], 'env_server'))
+        FileUtils.mkdir_p(File.join(Puppet[:environmentpath], 'env_agent'))
+
+        node.environment = 'env_server'
+        allow(Puppet::Node.indirection).to receive(:find).and_return(node)
+
+        @request.environment = 'env_agent'
+      end
+
+      it 'ignores mismatched environments by default' do
+        catalog = compiler.find(@request)
+
+        expect(catalog.environment).to eq('env_server')
+        expect(catalog).to have_resource('Stage[main]')
+      end
+
+      it 'returns an empty catalog if asked to check the environment and they are mismatched' do
+        @request.options[:check_environment] = "true"
+        catalog = compiler.find(@request)
+
+        expect(catalog.environment).to eq('env_server')
+        expect(catalog.resources).to be_empty
+      end
     end
   end
 

--- a/spec/unit/indirector/catalog/rest_spec.rb
+++ b/spec/unit/indirector/catalog/rest_spec.rb
@@ -33,6 +33,14 @@ describe Puppet::Resource::Catalog::Rest do
     described_class.indirection.find(certname, environment: Puppet::Node::Environment.remote('outerspace'))
   end
 
+  it "passes 'check_environment'" do
+    stub_request(:post, uri)
+      .with(body: hash_including('check_environment' => 'true'))
+      .to_return(**catalog_response(catalog))
+
+    described_class.indirection.find(certname, check_environment: true)
+  end
+
   it 'constructs a catalog environment_instance' do
     env = Puppet::Node::Environment.remote('outerspace')
     catalog = Puppet::Resource::Catalog.new(certname, env)


### PR DESCRIPTION
The agent now sends a `check_environment` query parameter when requesting its catalog via the v3 endpoint. The server-side indirector code converts the query parameter to an indirector request option and passes that to the compiler catalog terminus. If the option is `true`, then the server will check if the agent's current environment, that it last pluginsynced in, matches the server-specified environment, as determined by the node terminus, such as an ENC or PE Classifier. If the environments are mismatched, then the terminus short-circuits catalog compilation, returning an empty catalog with the server-specified environment. The agent will detect the mismatch, switch its current environment, and retry its convergence loop.

Prior to this change, if manifests in the server-specified environment referenced a fact that didn't exist in the agent's current environment, then compilation failed and the server returned HTTP 500, causing the agent run to fail.

Note the agent doesn't cache the empty catalog, because that step occurs [after the environment has converged](https://github.com/puppetlabs/puppet/blob/30ade2bb899482cfa52592a0e4ba74f169613579/lib/puppet/configurer.rb#L412-L423).

New agents talking to old servers will behave as before, since old servers ignore the unknown `check_environment` parameter. Similarly, old agents talking to new servers behave as before, because the agent doesn't send the parameter.