### PR TITLE
(PUP-11241) Check against a user's local 'home' and 'shell' when forcelocal is true

### DIFF
--- a/lib/puppet/provider/user/useradd.rb
+++ b/lib/puppet/provider/user/useradd.rb
@@ -77,6 +77,11 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
     get(:shell)
   end
 
+  def home
+    return localhome if @resource.forcelocal?
+    get(:home)
+  end
+
   def groups
      return localgroups if @resource.forcelocal?
      super
@@ -131,6 +136,11 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
   def localshell
     user = finduser(:account, resource[:name])
     user[:shell]
+  end
+
+  def localhome
+    user = finduser(:account, resource[:name])
+    user[:directory]
   end
 
   def localgroups

--- a/lib/puppet/provider/user/useradd.rb
+++ b/lib/puppet/provider/user/useradd.rb
@@ -72,6 +72,11 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
      get(:comment)
   end
 
+  def shell
+    return localshell if @resource.forcelocal?
+    get(:shell)
+  end
+
   def groups
      return localgroups if @resource.forcelocal?
      super
@@ -121,6 +126,11 @@ Puppet::Type.type(:user).provide :useradd, :parent => Puppet::Provider::NameServ
   def localcomment
     user = finduser(:account, resource[:name])
     user[:gecos]
+  end
+
+  def localshell
+    user = finduser(:account, resource[:name])
+    user[:shell]
   end
 
   def localgroups

--- a/spec/unit/provider/user/useradd_spec.rb
+++ b/spec/unit/provider/user/useradd_spec.rb
@@ -372,6 +372,26 @@ describe Puppet::Type.type(:user).provider(:useradd) do
     end
   end
 
+  describe "#home" do
+    before { described_class.has_feature :manages_local_users_and_groups }
+
+    let(:content) { "myuser:x:x:x:x:/opt/local_home:x" }
+
+    it "should return the local home string when forcelocal is true" do
+      resource[:forcelocal] = true
+      allow(Puppet::FileSystem).to receive(:exist?).with('/etc/passwd').and_return(true)
+      allow(Puppet::FileSystem).to receive(:each_line).with('/etc/passwd').and_yield(content)
+      expect(provider.home).to eq('/opt/local_home')
+    end
+
+    it "should fall back to nameservice home string when forcelocal is false" do
+      resource[:forcelocal] = false
+      allow(provider).to receive(:get).with(:home).and_return('/opt/remote_home')
+      expect(provider).not_to receive(:localhome)
+      expect(provider.home).to eq('/opt/remote_home')
+    end
+  end
+
   describe "#gid" do
     before { described_class.has_feature :manages_local_users_and_groups }
 

--- a/spec/unit/provider/user/useradd_spec.rb
+++ b/spec/unit/provider/user/useradd_spec.rb
@@ -352,6 +352,26 @@ describe Puppet::Type.type(:user).provider(:useradd) do
     end
   end
 
+  describe "#shell" do
+    before { described_class.has_feature :manages_local_users_and_groups }
+
+    let(:content) { "myuser:x:x:x:x:x:/bin/local_shell" }
+
+    it "should return the local shell string when forcelocal is true" do
+      resource[:forcelocal] = true
+      allow(Puppet::FileSystem).to receive(:exist?).with('/etc/passwd').and_return(true)
+      allow(Puppet::FileSystem).to receive(:each_line).with('/etc/passwd').and_yield(content)
+      expect(provider.shell).to eq('/bin/local_shell')
+    end
+
+    it "should fall back to nameservice shell string when forcelocal is false" do
+      resource[:forcelocal] = false
+      allow(provider).to receive(:get).with(:shell).and_return('/bin/remote_shell')
+      expect(provider).not_to receive(:localshell)
+      expect(provider.shell).to eq('/bin/remote_shell')
+    end
+  end
+
   describe "#gid" do
     before { described_class.has_feature :manages_local_users_and_groups }
 


### PR DESCRIPTION
Prior to this, when managing a `user` resource with `forcelocal => true`, directory services (i.e. LDAP) enabled on the host, and a duplicate username in LDAP and locally, the `shell` and `home` attributes of the user would be checked against their values from LDAP, not from `/etc/passwd`.

This caused Puppet runs to always show that the `shell` and `home` attributes were changing on each run if LDAP had different values for the user than the Puppet code did. Puppet would correctly set the values for those attributes in `/etc/passwd`, but they'd appear to change on each run.  The `user` resource was no longer idempotent.

After this, the values for `shell` and `home` will be checked against the local `/etc/passwd` file when `forcelocal => true` is set on a `user` resource.

Fixes [PUP-11241](https://tickets.puppetlabs.com/browse/PUP-11241)