### PR TITLE
(PUP-11187) Add `scripts` file serving mount

### DIFF
--- a/lib/puppet/file_serving/configuration.rb
+++ b/lib/puppet/file_serving/configuration.rb
@@ -6,6 +6,7 @@ require 'puppet/file_serving/mount/modules'
 require 'puppet/file_serving/mount/plugins'
 require 'puppet/file_serving/mount/locales'
 require 'puppet/file_serving/mount/pluginfacts'
+require 'puppet/file_serving/mount/scripts'
 require 'puppet/file_serving/mount/tasks'
 
 class Puppet::FileServing::Configuration
@@ -87,6 +88,8 @@ class Puppet::FileServing::Configuration
     @mounts["locales"].allow('*') if @mounts["locales"].empty?
     @mounts["pluginfacts"] ||= Mount::PluginFacts.new("pluginfacts")
     @mounts["pluginfacts"].allow('*') if @mounts["pluginfacts"].empty?
+    @mounts["scripts"] ||= Mount::Scripts.new("scripts")
+    @mounts["scripts"].allow('*') if @mounts["scripts"].empty?
     @mounts["tasks"] ||= Mount::Tasks.new("tasks")
     @mounts["tasks"].allow('*') if @mounts["tasks"].empty?
   end

--- a/lib/puppet/file_serving/configuration/parser.rb
+++ b/lib/puppet/file_serving/configuration/parser.rb
@@ -104,6 +104,8 @@ class Puppet::FileServing::Configuration::Parser
       mount = Mount::Modules.new(name)
     when "plugins"
       mount = Mount::Plugins.new(name)
+    when "scripts"
+      mount = Mount::Scripts.new(name)
     when "tasks"
       mount = Mount::Tasks.new(name)
     when "locales"

--- a/lib/puppet/file_serving/mount/scripts.rb
+++ b/lib/puppet/file_serving/mount/scripts.rb
@@ -1,0 +1,24 @@
+require 'puppet/file_serving/mount'
+
+class Puppet::FileServing::Mount::Scripts < Puppet::FileServing::Mount
+  # Return an instance of the appropriate class.
+  def find(path, request)
+    raise _("No module specified") if path.to_s.empty?
+    module_name, relative_path = path.split("/", 2)
+    mod = request.environment.module(module_name)
+    return nil unless mod
+
+    mod.script(relative_path)
+  end
+
+  def search(path, request)
+    result = find(path, request)
+    if result
+      [result]
+    end
+  end
+
+  def valid?
+    true
+  end
+end

--- a/spec/unit/file_serving/configuration/parser_spec.rb
+++ b/spec/unit/file_serving/configuration/parser_spec.rb
@@ -155,6 +155,29 @@ describe Puppet::FileServing::Configuration::Parser do
     end
   end
 
+  describe Puppet::FileServing::Configuration::Parser, " when parsing the scripts mount" do
+    include FSConfigurationParserTesting
+
+    before do
+      @mount = double('scriptsmount', :name => "scripts", :validate => true)
+    end
+
+    it "should create an instance of the Scripts Mount class" do
+      write_config_file "[scripts]\n"
+
+      expect(Puppet::FileServing::Mount::Scripts).to receive(:new).with("scripts").and_return(@mount)
+      @parser.parse
+    end
+
+    it "should warn if a path is set" do
+      write_config_file "[scripts]\npath /some/path\n"
+      expect(Puppet::FileServing::Mount::Scripts).to receive(:new).with("scripts").and_return(@mount)
+
+      expect(Puppet).to receive(:warning)
+      @parser.parse
+    end
+  end
+
   describe Puppet::FileServing::Configuration::Parser, " when parsing the plugins mount" do
     include FSConfigurationParserTesting
 

--- a/spec/unit/file_serving/configuration_spec.rb
+++ b/spec/unit/file_serving/configuration_spec.rb
@@ -80,15 +80,16 @@ describe Puppet::FileServing::Configuration do
       expect(config.mounted?("one")).to be_truthy
     end
 
-    it "should add modules, plugins, and tasks mounts even if the file does not exist" do
+    it "should add modules, plugins, scripts, and tasks mounts even if the file does not exist" do
       expect(Puppet::FileSystem).to receive(:exist?).and_return(false) # the file doesn't exist
       config = Puppet::FileServing::Configuration.configuration
       expect(config.mounted?("modules")).to be_truthy
       expect(config.mounted?("plugins")).to be_truthy
+      expect(config.mounted?("scripts")).to be_truthy
       expect(config.mounted?("tasks")).to be_truthy
     end
 
-    it "should allow all access to modules, plugins, and tasks if no fileserver.conf exists" do
+    it "should allow all access to modules, plugins, scripts, and tasks if no fileserver.conf exists" do
       expect(Puppet::FileSystem).to receive(:exist?).and_return(false) # the file doesn't exist
       modules = double('modules', :empty? => true)
       allow(Puppet::FileServing::Mount::Modules).to receive(:new).and_return(modules)
@@ -98,6 +99,10 @@ describe Puppet::FileServing::Configuration do
       allow(Puppet::FileServing::Mount::Plugins).to receive(:new).and_return(plugins)
       expect(plugins).to receive(:allow).with('*')
 
+      scripts = double('scripts', :empty? => true)
+      allow(Puppet::FileServing::Mount::Scripts).to receive(:new).and_return(scripts)
+      expect(scripts).to receive(:allow).with('*')
+
       tasks = double('tasks', :empty? => true)
       allow(Puppet::FileServing::Mount::Tasks).to receive(:new).and_return(tasks)
       expect(tasks).to receive(:allow).with('*')
@@ -105,7 +110,7 @@ describe Puppet::FileServing::Configuration do
       Puppet::FileServing::Configuration.configuration
     end
 
-    it "should not allow access from all to modules, plugins, and tasks if the fileserver.conf provided some rules" do
+    it "should not allow access from all to modules, plugins, scripts, and tasks if the fileserver.conf provided some rules" do
       expect(Puppet::FileSystem).to receive(:exist?).and_return(false) # the file doesn't exist
 
       modules = double('modules', :empty? => false)
@@ -116,6 +121,10 @@ describe Puppet::FileServing::Configuration do
       allow(Puppet::FileServing::Mount::Plugins).to receive(:new).and_return(plugins)
       expect(plugins).not_to receive(:allow).with('*')
 
+      scripts = double('scripts', :empty? => false)
+      allow(Puppet::FileServing::Mount::Scripts).to receive(:new).and_return(scripts)
+      expect(scripts).not_to receive(:allow).with('*')
+
       tasks = double('tasks', :empty? => false)
       allow(Puppet::FileServing::Mount::Tasks).to receive(:new).and_return(tasks)
       expect(tasks).not_to receive(:allow).with('*')
@@ -123,12 +132,13 @@ describe Puppet::FileServing::Configuration do
       Puppet::FileServing::Configuration.configuration
     end
 
-    it "should add modules, plugins, and tasks mounts even if they are not returned by the parser" do
+    it "should add modules, plugins, scripts, and tasks mounts even if they are not returned by the parser" do
       expect(@parser).to receive(:parse).and_return("one" => double("mount"))
       expect(Puppet::FileSystem).to receive(:exist?).and_return(true) # the file doesn't exist
       config = Puppet::FileServing::Configuration.configuration
       expect(config.mounted?("modules")).to be_truthy
       expect(config.mounted?("plugins")).to be_truthy
+      expect(config.mounted?("scripts")).to be_truthy
       expect(config.mounted?("tasks")).to be_truthy
     end
   end

--- a/spec/unit/file_serving/mount/scripts_spec.rb
+++ b/spec/unit/file_serving/mount/scripts_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+require 'puppet/file_serving/mount/scripts'
+
+describe Puppet::FileServing::Mount::Scripts do
+  before do
+    @mount = Puppet::FileServing::Mount::Scripts.new("scripts")
+
+    @environment = double('environment', :module => nil)
+    @request = double('request', :environment => @environment)
+  end
+
+  describe "when finding files" do
+    it "should fail if no module is specified" do
+      expect { @mount.find("", @request) }.to raise_error(/No module specified/)
+    end
+
+    it "should use the provided environment to find the module" do
+      expect(@environment).to receive(:module)
+
+      @mount.find("foo", @request)
+    end
+
+    it "should treat the first field of the relative path as the module name" do
+      expect(@environment).to receive(:module).with("foo")
+      @mount.find("foo/bar/baz", @request)
+    end
+
+    it "should return nil if the specified module does not exist" do
+      expect(@environment).to receive(:module).with("foo")
+      @mount.find("foo/bar/baz", @request)
+    end
+
+    it "should return the file path from the module" do
+      mod = double('module')
+      expect(mod).to receive(:script).with("bar/baz").and_return("eh")
+      expect(@environment).to receive(:module).with("foo").and_return(mod)
+      expect(@mount.find("foo/bar/baz", @request)).to eq("eh")
+    end
+  end
+
+  describe "when searching for files" do
+    it "should fail if no module is specified" do
+      expect { @mount.search("", @request) }.to raise_error(/No module specified/)
+    end
+
+    it "should use the node's environment to search the module" do
+      expect(@environment).to receive(:module)
+
+      @mount.search("foo", @request)
+    end
+
+    it "should treat the first field of the relative path as the module name" do
+      expect(@environment).to receive(:module).with("foo")
+      @mount.search("foo/bar/baz", @request)
+    end
+
+    it "should return nil if the specified module does not exist" do
+      expect(@environment).to receive(:module).with("foo").and_return(nil)
+      @mount.search("foo/bar/baz", @request)
+    end
+
+    it "should return the script path as an array from the module" do
+      mod = double('module')
+      expect(mod).to receive(:script).with("bar/baz").and_return("eh")
+      expect(@environment).to receive(:module).with("foo").and_return(mod)
+      expect(@mount.search("foo/bar/baz", @request)).to eq(["eh"])
+    end
+  end
+end


### PR DESCRIPTION
This adds a file serving mount "scripts" that loads scripts from the
`scripts/` directory of the specified module that is one of the default mounts. This is for use by
Puppetserver to serve file content and metadata for scripts through a
`scripts` mount_point.