### PR TITLE
(PUP-11165) Backport scripts loading from a `scripts` directory

### DIFF
--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -25,6 +25,7 @@ class Puppet::Module
     "plugins" => "lib",
     "pluginfacts" => "facts.d",
     "locales" => "locales",
+    "scripts" => "scripts",
   }
 
   # Find and return the +module+ that +path+ belongs to. If +path+ is

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -478,7 +478,7 @@ describe Puppet::Module do
     end
   end
 
-  [:plugins, :pluginfacts, :templates, :files, :manifests].each do |filetype|
+  [:plugins, :pluginfacts, :templates, :files, :manifests, :scripts].each do |filetype|
     case filetype
       when :plugins
         dirname = "lib"


### PR DESCRIPTION
This adds a new subdirectory to the `Module` class `scripts/` which
automatically generates the functions `scripts?()`, `scripts()`, and 
`script()` on the class for retrieving available scripts. This is part
of the [scripts milestone](https://github.com/puppetlabs/bolt/issues?q=is%3Aopen+is%3Aissue+milestone%3AScripts)
for Bolt, which aims to eventually standardize on more specific file
loading from either the `files/` directory or `scripts/` directory in a
module.

This doesn't include serving from the `scripts/` directory in Puppetserver, which is a separate ticket https://github.com/puppetlabs/bolt/issues/2919