### PR TITLE
(PUP-11265) Push last used environment and loaders onto the context

### DIFF
--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -1159,6 +1159,20 @@ describe Puppet::Configurer do
           expect(configurer.environment).to eq(last_server_specified_environment)
         end
 
+        it "pushes the converged environment found in lastrunfile over the existing context" do
+          initial_env = Puppet::Node::Environment.remote('production')
+          Puppet.push_context(
+            current_environment: initial_env,
+            loaders: Puppet::Pops::Loaders.new(initial_env, true))
+
+          expect(Puppet).to receive(:push_context).with(
+            hash_including(:current_environment, :loaders),
+            "Local node environment #{last_server_specified_environment} for configurer transaction"
+          ).once.and_call_original
+
+          configurer.run
+        end
+
         it "uses environment from Puppet[:environment] if strict_environment_mode is set" do
           Puppet[:strict_environment_mode] = true
           configurer.run


### PR DESCRIPTION
Previously, if the agent run decided to use the last server environment, it would not push the current environment and loaders onto the context.

Metadata requests that don't specify an environment will cause the indirector to fall back to the environment stored in the [context](https://github.com/puppetlabs/puppet/blob/3828aabe8d32368faa5cdc1a428189d0cb117e52/lib/puppet/indirector/request.rb#L33), which in our case is [the environment the agent started in](https://github.com/puppetlabs/puppet/blob/3828aabe8d32368faa5cdc1a428189d0cb117e52/lib/puppet/application/agent.rb#L389-L401) instead of the converged one.

Push the current environment and loaders if we're using the last server environment, and extract the logic to a separate method.