### PR TITLE
(PUP-11319) Move `DEFAULT_TIMEOUT` constant for Windows services

### DIFF
--- a/lib/puppet/util/windows.rb
+++ b/lib/puppet/util/windows.rb
@@ -9,6 +9,9 @@ module Puppet::Util::Windows
   module File; end
   module Registry
   end
+  module Service
+    DEFAULT_TIMEOUT = 30
+  end
   module SID
     class Principal; end
   end

--- a/lib/puppet/util/windows/service.rb
+++ b/lib/puppet/util/windows/service.rb
@@ -13,11 +13,6 @@ module Puppet::Util::Windows
 
     FILE = Puppet::Util::Windows::File
 
-    # integer value of the floor for timeouts when waiting for service pending states.
-    # puppet will wait the length of dwWaitHint if it is longer than this value, but
-    # no shorter
-    DEFAULT_TIMEOUT = 30
-
     # Service error codes
     # https://docs.microsoft.com/en-us/windows/desktop/debug/system-error-codes--1000-1299-
     ERROR_SERVICE_DOES_NOT_EXIST = 0x00000424


### PR DESCRIPTION
This commit moves the `DEFAULT_TIMEOUT` constant from `lib/puppet/util/windows/service.rb` to `lib/puppet/util/windows.rb` to avoid `uninitialized constant` errors when compiling catalogs on nonWindows OS.