### PR TITLE
(PUP-11236) Work around Thread#thread_variable? bug

### DIFF
--- a/lib/puppet/concurrent/thread_local_singleton.rb
+++ b/lib/puppet/concurrent/thread_local_singleton.rb
@@ -5,10 +5,12 @@ module Puppet
       def singleton
         key = (name + ".singleton").intern
         thread = Thread.current
-        unless thread.thread_variable?(key)
-          thread.thread_variable_set(key, new)
+        value = thread.thread_variable_get(key)
+        if value.nil?
+          value = new
+          thread.thread_variable_set(key, value)
         end
-        thread.thread_variable_get(key)
+        value
       end
     end
   end


### PR DESCRIPTION
Thread#thread_variable? sometimes returns false[1] on MRI, which causes the
ThreadLocalSingleton to not behave like a singleton. Instead call `thread_variable_get`
to see it's set. This means the singleton value can't be `nil`, but we
never do that in practice.

Kudos to @mikaelsmith for finding the ruby bug!

[1] https://bugs.ruby-lang.org/issues/16906

This reduces the many_modules benchmark (updated in https://github.com/puppetlabs/puppet/pull/8792) by about 37MB on MRI:

```
Total allocated: 184825386 bytes (2331704 objects)

allocated memory by file
-----------------------------------
  36832308  /home/josh/work/puppet/lib/puppet/pops/parser/lexer2.rb
```

```
Total allocated: 147626146 bytes (1993015 objects)

allocated memory by file
-----------------------------------
   5847972  /home/josh/work/puppet/lib/puppet/pops/parser/lexer2.rb
```
