### PR TITLE
(PUP-10308) Fix Puppet.lookup(:current_environment)

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -383,6 +383,15 @@ class Puppet::Configurer
         @environment = catalog.environment
         report.environment = @environment
 
+        new_env = Puppet::Node::Environment.remote(@environment)
+        Puppet.push_context(
+          {
+            :current_environment => new_env,
+            :loaders => Puppet::Pops::Loaders.new(new_env, true)
+          },
+          "Local node environment #{@environment} for configurer transaction"
+        )
+
         query_options, facts = get_facts(options)
         query_options[:configured_environment] = configured_environment
 

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -947,8 +947,22 @@ describe Puppet::Configurer do
       expect(Puppet::Resource::Catalog.indirection).to receive(:find).and_return(apple, banana, banana)
 
       allow(Puppet).to receive(:notice)
+      allow(Puppet).to receive(:push_context)
       expect(Puppet).to receive(:notice).with("Local environment: 'production' doesn't match server specified environment 'apple', restarting agent run with environment 'apple'")
       expect(Puppet).to receive(:notice).with("Local environment: 'apple' doesn't match server specified environment 'banana', restarting agent run with environment 'banana'")
+
+      expect(Puppet).to receive(:push_context).with(
+        hash_including(current_environment: an_object_having_attributes(name: :production)),
+        'Local node environment production for configurer transaction'
+      )
+      expect(Puppet).to receive(:push_context).with(
+        hash_including(current_environment: an_object_having_attributes(name: :apple)),
+        'Local node environment apple for configurer transaction'
+      )
+      expect(Puppet).to receive(:push_context).with(
+        hash_including(current_environment: an_object_having_attributes(name: :banana)),
+        'Local node environment banana for configurer transaction'
+      )
 
       configurer.run
     end


### PR DESCRIPTION
At the start of the configurer run, puppet pushes
its configured environment or the server-specified
environment onto the context.

If pluginsync causes environment to change,
then the agent switches to the new environment but
the new environment is not pushed onto the context,
leaving the old environment set.

This commit updates the `lib/puppet/configurer.rb`
to push the new environment after the convergence
is done.