### PR TITLE
(PUP-11158) Guard against environment expiration during compilation

### DIFF
--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -417,7 +417,7 @@ module Puppet::Environments
       Puppet.debug {"Caching environment #{name.inspect} #{cache_entry.label}"}
       @cache[name] = cache_entry
       @cache_expiration_service.created(cache_entry.value)
-      # REMIND: notify text domain service
+      @cache_textdomain_service.created(cache_entry.value)
     end
     private :add_entry
 

--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -387,23 +387,30 @@ module Puppet::Environments
 
     # @!macro loader_get
     def get(name)
+      entry = get_entry(name)
+      entry&.value
+    end
+
+    # Get a cache entry for an envionment. It returns nil if the
+    # environment doesn't exist.
+    def get_entry(name)
       # Aggressively evict all that has expired
       # This strategy favors smaller memory footprint over environment
       # retrieval time.
       clear_all_expired
-      result = @cache[name]
-      if result
-        Puppet.debug {"Found in cache #{name.inspect} #{result.label}"}
+      entry = @cache[name]
+      if entry
+        Puppet.debug {"Found in cache #{name.inspect} #{entry.label}"}
         # found in cache
-        result.touch
-        return result.value
+        entry.touch
       elsif (result = @loader.get(name))
         # environment loaded, cache it
-        cache_entry = entry(result)
-        add_entry(name, cache_entry)
-        result
+        entry = entry(result)
+        add_entry(name, entry)
       end
+      entry
     end
+    private :get_entry
 
     # Adds a cache entry to the cache
     def add_entry(name, cache_entry)

--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -1,4 +1,5 @@
 require 'puppet/concurrent/synchronized'
+require 'puppet/gettext/text_domain_service'
 
 # @api private
 module Puppet::Environments
@@ -348,6 +349,7 @@ module Puppet::Environments
     def initialize(loader)
       @loader = loader
       @cache_expiration_service = Puppet::Environments::Cached.cache_expiration_service
+      @cache_textdomain_service = Puppet::TextDomainService.create
       @cache = {}
     end
 
@@ -408,6 +410,7 @@ module Puppet::Environments
       Puppet.debug {"Caching environment #{name.inspect} #{cache_entry.label}"}
       @cache[name] = cache_entry
       @cache_expiration_service.created(cache_entry.value)
+      # REMIND: notify text domain service
     end
     private :add_entry
 
@@ -415,7 +418,7 @@ module Puppet::Environments
       @cache.delete(name)
       Puppet.debug {"Evicting cache entry for environment #{name.inspect}"}
       @cache_expiration_service.evicted(name.to_sym)
-      Puppet::GettextConfig.delete_text_domain(name)
+      @cache_textdomain_service.evicted(entry.value)
       Puppet.settings.clear_environment_settings(name)
     end
     private :clear_entry

--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -391,7 +391,7 @@ module Puppet::Environments
       clear_all_expired
       result = @cache[name]
       if result
-        Puppet.debug {"Found in cache '#{name}' #{result.label}"}
+        Puppet.debug {"Found in cache #{name.inspect} #{result.label}"}
         # found in cache
         result.touch
         return result.value
@@ -405,7 +405,7 @@ module Puppet::Environments
 
     # Adds a cache entry to the cache
     def add_entry(name, cache_entry)
-      Puppet.debug {"Caching environment '#{name}' #{cache_entry.label}"}
+      Puppet.debug {"Caching environment #{name.inspect} #{cache_entry.label}"}
       @cache[name] = cache_entry
       @cache_expiration_service.created(cache_entry.value)
     end
@@ -413,7 +413,7 @@ module Puppet::Environments
 
     def clear_entry(name, entry)
       @cache.delete(name)
-      Puppet.debug {"Evicting cache entry for environment '#{name}'"}
+      Puppet.debug {"Evicting cache entry for environment #{name.inspect}"}
       @cache_expiration_service.evicted(name.to_sym)
       Puppet::GettextConfig.delete_text_domain(name)
       Puppet.settings.clear_environment_settings(name)

--- a/lib/puppet/gettext/text_domain_service.rb
+++ b/lib/puppet/gettext/text_domain_service.rb
@@ -1,0 +1,25 @@
+module Puppet
+  class TextDomainService
+    def self.create
+      if Puppet[:disable_i18n]
+        TextDomainService.new
+      else
+        I18nTextDomainService.new
+      end
+    end
+
+    def created(env); end
+    def evicted(env); end
+  end
+
+  class I18nTextDomainService < TextDomainService
+    def created(env)
+      Puppet::GettextConfig.reset_text_domain(env.name)
+      Puppet::ModuleTranslations.load_from_modulepath(env.modules)
+    end
+
+    def evicted(env)
+      Puppet::GettextConfig.delete_text_domain(env.name)
+    end
+  end
+end

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -53,8 +53,12 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
     node.trusted_data = Puppet.lookup(:trusted_information) { Puppet::Context::TrustedInformation.local(node) }.to_h
 
     if node.environment
-      node.environment.with_text_domain do
+      envs = Puppet.lookup(:environments)
+      envs.guard(node.environment.name)
+      begin
         compile(node, request.options)
+      ensure
+        envs.unguard(node.environment.name)
       end
     else
       compile(node, request.options)

--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -305,7 +305,9 @@ class Puppet::Node::Environment
                        {}
                      end
       modulepath.each do |path|
-        Dir.entries(path).each do |name|
+        Puppet::FileSystem.children(path).map do |p|
+          Puppet::FileSystem.basename_string(p)
+        end.each do |name|
           next unless Puppet::Module.is_module_directory?(name, path)
           warn_about_mistaken_path(path, name)
           if not seen_modules[name]
@@ -358,7 +360,9 @@ class Puppet::Node::Environment
     modules_by_path = {}
     modulepath.each do |path|
       if Puppet::FileSystem.exist?(path)
-        module_names = Dir.entries(path).select do |name|
+        module_names = Puppet::FileSystem.children(path).map do |p|
+          Puppet::FileSystem.basename_string(p)
+        end.select do |name|
           Puppet::Module.is_module_directory?(name, path)
         end
         modules_by_path[path] = module_names.sort.map do |name|

--- a/spec/unit/environments_spec.rb
+++ b/spec/unit/environments_spec.rb
@@ -30,6 +30,7 @@ describe Puppet::Environments do
         ]),
         FS::MemoryFile.a_directory("another_environment", [
           FS::MemoryFile.a_missing_file("environment.conf"),
+          FS::MemoryFile.a_missing_directory("modules"),
         ]),
         FS::MemoryFile.a_missing_file("doesnotexist"),
         FS::MemoryFile.a_symlink("symlinked_environment", File.expand_path(File.join("top_level_dir", "versioned_env")))]),
@@ -401,11 +402,12 @@ config_version=$vardir/random/scripts
         base_dir = File.expand_path("envdir")
         original_envdir = FS::MemoryFile.a_directory(base_dir, [
           FS::MemoryFile.a_directory("env3", [
-            FS::MemoryFile.a_regular_file_containing("environment.conf", <<-EOF)
+            FS::MemoryFile.a_regular_file_containing("environment.conf", <<-EOF),
               manifest=/manifest_orig
-              modulepath=/modules_orig
+              modulepath=modules_orig
               environment_timeout=0
             EOF
+            FS::MemoryFile.a_directory('modules_orig', [])
           ]),
         ])
 
@@ -414,11 +416,12 @@ config_version=$vardir/random/scripts
 
           changed_envdir = FS::MemoryFile.a_directory(base_dir, [
             FS::MemoryFile.a_directory("env3", [
-              FS::MemoryFile.a_regular_file_containing("environment.conf", <<-EOF)
+              FS::MemoryFile.a_regular_file_containing("environment.conf", <<-EOF),
                 manifest=/manifest_changed
-                modulepath=/modules_changed
+                modulepath=modules_changed
                 environment_timeout=0
               EOF
+              FS::MemoryFile.a_directory('modules_changed', [])
             ]),
           ])
 
@@ -427,11 +430,11 @@ config_version=$vardir/random/scripts
 
             expect(original_env).to environment(:env3).
               with_manifest(File.expand_path("/manifest_orig")).
-              with_full_modulepath([File.expand_path("/modules_orig")])
+              with_full_modulepath([File.join(base_dir, "env3/modules_orig")])
 
             expect(changed_env).to environment(:env3).
               with_manifest(File.expand_path("/manifest_changed")).
-              with_full_modulepath([File.expand_path("/modules_changed")])
+              with_full_modulepath([File.join(base_dir, "env3/modules_changed")])
           end
         end
       end
@@ -617,15 +620,18 @@ config_version=$vardir/random/scripts
 
       it "does not list deleted environments" do
         env3 = FS::MemoryFile.a_directory("env3", [
-          FS::MemoryFile.a_regular_file_containing("environment.conf", '')
+          FS::MemoryFile.a_regular_file_containing("environment.conf", ''),
+          FS::MemoryFile.a_missing_directory("modules")
         ])
 
         envdir = FS::MemoryFile.a_directory(File.expand_path("envdir"), [
           FS::MemoryFile.a_directory("env1", [
-            FS::MemoryFile.a_regular_file_containing("environment.conf", '')
+            FS::MemoryFile.a_regular_file_containing("environment.conf", ''),
+            FS::MemoryFile.a_missing_directory("modules")
           ]),
           FS::MemoryFile.a_directory("env2", [
-            FS::MemoryFile.a_regular_file_containing("environment.conf", '')
+            FS::MemoryFile.a_regular_file_containing("environment.conf", ''),
+            FS::MemoryFile.a_missing_directory("modules")
           ]),
           env3
         ])
@@ -875,7 +881,8 @@ config_version=$vardir/random/scripts
       let(:base_dir) do
         FS::MemoryFile.a_directory(envdir, [
           FS::MemoryFile.a_directory("cached_env", [
-            FS::MemoryFile.a_missing_file("environment.conf")
+            FS::MemoryFile.a_missing_file("environment.conf"),
+            FS::MemoryFile.a_missing_directory("modules")
           ])
         ])
       end

--- a/spec/unit/gettext/text_domain_service_spec.rb
+++ b/spec/unit/gettext/text_domain_service_spec.rb
@@ -1,0 +1,48 @@
+require 'puppet/gettext/text_domain_service'
+require 'spec_helper'
+
+describe Puppet::TextDomainService do
+  let(:env) { Puppet::Node::Environment.create(:production, []) }
+
+  context 'when i18n is enabled' do
+    before :each do
+      Puppet[:disable_i18n] = false
+    end
+
+    subject { described_class.create }
+
+    it 'loads module translations' do
+      expect(Puppet::GettextConfig).to receive(:reset_text_domain).with(:production)
+      expect(Puppet::ModuleTranslations).to receive(:load_from_modulepath).with([])
+
+      subject.created(env)
+    end
+
+    it 'deletes module translations' do
+      expect(Puppet::GettextConfig).to receive(:delete_text_domain).with(:production)
+
+      subject.evicted(env)
+    end
+  end
+
+  context 'when i18n is disabled' do
+    before :each do
+      Puppet[:disable_i18n] = true
+    end
+
+    subject { described_class.create }
+
+    it 'does not load module translations' do
+      expect(Puppet::GettextConfig).to receive(:reset_text_domain).never
+      expect(Puppet::ModuleTranslations).to receive(:load_from_modulepath).never
+
+      subject.created(env)
+    end
+
+    it 'does not delete module translations' do
+      expect(Puppet::GettextConfig).to receive(:delete_text_domain).never
+
+      subject.evicted(env)
+    end
+  end
+end


### PR DESCRIPTION
The compiler terminus loads a text domain at the start of compilation. If `Cached#get_conf` is called it will try to clear expired environments. This doesn't
happen due to the environment cache containing strings, while `get_conf` is called with the environment's name as a symbol.

These commits add a `TextDomainService` which is called when an environment is added or cleared from the cache (similar to the expiration service). This ensures the text domain and module translations have the same lifetime as the environment.

It also adds a guard to prevent an environment from being evicted during compilation. That matches the old behavior, but it's done explicitly rather than relying on a bug.

Altogether it means the default environment_timeout=0 won't reload the environment multiple times during a single compilation. But it will reload prior to the next compilation.