### PR TITLE
(PUP-11170) User => absent deletes homedir on AIX (when managehome=true)

### DIFF
--- a/acceptance/tests/resource/user/should_destroy_with_managehome.rb
+++ b/acceptance/tests/resource/user/should_destroy_with_managehome.rb
@@ -1,30 +1,42 @@
-test_name "should delete a user with managehome=true"
-confine :except, :platform => /^eos-/ # See ARISTA-37
-confine :except, :platform => /^cisco_/ # See PUP-5828
-tag 'audit:high',
-    'audit:refactor',  # Use block style `test_run`
-    'audit:acceptance' # Could be done as integration tests, but would
-                       # require changing the system running the test
-                       # in ways that might require special permissions
-                       # or be harmful to the system running the test
+test_name "should delete a user with managehome=true" do
+  confine :except, :platform => /osx/
 
-name = "pl#{rand(999999).to_i}"
+  tag 'audit:high',
+      'audit:acceptance' # Could be done as integration tests, but would
+                         # require changing the system running the test
+                         # in ways that might require special permissions
+                         # or be harmful to the system running the test
 
-agents.each do |agent|
-  case  agent['platform'] 
-  when /osx/
-    skip_test("OSX doesn't support managehome")
+  agents.each do |agent|
+    home = ''
+    name = "pl#{rand(999999).to_i}"
+
+    teardown do
+      agent.user_absent(name)
+    end
+
+    step "ensure the user is present" do
+      agent.user_present(name)
+    end
+
+    step "get home directory path" do
+      on(agent, puppet_resource('user', name)) do |result|
+        info = result.stdout.match(/home\s+=>\s+'(.+)',/)
+        home = info[1] if info
+      end
+    end
+
+    step "delete the user with managehome=true" do
+      on(agent, puppet_resource('user', name, ['ensure=absent', 'managehome=true']))
+    end
+
+    step "verify the user was deleted" do
+      fail_test "User '#{name}' was not deleted" if agent.user_list.include?(name)
+    end
+
+    step "verify the home directory was deleted" do
+      skip_test("managehome parameter on Windows is not behaving as expected. See PUP-11202") if agent['platform'] =~ /windows/
+      on(agent, "test -d #{home}", :acceptable_exit_codes => [1])
+    end
   end
-
-  step "ensure the user is present"
-  agent.user_present(name)
-
-  step "delete the user with managehome=true"
-  on agent, puppet_resource('user', name, ['ensure=absent', 'managehome=true'])
-
-  step "verify the user was deleted"
-  fail_test "User #{name} was not deleted" if agent.user_list.include? name
-
-  step "delete the user, if any"
-  agent.user_absent(name)
 end

--- a/lib/puppet/provider/aix_object.rb
+++ b/lib/puppet/provider/aix_object.rb
@@ -279,7 +279,7 @@ class Puppet::Provider::AixObject < Puppet::Provider
         name = object[:name]
         id = object[:attributes].delete(:id)
 
-        Hash[[[:name, name,],[:id, id]]]
+        { name: name, id: id }
       end
     end
 

--- a/lib/puppet/provider/user/aix.rb
+++ b/lib/puppet/provider/user/aix.rb
@@ -265,6 +265,46 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
     end
   end
 
+  # Lists all instances of the given object, taking in an optional set
+  # of ia_module arguments. Returns an array of hashes, each hash
+  # having the schema
+  #   {
+  #     :name => <object_name>
+  #     :home => <object_home>
+  #   }
+  def list_all_homes(ia_module_args = [])
+    cmd = [command(:list), '-c', *ia_module_args, '-a', 'home', 'ALL']
+    parse_aix_objects(execute(cmd)).to_a.map do |object|
+      name = object[:name]
+      home = object[:attributes].delete(:home)
+
+      { name: name, home: home }
+    end
+  rescue => e
+    Puppet.debug("Could not list home of all users: #{e.message}")
+    {}
+  end
+
+  # Deletes this instance resource
+  def delete
+    homedir = home
+    super
+    return unless @resource.managehome?
+
+    if !Puppet::Util.absolute_path?(homedir) || File.realpath(homedir) == '/' || Puppet::FileSystem.symlink?(homedir)
+      Puppet.debug("Can not remove home directory '#{homedir}' of user '#{@resource[:name]}'. Please make sure the path is not relative, symlink or '/'.")
+      return
+    end
+
+    affected_home = list_all_homes.find { |info| info[:home].start_with?(File.realpath(homedir)) }
+    if affected_home
+      Puppet.debug("Can not remove home directory '#{homedir}' of user '#{@resource[:name]}' as it would remove the home directory '#{affected_home[:home]}' of user '#{affected_home[:name]}' also.")
+      return
+    end
+
+    FileUtils.remove_entry_secure(homedir, true)
+  end
+
   # UNSUPPORTED
   #- **profile_membership**
   #    Whether specified roles should be treated as the only roles
@@ -314,5 +354,4 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
   #    be treated as the minimum membership list.  Valid values are
   #    `inclusive`, `minimum`.
   # UNSUPPORTED
-
 end


### PR DESCRIPTION
Before this commit, when a manifest that deletes an AIX user is applied, with `managehome` parameter set to true, puppet would not delete the home directory for that user because it was using `rmuser`, and it has no flag to delete home directories.

This commit adds a simple folder removal of user home directory (when `managehome` is enabled) as `userdel` also removes the user from
`/etc/security/passwd`, and `rmuser` does not. Puppet will not remove user home directory if this is relative, '/', symlink or contains home directories of other users.