### PR TITLE
(PUP-7362) Fail fast if there are no facts for a node

### DIFF
--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -360,6 +360,10 @@ Copyright (c) 2015 Puppet Inc., LLC Licensed under the Apache 2.0 License
       facts = Puppet::Node::Facts.new(node, {}) if facts.nil?
       facts.add_extra_values(given_facts) if given_facts
 
+      if facts.values.empty?
+        raise _("No facts available for target node: %{node}") % { node: node}
+      end
+
       ni = Puppet::Node.indirection
       tc = ni.terminus_class
 

--- a/spec/integration/application/lookup_spec.rb
+++ b/spec/integration/application/lookup_spec.rb
@@ -7,7 +7,6 @@ describe 'lookup' do
   include PuppetSpec::Files
 
   context 'with an environment' do
-    let(:facts) { Puppet::Node::Facts.new("facts", {}) }
     let(:env_name) { 'spec' }
     let(:env_dir) { tmpdir('environments') }
     let(:environment_files) do
@@ -45,6 +44,11 @@ describe 'lookup' do
     let(:app) { Puppet::Application[:lookup] }
     let(:env) { Puppet::Node::Environment.create(env_name.to_sym, [File.join(populated_env_dir, env_name, 'modules')]) }
     let(:environments) { Puppet::Environments::Directories.new(populated_env_dir, []) }
+    let(:facts) { Puppet::Node::Facts.new("facts", {'my_fact' => 'my_fact_value'}) }
+
+    before do
+      allow(Puppet::Node::Facts.indirection).to receive(:find).and_return(facts)
+    end
 
     let(:populated_env_dir) do
       dir_contained_in(env_dir, environment_files)
@@ -110,7 +114,7 @@ describe 'lookup' do
       require 'puppet/indirector/node/exec'
       require 'puppet/indirector/node/plain'
 
-      let(:node) { Puppet::Node.new('testnode', :environment => env) }
+      let(:node) { Puppet::Node.new('testnode', :facts => facts, :environment => env) }
 
       it ':plain without --compile' do
         Puppet.settings[:node_terminus] = 'exec'

--- a/spec/unit/application/lookup_spec.rb
+++ b/spec/unit/application/lookup_spec.rb
@@ -631,6 +631,14 @@ Searching for "a"
             lookup.run_command
           }.to raise_error(/Incorrectly formatted data in .+ given via the --facts flag \(only accepts yaml and json files\)/)
         end
+
+        it "fails when a node doesn't have facts" do
+          lookup.options[:node] = "bad.node"
+          allow(lookup.command_line).to receive(:args).and_return(['c'])
+
+          expected_error = "No facts available for target node: #{lookup.options[:node]}"
+          expect { lookup.run_command }.to raise_error(RuntimeError, expected_error)
+        end
       end
     end
 


### PR DESCRIPTION
Previously, puppet lookup would return incorrect results for any target node that had no facts cached.

For example when using the `Per-node data` hierarchy, with the path to the data fail being the value of `$trusted[certname]`, a node that had the said fact cached would return the correct data from its data file, but a node which didn't have any facts cached, would default to a common configuration file, outputting the data from there.

This is misleading since it doesn't error out, giving the impression that the run went well, when in actuality it failed to fetch the correct data.

This commit fixes this issue by failing the run the moment we are able to see that the target node has no cached facts.

TODO:
- [ ] rebase and solve conflicts