### PR TITLE
(maint) Fix order dependent spec failures

### DIFF
--- a/spec/shared_contexts/l10n.rb
+++ b/spec/shared_contexts/l10n.rb
@@ -4,7 +4,11 @@ RSpec.shared_context('l10n') do |locale|
   before :all do
     @old_locale = Locale.current
     Locale.current = locale
+
+    @old_gettext_disabled = Puppet::GettextConfig.instance_variable_get(:@gettext_disabled)
+    Puppet::GettextConfig.instance_variable_set(:@gettext_disabled, false)
     Puppet::GettextConfig.setup_locale
+    Puppet::GettextConfig.create_default_text_domain
 
     # overwrite stubs with real implementation
     ::Object.send(:remove_method, :_)
@@ -17,6 +21,7 @@ RSpec.shared_context('l10n') do |locale|
   after :all do
     Locale.current = @old_locale
 
+    Puppet::GettextConfig.instance_variable_set(:@gettext_disabled, @old_gettext_disabled)
     # restore stubs
     load File.expand_path(File.join(__dir__, '../../lib/puppet/gettext/stubs.rb'))
   end


### PR DESCRIPTION
Previously, if a test set `Puppet[:disable_i18n] = true`, then the l10n
integration test would fail, because the `gettext_disabled` instance variable
was still true. This can be reproduced in 6.x via:

    $ bundle exec rspec spec/unit/node/environment_spec.rb \
        spec/integration/l10n/compiler_spec.rb
      ..
      expected: "それは楽しい時間です"
      got: "IT'S HAPPY FUN TIME"

Similarly, running these in order would fail, because the default text domain
was deleted but never readded:

    $ bundle exec rspec spec/unit/gettext/config_spec.rb \
      spec/integration/l10n/compiler_spec.rb
      ..
      FastGettext::Storage::NoTextDomainConfigured:
      Current textdomain (nil) was not added, use FastGettext.add_text_domain !

This updates the l10n shared context to more completely restore l10n support.