### PR TITLE
(maint) Fix a bug with the logger in clean.rb

### DIFF
--- a/lib/puppet/face/node/clean.rb
+++ b/lib/puppet/face/node/clean.rb
@@ -52,7 +52,7 @@ Puppet::Face.define(:node, '0.0.1') do
     end
 
     def warn(message)
-      Puppet.warning(message)
+      Puppet.warning(message) unless message =~ /cadir is currently configured to be inside/
     end
 
     def err(message)


### PR DESCRIPTION
This bug arose from adding the option to use debug logging to the puppetserver-ca gem.  The error happened when the test for Puppet's 'clean' face in 6.x is ran.  The reason behind the error is because we did not have a 'debug' option in our 'LoggerIO' class in 'clean' face.  Thus, the solution to the bug is to include the 'debug' option in our logger by adding a debug function in the LoggerIO class.  Furthermore, we decided to include the 'warn' option for the logger similar to Puppet's 'clean' face in 7.x so that it's less of a hassle when merging and having a uniform code base.