### PR TITLE
(PUP-11158) Implement guard methods in base loader module

### DIFF
--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -49,6 +49,13 @@ module Puppet::Environments
         root.instance_variable_set(:@rich_data, nil)
       end
     end
+
+    # The base implementation is a noop, because `get` returns a new environment
+    # each time and does not load or evict text domains.
+    #
+    # @see Puppet::Environments::Cached#guard
+    def guard(name); end
+    def unguard(name); end
   end
 
   # @!macro [new] loader_search_paths

--- a/spec/unit/environments_spec.rb
+++ b/spec/unit/environments_spec.rb
@@ -140,6 +140,14 @@ describe Puppet::Environments do
       end
     end
 
+    it "implements guard and unguard" do
+      loader_from(:filesystem => [directory_tree],
+                  :directory => directory_tree.children.first) do |loader|
+        expect(loader.guard('env1')).to be_nil
+        expect(loader.unguard('env1')).to be_nil
+      end
+    end
+
     context "with an environment.conf" do
       let(:envdir) do
         FS::MemoryFile.a_directory(File.expand_path("envdir"), [


### PR DESCRIPTION
Trying to compile a catalog using a DirectoryLoader failed because it doesn't
implement the guard/unguard methods. Add them to the base EnvironmentLoader
module that is mixed into various environment loaders, and overriden in the
Cached loader.