### PR TITLE
(PUP-10890) Gracefully ignore empty module lookup_options

### DIFF
--- a/lib/puppet/pops/lookup/lookup_adapter.rb
+++ b/lib/puppet/pops/lookup/lookup_adapter.rb
@@ -292,7 +292,8 @@ class LookupAdapter < DataAdapter
   PROVIDER_STACK = [:lookup_global, :lookup_in_environment, :lookup_in_module].freeze
 
   def validate_lookup_options(options, module_name)
-    raise Puppet::DataBinding::LookupError.new(_("value of %{opts} must be a hash") % { opts: LOOKUP_OPTIONS }) unless options.is_a?(Hash) unless options.nil?
+    return nil if options.nil?
+    raise Puppet::DataBinding::LookupError.new(_("value of %{opts} must be a hash") % { opts: LOOKUP_OPTIONS }) unless options.is_a?(Hash)
     return options if module_name.nil?
 
     pfx = "#{module_name}::"
@@ -352,7 +353,7 @@ class LookupAdapter < DataAdapter
               module_opts = validate_lookup_options(lookup_in_module(LookupKey::LOOKUP_OPTIONS, meta_invocation, merge_strategy), module_name)
               opts = if opts.nil?
                 module_opts
-              else
+              elsif module_opts
                 merge_strategy.lookup([GLOBAL_ENV_MERGE, "Module #{lookup_invocation.module_name}"], meta_invocation) do |n|
                   meta_invocation.with(:scope, n) { meta_invocation.report_found(LOOKUP_OPTIONS,  n == GLOBAL_ENV_MERGE ? opts : module_opts) }
                 end

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -870,6 +870,46 @@ describe "The lookup function" do
       end
     end
 
+    context 'with lookup_options' do
+      let(:environment_files) do
+        {
+          env_name => {
+            'hiera.yaml' => <<-YAML.unindent,
+              ---
+              version: 5
+              YAML
+            'data' => {
+              'common.yaml' => common_yaml
+            }
+          }
+        }
+      end
+
+      context 'that are empty' do
+        let(:common_yaml) { <<-YAML.unindent }
+          lookup_options:
+          a: b
+          YAML
+
+        it 'ignores empty options' do
+          expect(lookup('a')).to eq("b")
+        end
+      end
+
+      context 'that contains a legal yaml hash with unexpected types' do
+        let(:common_yaml) { <<-YAML.unindent }
+          lookup_options:
+            :invalid_symbol
+          YAML
+
+        it 'fails lookup and reports a type mismatch' do
+          expect {
+            lookup('a')
+          }.to raise_error(Puppet::DataBinding::LookupError, /has wrong type, expects Puppet::LookupValue, got Runtime\[ruby, 'Symbol'\]/)
+        end
+      end
+    end
+
     context 'with lookup_options configured using patterns' do
       let(:mod_common) {
         <<-YAML.unindent
@@ -1017,6 +1057,31 @@ describe "The lookup function" do
             'bca' => 'bca (from environment)'
           }
         })
+      end
+
+      context 'and lookup_options is empty' do
+        let(:mod_common) { <<-YAML.unindent }
+          lookup_options:
+          mod::a: b
+          YAML
+
+        it 'ignores empty options' do
+          pending
+          expect(lookup('mod::a')).to eq("b")
+        end
+      end
+
+      context 'and lookup_options contains a legal hash with unexpected types' do
+        let(:mod_common) { <<-YAML.unindent }
+          lookup_options:
+            :invalid_symbol
+          YAML
+
+        it 'fails lookup and reports a type mismatch' do
+          expect {
+            lookup('mod::a')
+          }.to raise_error(Puppet::DataBinding::LookupError, /has wrong type, expects Puppet::LookupValue, got Runtime\[ruby, 'Symbol'\]/)
+        end
       end
 
       context 'and patterns in module are not limited to module keys' do

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -1066,7 +1066,6 @@ describe "The lookup function" do
           YAML
 
         it 'ignores empty options' do
-          pending
           expect(lookup('mod::a')).to eq("b")
         end
       end


### PR DESCRIPTION
If module lookup_options are empty, then lookup failed with:

    NoMethodError: undefined method `each_pair' for nil:NilClass

Now module lookup_options are ignored in the same way they would be if they were not there.

Also adds some tests to assert environment and module lookup_options reject invalid `LookupKey` data types.