### PR TITLE
(PUP-11029) Fix pip package provider to query available versions

### DIFF
--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -127,7 +127,7 @@ Puppet::Type.type(:package).provide :pip, :parent => ::Puppet::Provider::Package
     if self.class.compare_pip_versions(command_version, '1.5.4') == -1
       available_versions_with_old_pip.last
     else
-      available_versions_with_new_pip.last
+      available_versions_with_new_pip(command_version).last
     end
   end
 
@@ -150,15 +150,17 @@ Puppet::Type.type(:package).provide :pip, :parent => ::Puppet::Provider::Package
     if self.class.compare_pip_versions(command_version, '1.5.4') == -1
       available_versions_with_old_pip
     else
-      available_versions_with_new_pip
+      available_versions_with_new_pip(command_version)
     end
   end
 
-  def available_versions_with_new_pip
+  def available_versions_with_new_pip(command_version)
     command = resource_or_provider_command
     self.class.validate_command(command)
 
     command_and_options = [self.class.quote(command), 'install', "#{@resource[:name]}==versionplease"]
+    extra_arg = list_extra_flags(command_version)
+    command_and_options << extra_arg if extra_arg
     command_and_options << install_options if @resource[:install_options]
     execpipe command_and_options do |process|
       process.collect do |line|
@@ -327,6 +329,16 @@ Puppet::Type.type(:package).provide :pip, :parent => ::Puppet::Provider::Package
       "\"#{path}\""
     else
       path
+    end
+  end
+
+  private
+
+  def list_extra_flags(command_version)
+    klass = self.class
+    if klass.compare_pip_versions(command_version, '20.2.4') == 1 &&
+      klass.compare_pip_versions(command_version, '21.1') == -1
+      '--use-deprecated=legacy-resolver'
     end
   end
 end

--- a/spec/unit/provider/package/pip_spec.rb
+++ b/spec/unit/provider/package/pip_spec.rb
@@ -266,6 +266,43 @@ describe Puppet::Type.type(:package).provider(:pip) do
       let(:pip_version) { '1.5.4' }
       let(:pip_path) { '/fake/bin/pip' }
 
+      context "with pip version >= 20.3 and < 21.1" do
+        let(:pip_version) { '20.3.1' }
+        let(:pip_path) { '/fake/bin/pip' }
+
+        it "should use legacy-resolver argument" do
+          p = StringIO.new(
+            <<-EOS
+            Collecting real-package==versionplease
+              Could not find a version that satisfies the requirement real-package==versionplease (from versions: 1.1.3, 1.0, 1.9b1)
+            No matching distribution found for real-package==versionplease
+            EOS
+          )
+          expect(Puppet::Util::Execution).to receive(:execpipe).with(["/fake/bin/pip", "install", "real_package==versionplease",
+            "--use-deprecated=legacy-resolver"]).and_yield(p).once
+          @resource[:name] = "real_package"
+          @provider.latest
+        end
+      end
+
+      context "with pip version >= 21.1" do
+        let(:pip_version) { '21.1' }
+        let(:pip_path) { '/fake/bin/pip' }
+
+        it "should not use legacy-resolver argument" do
+          p = StringIO.new(
+            <<-EOS
+            Collecting real-package==versionplease
+              Could not find a version that satisfies the requirement real-package==versionplease (from versions: 1.1.3, 1.0, 1.9b1)
+            No matching distribution found for real-package==versionplease
+            EOS
+          )
+          expect(Puppet::Util::Execution).to receive(:execpipe).with(["/fake/bin/pip", "install", "real_package==versionplease"]).and_yield(p).once
+          @resource[:name] = "real_package"
+          @provider.latest
+        end
+      end
+
       it "should find a version number for real_package" do
         p = StringIO.new(
           <<-EOS


### PR DESCRIPTION
Starting with version `20.3b1`, `pip` removed available versions of a package from output when trying to install a wrong or unavailable version. Puppet is using this output to gather all available versions of a package and determine the latest one. Even though this regression got fixed in `21.1` version of `pip`, this commit adds the `--use-deprecated=legacy-resolver` argument when querying available versions of the managed package and also using any of the affected versions of `pip`.

## Before fix:
```sh-session
➜ puppet resource package ‘colorize’ ensure=latest provider=pip3
Error: Could not get latest version: [nil, nil, nil, nil]
Error: /Package[colorize]/ensure: change from ‘1.1.0’ to ‘latest’ failed: Could not get latest version: [nil, nil, nil, nil]
package { ‘colorize’:
  ensure   => ‘1.1.0’,
  provider => ‘pip3’,
}
```

## After fix:
```sh-session
➜ puppet resource package ‘colorize’ ensure=latest provider=pip3
Notice: /Package[colorize]/ensure: created
package { ‘colorize’:
  ensure   => ‘1.1.0’,
  provider => ‘pip3’,
}
```

## Versions affected by this issue

### pip3 v20.2.4 output:
```sh-session
➜ pip3 install colorize==versionplease
ERROR: Could not find a version that satisfies the requirement colorize==versionplease (from versions: 0.2.0, 0.2.1, 1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.1.0)
ERROR: No matching distribution found for colorize==versionplease
```

### pip3 v20.3b1 output:
```sh-session
➜ pip3 install colorize==versionplease
ERROR: Could not find a version that satisfies the requirement colorize==versionplease
ERROR: No matching distribution found for colorize==versionplease
```

...

### pip3 v21.0.1 output:
```sh-session
➜ pip3 install colorize==versionplease
ERROR: Could not find a version that satisfies the requirement colorize==versionplease
ERROR: No matching distribution found for colorize==versionplease
```

### pip3 v21.1 output:
```sh-session
➜ pip3 install colorize==versionplease
ERROR: Could not find a version that satisfies the requirement colorize==versionplease (from versions: 0.2.0, 0.2.1, 1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.1.0)
ERROR: No matching distribution found for colorize==versionplease
```

Note: Fixed version also known from [pip3 changelog|https://pip.pypa.io/en/stable/news/].

### Output with `--use-deprecated=legacy-resolver` argument
```sh-session
➜ pip3 --version
pip 20.3b1 from /usr/local/lib/python3.6/dist-packages/pip (python 3.6)

➜ pip3 install colorize==versionplease --use-deprecated=legacy-resolver
ERROR: Could not find a version that satisfies the requirement colorize==versionplease (from versions: 0.2.0, 0.2.1, 1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.1.0)
ERROR: No matching distribution found for colorize==versionplease
```


## Useful info for testing this fix

### To get pip3 on a Ubuntu vm
```sh-session
➜ apt-get update -y
➜ apt-get install python3-pip -y
```

### To see current pip3 version
```sh-session
➜ pip3 --version
pip 20.3 from /usr/local/lib/python3.6/dist-packages/pip (python 3.6)
```

### To see available pip3 versions
```sh-session
➜ pip3 install pip==versionplease
Collecting pip==versionplease
  Could not find a version that satisfies the requirement pip==versionplease (from versions: 0.2, 0.2.1, 0.3, 0.3.1, 0.4, 0.5, 0.5.1, 0.6, 0.6.1, 0.6.2, 0.6.3, 0.7, 0.7.1, 0.7.2, 0.8, 0.8.1, 0.8.2, 0.8.3, 1.0, 1.0.1, 1.0.2, 1.1, 1.2, 1.2.1, 1.3, 1.3.1, 1.4, 1.4.1, 1.5, 1.5.1, 1.5.2, 1.5.3, 1.5.4, 1.5.5, 1.5.6, 6.0, 6.0.1, 6.0.2, 6.0.3, 6.0.4, 6.0.5, 6.0.6, 6.0.7, 6.0.8, 6.1.0, 6.1.1, 7.0.0, 7.0.1, 7.0.2, 7.0.3, 7.1.0, 7.1.1, 7.1.2, 8.0.0, 8.0.1, 8.0.2, 8.0.3, 8.1.0, 8.1.1, 8.1.2, 9.0.0, 9.0.1, 9.0.2, 9.0.3, 10.0.0b1, 10.0.0b2, 10.0.0, 10.0.1, 18.0, 18.1, 19.0, 19.0.1, 19.0.2, 19.0.3, 19.1, 19.1.1, 19.2, 19.2.1, 19.2.2, 19.2.3, 19.3, 19.3.1, 20.0, 20.0.1, 20.0.2, 20.1b1, 20.1, 20.1.1, 20.2b1, 20.2, 20.2.1, 20.2.2, 20.2.3, 20.2.4, 20.3b1, 20.3, 20.3.1, 20.3.2, 20.3.3, 20.3.4, 21.0, 21.0.1, 21.1, 21.1.1, 21.1.2, 21.1.3)
No matching distribution found for pip==versionplease
```

### To install a certain pip3 version
```sh-session
➜ pip3 install pip==21.1.3
Collecting pip==21.1.3
  Using cached pip-21.1.3-py3-none-any.whl (1.5 MB)
Installing collected packages: pip
  Attempting uninstall: pip
    Found existing installation: pip 20.3
    Uninstalling pip-20.3:
      Successfully uninstalled pip-20.3
Successfully installed pip-21.1.3
```

Note:
- Some versions might change location of `pip3` from `/usr/bin/pip3` to `/usr/local/bin/pip3`.
- If pip3 starts erroring out (due to known bugs of the installed version), use bellow commands to reinstall it:
```sh-session
➜ apt-get install --reinstall python3-pip
```
or
```sh-session
➜ curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py
```