### PR TITLE
(maint) Ensure benchmark's manifest matches class name

### DIFF
--- a/benchmarks/many_modules/benchmarker.rb
+++ b/benchmarks/many_modules/benchmarker.rb
@@ -84,7 +84,7 @@ class Benchmarker
 
       roles.each do |j|
         render(File.join(templates, 'module', 'role.pp.erb'),
-               File.join(manifests, "role#{i}.pp"),
+               File.join(manifests, "role#{j}.pp"),
                :name => module_name,
                :index => j)
       end


### PR DESCRIPTION
Use j not i when naming the manifest, so the name matches the class.