### PR TITLE
(PUP-10435) Facts provided in a file can't be used for classification

### DIFF
--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -337,18 +337,6 @@ Copyright (c) 2015 Puppet Inc., LLC Licensed under the Apache 2.0 License
       Puppet.settings[:facts_terminus] = 'facter'
     end
 
-    unless node.is_a?(Puppet::Node) # to allow unit tests to pass a node instance
-      ni = Puppet::Node.indirection
-      tc = ni.terminus_class
-      if tc == :plain || options[:compile]
-        node = ni.find(node)
-      else
-        ni.terminus_class = :plain
-        node = ni.find(node)
-        ni.terminus_class = tc
-      end
-    end
-
     fact_file = options[:fact_file]
 
     if fact_file
@@ -364,7 +352,26 @@ Copyright (c) 2015 Puppet Inc., LLC Licensed under the Apache 2.0 License
       unless given_facts.instance_of?(Hash)
         raise _("Incorrectly formatted data in %{fact_file} given via the --facts flag (only accepts yaml and json files)") % { fact_file: fact_file }
       end
-      node.add_extra_facts(given_facts)
+    end
+
+    unless node.is_a?(Puppet::Node) # to allow unit tests to pass a node instance
+      facts = Puppet::Node::Facts.indirection.find(node, :environment => Puppet.lookup(:current_environment))
+
+      facts = Puppet::Node::Facts.new(node, {}) if facts.nil?
+      facts.add_extra_values(given_facts) if given_facts
+
+      ni = Puppet::Node.indirection
+      tc = ni.terminus_class
+
+      if tc == :plain || options[:compile]
+        node = ni.find(node, facts: facts)
+      else
+        ni.terminus_class = :plain
+        node = ni.find(node, facts: facts)
+        ni.terminus_class = tc
+      end
+    else
+      node.add_extra_facts(given_facts) if given_facts
     end
 
     Puppet[:code] = 'undef' unless options[:compile]

--- a/spec/integration/application/lookup_spec.rb
+++ b/spec/integration/application/lookup_spec.rb
@@ -7,6 +7,7 @@ describe 'lookup' do
   include PuppetSpec::Files
 
   context 'with an environment' do
+    let(:facts) { Puppet::Node::Facts.new("facts", {}) }
     let(:env_name) { 'spec' }
     let(:env_dir) { tmpdir('environments') }
     let(:environment_files) do
@@ -98,6 +99,8 @@ describe 'lookup' do
 
     it 'skip loading of external facts when run with --node' do
       app.options[:node] = "random_node"
+
+      expect(Puppet::Node::Facts.indirection).to receive(:find).and_return(facts)
       expect(Facter).to receive(:load_external).once.with(false)
       expect(Facter).to receive(:load_external).once.with(true)
       lookup('a')


### PR DESCRIPTION
5cde767dc1e67afc729b4ff6cdf5d603e02228ae added the ability to use facts
from a fact file, but those facts were added after the classification
happened, meaning that any facts used as rules for classification
couldn't be overridden with the facts from the fact file.

This commit fixes this issue by querying pdb to get the target node's
facts, and merge the facts provided from the fact file, before the
classification happens.

- [x] fix tests
- [x] add tests