### PR TITLE
(maint) Make documentation group optional

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ group(:packaging) do
   gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.99')
 end
 
-group(:documentation) do
+group(:documentation, optional: true) do
   gem 'gettext-setup', '~> 0.28', require: false, platforms: [:ruby]
   gem 'ronn', '~> 0.7.3', require: false, platforms: [:ruby]
 end


### PR DESCRIPTION
Puppet does not depend on the ronn or gettext-setup gems, though they
are used in CI to automate man page generation and updating the pot
file, respectively. So change the group to be optional. To include the
gems use `bundle install --with documentation`.