### PR TITLE
(PUP-6802) Fallback to default environment when given is missing 

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1369,6 +1369,12 @@ EOT
         In either case, the path can point to a single file or to a directory of
         manifests to be evaluated in alphabetical order.",
     },
+    :default_agent_environment => {
+      :default  => "production",
+      :type     => :string,
+      :desc     => "The default environment for puppet agent. Set by default to 'production', and
+      is the fallback environment in case the agent runs in an environment not available on the server.",
+    },
     :disable_per_environment_manifest => {
       :default    => false,
       :type       => :boolean,

--- a/lib/puppet/network/http/api/indirected_routes.rb
+++ b/lib/puppet/network/http/api/indirected_routes.rb
@@ -94,7 +94,11 @@ class Puppet::Network::HTTP::API::IndirectedRoutes
     end
 
     configured_environment = Puppet.lookup(:environments).get(environment)
-    unless configured_environment.nil?
+    if configured_environment.nil?
+      Puppet.warning("Environment #{environment} does not exist, falling back to #{Puppet[:default_agent_environment]}")
+      configured_environment = Puppet.lookup(:environments).get(Puppet[:default_agent_environment])
+      params[:environment] = configured_environment if configured_environment
+    else
       configured_environment = configured_environment.override_from_commandline(Puppet.settings)
       params[:environment] = configured_environment
     end

--- a/spec/unit/network/http/api/indirected_routes_spec.rb
+++ b/spec/unit/network/http/api/indirected_routes_spec.rb
@@ -74,6 +74,11 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
       expect(handler.uri2indirection("GET", "#{master_url_prefix}/node/bar", params)[3][:environment]).to be_a(Puppet::Node::Environment)
     end
 
+    it "should fallback to the configured default_agent_environment setting and return the environment as a Puppet::Node::Environment" do
+      Puppet[:default_agent_environment] = "env"
+      expect(handler.uri2indirection("GET", "#{master_url_prefix}/node/bar", { :environment => "unavailable" })[3][:environment].to_s).to eq("env")
+    end
+
     it "should use the first field of the URI as the indirection name" do
       expect(handler.uri2indirection("GET", "#{master_url_prefix}/node/bar", params)[0].name).to eq(:node)
     end


### PR DESCRIPTION
When an agent runs with a environment that does not exist on the server,
puppet will fail with
```
Warning: Unable to fetch my node definition, but the agent run will continue:
Warning: Find /puppet/v3/node/steep-ribcage.delivery.puppetlabs.net resulted in 404 with the message: {"message":"Not Found: Could not find environment 'qwe'","issue_kind":"RUNTIME_ERROR"}
Info: Retrieving pluginfacts
Error: /File[/opt/puppetlabs/puppet/cache/facts.d]: Could not evaluate: Could not retrieve information from environment qwe source(s) puppet:///pluginfacts
Info: Retrieving plugin
Error: /File[/opt/puppetlabs/puppet/cache/lib]: Could not evaluate: Could not retrieve information from environment qwe source(s) puppet:///plugins
Info: Retrieving locales
Error: /File[/opt/puppetlabs/puppet/cache/locales]: Could not evaluate: Could not retrieve information from environment qwe source(s) puppet:///locales
Error: Could not retrieve catalog from remote server: Find /puppet/v3/catalog/steep-ribcage.delivery.puppetlabs.net resulted in 404 with the message: {"message":"Not Found: Could not find environment 'qwe'","issue_kind":"RUNTIME_ERROR"}
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
```

Now in case it cannot get the facts or catalog for the specified
environment, it will fallback to the environment configured in the
new default_agent_environment puppet setting.