### PR TITLE
(PUP-11217) do not eager load Puppet's HttpClient

### DIFF
--- a/lib/puppet/test/test_helper.rb
+++ b/lib/puppet/test/test_helper.rb
@@ -142,7 +142,8 @@ module Puppet::Test
         },
         "Context for specs")
 
-      Puppet.runtime.load_services
+      # trigger `require 'facter'`
+      Puppet.runtime[:facter]
 
       Puppet::Parser::Functions.reset
       Puppet::Application.clear!

--- a/spec/unit/network/http/connection_spec.rb
+++ b/spec/unit/network/http/connection_spec.rb
@@ -561,7 +561,6 @@ describe Puppet::Network::HTTP::Connection do
       end
 
       it "should sleep for no more than the Puppet runinterval" do
-        Puppet.runtime.clear
         retry_after('60')
 
         Puppet[:runinterval] = 30

--- a/spec/unit/network/http_pool_spec.rb
+++ b/spec/unit/network/http_pool_spec.rb
@@ -37,7 +37,6 @@ describe Puppet::Network::HttpPool do
     end
 
     it "switches to the external client implementation" do
-      Puppet.runtime.clear
       Puppet::Network::HttpPool.http_client_class = http_impl
 
       expect(Puppet.runtime[:http]).to be_an_instance_of(Puppet::HTTP::ExternalClient)


### PR DESCRIPTION
https://github.com/puppetlabs/puppet/pull/8749/files#diff-91bcbee7bf547ed6ab2546124a1a87c5e34d8189ef781252293b65725ea40bddR145 introduced a change
on how we load runtime services, setting them
upfront before running any tests. This breaks the
ability to mock the implementations and enforces
specific implementations to be injected when Puppet
is initialized. To avoid breaking other projects,
do not load the HttpClient for now, but let it be
lazy initailized as it was before #8749.