### PR TITLE
(PUP-10820) Convert data before saving to transactionstorefile

### DIFF
--- a/lib/puppet/transaction/persistence.rb
+++ b/lib/puppet/transaction/persistence.rb
@@ -93,7 +93,7 @@ class Puppet::Transaction::Persistence
         local_reference: false,
         type_by_reference: true,
         force_symbol: true,
-        silences_warnings: true,
+        silence_warnings: true,
         message_prefix: to_s
       }
     )

--- a/lib/puppet/transaction/persistence.rb
+++ b/lib/puppet/transaction/persistence.rb
@@ -87,7 +87,17 @@ class Puppet::Transaction::Persistence
 
   # Save data from internal class to persistence store on disk.
   def save
-    Puppet::Util::Yaml.dump(@new_data, Puppet[:transactionstorefile])
+    converted_data = Puppet::Pops::Serialization::ToDataConverter.convert(
+      @new_data, {
+        symbol_as_string: false,
+        local_reference: false,
+        type_by_reference: true,
+        force_symbol: true,
+        silences_warnings: true,
+        message_prefix: to_s
+      }
+    )
+    Puppet::Util::Yaml.dump(converted_data, Puppet[:transactionstorefile])
   end
 
   # Use the catalog and run_mode to determine if persistence should be enabled or not

--- a/spec/unit/pops/serialization/to_from_hr_spec.rb
+++ b/spec/unit/pops/serialization/to_from_hr_spec.rb
@@ -559,6 +559,29 @@ module Serialization
         expect(warnings).to eql(["['key'] contains the special value default. It will be converted to the String 'default'"])
       end
     end
+    context 'and force_symbol set to true' do
+      let(:to_converter) { ToDataConverter.new(:rich_data => false, :force_symbol => true) }
+
+      it 'A Hash with Symbol values is converted to hash with Symbol values' do
+        val = { 'one' => :one, 'two' => :two }
+        Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
+
+          # write and read methods does not work here as we cannot force Symbols in Json.
+          # and a hash with symbol values cannot be an instance of Types::TypeFactory.data.
+          # Using YAML for this instead
+          io.reopen
+          value = to_converter.convert(val)
+          io << [value].to_yaml
+          io.rewind
+
+          val2 = from_converter.convert(YAML::load(io.read)[0])
+
+          expect(val2).to be_a(Hash)
+          expect(val2).to eql({ 'one' => :one, 'two' => :two })
+        end
+        expect(warnings).to be_empty
+      end
+    end
   end
 
   context 'with rich_data is set to true' do
@@ -630,6 +653,41 @@ module Serialization
       expect do
         from_converter.convert({ '__ptype' => { '__ptype' => 'Pcore::TimestampType', '__pvalue' => 12345 }})
       end.to raise_error(/Cannot create a Pcore::TimestampType from a (Fixnum|Integer)/)
+    end
+  end
+
+  context 'when data is unknown' do
+    let(:to_converter) { ToDataConverter.new(:message_prefix => 'Test Hash') }
+    let(:logs) { [] }
+    let(:warnings) { logs.select { |log| log.level == :warning }.map { |log| log.message } }
+    let(:val) { Class.new }
+
+    context 'and :silence_warnings undefined or set to false' do
+      it 'convert the unknown data to string with warnings' do
+        Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
+          write(val)
+          val2 = read
+          expect(val2).to be_a(String)
+          expect(val2).to match(/Class/)
+        end
+        expect(warnings).to eql([
+          "Test Hash contains a #{val.class} value. It will be converted to the String '#{val.to_s}'"])
+      end
+    end
+
+    context 'and :silence_warnings undefined or set to true' do
+      let(:to_converter) { ToDataConverter.new(:message_prefix => 'Test Hash', :silence_warnings => true) }
+
+      it 'convert the unknown data to string without warnings if silence_warnings set to true' do
+        val = Class.new
+        Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
+          write(val)
+          val2 = read
+          expect(val2).to be_a(String)
+          expect(val2).to match(/Class/)
+        end
+        expect(warnings).to be_empty
+      end
     end
   end
 end


### PR DESCRIPTION
Binary, Sensitive, etc deferred results can corrupt the transaction
store if not converted with Puppet::Pops::Serialization::ToDataConverter
before saving to the file.