### PR TITLE
(PUP-11311) Monkey patch Pathname for Ruby < 3

### DIFF
--- a/benchmarks/many_modules/benchmarker.rb
+++ b/benchmarks/many_modules/benchmarker.rb
@@ -70,13 +70,24 @@ class Benchmarker
           )
       end
 
+      roles = 0.upto(10).to_a
+
       render(File.join(templates, 'module', 'init.pp.erb'),
              File.join(manifests, 'init.pp'),
-             :name => module_name)
+             :name => module_name,
+             :roles => roles
+            )
 
       render(File.join(templates, 'module', 'internal.pp.erb'),
              File.join(manifests, 'internal.pp'),
              :name => module_name)
+
+      roles.each do |i|
+        render(File.join(templates, 'module', 'role.pp.erb'),
+               File.join(manifests, "role#{i}.pp"),
+               :name => module_name,
+               :index => i)
+      end
     end
 
     render(File.join(templates, 'puppet.conf.erb'),

--- a/benchmarks/many_modules/module/init.pp.erb
+++ b/benchmarks/many_modules/module/init.pp.erb
@@ -1,3 +1,6 @@
 class <%= name %> {
   class { "<%= name %>::internal": }
+  <% roles.each do |role| %>
+    class { "<%= name %>::role<%= role %>": }
+  <% end %>
 }

--- a/benchmarks/many_modules/module/role.pp.erb
+++ b/benchmarks/many_modules/module/role.pp.erb
@@ -1,0 +1,3 @@
+class <%= name %>::role<%= index %> {
+  notify { "<%= name %>::role<%= index %>": }
+}

--- a/lib/puppet/util/monkey_patches.rb
+++ b/lib/puppet/util/monkey_patches.rb
@@ -29,6 +29,28 @@ class Object
   end
 end
 
+if RUBY_VERSION.to_f < 3.0
+  # absolute/relative were optimized to avoid chop_basename in ruby 3
+  # see https://github.com/ruby/ruby/commit/39312cf4d6c2ab3f07d688ad1a467c8f84b58db0
+  require 'pathname'
+  class Pathname
+    if File.dirname('A:') == 'A:.' # DOSish drive letter
+      ABSOLUTE_PATH = /\A(?:[A-Za-z]:|#{SEPARATOR_PAT})/o
+    else
+      ABSOLUTE_PATH = /\A#{SEPARATOR_PAT}/o
+    end
+    private_constant :ABSOLUTE_PATH
+
+    def absolute?
+      ABSOLUTE_PATH.match? @path
+    end
+
+    def relative?
+      !absolute?
+    end
+  end
+end
+
 # (#19151) Reject all SSLv2 ciphers and handshakes
 require 'puppet/ssl/openssl_loader'
 unless Puppet::Util::Platform.jruby_fips?


### PR DESCRIPTION
The unoptimized version makes N+1 substrings where N is the number of
path components:

   /a/b/c
   /a/b
   /a
   ''

It's worse on Windows due to the long install path. The optimization was
released in Ruby 3, so make it conditional.

The `many_modules` benchmark is reduced by ~1MB due to 21K fewer Pathname allocations

```
< Total allocated: 182369970 bytes (2324118 objects)
> Total allocated: 181314432 bytes (2303673 objects)

allocated memory by gem
-----------------------------------
<  28202981  pathname
>  27147491  pathname

allocated objects by gem
-----------------------------------
<    445128  pathname
>    424684  pathname
```