### PR TITLE
(PUP-8220) puppet lookup based on factfile restriction

### DIFF
--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -7,6 +7,7 @@ class Puppet::Application::Lookup < Puppet::Application
 
   RUN_HELP = _("Run 'puppet lookup --help' for more details").freeze
   DEEP_MERGE_OPTIONS = '--knock-out-prefix, --sort-merged-arrays, and --merge-hash-arrays'.freeze
+  TRUSTED_INFORMATION_FACTS = ["hostname", "domain", "fqdn", "clientcert"].freeze
 
   run_mode :server
 
@@ -351,6 +352,13 @@ Copyright (c) 2015 Puppet Inc., LLC Licensed under the Apache 2.0 License
 
       unless given_facts.instance_of?(Hash)
         raise _("Incorrectly formatted data in %{fact_file} given via the --facts flag (only accepts yaml and json files)") % { fact_file: fact_file }
+      end
+
+      if TRUSTED_INFORMATION_FACTS.any? { |key| given_facts.key? key }
+        unless TRUSTED_INFORMATION_FACTS.all? { |key| given_facts.key? key }
+          raise _("When overriding any of the %{trusted_facts_list} facts with %{fact_file} "\
+            "given via the --facts flag, they must all be overridden.") % { fact_file: fact_file ,trusted_facts_list: TRUSTED_INFORMATION_FACTS.join(',')}
+        end
       end
     end
 

--- a/spec/unit/application/lookup_spec.rb
+++ b/spec/unit/application/lookup_spec.rb
@@ -639,6 +639,33 @@ Searching for "a"
           expected_error = "No facts available for target node: #{lookup.options[:node]}"
           expect { lookup.run_command }.to raise_error(RuntimeError, expected_error)
         end
+
+        it 'raises error due to missing trusted information facts in --facts file' do
+          file_path = file_containing('facts.yaml', <<~CONTENT)
+            ---
+            fqdn: some.fqdn.com
+          CONTENT
+          lookup.options[:fact_file] = file_path
+
+          expect {
+            lookup.run_command
+          }.to raise_error(/When overriding any of the hostname,domain,fqdn,clientcert facts with #{file_path} given via the --facts flag, they must all be overridden./)
+        end
+
+        it 'does not fail when all trusted information facts are provided via --facts file' do
+          file_path = file_containing('facts.yaml', <<~CONTENT)
+            ---
+            fqdn: some.fqdn.com
+            hostname: some.hostname
+            domain: some.domain
+            clientcert: some.clientcert
+          CONTENT
+          lookup.options[:fact_file] = file_path
+
+          expect {
+            lookup.run_command
+          }.to exit_with(0)
+        end
       end
     end
 


### PR DESCRIPTION
When using puppet lookup with --facts, if the facts file overrides any of
hostname, domain, fqdn, clientcert, then it must override all of them.