### PR TITLE
(PUP-11200) Allow loading Task files from scripts mount

### DIFF
--- a/lib/puppet/module/plan.rb
+++ b/lib/puppet/module/plan.rb
@@ -50,7 +50,6 @@ class Puppet::Module
     RESERVED_DATA_TYPES = %w{any array boolean catalogentry class collection
         callable data default enum float hash integer numeric optional pattern
         resource runtime scalar string struct tuple type undef variant}
-    MOUNTS = %w[lib files plans]
 
     def self.is_plan_name?(name)
       return true if name =~ /^[a-z][a-z0-9_]*$/

--- a/lib/puppet/module/task.rb
+++ b/lib/puppet/module/task.rb
@@ -45,7 +45,7 @@ class Puppet::Module
     end
 
     FORBIDDEN_EXTENSIONS = %w{.conf .md}
-    MOUNTS = %w[lib files tasks]
+    MOUNTS = %w[files lib scripts tasks]
 
     def self.is_task_name?(name)
       return true if name =~ /^[a-z][a-z0-9_]*$/

--- a/spec/lib/puppet_spec/modules.rb
+++ b/spec/lib/puppet_spec/modules.rb
@@ -36,7 +36,7 @@ module PuppetSpec::Modules
         end
       end
 
-      if plans = options[:plans]
+      if (plans = options[:plans])
         plans_dir = File.join(module_dir, 'plans')
         FileUtils.mkdir_p(plans_dir)
         plans.each do |plan_file|
@@ -45,6 +45,17 @@ module PuppetSpec::Modules
             plan_file = { :name => plan_file, :content => "{}" }
           end
           File.write(File.join(plans_dir, plan_file[:name]), plan_file[:content])
+        end
+      end
+
+      if (scripts = options[:scripts])
+        scripts_dir = File.join(module_dir, 'scripts')
+        FileUtils.mkdir_p(scripts_dir)
+        scripts.each do |script_file|
+          if script_file.is_a?(String)
+            script_file = { :name => script_file, :content => "" }
+          end
+          File.write(File.join(scripts_dir, script_file[:name]), script_file[:content])
         end
       end
 
@@ -61,7 +72,7 @@ module PuppetSpec::Modules
       module_dir = File.join(dir, name)
       FileUtils.mkdir_p(module_dir)
 
-      if metadata = options[:metadata]
+      if (metadata = options[:metadata])
         File.open(File.join(module_dir, 'metadata.json'), 'w') do |f|
           f.write(metadata.to_json)
         end

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -567,6 +567,20 @@ describe Puppet::Module do
       expect(mod.task_file(task_exe)).to eq("#{mod.path}/tasks/#{task_exe}")
     end
 
+    it "should list files from the scripts directory if required by the task" do
+      mod         = 'loads_scripts'
+      task_dep    = 'myscript.sh'
+      script_ref  = "#{mod}/scripts/#{task_dep}"
+      task_json   = JSON.generate({'files' => [script_ref]})
+      task        = [['task', { name: 'task.json', content: task_json }]]
+      mod         = PuppetSpec::Modules.create(mod, @modpath, {:environment => env,
+                                                       :scripts     => [task_dep],
+                                                       :tasks       => task})
+
+      expect(mod.tasks.first.files).to include({'name' => script_ref,
+                                                'path' => /#{script_ref}/})
+    end
+
     it "should return nil when asked for an individual task file if it does not exist" do
       mod = PuppetSpec::Modules.create('task_file_neg', @modpath, {:environment => env,
                                                                    :tasks => []})


### PR DESCRIPTION
This adds the `scripts` mount point to the list of valid mount point to
load files specified under a Tasks `files` metadata from.