### PR TITLE
(maint) Mergeup 6.x to main

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -12,7 +12,6 @@ $LOAD_PATH.extend(Puppet::Concurrent::Synchronized)
 # see the bottom of the file for further inclusions
 # Also see the new Vendor support - towards the end
 #
-require 'facter'
 require_relative 'puppet/error'
 require_relative 'puppet/util'
 require_relative 'puppet/util/autoload'
@@ -87,9 +86,6 @@ module Puppet
 
   require_relative 'puppet/util/logging'
   extend Puppet::Util::Logging
-
-  # Setup facter's logging
-  Puppet::Util::Logging.setup_facter_logging!
 
   # The feature collection
   @features = Puppet::Util::Feature.new('puppet/feature')
@@ -193,11 +189,11 @@ module Puppet
   def self.initialize_facts
     # Add the puppetversion fact; this is done before generating the hash so it is
     # accessible to custom facts.
-    Facter.add(:puppetversion) do
+    Puppet.runtime[:facter].add(:puppetversion) do
       setcode { Puppet.version.to_s }
     end
 
-    Facter.add(:agent_specified_environment) do
+    Puppet.runtime[:facter].add(:agent_specified_environment) do
       setcode do
         Puppet.settings.set_by_cli(:environment) ||
           Puppet.settings.set_in_section(:environment, :agent) ||

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -611,7 +611,7 @@ class Puppet::Configurer
   # @return [false] If an exception is raised during fact generation or
   #   submission.
   def resubmit_facts
-    ::Facter.clear
+    Puppet.runtime[:facter].clear
     facts = find_facts
 
     client = Puppet.runtime[:http]

--- a/lib/puppet/confine/variable.rb
+++ b/lib/puppet/confine/variable.rb
@@ -18,7 +18,7 @@ class Puppet::Confine::Variable < Puppet::Confine
 
   # Retrieve the value from facter
   def facter_value
-    @facter_value ||= ::Facter.value(name).to_s.downcase
+    @facter_value ||= Puppet.runtime[:facter].value(name).to_s.downcase
   end
 
   def initialize(values)

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -3,7 +3,7 @@ require_relative '../puppet/util/platform'
 module Puppet
 
   def self.default_diffargs
-    if (Facter.value(:kernel) == "AIX" && Facter.value(:kernelmajversion) == "5300")
+    if (Puppet.runtime[:facter].value(:kernel) == "AIX" && Puppet.runtime[:facter].value(:kernelmajversion) == "5300")
       ""
     else
       "-u"
@@ -243,7 +243,7 @@ module Puppet
           internal Ruby stack trace interleaved with Puppet function frames.",
         :hook     => proc do |value|
           # Enable or disable Facter's trace option too
-          Facter.trace(value) if Facter.respond_to? :trace
+          Puppet.runtime[:facter].trace(value)
         end
     },
     :puppet_trace => {
@@ -1971,7 +1971,7 @@ EOT
       :call_hook => :on_initialize_and_write, # Call our hook with the default value, so we always get the value added to facter.
       :hook => proc do |value|
         paths = value.split(File::PATH_SEPARATOR)
-        Facter.search(*paths)
+        Puppet.runtime[:facter].search(*paths)
       end
     }
   )

--- a/lib/puppet/facter_impl.rb
+++ b/lib/puppet/facter_impl.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+#
+# @api private
+# Default Facter implementation that delegates to Facter API
+#
+
+module Puppet
+  class FacterImpl
+    def initialize
+      require 'facter'
+
+      setup_logging
+    end
+
+    def value(fact_name)
+      ::Facter.value(fact_name)
+    end
+
+    def add(name, &block)
+      ::Facter.add(name, &block)
+    end
+
+    def to_hash
+      ::Facter.to_hash
+    end
+
+    def clear
+      ::Facter.clear
+    end
+
+    def reset
+      ::Facter.reset
+    end
+
+    def resolve(options)
+      ::Facter.resolve(options)
+    end
+
+    def search_external(dirs)
+      ::Facter.search_external(dirs)
+    end
+
+    def search(*dirs)
+      ::Facter.search(*dirs)
+    end
+
+    def trace(value)
+      ::Facter.trace(value) if ::Facter.respond_to? :trace
+    end
+
+    def debugging(value)
+      ::Facter.debugging(value) if ::Facter.respond_to?(:debugging)
+    end
+
+    def load_external?
+      ::Facter.respond_to?(:load_external)
+    end
+
+    def load_external(value)
+      ::Facter.load_external(value) if self.load_external?
+    end
+
+    private
+
+    def setup_logging
+      return unless ::Facter.respond_to? :on_message
+
+      ::Facter.on_message do |level, message|
+        case level
+        when :trace, :debug
+          level = :debug
+        when :info
+          # Same as Puppet
+        when :warn
+          level = :warning
+        when :error
+          level = :err
+        when :fatal
+          level = :crit
+        else
+          next
+        end
+
+        Puppet::Util::Log.create(
+          {
+            :level => level,
+            :source => 'Facter',
+            :message => message
+          }
+        )
+        nil
+      end
+    end
+  end
+end

--- a/lib/puppet/file_serving/mount/file.rb
+++ b/lib/puppet/file_serving/mount/file.rb
@@ -3,12 +3,12 @@ require_relative '../../../puppet/file_serving/mount'
 class Puppet::FileServing::Mount::File < Puppet::FileServing::Mount
   def self.localmap
     @localmap ||= {
-      "h" => Facter.value("hostname"),
+      "h" => Puppet.runtime[:facter].value("hostname"),
       "H" => [
-               Facter.value("hostname"),
-               Facter.value("domain")
+               Puppet.runtime[:facter].value("hostname"),
+               Puppet.runtime[:facter].value("domain")
              ].join("."),
-      "d" => Facter.value("domain")
+      "d" => Puppet.runtime[:facter].value("domain")
     }
   end
 

--- a/lib/puppet/forge.rb
+++ b/lib/puppet/forge.rb
@@ -213,7 +213,7 @@ class Puppet::Forge < SemanticPuppet::Dependency::Source
     end
 
     def validate_checksum(file, checksum, digest_class)
-      if Facter.value(:fips_enabled) && digest_class == Digest::MD5
+      if Puppet.runtime[:facter].value(:fips_enabled) && digest_class == Digest::MD5
         raise _("Module install using MD5 is prohibited in FIPS mode.")
       end
 

--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -433,17 +433,17 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
       "serverip"  => "ipaddress",
       "serverip6" => "ipaddress6"
     }.each do |var, fact|
-      value = Facter.value(fact)
+      value = Puppet.runtime[:facter].value(fact)
       if !value.nil?
         @server_facts[var] = value
       end
     end
 
     if @server_facts["servername"].nil?
-      host = Facter.value(:hostname)
+      host = Puppet.runtime[:facter].value(:hostname)
       if host.nil?
         Puppet.warning _("Could not retrieve fact servername")
-      elsif domain = Facter.value(:domain) #rubocop:disable Lint/AssignmentInCondition
+      elsif domain = Puppet.runtime[:facter].value(:domain) #rubocop:disable Lint/AssignmentInCondition
         @server_facts["servername"] = [host, domain].join(".")
       else
         @server_facts["servername"] = host

--- a/lib/puppet/indirector/facts/facter.rb
+++ b/lib/puppet/indirector/facts/facter.rb
@@ -20,10 +20,10 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
 
   # Lookup a host's facts up in Facter.
   def find(request)
-    Facter.reset
+    Puppet.runtime[:facter].reset
 
     # Note: we need to setup puppet's external search paths before adding the puppetversion
-    # fact. This is because in Facter 2.x, the first `Facter.add` causes Facter to create
+    # fact. This is because in Facter 2.x, the first `Puppet.runtime[:facter].add` causes Facter to create
     # its directory loaders which cannot be changed, meaning other external facts won't
     # be resolved. (PUP-4607)
     self.class.setup_external_search_paths(request)
@@ -36,7 +36,7 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
                raise(Puppet::Error, _("puppet facts show requires version 4.0.40 or greater of Facter.")) unless Facter.respond_to?(:resolve)
                find_with_options(request)
              else
-               Puppet::Node::Facts.new(request.key, Facter.to_hash)
+               Puppet::Node::Facts.new(request.key, Puppet.runtime[:facter].to_hash)
              end
 
     result.add_local_facts unless request.options[:resolve_options]
@@ -68,7 +68,7 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
       true
     end
     dirs << request.options[:custom_dir] if request.options[:custom_dir]
-    Facter.search(*dirs)
+    Puppet.runtime[:facter].search(*dirs)
   end
 
   def self.setup_external_search_paths(request)
@@ -90,7 +90,7 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
     end
 
     dirs << request.options[:external_dir] if request.options[:external_dir]
-    Facter.search_external dirs
+    Puppet.runtime[:facter].search_external dirs
   end
 
   private
@@ -105,6 +105,6 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
     options_for_facter += " --no-cache" if options[:no_cache] == false
     options_for_facter += " --timing" if options[:timing]
 
-    Puppet::Node::Facts.new(request.key, Facter.resolve(options_for_facter))
+    Puppet::Node::Facts.new(request.key, Puppet.runtime[:facter].resolve(options_for_facter))
   end
 end

--- a/lib/puppet/module_tool/applications/uninstaller.rb
+++ b/lib/puppet/module_tool/applications/uninstaller.rb
@@ -89,7 +89,7 @@ module Puppet::ModuleTool
         mod = @installed.first
 
         unless @ignore_changes
-          raise _("Either the `--ignore_changes` or `--force` argument must be specified to uninstall modules when running in FIPS mode.") if Facter.value(:fips_enabled)
+          raise _("Either the `--ignore_changes` or `--force` argument must be specified to uninstall modules when running in FIPS mode.") if Puppet.runtime[:facter].value(:fips_enabled)
 
           changes = begin
             Puppet::ModuleTool::Applications::Checksummer.run(mod.path)

--- a/lib/puppet/module_tool/applications/upgrader.rb
+++ b/lib/puppet/module_tool/applications/upgrader.rb
@@ -27,7 +27,7 @@ module Puppet::ModuleTool
 
       def run
         # Disallow anything that invokes md5 to avoid un-friendly termination due to FIPS
-        raise _("Module upgrade is prohibited in FIPS mode.") if Facter.value(:fips_enabled)
+        raise _("Module upgrade is prohibited in FIPS mode.") if Puppet.runtime[:facter].value(:fips_enabled)
 
         name = @name.tr('/', '-')
         version = options[:version] || '>= 0.0.0'

--- a/lib/puppet/pal/pal_impl.rb
+++ b/lib/puppet/pal/pal_impl.rb
@@ -415,7 +415,7 @@ module Pal
 
     # Puppet requires Facter, which initializes its lookup paths. Reset Facter to
     # pickup the new $LOAD_PATH.
-    Facter.reset
+    Puppet.runtime[:facter].reset
 
     node = Puppet.lookup(:pal_current_node)
     pal_facts = Puppet.lookup(:pal_facts)

--- a/lib/puppet/provider.rb
+++ b/lib/puppet/provider.rb
@@ -289,7 +289,7 @@ class Puppet::Provider
   #   values. Given one or more Regexp instances, fact is compared via the basic
   #   pattern-matching operator.
   def self.fact_match(fact, values)
-    fact_val = Facter.value(fact).to_s.downcase
+    fact_val = Puppet.runtime[:facter].value(fact).to_s.downcase
     if fact_val.empty?
       return false
     else

--- a/lib/puppet/provider/group/groupadd.rb
+++ b/lib/puppet/provider/group/groupadd.rb
@@ -9,7 +9,7 @@ Puppet::Type.type(:group).provide :groupadd, :parent => Puppet::Provider::NameSe
 
   commands :add => "groupadd", :delete => "groupdel", :modify => "groupmod"
 
-  has_feature :system_groups unless %w{HP-UX Solaris}.include? Facter.value(:operatingsystem)
+  has_feature :system_groups unless %w{HP-UX Solaris}.include? Puppet.runtime[:facter].value(:operatingsystem)
 
   verify :gid, _("GID must be an integer") do |value|
     value.is_a? Integer

--- a/lib/puppet/provider/package/pkg.rb
+++ b/lib/puppet/provider/package/pkg.rb
@@ -228,7 +228,7 @@ Puppet::Type.type(:package).provide :pkg, :parent => Puppet::Provider::Package d
       command = 'update'
     end
     args = ['--accept']
-    if Puppet::Util::Package.versioncmp(Facter.value(:operatingsystemrelease), '11.2') >= 0
+    if Puppet::Util::Package.versioncmp(Puppet.runtime[:facter].value(:operatingsystemrelease), '11.2') >= 0
       args.push('--sync-actuators-timeout', '900')
     end
     args.concat(join_options(@resource[:install_options])) if @resource[:install_options]

--- a/lib/puppet/provider/package/puppet_gem.rb
+++ b/lib/puppet/provider/package/puppet_gem.rb
@@ -4,7 +4,7 @@ Puppet::Type.type(:package).provide :puppet_gem, :parent => :gem do
 
   has_feature :versionable, :install_options, :uninstall_options
 
-  confine :true => Facter.value(:aio_agent_version)
+  confine :true => Puppet.runtime[:facter].value(:aio_agent_version)
 
   def self.windows_gemcmd
     puppet_dir = Puppet::Util.get_env('PUPPET_DIR')

--- a/lib/puppet/provider/package/puppetserver_gem.rb
+++ b/lib/puppet/provider/package/puppetserver_gem.rb
@@ -145,7 +145,7 @@ Puppet::Type.type(:package).provide :puppetserver_gem, :parent => :gem do
 
     pe_puppetserver_conf_file = '/etc/puppetlabs/puppetserver/conf.d/pe-puppet-server.conf'
     os_puppetserver_conf_file = '/etc/puppetlabs/puppetserver/puppetserver.conf'
-    puppetserver_conf_file = Facter.value(:pe_server_version) ? pe_puppetserver_conf_file : os_puppetserver_conf_file
+    puppetserver_conf_file = Puppet.runtime[:facter].value(:pe_server_version) ? pe_puppetserver_conf_file : os_puppetserver_conf_file
     puppetserver_conf = Hocon.load(puppetserver_conf_file)
 
     gem_env = {}

--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -298,7 +298,7 @@ defaultfor :osfamily => :redhat, :operatingsystemmajrelease => (4..7).to_a
 
     # Yum on el-4 and el-5 returns exit status 0 when trying to install a package it doesn't recognize;
     # ensure we capture output to check for errors.
-    no_debug = if Facter.value(:operatingsystemmajrelease).to_i > 5 then ["-d", "0"] else [] end
+    no_debug = if Puppet.runtime[:facter].value(:operatingsystemmajrelease).to_i > 5 then ["-d", "0"] else [] end
     command = [command(:cmd)] + no_debug + ["-e", error_level, "-y", install_options, operation, wanted].compact
     output = execute(command)
 

--- a/lib/puppet/provider/service/base.rb
+++ b/lib/puppet/provider/service/base.rb
@@ -15,7 +15,7 @@ Puppet::Type.type(:service).provide :base, :parent => :service do
   # ported from the facter 2.x implementation, since facter 3.x
   # is dropping the fact (for which this was the only use)
   def getps
-    case Facter.value(:operatingsystem)
+    case Puppet.runtime[:facter].value(:operatingsystem)
     when 'OpenWrt'
       'ps www'
     when 'FreeBSD', 'NetBSD', 'OpenBSD', 'Darwin', 'DragonFly'

--- a/lib/puppet/provider/service/init.rb
+++ b/lib/puppet/provider/service/init.rb
@@ -4,7 +4,7 @@ Puppet::Type.type(:service).provide :init, :parent => :base do
   desc "Standard `init`-style service management."
 
   def self.defpath
-    case Facter.value(:operatingsystem)
+    case Puppet.runtime[:facter].value(:operatingsystem)
     when "FreeBSD", "DragonFly"
       ["/etc/rc.d", "/usr/local/etc/rc.d"]
     when "HP-UX"
@@ -21,8 +21,8 @@ Puppet::Type.type(:service).provide :init, :parent => :base do
   # Debian and Ubuntu should use the Debian provider.
   # RedHat systems should use the RedHat provider.
   confine :true => begin
-      os = Facter.value(:operatingsystem).downcase
-      family = Facter.value(:osfamily).downcase
+      os = Puppet.runtime[:facter].value(:operatingsystem).downcase
+      family = Puppet.runtime[:facter].value(:osfamily).downcase
       !(os == 'debian' || os == 'ubuntu' || family == 'redhat')
   end
 
@@ -54,7 +54,7 @@ Puppet::Type.type(:service).provide :init, :parent => :base do
     # these excludes were found with grep -r -L start /etc/init.d
     excludes += %w{rcS module-init-tools}
     # Prevent puppet failing on unsafe scripts from Yocto Linux
-    if Facter.value(:osfamily) == "cisco-wrlinux"
+    if Puppet.runtime[:facter].value(:osfamily) == "cisco-wrlinux"
       excludes += %w{banner.sh bootmisc.sh checkroot.sh devpts.sh dmesg.sh
                    hostname.sh mountall.sh mountnfs.sh populate-volatile.sh
                    rmnologin.sh save-rtc.sh sendsigs sysfs.sh umountfs
@@ -171,7 +171,7 @@ Puppet::Type.type(:service).provide :init, :parent => :base do
   end
 
   def service_execute(type, command, fof = true, squelch = false, combine = true)
-    if type == :start && Facter.value(:osfamily) == "Solaris"
+    if type == :start && Puppet.runtime[:facter].value(:osfamily) == "Solaris"
         command =  ["/usr/bin/ctrun -l child", command].flatten.join(" ")
     end
     super(type, command, fof, squelch, combine)

--- a/lib/puppet/provider/service/launchd.rb
+++ b/lib/puppet/provider/service/launchd.rb
@@ -70,7 +70,7 @@ Puppet::Type.type(:service).provide :launchd, :parent => :base do
   #
   # @api private
   def self.get_os_version
-    @os_version ||= Facter.value(:operatingsystemmajrelease).to_i
+    @os_version ||= Puppet.runtime[:facter].value(:operatingsystemmajrelease).to_i
   end
 
   # Defines the path to the overrides plist file where service enabling

--- a/lib/puppet/provider/service/redhat.rb
+++ b/lib/puppet/provider/service/redhat.rb
@@ -35,7 +35,7 @@ Puppet::Type.type(:service).provide :redhat, :parent => :init, :source => :init 
     # For Suse OS family, chkconfig returns 0 even if the service is disabled or non-existent
     # Therefore, check the output for '<name>  on' (or '<name>  B for boot services)
     # to see if it is enabled
-    return :false unless Facter.value(:osfamily) != 'Suse' || output =~ /^#{name}\s+(on|B)$/
+    return :false unless Puppet.runtime[:facter].value(:osfamily) != 'Suse' || output =~ /^#{name}\s+(on|B)$/
 
     :true
   end

--- a/lib/puppet/provider/service/smf.rb
+++ b/lib/puppet/provider/service/smf.rb
@@ -101,14 +101,14 @@ Puppet::Type.type(:service).provide :smf, :parent => :base do
 
   # Returns true if the provider supports incomplete services.
   def supports_incomplete_services?
-    Puppet::Util::Package.versioncmp(Facter.value(:operatingsystemrelease), '11.1') >= 0
+    Puppet::Util::Package.versioncmp(Puppet.runtime[:facter].value(:operatingsystemrelease), '11.1') >= 0
   end
 
   # Returns true if the service is complete. A complete service is a service that
   # has the general/complete property defined.
   def complete_service?
     unless supports_incomplete_services?
-      raise Puppet::Error, _("Cannot query if the %{service} service is complete: The concept of complete/incomplete services was introduced in Solaris 11.1. You are on a Solaris %{release} machine.") % { service: @resource[:name], release: Facter.value(:operatingsystemrelease) }
+      raise Puppet::Error, _("Cannot query if the %{service} service is complete: The concept of complete/incomplete services was introduced in Solaris 11.1. You are on a Solaris %{release} machine.") % { service: @resource[:name], release: Puppet.runtime[:facter].value(:operatingsystemrelease) }
     end
 
     return @complete_service if @complete_service
@@ -138,7 +138,7 @@ Puppet::Type.type(:service).provide :smf, :parent => :base do
   end
 
   def restartcmd
-    if Puppet::Util::Package.versioncmp(Facter.value(:operatingsystemrelease), '11.2') >= 0
+    if Puppet::Util::Package.versioncmp(Puppet.runtime[:facter].value(:operatingsystemrelease), '11.2') >= 0
       [command(:adm), :restart, "-s", self.service_fmri]
     else
       # Synchronous restart only supported in Solaris 11.2 and above

--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -110,7 +110,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
     # The indirect state indicates that the unit is not enabled.
     return :false if output == 'indirect'
     return :true if (code == 0)
-    if (output.empty?) && (code > 0) && (Facter.value(:osfamily).casecmp('debian').zero?)
+    if (output.empty?) && (code > 0) && (Puppet.runtime[:facter].value(:osfamily).casecmp('debian').zero?)
       ret = debian_enabled?
       return ret if ret
     end

--- a/lib/puppet/provider/service/upstart.rb
+++ b/lib/puppet/provider/service/upstart.rb
@@ -10,10 +10,10 @@ Puppet::Type.type(:service).provide :upstart, :parent => :debian do
   "
 
   confine :any => [
-    Facter.value(:operatingsystem) == 'Ubuntu',
-    (Facter.value(:osfamily) == 'RedHat' and Facter.value(:operatingsystemrelease) =~ /^6\./),
-    (Facter.value(:operatingsystem) == 'Amazon' and Facter.value(:operatingsystemmajrelease) =~ /\d{4}/),
-    Facter.value(:operatingsystem) == 'LinuxMint',
+    Puppet.runtime[:facter].value(:operatingsystem) == 'Ubuntu',
+    (Puppet.runtime[:facter].value(:osfamily) == 'RedHat' and Puppet.runtime[:facter].value(:operatingsystemrelease) =~ /^6\./),
+    (Puppet.runtime[:facter].value(:operatingsystem) == 'Amazon' and Puppet.runtime[:facter].value(:operatingsystemmajrelease) =~ /\d{4}/),
+    Puppet.runtime[:facter].value(:operatingsystem) == 'LinuxMint',
   ]
 
   defaultfor :operatingsystem => :ubuntu, :operatingsystemmajrelease => ["10.04", "12.04", "14.04", "14.10"]
@@ -57,7 +57,7 @@ Puppet::Type.type(:service).provide :upstart, :parent => :debian do
 
   def self.excludes
     excludes = super
-    if Facter.value(:osfamily) == 'RedHat'
+    if Puppet.runtime[:facter].value(:osfamily) == 'RedHat'
       # Puppet cannot deal with services that have instances, so we have to
       # ignore these services using instances on redhat based systems.
       excludes += %w[serial tty]

--- a/lib/puppet/provider/user/directoryservice.rb
+++ b/lib/puppet/provider/user/directoryservice.rb
@@ -159,7 +159,7 @@ Puppet::Type.type(:user).provide :directoryservice do
   end
 
   def self.get_os_version
-    @os_version ||= Facter.value(:macosx_productversion_major)
+    @os_version ||= Puppet.runtime[:facter].value(:macosx_productversion_major)
   end
 
   # Use dscl to retrieve an array of hashes containing attributes about all

--- a/lib/puppet/provider/user/useradd.rb
+++ b/lib/puppet/provider/user/useradd.rb
@@ -24,13 +24,13 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
   options :expiry, :method => :sp_expire,
     :munge => proc { |value|
       if value == :absent
-        if Facter.value(:operatingsystem)=='SLES' && Facter.value(:operatingsystemmajrelease) == "11"
+        if Puppet.runtime[:facter].value(:operatingsystem)=='SLES' && Puppet.runtime[:facter].value(:operatingsystemmajrelease) == "11"
           -1
         else
           ''
         end
       else
-        case Facter.value(:operatingsystem)
+        case Puppet.runtime[:facter].value(:operatingsystem)
         when 'Solaris'
           # Solaris uses %m/%d/%Y for useradd/usermod
           expiry_year, expiry_month, expiry_day = value.split('-')
@@ -196,7 +196,7 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
   end
 
   has_features :manages_homedir, :allows_duplicates, :manages_expiry
-  has_features :system_users unless %w{HP-UX Solaris}.include? Facter.value(:operatingsystem)
+  has_features :system_users unless %w{HP-UX Solaris}.include? Puppet.runtime[:facter].value(:operatingsystem)
 
   has_features :manages_passwords, :manages_password_age if Puppet.features.libshadow?
   has_features :manages_shell
@@ -231,8 +231,8 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
       # libuser does not implement the -m flag
       cmd << "-m" unless @resource.forcelocal?
     else
-      osfamily = Facter.value(:osfamily)
-      osversion = Facter.value(:operatingsystemmajrelease).to_i
+      osfamily = Puppet.runtime[:facter].value(:osfamily)
+      osversion = Puppet.runtime[:facter].value(:operatingsystemmajrelease).to_i
       # SLES 11 uses pwdutils instead of shadow, which does not have -M
       # Solaris and OpenBSD use different useradd flavors
       unless osfamily =~ /Solaris|OpenBSD/ || osfamily == 'Suse' && osversion <= 11
@@ -330,7 +330,7 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
       cmd = [command(:delete)]
     end
     # Solaris `userdel -r` will fail if the homedir does not exist.
-    if @resource.managehome? && (('Solaris' != Facter.value(:operatingsystem)) || Dir.exist?(Dir.home(@resource[:name])))
+    if @resource.managehome? && (('Solaris' != Puppet.runtime[:facter].value(:operatingsystem)) || Dir.exist?(Dir.home(@resource[:name])))
       cmd << '-r'
     end
     cmd << @resource[:name]

--- a/lib/puppet/reference/providers.rb
+++ b/lib/puppet/reference/providers.rb
@@ -15,7 +15,7 @@ providers = Puppet::Util::Reference.newreference :providers, :title => "Provider
   # Throw some facts in there, so we know where the report is from.
   ["Ruby Version", "Puppet Version", "Operating System", "Operating System Release"].each do |label|
     name = label.gsub(/\s+/, '')
-    value = Facter.value(name)
+    value = Puppet.runtime[:facter].value(name)
     ret << option(label, value)
   end
   ret << "\n"
@@ -61,7 +61,7 @@ providers = Puppet::Util::Reference.newreference :providers, :title => "Provider
               if Puppet.settings.valid?(name)
                 details << _("  - Setting %{name} (currently %{value}) not in list %{facts}\n") % { name: name, value: Puppet.settings.value(name).inspect, facts: facts.join(", ") }
               else
-                details << _("  - Fact %{name} (currently %{value}) not in list %{facts}\n") % { name: name, value: Facter.value(name).inspect, facts: facts.join(", ") }
+                details << _("  - Fact %{name} (currently %{value}) not in list %{facts}\n") % { name: name, value: Puppet.runtime[:facter].value(name).inspect, facts: facts.join(", ") }
               end
             end
           when :true

--- a/lib/puppet/runtime.rb
+++ b/lib/puppet/runtime.rb
@@ -1,4 +1,5 @@
 require_relative '../puppet/http'
+require_relative '../puppet/facter_impl'
 require 'singleton'
 
 # Provides access to runtime implementations.
@@ -16,10 +17,19 @@ class Puppet::Runtime
         else
           Puppet::HTTP::ExternalClient.new(klass)
         end
-      end
+      end,
+      facter: proc { Puppet::FacterImpl.new }
     }
   end
   private :initialize
+
+  # Loads all runtime implementations.
+  #
+  # @return Array[Symbol] the names of loaded implementations
+  # @api private
+  def load_services
+    @runtime_services.keys.each { |key| self[key] }
+  end
 
   # Get a runtime implementation.
   #

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -79,11 +79,11 @@ class Puppet::Settings
   end
 
   def self.hostname_fact()
-    Facter.value :hostname
+    Puppet.runtime[:facter].value :hostname
   end
 
   def self.domain_fact()
-    Facter.value :domain
+    Puppet.runtime[:facter].value :domain
   end
 
   def self.default_config_file_name

--- a/lib/puppet/test/test_helper.rb
+++ b/lib/puppet/test/test_helper.rb
@@ -142,7 +142,8 @@ module Puppet::Test
         },
         "Context for specs")
 
-      Puppet.runtime.clear
+      Puppet.runtime.load_services
+
       Puppet::Parser::Functions.reset
       Puppet::Application.clear!
       Puppet::Util::Profiler.clear
@@ -166,6 +167,7 @@ module Puppet::Test
 
       Puppet::Util::Storage.clear
       Puppet::Util::ExecutionStub.reset
+      Puppet.runtime.clear
 
       Puppet.clear_deprecation_warnings
 

--- a/lib/puppet/type/group.rb
+++ b/lib/puppet/type/group.rb
@@ -1,5 +1,4 @@
 require 'etc'
-require 'facter'
 require_relative '../../puppet/property/keyvalue'
 require_relative '../../puppet/parameter/boolean'
 

--- a/lib/puppet/type/resources.rb
+++ b/lib/puppet/type/resources.rb
@@ -175,7 +175,7 @@ Puppet::Type.newtype(:resources) do
     end
 
     # Otherwise, use a sensible default based on the OS family
-    @system_users_max_uid ||= case Facter.value(:osfamily)
+    @system_users_max_uid ||= case Puppet.runtime[:facter].value(:osfamily)
       when 'OpenBSD', 'FreeBSD'
         999
       else

--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -1,5 +1,4 @@
 require 'etc'
-require 'facter'
 require_relative '../../puppet/parameter/boolean'
 require_relative '../../puppet/property/list'
 require_relative '../../puppet/property/ordered_list'

--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -772,12 +772,13 @@ module Util
   # Executes a block of code, wrapped around Facter.load_external(false) and
   # Facter.load_external(true) which will cause Facter to not evaluate external facts.
   def skip_external_facts
-    return yield unless Facter.respond_to? :load_external
+    return yield unless Puppet.runtime[:facter].load_external?
+
     begin
-      Facter.load_external(false)
+      Puppet.runtime[:facter].load_external(false)
       yield
     ensure
-      Facter.load_external(true)
+      Puppet.runtime[:facter].load_external(true)
     end
   end
   module_function :skip_external_facts

--- a/lib/puppet/util/command_line.rb
+++ b/lib/puppet/util/command_line.rb
@@ -135,7 +135,7 @@ module Puppet
 
               # Puppet requires Facter, which initializes its lookup paths. Reset Facter to
               # pickup the new $LOAD_PATH.
-              Facter.reset
+              Puppet.runtime[:facter].reset
             end
           end
 

--- a/lib/puppet/util/filetype.rb
+++ b/lib/puppet/util/filetype.rb
@@ -215,7 +215,7 @@ class Puppet::Util::FileType
     # Remove a specific @path's cron tab.
     def remove
       cmd = "#{cmdbase} -r"
-      if %w{Darwin FreeBSD DragonFly}.include?(Facter.value("operatingsystem"))
+      if %w{Darwin FreeBSD DragonFly}.include?(Puppet.runtime[:facter].value("operatingsystem"))
         cmd = "/bin/echo yes | #{cmd}"
       end
 
@@ -244,7 +244,7 @@ class Puppet::Util::FileType
     # Only add the -u flag when the @path is different.  Fedora apparently
     # does not think I should be allowed to set the @path to my own user name
     def cmdbase
-      if @uid == Puppet::Util::SUIDManager.uid || Facter.value(:operatingsystem) == "HP-UX"
+      if @uid == Puppet::Util::SUIDManager.uid || Puppet.runtime[:facter].value(:operatingsystem) == "HP-UX"
         return "crontab"
       else
         return "crontab -u #{@path}"

--- a/lib/puppet/util/log.rb
+++ b/lib/puppet/util/log.rb
@@ -2,7 +2,6 @@ require_relative '../../puppet/util/tagging'
 require_relative '../../puppet/util/classgen'
 require_relative '../../puppet/util/psych_support'
 require_relative '../../puppet/network/format_support'
-require 'facter'
 
 # Pass feedback to the user.  Log levels are modeled after syslog's, and it is
 # expected that that will be the most common log destination.  Supports
@@ -111,7 +110,7 @@ class Puppet::Util::Log
     @loglevel = @levels.index(level)
 
     # Enable or disable Facter debugging
-    Facter.debugging(level == :debug) if Facter.respond_to? :debugging
+    Puppet.runtime[:facter].debugging(level == :debug)
   end
 
   def Log.levels

--- a/lib/puppet/util/logging.rb
+++ b/lib/puppet/util/logging.rb
@@ -2,8 +2,6 @@
 require_relative '../../puppet/util/log'
 require_relative '../../puppet/error'
 
-require 'facter'
-
 module Puppet::Util
 module Logging
 
@@ -254,29 +252,7 @@ module Logging
   # Sets up Facter logging.
   # This method causes Facter output to be forwarded to Puppet.
   def self.setup_facter_logging!
-    # Only recent versions of Facter support this feature
-    return false unless Facter.respond_to? :on_message
-
-    # The current Facter log levels are: :trace, :debug, :info, :warn, :error, and :fatal.
-    # Convert to the corresponding levels in Puppet
-    Facter.on_message do |level, message|
-      case level
-      when :trace, :debug
-        level = :debug
-      when :info
-        # Same as Puppet
-      when :warn
-        level = :warning
-      when :error
-        level = :err
-      when :fatal
-        level = :crit
-      else
-        next
-      end
-      Puppet::Util::Log.create({:level => level, :source => 'Facter', :message => message})
-      nil
-    end
+    Puppet.runtime[:facter]
     true
   end
 

--- a/lib/puppet/util/pidlock.rb
+++ b/lib/puppet/util/pidlock.rb
@@ -46,7 +46,7 @@ class Puppet::Util::Pidlock
   private
 
   def ps_argument_for_current_kernel
-    case Facter.value(:kernel)
+    case Puppet.runtime[:facter].value(:kernel)
       when "Linux"
         "-eq"
       when "AIX"

--- a/lib/puppet/util/rdoc/parser/puppet_parser_core.rb
+++ b/lib/puppet/util/rdoc/parser/puppet_parser_core.rb
@@ -154,7 +154,7 @@ module RDoc::PuppetParserCore
         # fetch comments
         if line =~ /^[ \t]*# ?(.*)$/
           comments += $1 + "\n"
-        elsif line =~ /^[ \t]*Facter.add\(['"](.*?)['"]\)/
+        elsif line =~ /^[ \t]*(Facter.add|Puppet\.runtime\[:facter\].add)\(['"](.*?)['"]\)/
           current_fact = RDoc::Fact.new($1,{})
           look_for_directives_in(container, comments) unless comments.empty?
           current_fact.comment = comments

--- a/lib/puppet/util/suidmanager.rb
+++ b/lib/puppet/util/suidmanager.rb
@@ -1,4 +1,3 @@
-require 'facter'
 require_relative '../../puppet/util/warnings'
 require 'forwardable'
 require 'etc'
@@ -18,7 +17,7 @@ module Puppet::Util::SUIDManager
 
   def osx_maj_ver
     return @osx_maj_ver unless @osx_maj_ver.nil?
-    @osx_maj_ver = Facter.value('macosx_productversion_major') || false
+    @osx_maj_ver = Puppet.runtime[:facter].value('macosx_productversion_major') || false
   end
   module_function :osx_maj_ver
 

--- a/lib/puppet/util/windows/user.rb
+++ b/lib/puppet/util/windows/user.rb
@@ -1,6 +1,5 @@
 require_relative '../../../puppet/util/windows'
 
-require 'facter'
 require 'ffi'
 
 module Puppet::Util::Windows::User

--- a/spec/integration/indirector/facts/facter_spec.rb
+++ b/spec/integration/indirector/facts/facter_spec.rb
@@ -13,7 +13,7 @@ describe Puppet::Node::Facts::Facter do
   end
 
   it "preserves case in fact values" do
-    Facter.add(:downcase_test) do
+    Puppet.runtime[:facter].add(:downcase_test) do
       setcode do
         "AaBbCc"
       end
@@ -34,9 +34,9 @@ describe Puppet::Node::Facts::Facter do
       FileUtils.mkdir_p(test_module)
 
       File.open(File.join(test_module, 'custom.rb'), 'wb') { |file| file.write(<<-EOF)}
-      Facter.add(:custom) do
+      Puppet.runtime[:facter].add(:custom) do
         setcode do
-          Facter.value('puppetversion')
+          Puppet.runtime[:facter].value('puppetversion')
         end
       end
       EOF

--- a/spec/integration/type/file_spec.rb
+++ b/spec/integration/type/file_spec.rb
@@ -1710,11 +1710,11 @@ describe Puppet::Type.type(:file), :uses_checksums => true do
 
   describe "when using validate_cmd" do
     test_cmd = '/bin/test'
-    if Facter.value(:osfamily) == 'Debian'
+    if Puppet.runtime[:facter].value(:osfamily) == 'Debian'
       test_cmd = '/usr/bin/test'
     end
 
-    if Facter.value(:operatingsystem) == 'Darwin'
+    if Puppet.runtime[:facter].value(:operatingsystem) == 'Darwin'
       stat_cmd = "stat -f '%Lp'"
     else
       stat_cmd = "stat --format=%a"

--- a/spec/integration/type/package_spec.rb
+++ b/spec/integration/type/package_spec.rb
@@ -9,7 +9,7 @@ describe Puppet::Type.type(:package), "when choosing a default package provider"
   def provider_name(os)
     case os
     when 'Solaris'
-      if Puppet::Util::Package.versioncmp(Facter.value(:kernelrelease), '5.11') >= 0
+      if Puppet::Util::Package.versioncmp(Puppet.runtime[:facter].value(:kernelrelease), '5.11') >= 0
         :pkg
       else
         :sun
@@ -21,19 +21,19 @@ describe Puppet::Type.type(:package), "when choosing a default package provider"
     when 'Darwin'
       :pkgdmg
     when 'RedHat'
-      if ['2.1', '3', '4'].include?(Facter.value(:lsbdistrelease))
+      if ['2.1', '3', '4'].include?(Puppet.runtime[:facter].value(:lsbdistrelease))
         :up2date
       else
         :yum
       end
     when 'Fedora'
-      if Puppet::Util::Package.versioncmp(Facter.value(:operatingsystemmajrelease), '22') >= 0
+      if Puppet::Util::Package.versioncmp(Puppet.runtime[:facter].value(:operatingsystemmajrelease), '22') >= 0
         :dnf
       else
         :yum
       end
     when 'Suse'
-      if Puppet::Util::Package.versioncmp(Facter.value(:operatingsystemmajrelease), '10') >= 0
+      if Puppet::Util::Package.versioncmp(Puppet.runtime[:facter].value(:operatingsystemmajrelease), '10') >= 0
         :zypper
       else
         :rug
@@ -54,8 +54,8 @@ describe Puppet::Type.type(:package), "when choosing a default package provider"
   end
 
   it "should choose the correct provider each platform" do
-    unless default_provider = provider_name(Facter.value(:operatingsystem))
-      pending("No default provider specified in this test for #{Facter.value(:operatingsystem)}")
+    unless default_provider = provider_name(Puppet.runtime[:facter].value(:operatingsystem))
+      pending("No default provider specified in this test for #{Puppet.runtime[:facter].value(:operatingsystem)}")
     end
     expect(Puppet::Type.type(:package).defaultprovider.name).to eq(default_provider)
   end

--- a/spec/integration/util/rdoc/parser_spec.rb
+++ b/spec/integration/util/rdoc/parser_spec.rb
@@ -91,7 +91,7 @@ end
         File.join(modules_dir, 'a_module', 'lib', 'facter', 'a_fact.rb'),
         <<-EOF
 # The a_fact fact comment
-Facter.add("a_fact") do
+Puppet.runtime[:facter].add("a_fact") do
 end
         EOF
       ],

--- a/spec/integration/util/windows/process_spec.rb
+++ b/spec/integration/util/windows/process_spec.rb
@@ -1,20 +1,12 @@
 require 'spec_helper'
-require 'facter'
 
 describe "Puppet::Util::Windows::Process", :if => Puppet::Util::Platform.windows?  do
   describe "as an admin" do
-    it "should have the SeCreateSymbolicLinkPrivilege necessary to create symlinks on Vista / 2008+",
-      :if => Facter.value(:kernelmajversion).to_f >= 6.0 && Puppet::Util::Platform.windows? do
+    it "should have the SeCreateSymbolicLinkPrivilege necessary to create symlinks" do
       # this is a bit of a lame duck test since it requires running user to be admin
       # a better integration test would create a new user with the privilege and verify
       expect(Puppet::Util::Windows::User).to be_admin
       expect(Puppet::Util::Windows::Process.process_privilege_symlink?).to be_truthy
-    end
-
-    it "should not have the SeCreateSymbolicLinkPrivilege necessary to create symlinks on 2003 and earlier",
-      :if => Facter.value(:kernelmajversion).to_f < 6.0 && Puppet::Util::Platform.windows? do
-      expect(Puppet::Util::Windows::User).to be_admin
-      expect(Puppet::Util::Windows::Process.process_privilege_symlink?).to be_falsey
     end
 
     it "should be able to lookup a standard Windows process privilege" do

--- a/spec/unit/facter_impl_spec.rb
+++ b/spec/unit/facter_impl_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe 'Puppet::FacterImpl' do
+  subject(:facter_impl) { Puppet::FacterImpl.new }
+
+  it { is_expected.to respond_to(:value) }
+  it { is_expected.to respond_to(:add) }
+
+  describe '.value' do
+    let(:method_name) { :value }
+
+    before { allow(Facter).to receive(method_name) }
+
+    it 'delegates to Facter API' do
+      facter_impl.value('test_fact')
+      expect(Facter).to have_received(method_name).with('test_fact')
+    end
+  end
+
+  describe '.add' do
+    let(:block) { Proc.new { setcode 'test' } }
+    let(:method_name) { :add }
+
+    before { allow(Facter).to receive(method_name) }
+
+    it 'delegates to Facter API' do
+      facter_impl.add('test_fact', &block)
+      expect(Facter).to have_received(method_name).with('test_fact', &block)
+    end
+  end
+end

--- a/spec/unit/file_bucket/dipper_spec.rb
+++ b/spec/unit/file_bucket/dipper_spec.rb
@@ -104,8 +104,8 @@ describe Puppet::FileBucket::Dipper, :uses_checksums => true do
           # Diff without the context
           # Lines we need to see match 'Content' instead of trimming diff output filter out
           # surrounding noise...or hard code the check values
-          if Facter.value(:osfamily) == 'Solaris' &&
-            Puppet::Util::Package.versioncmp(Facter.value(:operatingsystemrelease), '11.0') >= 0
+          if Puppet.runtime[:facter].value(:osfamily) == 'Solaris' &&
+            Puppet::Util::Package.versioncmp(Puppet.runtime[:facter].value(:operatingsystemrelease), '11.0') >= 0
             # Use gdiff on Solaris
             diff12 = Puppet::Util::Execution.execute("gdiff -uN #{file1} #{file2}| grep Content")
             diff21 = Puppet::Util::Execution.execute("gdiff -uN #{file2} #{file1}| grep Content")

--- a/spec/unit/network/http/connection_spec.rb
+++ b/spec/unit/network/http/connection_spec.rb
@@ -543,6 +543,7 @@ describe Puppet::Network::HTTP::Connection do
       end
 
       it "should sleep for no more than the Puppet runinterval" do
+        Puppet.runtime.clear
         retry_after('60')
 
         Puppet[:runinterval] = 30

--- a/spec/unit/network/http_pool_spec.rb
+++ b/spec/unit/network/http_pool_spec.rb
@@ -37,6 +37,7 @@ describe Puppet::Network::HttpPool do
     end
 
     it "switches to the external client implementation" do
+      Puppet.runtime.clear
       Puppet::Network::HttpPool.http_client_class = http_impl
 
       expect(Puppet.runtime[:http]).to be_an_instance_of(Puppet::HTTP::ExternalClient)

--- a/spec/unit/provider/package/gem_spec.rb
+++ b/spec/unit/provider/package/gem_spec.rb
@@ -476,7 +476,7 @@ context Puppet::Type.type(:package).provider(:gem) do
     end
 
     context 'when is defaultfor' do
-      let(:os) { Facter.value(:operatingsystem) }
+      let(:os) { Puppet.runtime[:facter].value(:operatingsystem) }
       subject do
         described_class.defaultfor(operatingsystem: os)
         described_class.specificity

--- a/spec/unit/provider/package/pip2_spec.rb
+++ b/spec/unit/provider/package/pip2_spec.rb
@@ -26,7 +26,7 @@ describe Puppet::Type.type(:package).provider(:pip2) do
     end
 
     context 'when is defaultfor' do
-      let(:os) { Facter.value(:operatingsystem) }
+      let(:os) { Puppet.runtime[:facter].value(:operatingsystem) }
       subject do
         described_class.defaultfor(operatingsystem: os)
         described_class.specificity

--- a/spec/unit/provider/package/pip3_spec.rb
+++ b/spec/unit/provider/package/pip3_spec.rb
@@ -26,7 +26,7 @@ describe Puppet::Type.type(:package).provider(:pip3) do
     end
 
     context 'when is defaultfor' do
-      let(:os) { Facter.value(:operatingsystem) }
+      let(:os) { Puppet.runtime[:facter].value(:operatingsystem) }
       subject do
         described_class.defaultfor(operatingsystem: os)
         described_class.specificity

--- a/spec/unit/provider/package/pip_spec.rb
+++ b/spec/unit/provider/package/pip_spec.rb
@@ -493,7 +493,7 @@ describe Puppet::Type.type(:package).provider(:pip) do
     end
 
     context 'when is defaultfor' do
-      let(:os) { Facter.value(:operatingsystem) }
+      let(:os) { Puppet.runtime[:facter].value(:operatingsystem) }
       subject do
         described_class.defaultfor(operatingsystem: os)
         described_class.specificity

--- a/spec/unit/provider/package/puppet_gem_spec.rb
+++ b/spec/unit/provider/package/puppet_gem_spec.rb
@@ -118,7 +118,7 @@ describe Puppet::Type.type(:package).provider(:puppet_gem) do
     end
 
     context 'when is defaultfor' do
-      let(:os) { Facter.value(:operatingsystem) }
+      let(:os) { Puppet.runtime[:facter].value(:operatingsystem) }
       subject do
         described_class.defaultfor(operatingsystem: os)
         described_class.specificity

--- a/spec/unit/provider/package/puppetserver_gem_spec.rb
+++ b/spec/unit/provider/package/puppetserver_gem_spec.rb
@@ -127,7 +127,7 @@ describe Puppet::Type.type(:package).provider(:puppetserver_gem) do
     end
 
     context 'when is defaultfor' do
-      let(:os) {  Facter.value(:operatingsystem) }
+      let(:os) {  Puppet.runtime[:facter].value(:operatingsystem) }
       subject do
         described_class.defaultfor(operatingsystem: os)
         described_class.specificity

--- a/spec/unit/provider/user/directoryservice_spec.rb
+++ b/spec/unit/provider/user/directoryservice_spec.rb
@@ -1142,7 +1142,7 @@ end
       provider.class.instance_variable_set(:@os_version, nil) if provider.class.instance_variable_defined? :@os_version
     end
 
-    it 'should call Facter.value(:macosx_productversion_major) ONLY ONCE no matter how ' +
+    it 'should call Puppet.runtime[:facter].value(:macosx_productversion_major) ONLY ONCE no matter how ' +
        'many times get_os_version() is called' do
       expect(Facter).to receive(:value).with(:macosx_productversion_major).once.and_return('10.8')
       expect(provider.class.get_os_version).to eq('10.8')

--- a/spec/unit/provider_spec.rb
+++ b/spec/unit/provider_spec.rb
@@ -222,18 +222,18 @@ describe Puppet::Provider do
       { :true => false } => false,
       { :false => false } => true,
       { :false => true } => false,
-      { :operatingsystem => Facter.value(:operatingsystem) } => true,
+      { :operatingsystem => Puppet.runtime[:facter].value(:operatingsystem) } => true,
       { :operatingsystem => :yayness } => false,
       { :nothing => :yayness } => false,
       { :exists => Puppet::Util.which(existing_command) } => true,
       { :exists => "/this/file/does/not/exist" } => false,
       { :true => true, :exists => Puppet::Util.which(existing_command) } => true,
       { :true => true, :exists => "/this/file/does/not/exist" } => false,
-      { :operatingsystem => Facter.value(:operatingsystem),
+      { :operatingsystem => Puppet.runtime[:facter].value(:operatingsystem),
         :exists => Puppet::Util.which(existing_command) } => true,
       { :operatingsystem => :yayness,
         :exists => Puppet::Util.which(existing_command) } => false,
-      { :operatingsystem => Facter.value(:operatingsystem),
+      { :operatingsystem => Puppet.runtime[:facter].value(:operatingsystem),
         :exists => "/this/file/does/not/exist" } => false,
       { :operatingsystem => :yayness,
         :exists => "/this/file/does/not/exist" } => false,
@@ -269,7 +269,7 @@ describe Puppet::Provider do
   end
 
   context "default providers" do
-    let :os do Facter.value(:operatingsystem) end
+    let :os do Puppet.runtime[:facter].value(:operatingsystem) end
 
     it { is_expected.to respond_to :specificity }
 

--- a/spec/unit/puppet_spec.rb
+++ b/spec/unit/puppet_spec.rb
@@ -91,12 +91,20 @@ describe Puppet do
       expect(Puppet.runtime[:http]).to be_an_instance_of(Puppet::HTTP::Client)
     end
 
-    it 'allows an implementation to be registered' do
-      impl = double('http')
-      Puppet.initialize_settings([], true, true, http: impl)
+    it 'allows a http implementation to be registered' do
+      http_impl = double('http')
+      Puppet.initialize_settings([], true, true, http: http_impl)
 
 
-      expect(Puppet.runtime[:http]).to eq(impl)
+      expect(Puppet.runtime[:http]).to eq(http_impl)
+    end
+
+    it 'allows a facter implementation to be registered' do
+      facter_impl = double('facter')
+      Puppet.initialize_settings([], true, true, facter: facter_impl)
+
+
+      expect(Puppet.runtime[:facter]).to eq(facter_impl)
     end
   end
 

--- a/spec/unit/type_spec.rb
+++ b/spec/unit/type_spec.rb
@@ -1142,7 +1142,7 @@ describe Puppet::Type, :unless => Puppet::Util::Platform.windows? do
 
       before :each do
         type.provide(:default) do
-          defaultfor :operatingsystem => Facter.value(:operatingsystem)
+          defaultfor :operatingsystem => Puppet.runtime[:facter].value(:operatingsystem)
           mk_resource_methods
           class << self
             attr_accessor :params
@@ -1172,7 +1172,7 @@ describe Puppet::Type, :unless => Puppet::Util::Platform.windows? do
     context "with a default provider" do
       before :each do
         type.provide(:default) do
-          defaultfor :operatingsystem => Facter.value(:operatingsystem)
+          defaultfor :operatingsystem => Puppet.runtime[:facter].value(:operatingsystem)
           mk_resource_methods
           class << self
             attr_accessor :names

--- a/spec/unit/util/logging_spec.rb
+++ b/spec/unit/util/logging_spec.rb
@@ -552,6 +552,7 @@ original
 
     describe 'does support debugging' do
       before :each do
+        allow(Facter).to receive(:respond_to?).with(:on_message).and_return(true)
         allow(Facter).to receive(:respond_to?).with(:debugging, any_args).and_return(true)
       end
 
@@ -568,6 +569,7 @@ original
 
     describe 'does support trace' do
       before :each do
+        allow(Facter).to receive(:respond_to?).with(:on_message)
         allow(Facter).to receive(:respond_to?).with(:trace, any_args).and_return(true)
       end
 

--- a/tasks/parallel.rake
+++ b/tasks/parallel.rake
@@ -5,9 +5,9 @@ require 'thread'
 begin
   require 'rspec'
   require 'rspec/core/formatters/helpers'
-  require 'facter'
+  require 'etc'
 rescue LoadError
-  # Don't define the task if we don't have rspec or facter present
+  # Don't define the task if we don't have rspec present
 else
   module Parallel
     module RSpec
@@ -401,7 +401,7 @@ else
       # Default group size in rspec examples
       DEFAULT_GROUP_SIZE = 1000
 
-      process_count = [(args[:process_count] || Facter.value("processorcount")).to_i, 1].max
+      process_count = [(args[:process_count] || Etc.nprocessors).to_i, 1].max
       group_size = [(args[:group_size] || DEFAULT_GROUP_SIZE).to_i, 1].max
 
       abort unless Parallel::RSpec::Parallelizer.new(process_count, group_size, color_output?, args.extras).run


### PR DESCRIPTION
* commit '5d4719643bea8231820692454fa228324d939428':
  (PUP-11217) explicitly load runtime services in tests
  (PUP-11217) use Etc instead of Facter in parallel.rake
  (PUP-11217) allow Puppet init without Facter
  (PUP-11216) Add support for multiple facter impl

Conflicts:
	lib/puppet.rb
	lib/puppet/defaults.rb
	lib/puppet/face/facts.rb
	lib/puppet/provider/service/init.rb
	lib/puppet/provider/service/smf.rb
	lib/puppet/runtime.rb
	lib/puppet/type/group.rb
	lib/puppet/type/user.rb
	lib/puppet/util/log.rb
	lib/puppet/util/suidmanager.rb
	lib/puppet/util/windows/user.rb
	spec/unit/defaults_spec.rb
	spec/unit/provider/package/gem_spec.rb
	spec/unit/provider/package/pip2_spec.rb
	spec/unit/provider/package/pip3_spec.rb
	spec/unit/provider/package/pip_spec.rb
	spec/unit/provider/package/puppet_gem_spec.rb

