### PR TITLE
(PUP-11322) Incrementally append parse results

### DIFF
--- a/lib/puppet/pops/parser/code_merger.rb
+++ b/lib/puppet/pops/parser/code_merger.rb
@@ -17,6 +17,27 @@ class Puppet::Pops::Parser::CodeMerger
     Puppet::Parser::AST::BlockExpression.new(:children => children)
   end
 
+  # Append new parse results on the +right+ with existing results on the +left+.
+  # @return Puppet::Parser::AST::BlockExpression
+  def append(left, right)
+    # if the left hasn't been flattened yet, then fall back to concatenate
+    can_append = left &&
+                 left.code.instance_of?(Puppet::Parser::AST::BlockExpression) &&
+                 !left.code.children.any? { |c| c.instance_of?(Puppet::Pops::Model::Factory) }
+
+    if can_append
+      child = flatten(right)
+      if child.instance_of?(Array)
+        left.code.children.concat(child)
+      else
+        left.code.children << child
+      end
+    else
+      left.code = concatenate([left, right])
+      left
+    end
+  end
+
   private
 
   def flatten(parsed_class)

--- a/lib/puppet/pops/parser/code_merger.rb
+++ b/lib/puppet/pops/parser/code_merger.rb
@@ -12,18 +12,24 @@ class Puppet::Pops::Parser::CodeMerger
     # below maps the logic as flatly as possible.
     #
     children = parse_results.select {|x| !x.nil? && x.code}.flat_map do |parsed_class|
-      case parsed_class.code
-      when Puppet::Parser::AST::BlockExpression
-        # the BlockExpression wraps a single 4x instruction that is most likely wrapped in a Factory
-        parsed_class.code.children.map {|c| c.is_a?(Puppet::Pops::Model::Factory) ? c.model : c }
-      when Puppet::Pops::Model::Factory
-        # If it is a 4x instruction wrapped in a Factory
-        parsed_class.code.model
-      else
-        # It is the instruction directly
-        parsed_class.code
-      end
+      flatten(parsed_class)
     end
     Puppet::Parser::AST::BlockExpression.new(:children => children)
+  end
+
+  private
+
+  def flatten(parsed_class)
+    case parsed_class.code
+    when Puppet::Parser::AST::BlockExpression
+      # the BlockExpression wraps a single 4x instruction that is most likely wrapped in a Factory
+      parsed_class.code.children.map {|c| c.is_a?(Puppet::Pops::Model::Factory) ? c.model : c }
+    when Puppet::Pops::Model::Factory
+      # If it is a 4x instruction wrapped in a Factory
+      parsed_class.code.model
+    else
+      # It is the instruction directly
+      parsed_class.code
+    end
   end
 end

--- a/lib/puppet/resource/type.rb
+++ b/lib/puppet/resource/type.rb
@@ -225,7 +225,7 @@ class Puppet::Resource::Type
       return
     end
 
-    self.code = Puppet::Parser::ParserFactory.code_merger.concatenate([self, other])
+    Puppet::Parser::ParserFactory.code_merger.append(self, other)
   end
 
   # Make an instance of the resource type, and place it in the catalog


### PR DESCRIPTION
Each time we parsed a manifest, we copied the already merged code for the `main`
hostclass to a new BlockExpression and then added the code for the one new
parsed result. This process repeated for each parsed manifest leading to N^2
memory allocation where N is the number of manifests.

This creates a new method `append` that should be used to append a new parsed
result to an existing set of results. In order to preserve the flattening
behavior, if the `left` results haven't been flattened yet, then we fallback
to concatenate.

This creates a new method `append` that should be used to add a new parsed
result to an existing set of results. It reduces memory usage by 14MB.

Still need to figure out why evaluator impl, thread local singleton and string memory went up!

Before

```
Total allocated: 144282231 bytes (1991718 objects)

allocated memory by gem
-----------------------------------
 103953781  puppet/lib

allocated memory by file
-----------------------------------
  29973316  /home/josh/.rbenv/versions/2.5.8/lib/ruby/2.5.0/pathname.rb
  14695616  /home/josh/work/puppet/lib/puppet/pops/parser/code_merger.rb
  12948728  /home/josh/work/puppet/lib/puppet/resource.rb
   5847972  /home/josh/work/puppet/lib/puppet/pops/parser/lexer2.rb
...
   3923864  /home/josh/work/puppet/lib/puppet/resource/type.rb
...
   2808032  /home/josh/work/puppet/lib/puppet/pops/evaluator/evaluator_impl.rb
   1804251  /home/josh/work/puppet/lib/puppet/concurrent/thread_local_singleton.rb

allocated memory by class
-----------------------------------
  50858977  String
  38910680  Array
  28325224  Hash
  11627976  MatchData
   1237440  Proc
```

After

```
Total allocated: 129779084 bytes (1989146 objects)

allocated memory by gem
-----------------------------------
  89450634  puppet/lib

allocated memory by file
-----------------------------------
  29973316  /home/josh/.rbenv/versions/2.5.8/lib/ruby/2.5.0/pathname.rb
  12948728  /home/josh/work/puppet/lib/puppet/resource.rb
   5847972  /home/josh/work/puppet/lib/puppet/pops/parser/lexer2.rb
...
   3871864  /home/josh/work/puppet/lib/puppet/resource/type.rb
...
   2912032  /home/josh/work/puppet/lib/puppet/pops/evaluator/evaluator_impl.rb
   1971951  /home/josh/work/puppet/lib/puppet/concurrent/thread_local_singleton.rb
...
     11920  /home/josh/work/puppet/lib/puppet/pops/parser/code_merger.rb

allocated memory by class
-----------------------------------
  51131590  String
  27326824  Hash
  25122840  Array
  11627976  MatchData
   1341440  Proc
```