### PR TITLE
(PUP-11235) versioncmp() strip redundant numbers

### DIFF
--- a/lib/puppet/functions/versioncmp.rb
+++ b/lib/puppet/functions/versioncmp.rb
@@ -8,6 +8,9 @@ require 'puppet/util/package'
 #
 # Where a and b are arbitrary version strings.
 #
+# Optional parameter ignore_trailing_zeroes is used to ignore unnecessary
+# trailing version numbers like .0 or .0.00
+#
 # This function returns:
 #
 # * `1` if version a is greater than version b
@@ -28,9 +31,10 @@ Puppet::Functions.create_function(:versioncmp) do
   dispatch :versioncmp do
     param 'String', :a
     param 'String', :b
+    optional_param 'Boolean', :ignore_trailing_zeroes
   end
 
-  def versioncmp(a, b)
-    Puppet::Util::Package.versioncmp(a, b)
+  def versioncmp(a, b, ignore_trailing_zeroes = false)
+    Puppet::Util::Package.versioncmp(a, b, ignore_trailing_zeroes)
   end
 end

--- a/lib/puppet/util/package.rb
+++ b/lib/puppet/util/package.rb
@@ -15,23 +15,18 @@ module Puppet::Util::Package
       a = ax.shift
       b = bx.shift
 
-      if( a == b )                 then next
-      elsif (a == '-' && b == '-') then next
-      elsif (a == '-')             then return -1
-      elsif (b == '-')             then return 1
-      elsif (a == '.' && b == '.') then next
-      elsif (a == '.' )            then return -1
-      elsif (b == '.' )            then return 1
-      elsif (a =~ /^\d+$/ && b =~ /^\d+$/) then
-        if( a =~ /^0/ or b =~ /^0/ ) then
-          return a.to_s.upcase <=> b.to_s.upcase
-        end
+      next      if a == b
+      return -1 if a == '-'
+      return 1  if b == '-'
+      return -1 if a == '.'
+      return 1  if b == '.'
+      if a =~ /^\d+$/ && b =~ /^\d+$/
+        return a.to_s.upcase <=> b.to_s.upcase if a =~ /^0/ || b =~ /^0/
         return a.to_i <=> b.to_i
-      else
-        return a.upcase <=> b.upcase
       end
+      return a.upcase <=> b.upcase
     end
-    version_a <=> version_b;
+    version_a <=> version_b
   end
   module_function :versioncmp
 

--- a/lib/puppet/util/package.rb
+++ b/lib/puppet/util/package.rb
@@ -1,6 +1,13 @@
+# frozen_string_literal: true
 module Puppet::Util::Package
-  def versioncmp(version_a, version_b)
+  def versioncmp(version_a, version_b, ignore_trailing_zeroes = false)
     vre = /[-.]|\d+|[^-.\d]+/
+
+    if ignore_trailing_zeroes
+      version_a = normalize(version_a)
+      version_b = normalize(version_b)
+    end
+
     ax = version_a.scan(vre)
     bx = version_b.scan(vre)
 
@@ -26,6 +33,13 @@ module Puppet::Util::Package
     end
     version_a <=> version_b;
   end
-
   module_function :versioncmp
+
+  def self.normalize(version)
+    version = version.split('-')
+    version.first.sub!(/([\.0]+)$/, '')
+
+    version.join('-')
+  end
+  private_class_method :normalize
 end

--- a/spec/unit/functions/versioncmp_spec.rb
+++ b/spec/unit/functions/versioncmp_spec.rb
@@ -19,16 +19,52 @@ describe "the versioncmp function" do
   let(:type_parser) { Puppet::Pops::Types::TypeParser.singleton }
 
   it 'should raise an Error if there is less than 2 arguments' do
-    expect { versioncmp('a,b') }.to raise_error(/expects 2 arguments, got 1/)
+    expect { versioncmp('a,b') }.to raise_error(/expects between 2 and 3 arguments, got 1/)
   end
 
-  it 'should raise an Error if there is more than 2 arguments' do
-    expect { versioncmp('a,b','foo', 'bar') }.to raise_error(/expects 2 arguments, got 3/)
+  it 'should raise an Error if there is more than 3 arguments' do
+    expect { versioncmp('a,b','foo', false, 'bar') }.to raise_error(/expects between 2 and 3 arguments, got 4/)
   end
 
   it "should call Puppet::Util::Package.versioncmp (included in scope)" do
-    expect(Puppet::Util::Package).to receive(:versioncmp).with('1.2', '1.3').and_return(-1)
+    expect(Puppet::Util::Package).to receive(:versioncmp).with('1.2', '1.3', false).and_return(-1)
 
     expect(versioncmp('1.2', '1.3')).to eq(-1)
+  end
+
+  context "when ignore_trailing_zeroes is true" do
+    it "should equate versions with 2 elements and dots but with unnecessary zero" do
+      expect(versioncmp("10.1.0", "10.1", true)).to eq(0)
+    end
+
+    it "should equate versions with 1 element and dot but with unnecessary zero" do
+      expect(versioncmp("11.0", "11", true)).to eq(0)
+    end
+
+    it "should equate versions with 1 element and dot but with unnecessary zeros" do
+      expect(versioncmp("11.00", "11", true)).to eq(0)
+    end
+
+    it "should equate versions with dots and iregular zeroes" do
+      expect(versioncmp("11.0.00", "11", true)).to eq(0)
+    end
+
+    it "should equate versions with dashes" do
+      expect(versioncmp("10.1-0", "10.1.0-0", true)).to eq(0)
+    end
+
+    it "should compare versions with dashes after normalization" do
+      expect(versioncmp("10.1-1", "10.1.0-0", true)).to eq(1)
+    end
+
+    it "should not normalize versions if zeros are not trailing" do
+      expect(versioncmp("1.1", "1.0.1", true)).to eq(1)
+    end
+  end
+
+  context "when ignore_trailing_zeroes is false" do
+    it "should not equate versions if zeros are not trailing" do
+      expect(versioncmp("1.1", "1.0.1")).to eq(1)
+    end
   end
 end


### PR DESCRIPTION
Before 356a602994a6d757aa48045fcbfb0043aa307b5b, `Puppet::Util::Package.versioncmp()` thought `11.0` is greater than `11`. Now it can trim trailing zeroes and dots from version before comparing, by setting the new argument `ignore_trailing_zeroes` to true. By default it is kept to `false` for backwards compatibility reasons.

04d94f23af5590c2ad60cfff113e81fc83407cce updates the `Puppet::Util::Package.versioncmp()` method to use more recent Ruby practices and removes unnecessary checks.