### PR TITLE
(maint) Merge 6.x into main

### DIFF
--- a/lib/puppet/concurrent/thread_local_singleton.rb
+++ b/lib/puppet/concurrent/thread_local_singleton.rb
@@ -5,10 +5,12 @@ module Puppet
       def singleton
         key = (name + ".singleton").intern
         thread = Thread.current
-        unless thread.thread_variable?(key)
-          thread.thread_variable_set(key, new)
+        value = thread.thread_variable_get(key)
+        if value.nil?
+          value = new
+          thread.thread_variable_set(key, value)
         end
-        thread.thread_variable_get(key)
+        value
       end
     end
   end

--- a/lib/puppet/provider/service/init.rb
+++ b/lib/puppet/provider/service/init.rb
@@ -84,7 +84,7 @@ Puppet::Type.type(:service).provide :init, :parent => :base do
     defpath = [defpath] unless defpath.is_a? Array
     instances = []
     defpath.each do |path|
-      unless FileTest.directory?(path)
+      unless Puppet::FileSystem.directory?(path)
         Puppet.debug "Service path #{path} does not exist"
         next
       end
@@ -97,8 +97,9 @@ Puppet::Type.type(:service).provide :init, :parent => :base do
         fullpath = File.join(path, name)
         next if name =~ /^\./
         next if exclude.include? name
-        next if not FileTest.executable?(fullpath)
-        next if not is_init?(fullpath)
+        next if Puppet::FileSystem.directory?(fullpath)
+        next unless Puppet::FileSystem.executable?(fullpath)
+        next unless is_init?(fullpath)
         instances << new(:name => name, :path => path, :hasstatus => true)
       end
     end
@@ -122,7 +123,7 @@ Puppet::Type.type(:service).provide :init, :parent => :base do
 
   def paths
     @paths ||= @resource[:path].find_all do |path|
-      if File.directory?(path)
+      if Puppet::FileSystem.directory?(path)
         true
       else
         if Puppet::FileSystem.exist?(path)

--- a/lib/puppet/util/windows.rb
+++ b/lib/puppet/util/windows.rb
@@ -10,6 +10,9 @@ module Puppet::Util::Windows
   module File; end
   module Registry
   end
+  module Service
+    DEFAULT_TIMEOUT = 30
+  end
   module SID
     class Principal; end
   end

--- a/lib/puppet/util/windows/service.rb
+++ b/lib/puppet/util/windows/service.rb
@@ -18,11 +18,6 @@ module Puppet::Util::Windows
     include Puppet::FFI::Windows::Functions
     extend Puppet::FFI::Windows::Functions
 
-    # integer value of the floor for timeouts when waiting for service pending states.
-    # puppet will wait the length of dwWaitHint if it is longer than this value, but
-    # no shorter
-    DEFAULT_TIMEOUT = 30
-
     # Returns true if the service exists, false otherwise.
     #
     # @param [String] service_name name of the service

--- a/spec/unit/provider/service/gentoo_spec.rb
+++ b/spec/unit/provider/service/gentoo_spec.rb
@@ -6,8 +6,8 @@ describe 'Puppet::Type::Service::Provider::Gentoo',
 
   before :each do
     allow(Puppet::Type.type(:service)).to receive(:defaultprovider).and_return(provider_class)
-    allow(FileTest).to receive(:file?).with('/sbin/rc-update').and_return(true)
-    allow(FileTest).to receive(:executable?).with('/sbin/rc-update').and_return(true)
+    allow(Puppet::FileSystem).to receive(:file?).with('/sbin/rc-update').and_return(true)
+    allow(Puppet::FileSystem).to receive(:executable?).with('/sbin/rc-update').and_return(true)
     allow(Facter).to receive(:value).with(:operatingsystem).and_return('Gentoo')
     allow(Facter).to receive(:value).with(:osfamily).and_return('Gentoo')
 
@@ -52,13 +52,14 @@ describe 'Puppet::Type::Service::Provider::Gentoo',
     end
 
     it "should get a list of services from /etc/init.d but exclude helper scripts" do
-      expect(FileTest).to receive(:directory?).with('/etc/init.d').and_return(true)
+      allow(Puppet::FileSystem).to receive(:directory?).and_call_original
+      allow(Puppet::FileSystem).to receive(:directory?).with('/etc/init.d').and_return(true)
       expect(Dir).to receive(:entries).with('/etc/init.d').and_return(initscripts)
       (initscripts - helperscripts).each do |script|
-        expect(FileTest).to receive(:executable?).with("/etc/init.d/#{script}").and_return(true)
+        expect(Puppet::FileSystem).to receive(:executable?).with("/etc/init.d/#{script}").and_return(true)
       end
       helperscripts.each do |script|
-        expect(FileTest).not_to receive(:executable?).with("/etc/init.d/#{script}")
+        expect(Puppet::FileSystem).not_to receive(:executable?).with("/etc/init.d/#{script}")
       end
 
       allow(Puppet::FileSystem).to receive(:symlink?).and_return(false)

--- a/spec/unit/provider/service/init_spec.rb
+++ b/spec/unit/provider/service/init_spec.rb
@@ -85,12 +85,18 @@ describe 'Puppet::Type::Service::Provider::Init',
       @services = ['one', 'two', 'three', 'four', 'umountfs']
       allow(Dir).to receive(:entries).and_call_original
       allow(Dir).to receive(:entries).with('tmp').and_return(@services)
-      expect(FileTest).to receive(:directory?).with('tmp').and_return(true)
-      allow(FileTest).to receive(:executable?).and_return(true)
+      allow(Puppet::FileSystem).to receive(:directory?).and_call_original
+      allow(Puppet::FileSystem).to receive(:directory?).with('tmp').and_return(true)
+      allow(Puppet::FileSystem).to receive(:executable?).and_return(true)
     end
 
     it "should return instances for all services" do
       expect(provider_class.instances.map(&:name)).to eq(@services)
+    end
+
+    it "should omit directories from the service list" do
+      expect(Puppet::FileSystem).to receive(:directory?).with('tmp/four').and_return(true)
+      expect(provider_class.instances.map(&:name)).to eq(@services - ['four'])
     end
 
     it "should omit an array of services from exclude list" do
@@ -140,9 +146,9 @@ describe 'Puppet::Type::Service::Provider::Init',
 
   describe "when checking valid paths" do
     it "should discard paths that do not exist" do
-      expect(File).to receive(:directory?).with(paths[0]).and_return(false)
+      expect(Puppet::FileSystem).to receive(:directory?).with(paths[0]).and_return(false)
       expect(Puppet::FileSystem).to receive(:exist?).with(paths[0]).and_return(false)
-      expect(File).to receive(:directory?).with(paths[1]).and_return(true)
+      expect(Puppet::FileSystem).to receive(:directory?).with(paths[1]).and_return(true)
 
       expect(provider.paths).to eq([paths[1]])
     end
@@ -150,7 +156,7 @@ describe 'Puppet::Type::Service::Provider::Init',
     it "should discard paths that are not directories" do
       paths.each do |path|
         expect(Puppet::FileSystem).to receive(:exist?).with(path).and_return(true)
-        expect(File).to receive(:directory?).with(path).and_return(false)
+        expect(Puppet::FileSystem).to receive(:directory?).with(path).and_return(false)
       end
       expect(provider.paths).to be_empty
     end
@@ -158,7 +164,7 @@ describe 'Puppet::Type::Service::Provider::Init',
 
   describe "when searching for the init script" do
     before :each do
-      paths.each {|path| expect(File).to receive(:directory?).with(path).and_return(true) }
+      paths.each {|path| expect(Puppet::FileSystem).to receive(:directory?).with(path).and_return(true) }
     end
 
     it "should be able to find the init script in the service path" do
@@ -191,9 +197,9 @@ describe 'Puppet::Type::Service::Provider::Init',
 
   describe "if the init script is present" do
     before :each do
-      allow(File).to receive(:directory?).and_call_original
-      allow(File).to receive(:directory?).with("/service/path").and_return(true)
-      allow(File).to receive(:directory?).with("/alt/service/path").and_return(true)
+      allow(Puppet::FileSystem).to receive(:directory?).and_call_original
+      allow(Puppet::FileSystem).to receive(:directory?).with("/service/path").and_return(true)
+      allow(Puppet::FileSystem).to receive(:directory?).with("/alt/service/path").and_return(true)
       allow(Puppet::FileSystem).to receive(:exist?).with("/service/path/myservice").and_return(true)
     end
 

--- a/spec/unit/provider/service/openwrt_spec.rb
+++ b/spec/unit/provider/service/openwrt_spec.rb
@@ -2,63 +2,56 @@ require 'spec_helper'
 
 describe 'Puppet::Type::Service::Provider::Openwrt',
          unless: Puppet::Util::Platform.windows? || Puppet::Util::Platform.jruby? do
+
   let(:provider_class) { Puppet::Type.type(:service).provider(:openwrt) }
 
   let(:resource) do
-    resource = double('resource')
-    allow(resource).to receive(:[]).and_return(nil)
-    allow(resource).to receive(:[]).with(:name).and_return("myservice")
-    allow(resource).to receive(:[]).with(:path).and_return(["/etc/init.d"])
-
-    resource
+    Puppet::Type.type(:service).new(
+      :name       => 'myservice',
+      :path       => '/etc/init.d',
+      :hasrestart => true,
+    )
   end
 
   let(:provider) do
     provider = provider_class.new
-    allow(provider).to receive(:get).with(:hasstatus).and_return(false)
-
+    provider.resource = resource
     provider
   end
 
   before :each do
-    allow(resource).to receive(:provider).and_return(provider)
-    provider.resource = resource
-
-    allow(FileTest).to receive(:file?).with('/etc/rc.common').and_return(true)
-    allow(FileTest).to receive(:executable?).with('/etc/rc.common').and_return(true)
+    resource.provider = provider
 
     # All OpenWrt tests operate on the init script directly. It must exist.
-    allow(File).to receive(:directory?).and_call_original
-    allow(File).to receive(:directory?).with('/etc/init.d').and_return(true)
+    allow(Puppet::FileSystem).to receive(:directory?).and_call_original
+    allow(Puppet::FileSystem).to receive(:directory?).with('/etc/init.d').and_return(true)
 
     allow(Puppet::FileSystem).to receive(:exist?).with('/etc/init.d/myservice').and_return(true)
-    allow(FileTest).to receive(:file?).and_call_original
-    allow(FileTest).to receive(:file?).with('/etc/init.d/myservice').and_return(true)
-    allow(FileTest).to receive(:executable?).with('/etc/init.d/myservice').and_return(true)
+    allow(Puppet::FileSystem).to receive(:file?).and_call_original
+    allow(Puppet::FileSystem).to receive(:file?).with('/etc/init.d/myservice').and_return(true)
+    allow(Puppet::FileSystem).to receive(:executable?).with('/etc/init.d/myservice').and_return(true)
   end
 
-  operatingsystem = 'openwrt'
-  it "should be the default provider on #{operatingsystem}" do
-    expect(Facter).to receive(:value).with(:operatingsystem).and_return(operatingsystem)
+  it "should be the default provider on 'openwrt'" do
+    expect(Facter).to receive(:value).with(:operatingsystem).and_return('openwrt')
     expect(provider_class.default?).to be_truthy
   end
 
   # test self.instances
   describe "when getting all service instances" do
-    let(:services) {['dnsmasq', 'dropbear', 'firewall', 'led', 'puppet', 'uhttpd' ]}
+    let(:services) { ['dnsmasq', 'dropbear', 'firewall', 'led', 'puppet', 'uhttpd' ] }
 
     before :each do
       allow(Dir).to receive(:entries).and_call_original
       allow(Dir).to receive(:entries).with('/etc/init.d').and_return(services)
-      allow(FileTest).to receive(:directory?).and_return(true)
-      allow(FileTest).to receive(:executable?).and_return(true)
+      allow(Puppet::FileSystem).to receive(:executable?).and_return(true)
     end
 
     it "should return instances for all services" do
       services.each do |inst|
         expect(provider_class).to receive(:new).with(hash_including(:name => inst, :path => '/etc/init.d')).and_return("#{inst}_instance")
       end
-      results = services.collect {|x| "#{x}_instance"}
+      results = services.collect { |x| "#{x}_instance"}
       expect(provider_class.instances).to eq(results)
     end
   end
@@ -82,14 +75,13 @@ describe 'Puppet::Type::Service::Provider::Openwrt',
 
     describe "when running #{method}" do
       it "should use any provided explicit command" do
-        allow(resource).to receive(:[]).with(method).and_return("/user/specified/command")
-        expect(provider).to receive(:execute).with(["/user/specified/command"], any_args)
+        resource[method] = '/user/specified/command'
+        expect(provider).to receive(:execute).with(['/user/specified/command'], any_args)
         provider.send(method)
       end
 
       it "should execute the init script with #{method} when no explicit command is provided" do
-        allow(resource).to receive(:[]).with("has#{method}".intern).and_return(:true)
-        expect(provider).to receive(:execute).with(['/etc/init.d/myservice', method ], any_args)
+        expect(provider).to receive(:execute).with(['/etc/init.d/myservice', method], any_args)
         provider.send(method)
       end
     end

--- a/spec/unit/provider/service/redhat_spec.rb
+++ b/spec/unit/provider/service/redhat_spec.rb
@@ -41,8 +41,9 @@ describe 'Puppet::Type::Service::Provider::Redhat',
       @services = ['one', 'two', 'three', 'four', 'kudzu', 'functions', 'halt', 'killall', 'single', 'linuxconf', 'boot', 'reboot']
       @not_services = ['functions', 'halt', 'killall', 'single', 'linuxconf', 'reboot', 'boot']
       allow(Dir).to receive(:entries).and_return(@services)
-      allow(FileTest).to receive(:directory?).and_return(true)
-      allow(FileTest).to receive(:executable?).and_return(true)
+      allow(Puppet::FileSystem).to receive(:directory?).and_call_original
+      allow(Puppet::FileSystem).to receive(:directory?).with('/etc/init.d').and_return(true)
+      allow(Puppet::FileSystem).to receive(:executable?).and_return(true)
     end
 
     it "should return instances for all services" do


### PR DESCRIPTION
* Commits:
  - (PUP-11236) Work around Thread#thread_variable? bug
  - (PUP-11319) Move `DEFAULT_TIMEOUT` constant for Windows services
  - (maint) Rewrite openwrt_spec.rb to avoid overstubbing
  - (maint) Update init provider to use Puppet::FileSystem
  - (PUP-11313) Prevent puppet from executing directories

* Conflicts:
  - lib/puppet/util/windows/service.rb - due to constants and structs
   still existing in the file on 6.x but not on main (when moving the
DEFAULT_TIMEOUT constant in 44eb687)