### PR TITLE
(PUP-11196) Remove BOM warning when using US-ASCII encoding

### DIFF
--- a/lib/puppet/file_system/file_impl.rb
+++ b/lib/puppet/file_system/file_impl.rb
@@ -84,7 +84,9 @@ class Puppet::FileSystem::FileImpl
   end
 
   def read_preserve_line_endings(path)
-    read(path, encoding: "bom|#{Encoding.default_external.name}")
+    default_encoding = Encoding.default_external.name
+    encoding = default_encoding.downcase.start_with?('utf-') ? "bom|#{default_encoding}" : default_encoding
+    read(path, encoding: encoding)
   end
 
   def binread(path)

--- a/spec/unit/file_system_spec.rb
+++ b/spec/unit/file_system_spec.rb
@@ -296,6 +296,13 @@ describe "Puppet::FileSystem" do
         expect(Puppet::FileSystem.read_preserve_line_endings(file)).to eq("file content \n")
       end
     end
+
+    it "should not warn about misusage of BOM with non-UTF encoding" do
+      allow(Encoding).to receive(:default_external).and_return(Encoding::US_ASCII)
+      with_file_content("file content \n") do |file|
+        expect{ Puppet::FileSystem.read_preserve_line_endings(file) }.not_to output(/BOM with non-UTF encoding US-ASCII is nonsense/).to_stderr
+      end
+    end
   end
 
   context "read without an encoding specified" do


### PR DESCRIPTION
Since ASCII characters are single bytes, there is no need for a BOM to detect byte ordering (LSB/MSB). Before this commit, `Puppet::FileSystem.read_preserve_line_endings` method was always adding this and causing the following warning:
```
BOM with non-UTF encoding US-ASCII is nonsense
```