### PR TITLE
(PUP-11318) Use flat_map not +

### DIFF
--- a/benchmarks/many_modules/benchmarker.rb
+++ b/benchmarks/many_modules/benchmarker.rb
@@ -70,13 +70,24 @@ class Benchmarker
           )
       end
 
+      roles = 0.upto(10).to_a
+
       render(File.join(templates, 'module', 'init.pp.erb'),
              File.join(manifests, 'init.pp'),
-             :name => module_name)
+             :name => module_name,
+             :roles => roles
+            )
 
       render(File.join(templates, 'module', 'internal.pp.erb'),
              File.join(manifests, 'internal.pp'),
              :name => module_name)
+
+      roles.each do |j|
+        render(File.join(templates, 'module', 'role.pp.erb'),
+               File.join(manifests, "role#{i}.pp"),
+               :name => module_name,
+               :index => j)
+      end
     end
 
     render(File.join(templates, 'puppet.conf.erb'),

--- a/benchmarks/many_modules/benchmarker.rb
+++ b/benchmarks/many_modules/benchmarker.rb
@@ -84,7 +84,7 @@ class Benchmarker
 
       roles.each do |j|
         render(File.join(templates, 'module', 'role.pp.erb'),
-               File.join(manifests, "role#{i}.pp"),
+               File.join(manifests, "role#{j}.pp"),
                :name => module_name,
                :index => j)
       end

--- a/benchmarks/many_modules/module/init.pp.erb
+++ b/benchmarks/many_modules/module/init.pp.erb
@@ -1,3 +1,6 @@
 class <%= name %> {
   class { "<%= name %>::internal": }
+  <% roles.each do |role| %>
+    class { "<%= name %>::role<%= role %>": }
+  <% end %>
 }

--- a/benchmarks/many_modules/module/role.pp.erb
+++ b/benchmarks/many_modules/module/role.pp.erb
@@ -1,0 +1,3 @@
+class <%= name %>::role<%= index %> {
+  notify { "<%= name %>::role<%= index %>": }
+}


### PR DESCRIPTION
Commit af560639d0 flattened the code produced by the code merger to avoid
a deeply nested tree, but it used += to concatenate the children.

Commit f2ae1b0404 switched to `+` which eliminated the Lint/UselessAssignment
rubocop warning, but still created a new Array containing a copy of the memo and
the parsed class' code. This meant every iteration copied the memo and the memo
increased in size each time.

This commit uses `flat_map`, which correctly appends a single element or an
array of elements to the `children` array and has the same memory profile as
calling concat (for arrays) or << (for an element).

The many_modules benchmark shows a reduction in allocated memory by 3.2MB, all of which comes from memory allocated by Arrays.

Before

```
Total allocated: 157407598 bytes (2131019 objects)

allocated memory by file
-----------------------------------
  17661400  /home/josh/work/puppet/lib/puppet/pops/parser/code_merger.rb

allocated memory by class
-----------------------------------
  42876832  Array
```

After

```
Total allocated: 154204098 bytes (2129718 objects)

allocated memory by file
-----------------------------------
  14383376  /home/josh/work/puppet/lib/puppet/pops/parser/code_merger.rb

allocated memory by class
-----------------------------------
  39598808  Array
```
