### PR TITLE
(maint) Teardown remaining lastrunfile after using tmp env

### DIFF
--- a/acceptance/tests/direct_puppet/cached_catalog_remediate_local_drift.rb
+++ b/acceptance/tests/direct_puppet/cached_catalog_remediate_local_drift.rb
@@ -27,6 +27,12 @@ test_name "PUP-5122: Puppet remediates local drift using code_id and content_uri
   teardown do
     cleanup_puppetserver_code_id_scripts(master, basedir)
     on master, "rm -rf #{basedir}"
+
+    agents.each do |agent|
+      on(agent, puppet('config print lastrunfile')) do |command_result|
+        agent.rm_rf(command_result.stdout)
+      end
+    end
   end
 
   step "Create a module and a file with content representing the first code_id version" do

--- a/acceptance/tests/direct_puppet/static_catalog_env_control.rb
+++ b/acceptance/tests/direct_puppet/static_catalog_env_control.rb
@@ -169,6 +169,11 @@ MANIFEST
 teardown do
   on(master, "mv #{@confdir}/puppetserver.conf.bak #{@confdir}/puppetserver.conf")
   on(master, "rm -rf #{@testroot}")
+  agents.each do |agent|
+    on(agent, puppet('config print lastrunfile')) do |command_result|
+      agent.rm_rf(command_result.stdout)
+    end
+  end
 end
 
 step 'apply main manifest, static_catalogs unspecified in global scope, unspecified in production environment, disabled in canary environment'

--- a/acceptance/tests/environment/custom_type_provider_from_same_environment.rb
+++ b/acceptance/tests/environment/custom_type_provider_from_same_environment.rb
@@ -21,6 +21,12 @@ tag 'audit:high',
     step 'clean out file resources' do
       on(hosts, "rm #{file_correct} #{file_wrong}", :accept_all_exit_codes => true)
     end
+
+    agents.each do |agent|
+      on(agent, puppet('config print lastrunfile')) do |command_result|
+        agent.rm_rf(command_result.stdout)
+      end
+    end
   end
 
   step "create a custom type and provider in each of production and #{tmp_environment}" do

--- a/acceptance/tests/environment/variables_refreshed_each_compilation.rb
+++ b/acceptance/tests/environment/variables_refreshed_each_compilation.rb
@@ -8,6 +8,14 @@ test_name 'C98115 compilation should get new values in variables on each compila
       'audit:integration',
       'server'
 
+  teardown do
+    agents.each do |agent|
+      on(agent, puppet('config print lastrunfile')) do |command_result|
+        agent.rm_rf(command_result.stdout)
+      end
+    end
+  end
+
   app_type               = File.basename(__FILE__, '.*')
   tmp_environment        = mk_tmp_environment_with_teardown(master, app_type)
   fq_tmp_environmentpath = "#{environmentpath}/#{tmp_environment}"

--- a/acceptance/tests/face/parser_validate.rb
+++ b/acceptance/tests/face/parser_validate.rb
@@ -11,6 +11,14 @@ tag 'audit:high',
 
   app_type = File.basename(__FILE__, '.*')
 
+  teardown do
+    agents.each do |agent|
+      on(agent, puppet('config print lastrunfile')) do |command_result|
+        agent.rm_rf(command_result.stdout)
+      end
+    end
+  end
+
   agents.each do |agent|
     skip_test('this test fails on windows French due to Cygwin/UTF Issues - PUP-8319,IMAGES-492') if agent['platform'] =~ /windows/ && agent['locale'] == 'fr'
 

--- a/acceptance/tests/i18n/modules/puppet_agent.rb
+++ b/acceptance/tests/i18n/modules/puppet_agent.rb
@@ -41,6 +41,11 @@ test_name 'C100565: puppet agent with module should translate messages' do
       end
       uninstall_i18n_demo_module(master)
     end
+    agents.each do |agent|
+      on(agent, puppet('config print lastrunfile')) do |command_result|
+        agent.rm_rf(command_result.stdout)
+      end
+    end
   end
 
   agents.each do |agent|

--- a/acceptance/tests/i18n/modules/puppet_agent_cached_catalog.rb
+++ b/acceptance/tests/i18n/modules/puppet_agent_cached_catalog.rb
@@ -41,6 +41,11 @@ test_name 'C100566: puppet agent with module should translate messages when usin
       end
       uninstall_i18n_demo_module(master)
     end
+    agents.each do |agent|
+      on(agent, puppet('config print lastrunfile')) do |command_result|
+        agent.rm_rf(command_result.stdout)
+      end
+    end
   end
 
   agents.each do |agent|

--- a/acceptance/tests/i18n/modules/puppet_agent_with_multiple_environments.rb
+++ b/acceptance/tests/i18n/modules/puppet_agent_with_multiple_environments.rb
@@ -49,6 +49,11 @@ test_name 'C100575: puppet agent with different modules in different environment
       on(master, puppet("config set disable_i18n #{ disable_i18n_default_master }"))
       reset_master_system_locale
     end
+    agents.each do |agent|
+      on(agent, puppet('config print lastrunfile')) do |command_result|
+        agent.rm_rf(command_result.stdout)
+      end
+    end
   end
 
   agents.each do |agent|

--- a/acceptance/tests/language/binary_data_type.rb
+++ b/acceptance/tests/language/binary_data_type.rb
@@ -9,6 +9,14 @@ test_name 'C98346: Binary data type' do
                            # should not be OS sensitive.
       'server'
 
+  teardown do
+    agents.each do |agent|
+      on(agent, puppet('config print lastrunfile')) do |command_result|
+        agent.rm_rf(command_result.stdout)
+      end
+    end
+  end
+
   app_type               = File.basename(__FILE__, '.*')
   tmp_environment        = mk_tmp_environment_with_teardown(master, app_type)
 

--- a/acceptance/tests/language/exported_resources.rb
+++ b/acceptance/tests/language/exported_resources.rb
@@ -26,6 +26,11 @@ tag 'audit:high',
     step 'clean out collected resources' do
       on(hosts, puppet_resource("user #{exported_username} ensure=absent"), :accept_all_exit_codes => true)
     end
+    agents.each do |agent|
+      on(agent, puppet('config print lastrunfile')) do |command_result|
+        agent.rm_rf(command_result.stdout)
+      end
+    end
   end
 
   storeconfigs_backend_name = 'pson_storeconfigs'

--- a/acceptance/tests/language/functions_in_puppet_language.rb
+++ b/acceptance/tests/language/functions_in_puppet_language.rb
@@ -10,6 +10,12 @@ teardown do
   on master, 'rm -rf /etc/puppetlabs/code/environments/tommy'
   on master, 'rm -rf /etc/puppetlabs/code/environments/production/modules/one'
   on master, 'rm -rf /etc/puppetlabs/code/environments/production/modules/three'
+
+  agents.each do |agent|
+    on(agent, puppet('config print lastrunfile')) do |command_result|
+      agent.rm_rf(command_result.stdout)
+    end
+  end
 end
 
 step 'Create some functions' do

--- a/acceptance/tests/language/pcore_generate_env_isolation.rb
+++ b/acceptance/tests/language/pcore_generate_env_isolation.rb
@@ -6,6 +6,14 @@ tag 'audit:high',
     'audit:integration',
     'server'
 
+  teardown do
+    agents.each do |agent|
+      on(agent, puppet('config print lastrunfile')) do |command_result|
+        agent.rm_rf(command_result.stdout)
+      end
+    end
+  end
+
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)
   tmp_environment2 = mk_tmp_environment_with_teardown(master, app_type)

--- a/acceptance/tests/language/sensitive_data_type.rb
+++ b/acceptance/tests/language/sensitive_data_type.rb
@@ -9,6 +9,13 @@ tag 'audit:high',
                           # written logs.
     'server'
 
+  teardown do
+    agents.each do |agent|
+      on(agent, puppet('config print lastrunfile')) do |command_result|
+        agent.rm_rf(command_result.stdout)
+      end
+    end
+  end
 
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)

--- a/acceptance/tests/language/server_set_facts.rb
+++ b/acceptance/tests/language/server_set_facts.rb
@@ -6,6 +6,14 @@ tag 'audit:high',
     'audit:acceptance', # Validating server/client interaction
     'server'
 
+  teardown do
+    agents.each do |agent|
+      on(agent, puppet('config print lastrunfile')) do |command_result|
+        agent.rm_rf(command_result.stdout)
+      end
+    end
+  end
+
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type)
 

--- a/acceptance/tests/loader/autoload_from_resource_type_decl.rb
+++ b/acceptance/tests/loader/autoload_from_resource_type_decl.rb
@@ -30,6 +30,10 @@ test_name 'C100303: Resource type statement triggered auto-loading works both wi
     on(master, "rm -f '#{execution_log[agent_to_fqdn(master)]}'")
     agents.each do |agent|
       on(agent, "rm -f '#{execution_log[agent_to_fqdn(agent)]}'")
+
+      on(agent, puppet('config print lastrunfile')) do |command_result|
+        agent.rm_rf(command_result.stdout)
+      end
     end
   end
 

--- a/acceptance/tests/loader/resource_triggers_autoload.rb
+++ b/acceptance/tests/loader/resource_triggers_autoload.rb
@@ -8,6 +8,14 @@ test_name 'C100296: can auto-load defined types using a Resource statement' do
   tmp_environment        = mk_tmp_environment_with_teardown(master, app_type)
   fq_tmp_environmentpath = "#{environmentpath}/#{tmp_environment}"
 
+  teardown do
+    agents.each do |agent|
+      on(agent, puppet('config print lastrunfile')) do |command_result|
+        agent.rm_rf(command_result.stdout)
+      end
+    end
+  end
+
   relative_define_type_dir    = 'modules/one/manifests'
   relative_define_type_1_path = "#{relative_define_type_dir}/tst1.pp"
   relative_define_type_2_path = "#{relative_define_type_dir}/tst2.pp"

--- a/acceptance/tests/lookup/config3_interpolation.rb
+++ b/acceptance/tests/lookup/config3_interpolation.rb
@@ -22,6 +22,11 @@ tag 'audit:high',
 
   teardown do
     on(master, "mv #{hiera_conf_backup} #{master_confdir}/hiera.yaml", :acceptable_exit_codes => [0,1])
+    agents.each do |agent|
+      on(agent, puppet('config print lastrunfile')) do |command_result|
+        agent.rm_rf(command_result.stdout)
+      end
+    end
   end
 
   step "create hiera configs in #{tmp_environment} and global" do

--- a/acceptance/tests/lookup/config5_interpolation.rb
+++ b/acceptance/tests/lookup/config5_interpolation.rb
@@ -13,6 +13,14 @@ tag 'audit:high',
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type + '1')
   fq_tmp_environmentpath  = "#{environmentpath}/#{tmp_environment}"
 
+  teardown do
+    agents.each do |agent|
+      on(agent, puppet('config print lastrunfile')) do |command_result|
+        agent.rm_rf(command_result.stdout)
+      end
+    end
+  end
+
   step "create environment hiera5.yaml and environment data" do
 
     create_remote_file(master, "#{fq_tmp_environmentpath}/hiera.yaml", <<-HIERA)

--- a/acceptance/tests/lookup/hiera3_custom_backend.rb
+++ b/acceptance/tests/lookup/hiera3_custom_backend.rb
@@ -27,6 +27,12 @@ tag 'audit:high',
       on(master, "rm #{existing_loadpath}/hiera/backend/custom_backend.rb", :acceptable_exit_codes => [0,1])
       on(master, "mv #{hiera_conf_backup} #{confdir}/hiera.yaml", :acceptable_exit_codes => [0,1])
     end
+
+    agents.each do |agent|
+      on(agent, puppet('config print lastrunfile')) do |command_result|
+        agent.rm_rf(command_result.stdout)
+      end
+    end
   end
 
   step "create hiera v5 config and v3 custom backend" do

--- a/acceptance/tests/lookup/lookup.rb
+++ b/acceptance/tests/lookup/lookup.rb
@@ -111,6 +111,14 @@ PPmetadata
     end
   end
 
+  teardown do
+    agents.each do |agent|
+      on(agent, puppet('config print lastrunfile')) do |command_result|
+        agent.rm_rf(command_result.stdout)
+      end
+    end
+  end
+
   module_manifest1 = mod_manifest_entry(module_name, testdir, module_data_implied_key,
                          module_data_implied_value, module_data_key, module_data_value,
                          hash_name, module_hash_key, module_hash_value, array_key,

--- a/acceptance/tests/lookup/lookup_rich_values.rb
+++ b/acceptance/tests/lookup/lookup_rich_values.rb
@@ -21,6 +21,14 @@ tag 'audit:high',
   sensitive_value_pp = 'toe, no step'
   sensitive_value_pp2 = 'toe, no module'
 
+  teardown do
+    agents.each do |agent|
+      on(agent, puppet('config print lastrunfile')) do |command_result|
+        agent.rm_rf(command_result.stdout)
+      end
+    end
+  end
+
   step "create ruby lookup function in #{tmp_environment}" do
     on(master, "mkdir -p #{fq_tmp_environmentpath}/lib/puppet/functions/environment")
     create_remote_file(master, "#{fq_tmp_environmentpath}/hiera.yaml", <<-HIERA)

--- a/acceptance/tests/lookup/merge_strategies.rb
+++ b/acceptance/tests/lookup/merge_strategies.rb
@@ -20,6 +20,12 @@ tag 'audit:high',
     step "restore default global hiera.yaml" do
       on(master, "mv #{hiera_conf_backup} #{master_confdir}/hiera.yaml", :acceptable_exit_codes => [0,1])
     end
+
+    agents.each do |agent|
+      on(agent, puppet('config print lastrunfile')) do |command_result|
+        agent.rm_rf(command_result.stdout)
+      end
+    end
   end
 
   step "create global hiera.yaml and environment data" do

--- a/acceptance/tests/lookup/v3_config_and_data.rb
+++ b/acceptance/tests/lookup/v3_config_and_data.rb
@@ -24,6 +24,12 @@ tag 'audit:high',
       step "restore global hiera.yaml" do
         on(master, "mv #{hiera_conf_backup} #{confdir}/hiera.yaml", :acceptable_exit_codes => [0,1])
       end
+
+      agents.each do |agent|
+        on(agent, puppet('config print lastrunfile')) do |command_result|
+          agent.rm_rf(command_result.stdout)
+        end
+      end
     end
 
     step "create global hiera.yaml and module data" do

--- a/acceptance/tests/lookup/v4_hieradata_with_v5_configs.rb
+++ b/acceptance/tests/lookup/v4_hieradata_with_v5_configs.rb
@@ -22,6 +22,12 @@ tag 'audit:high',
     step "restore global hiera.yaml" do
       on(master, "mv #{hiera_conf_backup} #{confdir}/hiera.yaml", :acceptable_exit_codes => [0,1])
     end
+
+    agents.each do |agent|
+      on(agent, puppet('config print lastrunfile')) do |command_result|
+        agent.rm_rf(command_result.stdout)
+      end
+    end
   end
 
   step "create global hiera.yaml and data" do

--- a/acceptance/tests/pluginsync/feature/pluginsync_should_sync_features.rb
+++ b/acceptance/tests/pluginsync/feature/pluginsync_should_sync_features.rb
@@ -17,6 +17,14 @@ test_name "the pluginsync functionality should sync feature and function definit
   require 'puppet/acceptance/temp_file_utils'
   extend Puppet::Acceptance::TempFileUtils
 
+  teardown do
+    agents.each do |agent|
+      on(agent, puppet('config print lastrunfile')) do |command_result|
+        agent.rm_rf(command_result.stdout)
+      end
+    end
+  end
+
   module_name = 'superbogus'
   tmp_environment = mk_tmp_environment_with_teardown(master, 'sync')
   master_module_dir = "#{environmentpath}/#{tmp_environment}/modules"

--- a/acceptance/tests/reports/corrective_change_new_resource.rb
+++ b/acceptance/tests/reports/corrective_change_new_resource.rb
@@ -26,6 +26,11 @@ test_name "C98092 - a new resource should not be reported as a corrective change
         if tmp_file.has_key?(agent_to_fqdn(agent)) && tmp_file[agent_to_fqdn(agent)] != ''
           on(agent, "rm '#{tmp_file[agent_to_fqdn(agent)]}'", :accept_all_exit_codes => true)
         end
+
+
+        on(agent, puppet('config print lastrunfile')) do |command_result|
+          agent.rm_rf(command_result.stdout)
+        end
       end
     end
   end

--- a/acceptance/tests/reports/corrective_change_outside_puppet.rb
+++ b/acceptance/tests/reports/corrective_change_outside_puppet.rb
@@ -27,6 +27,10 @@ test_name "C98093 - a resource changed outside of Puppet will be reported as a c
         if tmp_file.has_key?(agent_to_fqdn(agent)) && tmp_file[agent_to_fqdn(agent)] != ''
           on(agent, "rm '#{tmp_file[agent_to_fqdn(agent)]}'", :accept_all_exit_codes => true)
         end
+
+        on(agent, puppet('config print lastrunfile')) do |command_result|
+          agent.rm_rf(command_result.stdout)
+        end
       end
     end
   end

--- a/acceptance/tests/resource/file/ticket_6448_file_with_utf8_source.rb
+++ b/acceptance/tests/resource/file/ticket_6448_file_with_utf8_source.rb
@@ -18,10 +18,15 @@ test_name 'Ensure a file resource can have a UTF-8 source attribute, content, an
   end
 
   teardown do
-    step 'remove all test files on agents' do
-      agents.each {|agent| on(agent, "rm -r '#{agent_tmp_dirs[agent_to_fqdn(agent)]}'", :accept_all_exit_codes => true)}
-    end
     # note - master teardown is registered by #mk_tmp_environment_with_teardown
+    step 'remove all test files on agents' do
+      agents.each do |agent|
+        on(agent, "rm -r '#{agent_tmp_dirs[agent_to_fqdn(agent)]}'", :accept_all_exit_codes => true)
+        on(agent, puppet('config print lastrunfile')) do |command_result|
+          agent.rm_rf(command_result.stdout)
+        end
+      end
+    end
   end
 
   step 'create unicode source file served via module on master' do


### PR DESCRIPTION
Recent work allowed the agent to skip node requests by inspecting a
lastrunfile if it exists and start the agent check-in process with the
environment listed there. However, the acceptance tests often create
dummy enviroments and do not clean up the lastrunfile.

A first pass updated many tests to remove the lastrunfile on all agents
if they used a temporary environment. However, several were missed as
the agent testing will only test a subset of the server tests. In an
attempt to quickly rectify the situation this patch audits all
acceptance tests that use, or mention that they should use,
`mk_tmp_environment_with_teardown` and extends their teardowns to use
the existing pattern for removing the lastrunfile.