### PR TITLE
(PUP-11190) Fix user resource not removing password on AIX agents

### DIFF
--- a/lib/puppet/provider/user/aix.rb
+++ b/lib/puppet/provider/user/aix.rb
@@ -305,6 +305,10 @@ Puppet::Type.type(:user).provide :aix, :parent => Puppet::Provider::AixObject do
     FileUtils.remove_entry_secure(homedir, true)
   end
 
+  def deletecmd
+    [self.class.command(:delete), '-p'] + ia_module_args + [@resource[:name]]
+  end
+
   # UNSUPPORTED
   #- **profile_membership**
   #    Whether specified roles should be treated as the only roles

--- a/spec/unit/provider/user/aix_spec.rb
+++ b/spec/unit/provider/user/aix_spec.rb
@@ -306,4 +306,15 @@ describe 'Puppet::Type::User::Provider::Aix' do
       end
     end
   end
+
+  describe '#deletecmd' do
+    it 'uses the -p flag when removing the user' do
+      allow(provider.class).to receive(:command).with(:delete).and_return('delete')
+      allow(provider).to receive(:ia_module_args).and_return(['ia_module_args'])
+
+      expect(provider.deletecmd).to eql(
+        ['delete', '-p', 'ia_module_args', provider.resource.name]
+      )
+    end
+  end
 end


### PR DESCRIPTION
This pull requests adds the `-p` flag to the `rmuser` command, to ensure that the user's password was deleted.