### PR TITLE
(PUP-11237) Detect recursive json generation

### DIFF
--- a/lib/puppet/util/json.rb
+++ b/lib/puppet/util/json.rb
@@ -60,6 +60,9 @@ module Puppet::Util
     def self.dump(object, options = {})
       if defined? MultiJson
         MultiJson.dump(object, options)
+      elsif options.is_a?(JSON::State)
+        # we're being called recursively
+        object.to_json(options)
       else
         options.merge!(::JSON::PRETTY_STATE_PROTOTYPE.to_h) if options.delete(:pretty)
         object.to_json(options)

--- a/spec/unit/network/formats_spec.rb
+++ b/spec/unit/network/formats_spec.rb
@@ -368,6 +368,12 @@ describe "Puppet Network Format" do
       expect(json.render_multiple(instances)).to eq([{"string" => "foo"}].to_json)
     end
 
+    it "should render multiple instances as a JSON array of hashes when multi_json is not present" do
+      hide_const("MultiJson") if defined?(MultiJson)
+      instances = [FormatsTest.new("foo")]
+      expect(json.render_multiple(instances)).to eq([{"string" => "foo"}].to_json)
+    end
+
     it "should intern an instance from a JSON hash" do
       text = Puppet::Util::Json.dump({"string" => "parsed_json"})
       instance = json.intern(FormatsTest, text)


### PR DESCRIPTION
If the `MultiJson` gem was absent, then `Puppet::Util::Json.dump` failed if
given an array or hash containing an indirected object. The issue occurred because the
json library will call the object's `to_json` method (since it's not a primitive
type) passing an instance of `JSON::State` as the `options` argument. The
`to_json` method for indirected objects is implemented in
`Puppet::Network::FormatSupport`, and that calls `Puppet::Util::Json.dump`
recursively.

Now we detect if the `options` is a `JSON::State` object, similar to how the
JSON library detects if it's being called recursively[1].

https://github.com/ruby/ruby/blob/v2_7_3/ext/json/generator/generator.c#L1071-L1088