### PR TITLE
(PUP-11158) Guard environment from reloading

### DIFF
--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -385,23 +385,30 @@ module Puppet::Environments
 
     # @!macro loader_get
     def get(name)
+      entry = get_entry(name)
+      entry ? entry.value : nil
+    end
+
+    # Get a cache entry for an envionment. It returns nil if the
+    # environment doesn't exist.
+    def get_entry(name)
       # Aggressively evict all that has expired
       # This strategy favors smaller memory footprint over environment
       # retrieval time.
       clear_all_expired
-      result = @cache[name]
-      if result
-        Puppet.debug {"Found in cache #{name.inspect} #{result.label}"}
+      entry = @cache[name]
+      if entry
+        Puppet.debug {"Found in cache #{name.inspect} #{entry.label}"}
         # found in cache
-        result.touch
-        return result.value
+        entry.touch
       elsif (result = @loader.get(name))
         # environment loaded, cache it
-        cache_entry = entry(result)
-        add_entry(name, cache_entry)
-        result
+        entry = entry(result)
+        add_entry(name, entry)
       end
+      entry
     end
+    private :get_entry
 
     # Adds a cache entry to the cache
     def add_entry(name, cache_entry)

--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -337,11 +337,11 @@ module Puppet::Environments
     end
 
     def self.cache_expiration_service=(service)
-      @cache_expiration_service = service
+      @cache_expiration_service_singleton = service
     end
 
     def self.cache_expiration_service
-      @cache_expiration_service || DefaultCacheExpirationService.new
+      @cache_expiration_service_singleton || DefaultCacheExpirationService.new
     end
 
     # Returns the end of time (the next Mesoamerican Long Count cycle-end after 2012 (5125+2012) = 7137

--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -344,14 +344,6 @@ module Puppet::Environments
       @cache_expiration_service_singleton || DefaultCacheExpirationService.new
     end
 
-    # Returns the end of time (the next Mesoamerican Long Count cycle-end after 2012 (5125+2012) = 7137
-    def self.end_of_time
-      Time.gm(7137)
-    end
-
-    END_OF_TIME = end_of_time
-    START_OF_TIME = Time.gm(1)
-
     def initialize(loader)
       @loader = loader
       @cache_expiration_service = Puppet::Environments::Cached.cache_expiration_service
@@ -363,7 +355,7 @@ module Puppet::Environments
       # Evict all that have expired, in the same way as `get`
       clear_all_expired
 
-      # Evict all that was removed from diks
+      # Evict all that was removed from disk
       cached_envs = @cache.keys.map!(&:to_sym)
       loader_envs = @loader.list.map!(&:name)
       removed_envs = cached_envs - loader_envs
@@ -457,13 +449,14 @@ module Puppet::Environments
     # Clears all environments that have expired, either by exceeding their time to live, or
     # through an explicit eviction determined by the cache expiration service.
     #
-    def clear_all_expired()
+    def clear_all_expired
       t = Time.now
 
       @cache.each_pair do |name, entry|
         clear_if_expired(name, entry, t)
       end
     end
+    private :clear_all_expired
 
     # Clear an environment if it is expired, either by exceeding its time to live, or
     # through an explicit eviction determined by the cache expiration service.

--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -391,7 +391,7 @@ module Puppet::Environments
       clear_all_expired
       result = @cache[name]
       if result
-        Puppet.debug {"Found in cache '#{name}' #{result.label}"}
+        Puppet.debug {"Found in cache #{name.inspect} #{result.label}"}
         # found in cache
         result.touch
         return result.value
@@ -405,7 +405,7 @@ module Puppet::Environments
 
     # Adds a cache entry to the cache
     def add_entry(name, cache_entry)
-      Puppet.debug {"Caching environment '#{name}' #{cache_entry.label}"}
+      Puppet.debug {"Caching environment #{name.inspect} #{cache_entry.label}"}
       @cache[name] = cache_entry
       @cache_expiration_service.created(cache_entry.value)
     end
@@ -413,7 +413,7 @@ module Puppet::Environments
 
     def clear_entry(name, entry)
       @cache.delete(name)
-      Puppet.debug {"Evicting cache entry for environment '#{name}'"}
+      Puppet.debug {"Evicting cache entry for environment #{name.inspect}"}
       @cache_expiration_service.evicted(name.to_sym)
       Puppet::GettextConfig.delete_text_domain(name)
       Puppet.settings.clear_environment_settings(name)

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -54,7 +54,13 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
 
     if node.environment
       node.environment.with_text_domain do
-        compile(node, request.options)
+        envs = Puppet.lookup(:environments)
+        envs.guard(node.environment.name)
+        begin
+          compile(node, request.options)
+        ensure
+          envs.unguard(node.environment.name)
+        end
       end
     else
       compile(node, request.options)

--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -305,7 +305,9 @@ class Puppet::Node::Environment
                        {}
                      end
       modulepath.each do |path|
-        Dir.entries(path).each do |name|
+        Puppet::FileSystem.children(path).map do |p|
+          Puppet::FileSystem.basename_string(p)
+        end.each do |name|
           next unless Puppet::Module.is_module_directory?(name, path)
           warn_about_mistaken_path(path, name)
           if not seen_modules[name]
@@ -358,7 +360,9 @@ class Puppet::Node::Environment
     modules_by_path = {}
     modulepath.each do |path|
       if Puppet::FileSystem.exist?(path)
-        module_names = Dir.entries(path).select do |name|
+        module_names = Puppet::FileSystem.children(path).map do |p|
+          Puppet::FileSystem.basename_string(p)
+        end.select do |name|
           Puppet::Module.is_module_directory?(name, path)
         end
         modules_by_path[path] = module_names.sort.map do |name|

--- a/spec/unit/indirector/catalog/compiler_spec.rb
+++ b/spec/unit/indirector/catalog/compiler_spec.rb
@@ -236,6 +236,19 @@ describe Puppet::Resource::Catalog::Compiler do
       expect { compiler.find(@request) }.to raise_error Puppet::Error,
         "Unable to find a common checksum type between agent '' and master '[:sha256, :sha256lite, :md5, :md5lite, :sha1, :sha1lite, :sha512, :sha384, :sha224, :mtime, :ctime, :none]'."
     end
+
+    it "prevents the environment from being evicted during compilation" do
+      Puppet[:environment_timeout] = 0
+
+      envs = Puppet.lookup(:environments)
+
+      expect(compiler).to receive(:compile) do
+        # we should get the same object
+        expect(envs.get!(:production)).to equal(envs.get!(:production))
+      end
+
+      compiler.find(@request)
+    end
   end
 
   describe "when handling a request with facts" do


### PR DESCRIPTION
This PR is similar to what was attempted in PR #8673 except:

1. It preserves the existing way of managing text domains via compilation using `node.environment.with_text_domain`
2. It defines noop guard/unguard methods on the base EnvironmentLoader module.
3. Environments are not expired when guard/unguard are called
4. An environment won't be evicted if it is guarded but marked as expired by the cache expiration service (puppetserver)