### PR TITLE
(maint) Cleanup pending specs

### DIFF
--- a/spec/shared_behaviours/documentation_on_faces.rb
+++ b/spec/shared_behaviours/documentation_on_faces.rb
@@ -176,8 +176,6 @@ shared_examples_for "documentation on faces" do
       subject.license = "foo"
       expect(subject.license).to eq("foo")
     end
-
-    it "should accept symbols to specify existing licenses..."
   end
 
   describe "#copyright" do

--- a/spec/unit/indirector/store_configs_spec.rb
+++ b/spec/unit/indirector/store_configs_spec.rb
@@ -1,7 +1,0 @@
-require 'spec_helper'
-
-require 'puppet/indirector/store_configs'
-
-describe Puppet::Indirector::StoreConfigs do
-  pending "REVISIT: creating an instance requires ludicrous amounts of stubbing, and there is relatively little to actually test here.  What to do?  Shared behaviours allow us to push down a lot of the testing into the implementation class tests anyhow..."
-end

--- a/spec/unit/interface/action_spec.rb
+++ b/spec/unit/interface/action_spec.rb
@@ -537,15 +537,6 @@ describe Puppet::Interface::Action do
     end
   end
 
-  context "#when_rendering" do
-    it "should fail if no type is given when_rendering"
-    it "should accept a when_rendering block"
-    it "should accept multiple when_rendering blocks"
-    it "should fail if when_rendering gets a non-symbol identifier"
-    it "should fail if a second block is given for the same type"
-    it "should return the block if asked"
-  end
-
   context "#validate_and_clean" do
     subject do
       Puppet::Interface.new(:validate_args, '1.0.0') do

--- a/spec/unit/network/authstore_spec.rb
+++ b/spec/unit/network/authstore_spec.rb
@@ -101,21 +101,6 @@ describe Puppet::Network::AuthStore::Declaration do
     }
   }
 
-  describe "when the pattern is a numeric IP with a back reference" do
-    pending("implementation of backreferences for IP") do
-      before :each do
-        @ip = '100.101.$1'
-        @declaration = Puppet::Network::AuthStore::Declaration.new(:allow_ip,@ip).interpolate('12.34'.match(/(.*)/))
-      end
-      it "should match an IP with the appropriate interpolation" do
-        @declaration.should be_match('www.testsite.org',@ip.sub(/\$1/,'12.34'))
-      end
-      it "should not match other IPs" do
-        @declaration.should_not be_match('www.testsite.org',@ip.sub(/\$1/,'66.34'))
-      end
-    end
-  end
-
   [
     "02001:0000:1234:0000:0000:C1C0:ABCD:0876",
     "2001:0000:1234:0000:00001:C1C0:ABCD:0876",

--- a/spec/unit/ssl/certificate_request_spec.rb
+++ b/spec/unit/ssl/certificate_request_spec.rb
@@ -338,33 +338,27 @@ describe Puppet::SSL::CertificateRequest do
       expect(csr.verify(key.content)).to be_truthy
     end
 
-    # Attempts to use SHA512 and SHA384 for signing certificates don't seem to work
-    # So commenting it out till it is sorted out
-    # The problem seems to be with the ability to sign a CSR when using either of
-    # these hash algorithms
-    pending "should use SHA512 to sign the csr when SHA256 and SHA1 aren't available" do
+    it "should use SHA512 to sign the csr when SHA256 and SHA1 aren't available" do
+      key = OpenSSL::PKey::RSA.new(2048)
       csr = OpenSSL::X509::Request.new
       expect(OpenSSL::Digest).to receive(:const_defined?).with("SHA256").and_return(false)
       expect(OpenSSL::Digest).to receive(:const_defined?).with("SHA1").and_return(false)
       expect(OpenSSL::Digest).to receive(:const_defined?).with("SHA512").and_return(true)
       signer = Puppet::SSL::CertificateSigner.new
-      signer.sign(csr, key.content)
-      expect(csr.verify(key.content)).to be_truthy
+      signer.sign(csr, key)
+      expect(csr.verify(key)).to be_truthy
     end
 
-    # Attempts to use SHA512 and SHA384 for signing certificates don't seem to work
-    # So commenting it out till it is sorted out
-    # The problem seems to be with the ability to sign a CSR when using either of
-    # these hash algorithms
-    pending "should use SHA384 to sign the csr when SHA256/SHA1/SHA512 aren't available" do
+    it "should use SHA384 to sign the csr when SHA256/SHA1/SHA512 aren't available" do
+      key = OpenSSL::PKey::RSA.new(2048)
       csr = OpenSSL::X509::Request.new
       expect(OpenSSL::Digest).to receive(:const_defined?).with("SHA256").and_return(false)
       expect(OpenSSL::Digest).to receive(:const_defined?).with("SHA1").and_return(false)
       expect(OpenSSL::Digest).to receive(:const_defined?).with("SHA512").and_return(false)
       expect(OpenSSL::Digest).to receive(:const_defined?).with("SHA384").and_return(true)
       signer = Puppet::SSL::CertificateSigner.new
-      signer.sign(csr, key.content)
-      expect(csr.verify(key.content)).to be_truthy
+      signer.sign(csr, key)
+      expect(csr.verify(key)).to be_truthy
     end
 
     it "should use SHA224 to sign the csr when SHA256/SHA1/SHA512/SHA384 aren't available" do


### PR DESCRIPTION
Deletes pending tests that are useless, tested elsewhere or deleted in 7.

Cherrypicks commit to fix pending CSR tests.

There is one pending test left (which is included 5 times, once for each checksum type). I think it's related to PUP-10122, when collecting file metadata for a link, so I kept it.