### PR TITLE
(PUP-6802) Skip pluginsync if node request fails with 404 error

### DIFF
--- a/acceptance/tests/environment/environment_scenario-bad.rb
+++ b/acceptance/tests/environment/environment_scenario-bad.rb
@@ -53,14 +53,14 @@ test_name 'Test behavior of directory environments when environmentpath is set t
             :matches   => [%r{Could not find a directory environment named '#{env}' anywhere in the path.*#{env_path}}],
         },
         :puppet_agent            => {
-            :exit_code => 1,
+            :exit_code => 0,
         },
     }
 
     agents.each do |host|
       unless host['locale'] == 'ja'
-        expectations[:puppet_agent][:matches] = [%r{(Warning|Error).*(404|400).*Could not find environment '#{env}'},
-                                                 %r{Could not retrieve catalog; skipping run}]
+        expectations[:puppet_agent][:matches] = [%r{Environment '#{env}' not found on server, skipping initial pluginsync.},
+                                                 %r{Local environment: '#{env}' doesn't match server specified environment 'production', restarting agent run with environment 'production'}]
       end
     end
 

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -84,6 +84,10 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
     Puppet.run_mode.server?
   end
 
+  def require_environment?
+    false
+  end
+
   private
 
   # @param facts [String] facts in a wire format for decoding

--- a/lib/puppet/indirector/terminus.rb
+++ b/lib/puppet/indirector/terminus.rb
@@ -143,6 +143,10 @@ class Puppet::Indirector::Terminus
     self.class.name
   end
 
+  def require_environment?
+    true
+  end
+
   def allow_remote_requests?
     true
   end

--- a/lib/puppet/network/http/api/indirected_routes.rb
+++ b/lib/puppet/network/http/api/indirected_routes.rb
@@ -105,7 +105,7 @@ class Puppet::Network::HTTP::API::IndirectedRoutes
       raise Puppet::Network::HTTP::Error::HTTPNotAuthorizedError.new(e.message)
     end
 
-    if configured_environment.nil?
+    if configured_environment.nil? && indirection.terminus.require_environment?
       raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new(
         _("Could not find environment '%{environment}'") % { environment: environment })
     end

--- a/spec/lib/puppet_spec/puppetserver.rb
+++ b/spec/lib/puppet_spec/puppetserver.rb
@@ -31,6 +31,13 @@ class PuppetSpec::Puppetserver
     end
   end
 
+  class FileMetadataServlet < WEBrick::HTTPServlet::AbstractServlet
+    def do_GET request, response
+      response['Content-Type'] = 'application/json'
+      response.body = "{\"path\":\"/etc/puppetlabs/code/environments/production/modules\",\"relative_path\":\".\",\"links\":\"follow\",\"owner\":0,\"group\":0,\"mode\":493,\"checksum\":{\"type\":\"ctime\",\"value\":\"{ctime}2020-03-06 20:14:25 UTC\"},\"type\":\"directory\",\"destination\":null}"
+    end
+  end
+
   class ReportServlet < WEBrick::HTTPServlet::AbstractServlet
     def do_PUT request, response
       response['Content-Type'] = 'application/json'
@@ -106,6 +113,7 @@ class PuppetSpec::Puppetserver
     register_mount('/status/v1/simple/master', proc { |req, res|  }, nil)
     register_mount('/puppet/v3/node', mounts[:node], NodeServlet)
     register_mount('/puppet/v3/catalog', mounts[:catalog], CatalogServlet)
+    register_mount('/puppet/v3/file_metadata', mounts[:file_metadata], FileMetadataServlet)
     register_mount('/puppet/v3/file_metadatas', mounts[:file_metadatas], FileMetadatasServlet)
     register_mount('/puppet/v3/static_file_content', mounts[:static_file_content], StaticFileContentServlet)
     register_mount('/puppet/v3/report', mounts[:report], ReportServlet)

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -7,6 +7,9 @@ describe Puppet::Configurer do
     Puppet[:report] = true
 
     catalog.add_resource(resource)
+    allow_any_instance_of(described_class).to(
+      receive(:valid_server_environment?).and_return(true)
+    )
   end
 
   let(:node_name) { Puppet[:node_name_value] }
@@ -76,6 +79,12 @@ describe Puppet::Configurer do
     it "does not download plugins when told" do
       expect(configurer).not_to receive(:download_plugins)
       configurer.run(:pluginsync => false)
+    end
+
+    it "does not download plugins when specified environment is not vaild on server" do
+      expect(configurer).to receive(:valid_server_environment?).and_return(false)
+      expect(configurer).not_to receive(:download_plugins)
+      configurer.run(:pluginsync => true)
     end
 
     it "fails the run if pluginsync fails when usecacheonfailure is false" do


### PR DESCRIPTION
Previous to this PR, when an agent agent starts a run with an environment not
available on the server, it will also try to pluginsync with the unexistent
environment.

Now, a request is sent to the server checking if there is anything to
pluginsync, or if the environment even exists.