### PR TITLE
(PUP-6708) Ensure last run report is always saved

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -493,7 +493,14 @@ class Puppet::Configurer
   def send_report(report)
     puts report.summary if Puppet[:summarize]
     save_last_run_summary(report)
-    Puppet::Transaction::Report.indirection.save(report, nil, :environment => Puppet::Node::Environment.remote(@environment)) if Puppet[:report]
+    if Puppet[:report]
+      remote = Puppet::Node::Environment.remote(@environment)
+      begin
+        Puppet::Transaction::Report.indirection.save(report, nil, ignore_cache: true, environment: remote)
+      ensure
+        Puppet::Transaction::Report.indirection.save(report, nil, ignore_terminus: true, environment: remote)
+      end
+    end
   rescue => detail
     Puppet.log_exception(detail, _("Could not send report: %{detail}") % { detail: detail })
   end

--- a/lib/puppet/indirector/indirection.rb
+++ b/lib/puppet/indirector/indirection.rb
@@ -313,7 +313,7 @@ class Puppet::Indirector::Indirection
     request = request(:save, key, instance, options)
     terminus = prepare(request)
 
-    result = terminus.save(request)
+    result = terminus.save(request) if !request.ignore_terminus?
 
     # If caching is enabled, save our document there
     cache.save(request) if cache? && !request.ignore_cache_save?

--- a/spec/integration/application/agent_spec.rb
+++ b/spec/integration/application/agent_spec.rb
@@ -623,6 +623,22 @@ describe "puppet agent", unless: Puppet::Util::Platform.jruby? do
         expect(report.metrics).to_not be_empty
       end
     end
+
+    it "caches a report even if the REST request fails" do
+      server.start_server do |port|
+        Puppet[:serverport] = port
+        Puppet[:report_port] = "-1"
+        expect {
+          agent.command_line.args << '--test'
+          agent.run
+        }.to exit_with(0)
+         .and output(%r{Applied catalog}).to_stdout
+         .and output(%r{Could not send report}).to_stderr
+
+        report = Puppet::Transaction::Report.convert_from(:yaml, File.read(Puppet[:lastrunreport]))
+        expect(report).to be
+      end
+    end
   end
 
   context "environment convergence" do

--- a/spec/integration/configurer_spec.rb
+++ b/spec/integration/configurer_spec.rb
@@ -23,7 +23,7 @@ describe Puppet::Configurer do
       expect(Puppet::Transaction::Report.indirection).to receive(:save) do |report, x|
         expect(report.time).to be_a(Time)
         expect(report.logs.length).to be > 0
-      end
+      end.twice
 
       Puppet[:report] = true
 

--- a/spec/integration/transaction/report_spec.rb
+++ b/spec/integration/transaction/report_spec.rb
@@ -48,7 +48,7 @@ describe Puppet::Transaction::Report do
       expect(Puppet::Transaction::Report.indirection).to receive(:save) do |report, x|
         last_run_report = report
         true
-      end.twice
+      end.exactly(4)
 
       Puppet[:report] = true
       Puppet[:noop] = noop1

--- a/spec/unit/indirector/indirection_spec.rb
+++ b/spec/unit/indirector/indirection_spec.rb
@@ -499,7 +499,7 @@ describe Puppet::Indirector::Indirection do
         end
 
         it "should return the result of saving to the terminus" do
-          request = double('request', :instance => @instance, :node => nil, :ignore_cache_save? => false)
+          request = double('request', :instance => @instance, :node => nil, :ignore_cache_save? => false, :ignore_terminus? => false)
 
           expect(@indirection).to receive(:request).and_return(request)
 
@@ -509,7 +509,7 @@ describe Puppet::Indirector::Indirection do
         end
 
         it "should use a request to save the object to the cache" do
-          request = double('request', :instance => @instance, :node => nil, :ignore_cache_save? => false)
+          request = double('request', :instance => @instance, :node => nil, :ignore_cache_save? => false, :ignore_terminus? => false)
 
           expect(@indirection).to receive(:request).and_return(request)
 
@@ -519,7 +519,7 @@ describe Puppet::Indirector::Indirection do
         end
 
         it "should not save to the cache if the normal save fails" do
-          request = double('request', :instance => @instance, :node => nil)
+          request = double('request', :instance => @instance, :node => nil, :ignore_terminus? => false)
 
           expect(@indirection).to receive(:request).and_return(request)
 
@@ -533,6 +533,13 @@ describe Puppet::Indirector::Indirection do
           expect(@cache).not_to receive(:save)
 
           @indirection.save(@instance, '/my/key', :ignore_cache_save => true)
+        end
+
+        it "should only save to the cache if the request specifies not to use the terminus" do
+          expect(@terminus).not_to receive(:save)
+          expect(@cache).to receive(:save)
+
+          @indirection.save(@instance, "/my/key", :ignore_terminus => true)
         end
       end
     end


### PR DESCRIPTION
Always cache the last run report, even if the REST request to the report server fails.