### PR TITLE
(PUP-11216) Add support for multiple facter impl

### DIFF
--- a/lib/puppet/facter_impl.rb
+++ b/lib/puppet/facter_impl.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+#
+# @api private
+# Default Facter implementation that delegates to Facter API
+#
+
+module Puppet
+  class FacterImpl
+    def initialize
+      require 'facter'
+    end
+
+    def value(fact_name)
+      ::Facter.value(fact_name)
+    end
+
+    def add(name, &block)
+      ::Facter.add(name, &block)
+    end
+  end
+end

--- a/lib/puppet/runtime.rb
+++ b/lib/puppet/runtime.rb
@@ -1,4 +1,5 @@
 require 'puppet/http'
+require 'puppet/facter_impl'
 require 'singleton'
 
 # Provides access to runtime implementations.
@@ -17,7 +18,8 @@ class Puppet::Runtime
         else
           Puppet::HTTP::ExternalClient.new(klass)
         end
-      end
+      end,
+      facter: proc { Puppet::FacterImpl.new }
     }
   end
   private :initialize

--- a/spec/unit/facter_impl_spec.rb
+++ b/spec/unit/facter_impl_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe 'Puppet::FacterImpl' do
+  subject(:facter_impl) { Puppet::FacterImpl.new }
+
+  it { is_expected.to respond_to(:value) }
+  it { is_expected.to respond_to(:add) }
+
+  describe '.value' do
+    let(:method_name) { :value }
+
+    before { allow(Facter).to receive(method_name) }
+
+    it 'delegates to Facter API' do
+      facter_impl.value('test_fact')
+      expect(Facter).to have_received(method_name).with('test_fact')
+    end
+  end
+
+  describe '.add' do
+    let(:block) { Proc.new { setcode 'test' } }
+    let(:method_name) { :add }
+
+    before { allow(Facter).to receive(method_name) }
+
+    it 'delegates to Facter API' do
+      facter_impl.add('test_fact', &block)
+      expect(Facter).to have_received(method_name).with('test_fact', &block)
+    end
+  end
+end

--- a/spec/unit/puppet_spec.rb
+++ b/spec/unit/puppet_spec.rb
@@ -91,12 +91,20 @@ describe Puppet do
       expect(Puppet.runtime[:http]).to be_an_instance_of(Puppet::HTTP::Client)
     end
 
-    it 'allows an implementation to be registered' do
-      impl = double('http')
-      Puppet.initialize_settings([], true, true, http: impl)
+    it 'allows a http implementation to be registered' do
+      http_impl = double('http')
+      Puppet.initialize_settings([], true, true, http: http_impl)
 
 
-      expect(Puppet.runtime[:http]).to eq(impl)
+      expect(Puppet.runtime[:http]).to eq(http_impl)
+    end
+
+    it 'allows a facter implementation to be registered' do
+      facter_impl = double('facter')
+      Puppet.initialize_settings([], true, true, facter: facter_impl)
+
+
+      expect(Puppet.runtime[:facter]).to eq(facter_impl)
     end
   end
 


### PR DESCRIPTION
Add support for multiple facter implementations and
provide default FacterImpl that is used to delegate
all methods to Facter.

Any client can register its own Facter implementation:

```
Puppet.initialize_settings([], true, true, facter: facter_impl)
```