### PR TITLE
(maint) Remove references to git scheme

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -4,8 +4,8 @@
 # This gemspec is not intended to be used for building the Puppet gem.  This
 # gemspec is intended for use with bundler when Puppet is a dependency of
 # another project.  For example, the stdlib project is able to integrate with
-# the master branch of Puppet by using a Gemfile path of
-# git://github.com/puppetlabs/puppet.git
+# the main branch of Puppet by using a Gemfile path of
+# https://github.com/puppetlabs/puppet
 #
 # Please see the [packaging
 # repository](https://github.com/puppetlabs/packaging) for information on how

--- a/acceptance/tests/face/loadable_from_modules.rb
+++ b/acceptance/tests/face/loadable_from_modules.rb
@@ -20,7 +20,7 @@ metadata_json_file = <<-FILE
   "author": "Puppet Labs",
   "summary": "Nginx Module",
   "license": "Apache Version 2.0",
-  "source": "git://github.com/puppetlabs/puppetlabs-nginx.git",
+  "source": "https://github.com/puppetlabs/puppetlabs-nginx",
   "project_page": "https://github.com/puppetlabs/puppetlabs-nginx",
   "issues_url": "https://github.com/puppetlabs/puppetlabs-nginx",
   "dependencies": [

--- a/acceptance/tests/modules/changes/missing_checksums_json.rb
+++ b/acceptance/tests/modules/changes/missing_checksums_json.rb
@@ -20,7 +20,7 @@ apply_manifest_on master, %Q{
   "author": "Puppet Labs",
   "summary": "Nginx Module",
   "license": "Apache Version 2.0",
-  "source": "git://github.com/puppetlabs/puppetlabs-nginx.git",
+  "source": "https://github.com/puppetlabs/puppetlabs-nginx",
   "project_page": "https://github.com/puppetlabs/puppetlabs-nginx",
   "issues_url": "https://github.com/puppetlabs/puppetlabs-nginx",
   "dependencies": [

--- a/spec/fixtures/unit/forge/bacula.json
+++ b/spec/fixtures/unit/forge/bacula.json
@@ -37,7 +37,7 @@
           "license": "Apache 2.0",
           "checksums": { },
           "version": "0.0.2",
-          "source": "git://github.com/puppetlabs/puppetlabs-bacula.git",
+          "source": "https://github.com/puppetlabs/puppetlabs-bacula",
           "project_page": "https://github.com/puppetlabs/puppetlabs-bacula",
           "summary": "bacula",
           "dependencies": [ ],

--- a/spec/unit/forge/module_release_spec.rb
+++ b/spec/unit/forge/module_release_spec.rb
@@ -90,7 +90,7 @@ describe Puppet::Forge::ModuleRelease do
         "checksums": { },
         "version": "#{module_version}",
         "description": "Standard Library for Puppet Modules",
-        "source": "git://github.com/puppetlabs/puppetlabs-stdlib.git",
+        "source": "https://github.com/puppetlabs/puppetlabs-stdlib",
         "project_page": "https://github.com/puppetlabs/puppetlabs-stdlib",
         "summary": "Puppet Module Standard Library",
         "dependencies": [
@@ -204,7 +204,7 @@ describe Puppet::Forge::ModuleRelease do
         "checksums": { },
         "version": "#{module_version}",
         "description": "Standard Library for Puppet Modules",
-        "source": "git://github.com/puppetlabs/puppetlabs-stdlib.git",
+        "source": "https://github.com/puppetlabs/puppetlabs-stdlib",
         "project_page": "https://github.com/puppetlabs/puppetlabs-stdlib",
         "summary": "Puppet Module Standard Library",
         "author": "#{module_author}",
@@ -279,7 +279,7 @@ describe Puppet::Forge::ModuleRelease do
         "checksums": { },
         "version": "#{module_version}",
         "description": "Standard Library for Puppet Modules",
-        "source": "git://github.com/puppetlabs/puppetlabs-stdlib.git",
+        "source": "https://github.com/puppetlabs/puppetlabs-stdlib",
         "project_page": "https://github.com/puppetlabs/puppetlabs-stdlib",
         "summary": "Puppet Module Standard Library",
         "dependencies": [


### PR DESCRIPTION
This updates test fixtures for puppet module metadata to use https instead of
git. Note `.git` extension is removed, because that's a redirect to a URL that
doesn't have the extension.