### PR TITLE
(maint) Accept 0 digit

### DIFF
--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -191,7 +191,7 @@ describe Puppet::Configurer do
       }
       Puppet::Node::Facts.indirection.save(facts)
 
-      expect(Puppet).to receive(:warning).with(/Payload with the current size of: '[1-9]*' exceeds the payload size limit: [1-9]*/)
+      expect(Puppet).to receive(:warning).with(/Payload with the current size of: '\d*' exceeds the payload size limit: \d*/)
       configurer.run
     end
 


### PR DESCRIPTION
CI was failing due to a fact of size 410 not matching the regex [1-9]*. Use \d
to match digits.