### PR TITLE
(PUP-11318) Use Array#concat not +

### DIFF
--- a/lib/puppet/pops/parser/code_merger.rb
+++ b/lib/puppet/pops/parser/code_merger.rb
@@ -15,10 +15,10 @@ class Puppet::Pops::Parser::CodeMerger
       case parsed_class.code
       when Puppet::Parser::AST::BlockExpression
         # the BlockExpression wraps a single 4x instruction that is most likely wrapped in a Factory
-        memo + parsed_class.code.children.map {|c| c.is_a?(Puppet::Pops::Model::Factory) ? c.model : c }
+        memo.concat(parsed_class.code.children.map {|c| c.is_a?(Puppet::Pops::Model::Factory) ? c.model : c })
       when Puppet::Pops::Model::Factory
         # If it is a 4x instruction wrapped in a Factory
-        memo + parsed_class.code.model
+        memo.concat(parsed_class.code.model)
       else
         # It is the instruction directly
         memo << parsed_class.code


### PR DESCRIPTION
The plus method creates a new Array containing a copy of the left and right
arrays, and the new array becomes the memo for the next iteration. We can avoid
copying the left array, by using Array#concat instead.

before

```
Total allocated: 155405726 bytes (2088332 objects)

allocated memory by file
-----------------------------------
  17661400  /home/josh/work/puppet/lib/puppet/pops/parser/code_merger.rb
```

after

```
Total allocated: 152127702 bytes (2087032 objects)

allocated memory by file
-----------------------------------
  14383376  /home/josh/work/puppet/lib/puppet/pops/parser/code_merger.rb
```
