### PR TITLE
(maint) Add l10n integration test

### DIFF
--- a/spec/fixtures/integration/l10n/envs/prod/modules/demo/Gemfile
+++ b/spec/fixtures/integration/l10n/envs/prod/modules/demo/Gemfile
@@ -1,0 +1,4 @@
+source ENV['GEM_SOURCE'] || "https://rubygems.org"
+
+gem 'gettext-setup', '~> 0.28', require: false, platforms: [:ruby]
+gem "rake"

--- a/spec/fixtures/integration/l10n/envs/prod/modules/demo/Rakefile
+++ b/spec/fixtures/integration/l10n/envs/prod/modules/demo/Rakefile
@@ -1,0 +1,3 @@
+spec = Gem::Specification.find_by_name 'gettext-setup'
+load "#{spec.gem_dir}/lib/tasks/gettext.rake"
+GettextSetup.initialize(File.absolute_path('locales', File.dirname(__FILE__)))

--- a/spec/fixtures/integration/l10n/envs/prod/modules/demo/lib/puppet/functions/l10n.rb
+++ b/spec/fixtures/integration/l10n/envs/prod/modules/demo/lib/puppet/functions/l10n.rb
@@ -1,0 +1,8 @@
+Puppet::Functions.create_function(:l10n) do
+  dispatch :l10n_impl do
+  end
+
+  def l10n_impl
+    _("IT'S HAPPY FUN TIME")
+  end
+end

--- a/spec/fixtures/integration/l10n/envs/prod/modules/demo/locales/config.yaml
+++ b/spec/fixtures/integration/l10n/envs/prod/modules/demo/locales/config.yaml
@@ -1,0 +1,25 @@
+---
+# This is the project-specific configuration file for setting up
+# fast_gettext for your project.
+gettext:
+  # This is used for the name of the .pot and .po files; they will be
+  # called <project_name>.pot?
+  project_name: 'puppet-l10n'
+  # This is used in comments in the .pot and .po files to indicate what
+  # project the files belong to and should bea little more descriptive than
+  # <project_name>
+  package_name: puppet l10n demo
+  # The locale that the default messages in the .pot file are in
+  default_locale: en
+  # The email used for sending bug reports.
+  bugs_address: docs@puppetlabs.com
+  # The holder of the copyright.
+  copyright_holder: Puppet Labs, LLC.
+  # This determines which comments in code should be eligible for translation.
+  # Any comments that start with this string will be externalized. (Leave
+  # empty to include all.)
+  comments_tag: TRANSLATORS
+  # Patterns for +Dir.glob+ used to find all files that might contain
+  # translatable content, relative to the project root directory
+  source_files:
+    - 'lib/**/*.rb'

--- a/spec/fixtures/integration/l10n/envs/prod/modules/demo/locales/ja/puppet-l10n.po
+++ b/spec/fixtures/integration/l10n/envs/prod/modules/demo/locales/ja/puppet-l10n.po
@@ -1,0 +1,19 @@
+# Puppet, 2021
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: 1.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-03-29 12:41+0000\n"
+"PO-Revision-Date: 2018-03-29 12:43+0000\n"
+"Last-Translator: Puppet\n"
+"Language-Team: English\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../lib/puppet/functions/l10n.rb:5
+msgid "IT'S HAPPY FUN TIME"
+msgstr "それは楽しい時間です"

--- a/spec/fixtures/integration/l10n/envs/prod/modules/demo/locales/puppet-l10n.pot
+++ b/spec/fixtures/integration/l10n/envs/prod/modules/demo/locales/puppet-l10n.pot
@@ -1,0 +1,20 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2021 Puppet Labs, LLC.
+# This file is distributed under the same license as the puppet l10n demo package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: puppet l10n demo 6.23.0-100-gdc4e95bd86\n"
+"\n"
+"Report-Msgid-Bugs-To: docs@puppetlabs.com\n"
+"POT-Creation-Date: 2021-07-16 16:48-0700\n"
+"PO-Revision-Date: 2021-07-16 16:48-0700\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"

--- a/spec/fixtures/integration/l10n/envs/prod/modules/demo/metadata.json
+++ b/spec/fixtures/integration/l10n/envs/prod/modules/demo/metadata.json
@@ -1,0 +1,8 @@
+{
+    "name": "puppet-l10n",
+    "version": "0.0.1",
+    "author": "puppet",
+    "source": "",
+    "license": "Apache-2.0",
+    "dependencies": []
+}

--- a/spec/integration/l10n/compiler_spec.rb
+++ b/spec/integration/l10n/compiler_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe 'compiler localization' do
+  include_context 'l10n', 'ja'
+
+  let(:envdir) { File.join(my_fixture_dir, '..', 'envs') }
+  let(:environments) do
+    Puppet::Environments::Cached.new(
+      Puppet::Environments::Directories.new(envdir, [])
+    )
+  end
+  let(:env) { Puppet::Node::Environment.create(:prod, [File.join(envdir, 'prod', 'modules')]) }
+  let(:node) { Puppet::Node.new('test', :environment => env) }
+
+  around(:each) do |example|
+    Puppet.override(current_environment: env,
+                    loaders: Puppet::Pops::Loaders.new(env),
+                    environments: environments) do
+      example.run
+    end
+  end
+
+  it 'localizes strings in functions' do
+    Puppet[:code] = <<~END
+      notify { 'demo':
+        message => l10n()
+      }
+    END
+
+    Puppet::Resource::Catalog.indirection.terminus_class = :compiler
+    catalog = Puppet::Resource::Catalog.indirection.find(node.name)
+    resource = catalog.resource(:notify, 'demo')
+
+    expect(resource).to be
+    expect(resource[:message]).to eq("それは楽しい時間です")
+  end
+end

--- a/spec/shared_contexts/l10n.rb
+++ b/spec/shared_contexts/l10n.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+RSpec.shared_context('l10n') do |locale|
+  before :all do
+    @old_locale = Locale.current
+    Locale.current = locale
+    Puppet::GettextConfig.setup_locale
+
+    # overwrite stubs with real implementation
+    ::Object.send(:remove_method, :_)
+    ::Object.send(:remove_method, :n_)
+    class ::Object
+      include FastGettext::Translation
+    end
+  end
+
+  after :all do
+    Locale.current = @old_locale
+
+    # restore stubs
+    load File.expand_path(File.join(__dir__, '../../lib/puppet/gettext/stubs.rb'))
+  end
+
+  before :each do
+    Puppet[:disable_i18n] = false
+  end
+end


### PR DESCRIPTION
While working on PUP-11158 I found that module translations were not present if the environment was reloaded during compilation. This adds an integration test to ensure a function in a module can generate a localized message using translations from the module's `locale` directory. There are beaker tests, but the feedback cycle is long.

Also note translations are disabled in spec tests, see https://github.com/puppetlabs/puppet/blob/846e5e41d50d363e738658588c497313a59900a5/spec/spec_helper.rb#L18-L21 so this provides a way for integration tests to selectively enable localizations using a shared context.