### PR TITLE
(PUP-11169) Fix missing trailing `/` for versioned dirs static catalogs

### DIFF
--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -188,7 +188,7 @@ module Puppet::Environments
 
     def self.real_path(dir)
       if Puppet::FileSystem.symlink?(dir) && Puppet[:versioned_environment_dirs]
-        dir = Puppet::FileSystem.expand_path(Puppet::FileSystem.readlink(dir))
+        dir = Pathname.new Puppet::FileSystem.expand_path(Puppet::FileSystem.readlink(dir))
       end
       return dir
     end
@@ -241,7 +241,7 @@ module Puppet::Environments
 
     def validated_directory(envdir)
       env_name = Puppet::FileSystem.basename_string(envdir)
-      envdir = Puppet::Environments::Directories.real_path(envdir)
+      envdir = Puppet::Environments::Directories.real_path(envdir).to_s
       if Puppet::FileSystem.directory?(envdir) && Puppet::Node::Environment.valid_name?(env_name)
         envdir
       else

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -154,7 +154,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
     location = Puppet::Module::FILETYPES['files']
 
     !!(source_as_uri.path =~ /^\/modules\// &&
-       metadata.full_path =~ /#{environment_path}[^\/]+\/[^\/]+\/#{location}\/.+/)
+       metadata.full_path =~ /#{environment_path}\/[^\/]+\/[^\/]+\/#{location}\/.+/)
   end
 
   # Helper method to log file resources that could not be inlined because they
@@ -173,7 +173,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
   # Inline file metadata for static catalogs
   # Initially restricted to files sourced from codedir via puppet:/// uri.
   def inline_metadata(catalog, checksum_type)
-    environment_path = Pathname.new File.join(Puppet[:environmentpath], catalog.environment, "")
+    environment_path = Pathname.new File.join(Puppet[:environmentpath], catalog.environment)
     environment_path = Puppet::Environments::Directories.real_path(environment_path)
     list_of_resources = catalog.resources.find_all { |res| res.type == "File" }
 


### PR DESCRIPTION
Previous to this change, the `environmentpath` was set using the
internal Puppet::FileSystem.expand_path, which had the side effect
of stripping the value's trailing slash. This broke the regex used
for determining if a file met the criteria for
`inlineable_metadata?` and stopped catalogs from getting any
metadata values for files.

This change moves the trailing slash into the regex, so that the
`environmentpath` is not required to contain the slash to match. It
also ensures that the object returned by `real_path` is a Pathname,
as that is a requirement for the `get_content_uri` method.