### PR TITLE
(PUP-10955) Normalize environment name to symbol before caching

### DIFF
--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -398,14 +398,15 @@ module Puppet::Environments
       # This strategy favors smaller memory footprint over environment
       # retrieval time.
       clear_all_expired
+      name = name.to_sym
       entry = @cache[name]
       if entry
         Puppet.debug {"Found in cache #{name.inspect} #{entry.label}"}
         # found in cache
         entry.touch
-      elsif (result = @loader.get(name))
+      elsif (env = @loader.get(name))
         # environment loaded, cache it
-        entry = entry(result)
+        entry = entry(env)
         add_entry(name, entry)
       end
       entry
@@ -433,6 +434,7 @@ module Puppet::Environments
     # Clears the cache of the environment with the given name.
     # (The intention is that this could be used from a MANUAL cache eviction command (TBD)
     def clear(name)
+      name = name.to_sym
       entry = @cache[name]
       clear_entry(name, entry) if entry
     end
@@ -482,6 +484,7 @@ module Puppet::Environments
     #
     # @!macro loader_get_conf
     def get_conf(name)
+      name = name.to_sym
       clear_if_expired(name, @cache[name])
       @loader.get_conf(name)
     end

--- a/spec/unit/environments_spec.rb
+++ b/spec/unit/environments_spec.rb
@@ -637,7 +637,7 @@ config_version=$vardir/random/scripts
         ])
 
         loader_from(:filesystem => [envdir], :directory => envdir) do |loader|
-         cached = Puppet::Environments::Cached.new(loader)
+          cached = Puppet::Environments::Cached.new(loader)
           cached.get(:env1)
           cached.get(:env2)
           cached.get(:env3)
@@ -646,6 +646,51 @@ config_version=$vardir/random/scripts
           expect(cached.list).to contain_exactly(environment(:env1),environment(:env2))
           expect(cached.get(:env3)).to be_nil
         end
+      end
+
+      it "normalizes environment name to symbol" do
+        env = Puppet::Node::Environment.create(:cached, [])
+        mocked_loader = double('loader')
+
+        expect(mocked_loader).not_to receive(:get).with('cached')
+        expect(mocked_loader).to receive(:get).with(:cached).and_return(env).once
+        expect(mocked_loader).to receive(:get_conf).with(:cached).and_return(Puppet::Settings::EnvironmentConf.static_for(env, 20)).once
+
+        cached = Puppet::Environments::Cached.new(mocked_loader)
+        cached.get('cached')
+        cached.get(:cached)
+      end
+
+      it "caches environment name as symbol and only once" do
+        mocked_loader = double('loader')
+
+        env = Puppet::Node::Environment.create(:cached, [])
+        allow(mocked_loader).to receive(:get).with(:cached).and_return(env)
+        allow(mocked_loader).to receive(:get_conf).with(:cached).and_return(Puppet::Settings::EnvironmentConf.static_for(env, 20))
+
+        cached = Puppet::Environments::Cached.new(mocked_loader)
+        cached.get(:cached)
+        cached.get('cached')
+
+        expect(cached.instance_variable_get(:@cache).keys).to eq([:cached])
+      end
+
+      it "is able to cache multiple environments" do
+        mocked_loader = double('loader')
+
+        env1 = Puppet::Node::Environment.create(:env1, [])
+        allow(mocked_loader).to receive(:get).with(:env1).and_return(env1)
+        allow(mocked_loader).to receive(:get_conf).with(:env1).and_return(Puppet::Settings::EnvironmentConf.static_for(env1, 20))
+
+        env2 = Puppet::Node::Environment.create(:env2, [])
+        allow(mocked_loader).to receive(:get).with(:env2).and_return(env2)
+        allow(mocked_loader).to receive(:get_conf).with(:env2).and_return(Puppet::Settings::EnvironmentConf.static_for(env2, 20))
+
+        cached = Puppet::Environments::Cached.new(mocked_loader)
+        cached.get('env1')
+        cached.get('env2')
+
+        expect(cached.instance_variable_get(:@cache).keys).to eq([:env1, :env2])
       end
 
       it "returns nil if env not found" do
@@ -700,6 +745,17 @@ config_version=$vardir/random/scripts
         cached = Puppet::Environments::Cached.new(mocked_loader)
 
         cached.get_conf(:cached)
+        cached.get_conf(:cached)
+      end
+
+      it "normalizes environment name to symbol" do
+        env = Puppet::Node::Environment.create(:cached, [])
+        mocked_loader = double('loader')
+        expect(mocked_loader).to receive(:get_conf).with(:cached).and_return(Puppet::Settings::EnvironmentConf.static_for(env, 20)).twice
+
+        cached = Puppet::Environments::Cached.new(mocked_loader)
+
+        cached.get_conf('cached')
         cached.get_conf(:cached)
       end
 
@@ -866,6 +922,14 @@ config_version=$vardir/random/scripts
       it "evicts an environment" do
         with_environment_loaded(service) do |cached|
           cached.clear(:an_environment)
+        end
+
+        expect(service.evicted_envs).to eq([:an_environment])
+      end
+
+      it "normalizes environment name to symbol" do
+        with_environment_loaded(service) do |cached|
+          cached.clear('an_environment')
         end
 
         expect(service.evicted_envs).to eq([:an_environment])

--- a/spec/unit/functions/logging_spec.rb
+++ b/spec/unit/functions/logging_spec.rb
@@ -6,6 +6,7 @@ describe 'the log function' do
 
   def collect_logs(code)
     Puppet[:code] = code
+    Puppet[:environment_timeout] = 10
     node = Puppet::Node.new('logtest')
     compiler = Puppet::Parser::Compiler.new(node)
     node.environment.check_for_reparse


### PR DESCRIPTION
The `Puppet::Environments::Cached.get` method says it accepts Strings or Symbols. This commit normalizes the environment name before caching and getting the environment to avoid duplicated environments in cache (as String and as Symbol).