### PR TITLE
(PUP-10105) puppet resource --to_yaml emits puppet class tags

### DIFF
--- a/lib/puppet/application/resource.rb
+++ b/lib/puppet/application/resource.rb
@@ -224,7 +224,8 @@ Copyright (c) 2011 Puppet Inc., LLC Licensed under the Apache 2.0 License
 
   def find_or_save_resources(type, name, params)
     key = local_key(type, name)
-
+    
+    Puppet.push_context({:stringify_rich => true})
     if name
       if params.empty?
         [ Puppet::Resource.indirection.find( key ) ]

--- a/lib/puppet/pops/serialization/to_stringified_converter.rb
+++ b/lib/puppet/pops/serialization/to_stringified_converter.rb
@@ -62,7 +62,7 @@ module Serialization
     end
 
     def to_data(value)
-      if value.is_a?(String)
+      if value.instance_of?(String)
         to_string_or_binary(value)
       elsif value.nil? || Types::PScalarDataType::DEFAULT.instance?(value)
         value

--- a/lib/puppet/pops/types/p_binary_type.rb
+++ b/lib/puppet/pops/types/p_binary_type.rb
@@ -136,7 +136,7 @@ class PBinaryType < PAnyType
   # Only instances of Binary are instances of the PBinaryType
   #
   def instance?(o, guard = nil)
-    o.is_a?(Binary)
+    o.instance_of?(Binary)
   end
 
   def eql?(o)

--- a/lib/puppet/pops/types/p_runtime_type.rb
+++ b/lib/puppet/pops/types/p_runtime_type.rb
@@ -99,7 +99,7 @@ class PRuntimeType < PAnyType
 
     onp = o.name_or_pattern
     return true if @name_or_pattern == onp
-    return false unless @name_or_pattern.is_a?(String) && onp.is_a?(String)
+    return false unless @name_or_pattern.instance_of?(String) && onp.instance_of?(String)
 
     # NOTE: This only supports Ruby, must change when/if the set of runtimes is expanded
     begin

--- a/lib/puppet/pops/types/p_sem_ver_range_type.rb
+++ b/lib/puppet/pops/types/p_sem_ver_range_type.rb
@@ -95,7 +95,7 @@ class PSemVerRangeType < PAnyType
   end
 
   def instance?(o, guard = nil)
-    o.is_a?(SemanticPuppet::VersionRange)
+    o.instance_of?(SemanticPuppet::VersionRange)
   end
 
   def eql?(o)

--- a/lib/puppet/pops/types/p_sem_ver_type.rb
+++ b/lib/puppet/pops/types/p_sem_ver_type.rb
@@ -24,7 +24,7 @@ class PSemVerType < PScalarType
   end
 
   def instance?(o, guard = nil)
-    o.is_a?(SemanticPuppet::Version) && (@ranges.empty? || @ranges.any? {|range| range.include?(o) })
+    o.instance_of?(SemanticPuppet::Version) && (@ranges.empty? || @ranges.any? {|range| range.include?(o) })
   end
 
   def eql?(o)

--- a/lib/puppet/pops/types/p_timespan_type.rb
+++ b/lib/puppet/pops/types/p_timespan_type.rb
@@ -183,7 +183,7 @@ module Types
     end
 
     def instance?(o, guard = nil)
-      o.is_a?(Time::Timespan) && o >= @from && o <= @to
+      o.instance_of?(Time::Timespan) && o >= @from && o <= @to
     end
 
     DEFAULT = PTimespanType.new(nil, nil)

--- a/lib/puppet/pops/types/p_timestamp_type.rb
+++ b/lib/puppet/pops/types/p_timestamp_type.rb
@@ -64,7 +64,7 @@ module Types
     end
 
     def instance?(o, guard = nil)
-      o.is_a?(Time::Timestamp) && o >= @from && o <= @to
+      o.instance_of?(Time::Timestamp) && o >= @from && o <= @to
     end
 
     DEFAULT = PTimestampType.new(nil, nil)

--- a/lib/puppet/pops/types/p_type_set_type.rb
+++ b/lib/puppet/pops/types/p_type_set_type.rb
@@ -350,7 +350,7 @@ class PTypeSetType < PMetaType
   end
 
   def instance?(o, guard = nil)
-    o.is_a?(PTypeSetType)
+    o.instance_of?(PTypeSetType)
   end
 
   DEFAULT = self.new({

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -738,7 +738,7 @@ class PScalarDataType < PScalarType
     create_ptype(loader, ir, 'ScalarType')
   end
 
-  def instance?(o, guard = nil) 
+  def instance?(o, guard = nil)
     return o.instance_of?(String) || o.is_a?(Integer) || o.is_a?(Float) || o.instance_of?(TrueClass) || o.instance_of?(FalseClass)
   end
 
@@ -812,7 +812,7 @@ class PEnumType < PScalarDataType
   end
 
   def instance?(o, guard = nil)
-    if o.is_a?(String)
+    if o.instance_of?(String)
       @case_insensitive ? @values.any? { |p| p.casecmp(o) == 0 } : @values.any? { |p| p == o }
     else
       false
@@ -1549,7 +1549,7 @@ class PStringType < PScalarDataType
 
   def instance?(o, guard = nil)
     # true if size compliant
-    if o.is_a?(String)
+    if o.instance_of?(String)
       if @size_type_or_value.is_a?(PIntegerType)
         @size_type_or_value.instance?(o.size, guard)
       else
@@ -1753,7 +1753,7 @@ class PRegexpType < PScalarType
   end
 
   def instance?(o, guard=nil)
-    o.is_a?(Regexp) && @pattern.nil? || regexp == o
+    o.instance_of?(Regexp) && @pattern.nil? || regexp == o
   end
 
   DEFAULT = PRegexpType.new(nil)
@@ -1797,7 +1797,7 @@ class PPatternType < PScalarDataType
   end
 
   def instance?(o, guard = nil)
-    o.is_a?(String) && (@patterns.empty? || @patterns.any? { |p| p.regexp.match(o) })
+    o.instance_of?(String) && (@patterns.empty? || @patterns.any? { |p| p.regexp.match(o) })
   end
 
   DEFAULT = PPatternType.new(EMPTY_ARRAY)

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -695,7 +695,10 @@ class PScalarType < PAnyType
   end
 
   def instance?(o, guard = nil)
-    if o.is_a?(String) || o.is_a?(Numeric) || o.is_a?(TrueClass) || o.is_a?(FalseClass) || o.is_a?(Regexp)
+    # Numeric is the base class for several different number related classes such as Integer, Float, Fixnum and Bignum.
+    # The latter 2 are subclasses of Integer, so in this specific case we should use is_a? instead of instance_of? since we
+    # want to check child classes aswell.
+    if o.instance_of?(String) || o.is_a?(Numeric) || o.instance_of?(TrueClass) || o.instance_of?(FalseClass) || o.instance_of?(Regexp)
       true
     elsif o.instance_of?(Array) || o.instance_of?(Hash) || o.is_a?(PAnyType) || o.is_a?(NilClass)
       false
@@ -735,8 +738,8 @@ class PScalarDataType < PScalarType
     create_ptype(loader, ir, 'ScalarType')
   end
 
-  def instance?(o, guard = nil)
-    return o.is_a?(String) || o.is_a?(Integer) || o.is_a?(Float) || o.is_a?(TrueClass) || o.is_a?(FalseClass)
+  def instance?(o, guard = nil) 
+    return o.instance_of?(String) || o.is_a?(Integer) || o.is_a?(Float) || o.instance_of?(TrueClass) || o.instance_of?(FalseClass)
   end
 
   DEFAULT = PScalarDataType.new


### PR DESCRIPTION
Previously some puppet resources would be the objects of `Puppet::Util::Execution::ProcessOutput` which extends ruby String. When pops serialization checked whether a resource was a String, it used the method `is_a?`, which returned True for ProcessOutput since it is a child of String, resulting in weird yaml output.

This commit updates all the `Data` and `RichData` data types `instance?` methods to use `instance_of?` instead of `is_a?`, since it only returns True if an object is an object of the exact class, not a subclass

Output without fix:
```
puppet resource mysql_database --to_yaml
---
mysql_database:
  information_schema:
    ensure: present
    charset: !ruby/string:Puppet::Util::Execution::ProcessOutput utf8
    collate: !ruby/string:Puppet::Util::Execution::ProcessOutput utf8_general_ci
    provider: mysql
  mydb:
    ensure: present
    charset: !ruby/string:Puppet::Util::Execution::ProcessOutput utf8
    collate: !ruby/string:Puppet::Util::Execution::ProcessOutput utf8_general_ci
    provider: mysql
  mysql:
    ensure: present
    charset: !ruby/string:Puppet::Util::Execution::ProcessOutput latin1
    collate: !ruby/string:Puppet::Util::Execution::ProcessOutput latin1_swedish_ci
    provider: mysql
  performance_schema:
    ensure: present
    charset: !ruby/string:Puppet::Util::Execution::ProcessOutput utf8
    collate: !ruby/string:Puppet::Util::Execution::ProcessOutput utf8_general_ci
    provider: mysql
  test:
    ensure: present
    charset: !ruby/string:Puppet::Util::Execution::ProcessOutput latin1
    collate: !ruby/string:Puppet::Util::Execution::ProcessOutput latin1_swedish_ci
    provider: mysql
```
Output with fix:
```
bundle exec puppet resource mysql_database --to_yaml
---
mysql_database:
  information_schema:
    ensure: present
    charset: utf8
    collate: utf8_general_ci
    provider: mysql
  mydb:
    ensure: present
    charset: utf8
    collate: utf8_general_ci
    provider: mysql
  mysql:
    ensure: present
    charset: latin1
    collate: latin1_swedish_ci
    provider: mysql
  performance_schema:
    ensure: present
    charset: utf8
    collate: utf8_general_ci
    provider: mysql
  test:
    ensure: present
    charset: latin1
    collate: latin1_swedish_ci
    provider: mysql
```