### PR TITLE
(PUP-11312) Reduce Pathname allocation

### DIFF
--- a/lib/puppet/file_system/path_pattern.rb
+++ b/lib/puppet/file_system/path_pattern.rb
@@ -5,10 +5,9 @@ module Puppet::FileSystem
   class PathPattern
     class InvalidPattern < Puppet::Error; end
 
-    TRAVERSAL = /^\.\.$/
+    DOTDOT = '..'.freeze
     ABSOLUTE_UNIX = /^\//
     ABSOLUTE_WINDOWS = /^[a-z]:/i
-    #ABSOLUT_VODKA #notappearinginthisclass
     CURRENT_DRIVE_RELATIVE_WINDOWS = /^\\/
 
     def self.relative(pattern)
@@ -46,12 +45,9 @@ module Puppet::FileSystem
     private
 
     def validate
-      @pathname.each_filename do |e|
-        if e =~ TRAVERSAL
-          raise(InvalidPattern, _("PathPatterns cannot be created with directory traversals."))
-        end
-      end
-      if @pathstr.match?(CURRENT_DRIVE_RELATIVE_WINDOWS)
+      if @pathstr.split(Pathname::SEPARATOR_PAT).any? { |f| f == DOTDOT }
+        raise(InvalidPattern, _("PathPatterns cannot be created with directory traversals."))
+      elsif @pathstr.match?(CURRENT_DRIVE_RELATIVE_WINDOWS)
         raise(InvalidPattern, _("A PathPattern cannot be a Windows current drive relative path."))
       end
     end

--- a/lib/puppet/file_system/path_pattern.rb
+++ b/lib/puppet/file_system/path_pattern.rb
@@ -32,11 +32,11 @@ module Puppet::FileSystem
     end
 
     def glob
-      Dir.glob(pathname.to_s)
+      Dir.glob(@pathstr)
     end
 
     def to_s
-      pathname.to_s
+      @pathstr
     end
 
     protected
@@ -51,8 +51,7 @@ module Puppet::FileSystem
           raise(InvalidPattern, _("PathPatterns cannot be created with directory traversals."))
         end
       end
-      case @pathname.to_s
-      when CURRENT_DRIVE_RELATIVE_WINDOWS
+      if @pathstr.match?(CURRENT_DRIVE_RELATIVE_WINDOWS)
         raise(InvalidPattern, _("A PathPattern cannot be a Windows current drive relative path."))
       end
     end
@@ -60,6 +59,7 @@ module Puppet::FileSystem
     def initialize(pattern)
       begin
         @pathname = Pathname.new(pattern.strip)
+        @pathstr = @pathname.to_s
       rescue ArgumentError => error
         raise InvalidPattern.new(_("PathPatterns cannot be created with a zero byte."), error)
       end
@@ -74,10 +74,9 @@ module Puppet::FileSystem
 
     def validate
       super
-      case @pathname.to_s
-      when ABSOLUTE_WINDOWS
+      if @pathstr.match?(ABSOLUTE_WINDOWS)
         raise(InvalidPattern, _("A relative PathPattern cannot be prefixed with a drive."))
-      when ABSOLUTE_UNIX
+      elsif @pathstr.match?(ABSOLUTE_UNIX)
         raise(InvalidPattern, _("A relative PathPattern cannot be an absolute path."))
       end
     end
@@ -90,7 +89,7 @@ module Puppet::FileSystem
 
     def validate
       super
-      if @pathname.to_s !~ ABSOLUTE_UNIX and @pathname.to_s !~ ABSOLUTE_WINDOWS
+      if !@pathstr.match?(ABSOLUTE_UNIX) && !@pathstr.match?(ABSOLUTE_WINDOWS)
         raise(InvalidPattern, _("An absolute PathPattern cannot be a relative path."))
       end
     end

--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -614,20 +614,25 @@ class Checker4_0 < Evaluator::LiteralEvaluator
     string_path == manifest_setting || string_path.start_with?(manifest_setting)
   end
 
+  # Get the path of +file_path+ relative to the first directory in
+  # +modulepath_directories+ that is an ancestor of +file_path+. Return NO_PATH
+  # if none is found.
   def get_module_relative_path(file_path, modulepath_directories)
-    clean_file = file_path.cleanpath
+    clean_file = file_path.cleanpath.to_s
     parent_path = modulepath_directories.find { |path_dir| is_parent_dir_of(path_dir, clean_file) }
     return NO_PATH if parent_path.nil?
 
     file_path.relative_path_from(Pathname.new(parent_path))
   end
+  private :get_module_relative_path
 
   def is_parent_dir_of(parent_dir, child_dir)
     parent_dir_path = Pathname.new(parent_dir)
     clean_parent = parent_dir_path.cleanpath.to_s + File::SEPARATOR
 
-    return child_dir.to_s.start_with?(clean_parent)
+    return child_dir.start_with?(clean_parent)
   end
+  private :is_parent_dir_of
 
   def dir_to_names(relative_path)
     # Downcasing here because check is case-insensitive


### PR DESCRIPTION
`PathPattern` now caches its `Pathname#to_s` eliminating 4 copies during validation.

It also no longer uses `Pathname#each_filename` to check for `..`, as that method is implemented using `Pathname#chop_basename` and is slow.

Memory allocation for the `many_modules` benchmark is reduced by 2.3MB due to fewer calls to `Pathname#to_s`

Before
```
Total allocated: 118278927 bytes (1750119 objects)
Total retained:  7348796 bytes (103634 objects)

allocated memory by gem
-----------------------------------
  91126921  puppet/lib
  21367896  pathname
  ...
allocated memory by file
-----------------------------------
  21367896  /home/josh/.rbenv/versions/2.7.3/lib/ruby/2.7.0/pathname.rb
   ...
   1024342  /home/josh/work/puppet/lib/puppet/file_system/path_pattern.rb
   ...
allocated memory by location
-----------------------------------
   8934743  /home/josh/.rbenv/versions/2.7.3/lib/ruby/2.7.0/pathname.rb:43
   ...
   5467360  /home/josh/.rbenv/versions/2.7.3/lib/ruby/2.7.0/pathname.rb:47
```

After
```
Total allocated: 116041911 bytes (1706995 objects)
Total retained:  7352805 bytes (103734 objects)

allocated memory by gem
-----------------------------------
  91843595  puppet/lib
  18414206  pathname
  ...
allocated memory by file
-----------------------------------
  18414206  /home/josh/.rbenv/versions/2.7.3/lib/ruby/2.7.0/pathname.rb
   ...
   1741016  /home/josh/work/puppet/lib/puppet/file_system/path_pattern.rb
   ...
allocated memory by location
-----------------------------------
   7299445  /home/josh/.rbenv/versions/2.7.3/lib/ruby/2.7.0/pathname.rb:43
   ...
   4546800  /home/josh/.rbenv/versions/2.7.3/lib/ruby/2.7.0/pathname.rb:47
   ...
   1083322  /home/josh/work/puppet/lib/puppet/file_system/path_pattern.rb:48

```