### PR TITLE
(maint) reduce debug output clutter and remove 'broken' test filtering

### DIFF
--- a/spec/integration/application/filebucket_spec.rb
+++ b/spec/integration/application/filebucket_spec.rb
@@ -18,6 +18,11 @@ describe "puppet filebucket", unless: Puppet::Util::Platform.jruby? do
     File.binwrite(backup_file, text)
   end
 
+  after :each do
+    # mute debug messages generated during `after :each` blocks
+    Puppet::Util::Log.close_all
+  end
+
   it "backs up to and restores from the local filebucket" do
     filebucket.command_line.args = ['backup', backup_file, '--local']
     expect {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -68,16 +68,7 @@ VCR.turn_off!
 RSpec.configure do |config|
   include PuppetSpec::Fixtures
 
-  # Examples or groups can selectively tag themselves as broken.
-  # For example;
-  #
-  # rbv = "#{RUBY_VERSION}-p#{RbConfig::CONFIG['PATCHLEVEL']}"
-  # describe "mostly working", :broken => false unless rbv == "1.9.3-p327" do
-  #  it "parses a valid IP" do
-  #    IPAddr.new("::2:3:4:5:6:7:8")
-  #  end
-  # end
-  exclude_filters = {:broken => true}
+  exclude_filters = {}
   exclude_filters[:benchmark] = true unless ENV['BENCHMARK']
   config.filter_run_excluding exclude_filters
 

--- a/spec/unit/pops/parser/parse_containers_spec.rb
+++ b/spec/unit/pops/parser/parse_containers_spec.rb
@@ -95,18 +95,7 @@ describe "egrammar parsing containers" do
         expect(dump(parse("class foo::default {}"))).to eq("(class foo::default ())")
       end
 
-      it "class class inherits default {} # inherits default", :broken => true do
-        expect {
-          parse("class class inherits default {}")
-        }.to raise_error(/not a valid classname/)
-      end
-
       it "class class inherits default {} # inherits default" do
-        # TODO: See previous test marked as :broken=>true, it is actually this test (result) that is wacky,
-        # this because a class is named at parse time (since class evaluation is lazy, the model must have the
-        # full class name for nested classes - only, it gets this wrong when a class is named "class" - or at least
-        # I think it is wrong.)
-        #
         expect { parse("class class inherits default {}") }.to raise_error(/'class' keyword not allowed at this location/)
       end
 


### PR DESCRIPTION
Reduces debug output when running tests via `bundle exec rspec spec/integration/application/filebucket_spec.rb`. The issue was partially masked when running `parallel:spec`.

Remove filtering of tests using the `:broken` filter. Just use `pending`.