### PR TITLE
(PUP-10925) Fix service timeout parameter default value for syncing properties

### DIFF
--- a/lib/puppet/type/service.rb
+++ b/lib/puppet/type/service.rb
@@ -273,8 +273,13 @@ module Puppet
     newparam(:timeout, :required_features => :configurable_timeout) do
       desc "Specify an optional minimum timeout (in seconds) for puppet to wait when syncing service properties"
       defaultto { provider.respond_to?(:default_timeout) ? provider.default_timeout : 10 }
-      validate do |value|
-        if (not value.is_a? Integer) || value < 1
+
+      munge do |value|
+        begin
+          value = value.to_i
+          raise if value < 1
+          value
+        rescue
           raise Puppet::Error.new(_("\"%{value}\" is not a positive integer: the timeout parameter must be specified as a positive integer") % { value: value })
         end
       end

--- a/lib/puppet/type/service.rb
+++ b/lib/puppet/type/service.rb
@@ -272,7 +272,7 @@ module Puppet
 
     newparam(:timeout, :required_features => :configurable_timeout) do
       desc "Specify an optional minimum timeout (in seconds) for puppet to wait when syncing service properties"
-      defaultto { provider.class.respond_to?(:default_timeout) ? provider.default_timeout : 10 }
+      defaultto { provider.respond_to?(:default_timeout) ? provider.default_timeout : 10 }
       validate do |value|
         if (not value.is_a? Integer) || value < 1
           raise Puppet::Error.new(_("\"%{value}\" is not a positive integer: the timeout parameter must be specified as a positive integer") % { value: value })

--- a/spec/unit/type/service_spec.rb
+++ b/spec/unit/type/service_spec.rb
@@ -158,6 +158,24 @@ describe test_title, "when validating attribute values" do
         expect(srv[:timeout]).to eq(int)
       end
     end
+
+    it "should default :timeout to 10 when provider has no default value" do
+      srv = Puppet::Type.type(:service).new(:name => "yay")
+      expect(srv[:timeout]).to eq(10)
+    end
+
+    it "should default :timeout to provider given default time when it has one" do
+      provider_class_with_timeout = Puppet::Type.type(:service).provide(:simple) do
+        has_features :configurable_timeout
+        def default_timeout
+          30
+        end
+      end
+      allow(Puppet::Type.type(:service)).to receive(:defaultprovider).and_return(provider_class_with_timeout)
+
+      srv = Puppet::Type.type(:service).new(:name => "yay")
+      expect(srv[:timeout]).to eq(30)
+    end
   end
 
   describe "the service logon credentials" do 

--- a/spec/unit/type/service_spec.rb
+++ b/spec/unit/type/service_spec.rb
@@ -176,6 +176,15 @@ describe test_title, "when validating attribute values" do
       srv = Puppet::Type.type(:service).new(:name => "yay")
       expect(srv[:timeout]).to eq(30)
     end
+
+    it "should accept string as value" do
+      srv = Puppet::Type.type(:service).new(:name => "yay", :timeout => "25")
+      expect(srv[:timeout]).to eq(25)
+    end
+
+    it "should not support values that cannot be converted to Integer such as Array" do
+      expect { Puppet::Type.type(:service).new(:name => "yay", :timeout => [25]) }.to raise_error(Puppet::Error)
+    end
   end
 
   describe "the service logon credentials" do 


### PR DESCRIPTION
ab3870c allows provider to be asked for default `timeout` value for syncing service properties when it has one instead of always defaulting to `10`. This was causing issues on Windows when services were taking more than 10 seconds to change state or sync properties instead of waiting for 30 seconds as the provider was set to.

https://github.com/puppetlabs/puppet/commit/ba93e860e725a2faef084fe820dae2aa90028dbb allows the `timeout` parameter of service to be String and munges it to Integer to be further used. This seemed like a common problem when trying to manage a service from cli and specifying a timeout such as:
```sh-session
puppet resource service puppet ensure=running timeout=20
```

Before this commit, above command was raising:
```sh-session
Error: Could not run: Parameter timeout failed on Service[puppet]: "20" is not a positive integer: the timeout parameter must be specified as a positive integer
```