### PR TITLE
(PE-31696) Prefer builtin lib code over external gems when autoloading

### DIFF
--- a/lib/puppet/util/autoload.rb
+++ b/lib/puppet/util/autoload.rb
@@ -157,9 +157,9 @@ class Puppet::Util::Autoload
       # "app_defaults_initialized?" method on the main puppet Settings object.
       # --cprice 2012-03-16
       if Puppet.settings.app_defaults_initialized?
-        gem_directories + module_directories(env) + $LOAD_PATH
+        module_directories(env) + $LOAD_PATH + gem_directories
       else
-        gem_directories + $LOAD_PATH
+        $LOAD_PATH + gem_directories
       end
     end
 


### PR DESCRIPTION
In PE we use the ruby interpreter shipped with puppet agent to run the ace server. The ace server is responsible for executing remote tasks. Remote tasks will often use the `puppet` library. Remote ruby tasks run in ace over the local transport (and thus bolt) execute code with the same environment variables as the ruby process running the task runner uses. In the case of ace, we ship a puppet gem in addition to many of the other gems bolt depends on. Now that puppet has moved to using require_relative there is a bug whereby a new combination of code is loaded between the puppet gem and the puppet code shipped with the agent (because we set GEM_HOME and GEM_PATH when we start the service). This commit updates the autoloader to prefer loading code from the $LOAD_PATH. This helps solve the problem of loading code from both places in ace-server for remote tasks. The only consequence it may have would be if users somehow relied on shadowing shipped puppet code with external gems, though it is hard to imagine how they would manage to reliably configure this.