### PR TITLE
(PUP-11328) Fallback to node request in configurer

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -513,7 +513,17 @@ class Puppet::Configurer
                                              :transaction_uuid => @transaction_uuid,
                                              :fail_on_404 => true)
 
-        @server_specified_environment = node.environment.name.to_s
+        # The :rest node terminus returns a node with an environment_name, but not an
+        # environment instance. Attempting to get the environment instance will load
+        # it from disk, which will likely fail. So create a remote environment.
+        #
+        # The :plain node terminus returns a node with an environment, but not an
+        # environment_name.
+        if !node.has_environment_instance? && node.environment_name
+          node.environment = Puppet::Node::Environment.remote(node.environment_name)
+        end
+
+        @server_specified_environment = node.environment.to_s
 
         if @server_specified_environment != @environment
           Puppet.notice _("Local environment: '%{local_env}' doesn't match server specified node environment '%{node_env}', switching agent to '%{node_env}'.") % { local_env: @environment, node_env: @server_specified_environment }

--- a/spec/integration/application/agent_spec.rb
+++ b/spec/integration/application/agent_spec.rb
@@ -643,7 +643,14 @@ describe "puppet agent", unless: Puppet::Util::Platform.jruby? do
 
   context "environment convergence" do
     it "falls back to making a node request if the last server-specified environment cannot be loaded" do
-      server.start_server do |port|
+      mounts = {}
+      mounts[:node] = -> (req, res) {
+        node = Puppet::Node.new('test', environment: Puppet::Node::Environment.remote('doesnotexistonagent'))
+        res.body = formatter.render(node)
+        res['Content-Type'] = formatter.mime
+      }
+
+      server.start_server(mounts: mounts) do |port|
         Puppet[:serverport] = port
         Puppet[:log_level] = 'debug'
 


### PR DESCRIPTION
If we can't load our last server specified environment, then fallback to
making a node request like we used to. This way if we're supposed to use
a server specified environment and we upgrade, then we don't revert to
"production" and redownload plugins.

A node request will not be made if the `initial_environment` and the
`converged_environment` in the lastrunfile are identical, and the
`run_mode` is `agent`.

The logic is similar to what was removed in commit 39df438ef except
we're using `fail_on_404` so `Puppet::Node.indirection.find` will raise
instead of returning nil.

We also don't clear facts/query_options.