### PR TITLE
Change the default CA name to be legal in a SAN DNSname

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1096,7 +1096,7 @@ EOT
     settings.define_settings(
     :ca,
     :ca_name => {
-      :default => "Puppet CA: $certname",
+      :default => "Puppet-CA.$certname",
       :desc    => "The name to use the Certificate Authority certificate.",
     },
     :cadir => {

--- a/man/man5/puppet.conf.5
+++ b/man/man5/puppet.conf.5
@@ -143,7 +143,7 @@ The expected fingerprint of the CA certificate\. If specified, the agent will co
 The name to use the Certificate Authority certificate\.
 .
 .IP "\(bu" 4
-\fIDefault\fR: \fBPuppet CA: $certname\fR
+\fIDefault\fR: \fBPuppet-CA.$certname\fR
 .
 .IP "" 0
 .


### PR DESCRIPTION
It appears that puppet now puts the default CA name in a SAN DNSname in the CA certificate. This bit
a puppet user who talked to me about it here:

https://github.com/libressl-portable/portable/issues/684

The default value is slightly problematic for this, because it contains spaces and colons that are not allowed in a SAN DNSname

This change would fix it by changing the default value to be a legal SAN DNSname. 

(You could also avoid the problem by not using this value in the SAN DNSname field of the cert)

