### PR TITLE
(PUP-10956) Allow pkg provider to update and unhold package in same run

### DIFF
--- a/acceptance/tests/resource/package/ips/should_be_updateable_and_unholdable_at_same_time.rb
+++ b/acceptance/tests/resource/package/ips/should_be_updateable_and_unholdable_at_same_time.rb
@@ -1,0 +1,38 @@
+test_name "Package:IPS test for updatable holded package" do
+  confine :to, :platform => 'solaris-11'
+
+  tag 'audit:high'
+
+  require 'puppet/acceptance/solaris_util'
+  extend Puppet::Acceptance::IPSUtils
+
+  agents.each do |agent|
+    teardown do
+      clean agent
+    end
+
+    step "IPS: setup" do
+      setup agent
+      setup_fakeroot agent
+      send_pkg agent, :pkg => 'mypkg@0.0.1'
+      set_publisher agent
+    end
+
+    step "IPS: it should create and hold in same manifest" do
+      apply_manifest_on(agent, 'package {mypkg : ensure=>"0.0.1", mark=>hold}') do
+        assert_match( /ensure: created/, result.stdout, "err: #{agent}")
+      end
+    end
+
+    step "IPS: it should update and unhold in same manifest" do
+      send_pkg agent, :pkg => 'mypkg@0.0.2'
+      apply_manifest_on(agent, 'package {mypkg : ensure=>"0.0.2", mark=>"none"}')
+    end
+
+    step "IPS: ensure it was upgraded" do
+      on agent, "pkg list -v mypkg" do
+        assert_match( /mypkg@0.0.2/, result.stdout, "err: #{agent}")
+      end
+    end
+  end
+end

--- a/lib/puppet/provider/package/pkg.rb
+++ b/lib/puppet/provider/package/pkg.rb
@@ -165,7 +165,14 @@ Puppet::Type.type(:package).provide :pkg, :parent => Puppet::Provider::Package d
         command = is == :absent ? 'install' : 'update'
         options = ['-n']
         options.concat(join_options(@resource[:install_options])) if @resource[:install_options]
-        status = exec_cmd(command(:pkg), command, *options, "#{name}@#{p[:ensure]}")[:exit]
+
+        begin
+          unhold if properties[:mark] == :hold
+          status = exec_cmd(command(:pkg), command, *options, "#{name}@#{p[:ensure]}")[:exit]
+        ensure
+          hold if properties[:mark] == :hold
+        end
+
         case status
         when 4
           # if the first installable match would cause no changes, we're in sync

--- a/spec/unit/provider/package/pkg_spec.rb
+++ b/spec/unit/provider/package/pkg_spec.rb
@@ -352,12 +352,15 @@ describe Puppet::Type.type(:package).provider(:pkg), unless: Puppet::Util::Platf
             resource[:ensure] = '1.0-0.151006'
             is = :absent
             expect(provider).to receive(:query).with(no_args).and_return({:ensure => is})
-            expect(provider).to receive(:properties).and_return({:mark => :hold})
+            expect(provider).to receive(:properties).and_return({:mark => :hold}).exactly(3).times
+
             expect(described_class).to receive(:pkg)
               .with(:list, '-Hvfa', 'dummy@1.0-0.151006')
               .and_return(Puppet::Util::Execution::ProcessOutput.new(File.read(my_fixture('dummy_implicit_version')), 0))
             expect(Puppet::Util::Execution).to receive(:execute).with(['/bin/pkg', 'install', '-n', 'dummy@1.0,5.11-0.151006:20140220T084443Z'], {:failonfail => false, :combine => true})
-            expect(provider).to receive(:unhold).with(no_args)
+            expect(provider).to receive(:unhold).with(no_args).twice
+            expect(described_class).to receive(:pkg)
+              .with(:freeze, 'dummy')
             expect(Puppet::Util::Execution).to receive(:execute).with(['/bin/pkg', 'install', *hash[:flags], 'dummy@1.0,5.11-0.151006:20140220T084443Z'], {:failonfail => false, :combine => true})
             allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
             provider.insync?(is)
@@ -368,10 +371,14 @@ describe Puppet::Type.type(:package).provider(:pkg), unless: Puppet::Util::Platf
             resource[:ensure] = '1.0-0.151006'
             is = '1.0,5.11-0.151006:20140219T191204Z'
             expect(provider).to receive(:query).with(no_args).and_return({:ensure => is})
-            expect(provider).to receive(:properties).and_return({:mark => :hold})
+            expect(provider).to receive(:properties).and_return({:mark => :hold}).exactly(3).times
+
             expect(described_class).to receive(:pkg).with(:list, '-Hvfa', 'dummy@1.0-0.151006').and_return(File.read(my_fixture('dummy_implicit_version')))
+            expect(described_class).to receive(:pkg)
+              .with(:freeze, 'dummy')
             expect(Puppet::Util::Execution).to receive(:execute).with(['/bin/pkg', 'update', '-n', 'dummy@1.0,5.11-0.151006:20140220T084443Z'], {:failonfail => false, :combine => true})
-            expect(provider).to receive(:unhold).with(no_args)
+              .and_return(File.read(my_fixture('dummy_implicit_version')))
+            expect(provider).to receive(:unhold).with(no_args).twice
             expect(Puppet::Util::Execution).to receive(:execute).with(['/bin/pkg', 'update', *hash[:flags], 'dummy@1.0,5.11-0.151006:20140220T084443Z'], {:failonfail => false, :combine => true})
             allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
             provider.insync?(is)
@@ -385,6 +392,8 @@ describe Puppet::Type.type(:package).provider(:pkg), unless: Puppet::Util::Platf
             expect(described_class).to receive(:pkg)
               .with(:list, '-Hvfa', 'dummy@1.0-0.151006')
               .and_return(Puppet::Util::Execution::ProcessOutput.new(File.read(my_fixture('dummy_implicit_version')), 0))
+            expect(Puppet::Util::Execution).to receive(:execute).with(["/bin/pkg", "list", "-Hv", "dummy"], {:failonfail => false, :combine => true})
+              .and_return(File.read(my_fixture('dummy_implicit_version')))
             expect(Puppet::Util::Execution).to receive(:execute).with(['/bin/pkg', 'update', '-n', 'dummy@1.0,5.11-0.151006:20140220T084443Z'], {:failonfail => false, :combine => true})
             allow($CHILD_STATUS).to receive(:exitstatus).and_return(4)
             provider.insync?(is)
@@ -396,6 +405,8 @@ describe Puppet::Type.type(:package).provider(:pkg), unless: Puppet::Util::Platf
             expect(provider).to receive(:warning).with("Implicit version 1.0-0.151006 has 3 possible matches")
             expect(provider).to receive(:warning).with("Selecting version '1.0,5.11-0.151006:20140220T084443Z' for implicit '1.0-0.151006'")
             expect(described_class).to receive(:pkg).with(:list, '-Hvfa', 'dummy@1.0-0.151006').and_return(File.read(my_fixture('dummy_implicit_version')))
+            expect(Puppet::Util::Execution).to receive(:execute).with(["/bin/pkg", "list", "-Hv", "dummy"], {:failonfail => false, :combine => true})
+              .and_return(File.read(my_fixture('dummy_implicit_version')))
             expect(Puppet::Util::Execution).to receive(:execute).with(['/bin/pkg', 'install', '-n', 'dummy@1.0,5.11-0.151006:20140220T084443Z'], {:failonfail => false, :combine => true})
             allow($CHILD_STATUS).to receive(:exitstatus).and_return(0)
             provider.insync?(is)


### PR DESCRIPTION
Before this commit, the `pkg` provider was unable to handle manifests where a package was updated and marked as unhold at the same time. This fix ensures the package is first unhold and then updated when trying to install certain versions.