### PR TITLE
(PUP-11168) Fix RHEL9 support for service provider

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -14,7 +14,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   confine :true => Puppet::FileSystem.exist?('/proc/1/comm') && Puppet::FileSystem.read('/proc/1/comm').include?('systemd')
 
   defaultfor :osfamily => [:archlinux]
-  defaultfor :osfamily => :redhat, :operatingsystemmajrelease => ["7", "8"]
+  defaultfor :osfamily => :redhat, :operatingsystemmajrelease => ["7", "8", "9"]
   defaultfor :osfamily => :redhat, :operatingsystem => :fedora
   defaultfor :osfamily => :suse
   defaultfor :osfamily => :coreos

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -34,7 +34,7 @@ describe 'Puppet::Type::Service::Provider::Systemd',
     end
   end
 
-  [7, 8].each do |ver|
+  [7, 8, 9].each do |ver|
     it "should be the default provider on rhel#{ver}" do
       allow(Facter).to receive(:value).with(:osfamily).and_return(:redhat)
       allow(Facter).to receive(:value).with(:operatingsystem).and_return(:redhat)


### PR DESCRIPTION
The systemd provider should be the default since RHEL7 and going
forward. With CentOS Stream 9 coming out shortly, it should continue to
function like CentOS 8 by using the systemd provider by default.

Signed-off-by: Alex Schultz <aschultz@redhat.com>