### PR TITLE
(maint) Merge up fd0a86e to main

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -4,8 +4,8 @@
 # This gemspec is not intended to be used for building the Puppet gem.  This
 # gemspec is intended for use with bundler when Puppet is a dependency of
 # another project.  For example, the stdlib project is able to integrate with
-# the master branch of Puppet by using a Gemfile path of
-# git://github.com/puppetlabs/puppet.git
+# the main branch of Puppet by using a Gemfile path of
+# https://github.com/puppetlabs/puppet
 #
 # Please see the [packaging
 # repository](https://github.com/puppetlabs/packaging) for information on how

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source ENV['GEM_SOURCE'] || "https://rubygems.org"
 gemspec
 
 def location_for(place, fake_version = nil)
-  if place.is_a?(String) && place =~ /^(git[:@][^#]*)#(.*)/
+  if place.is_a?(String) && place =~ /^((?:git[:@]|https:)[^#]*)#(.*)/
     [fake_version, { git: $1, branch: $2, require: false }].compact
   elsif place.is_a?(String) && place =~ /^file:\/\/(.*)/
     ['>= 0', { path: File.expand_path($1), require: false }]

--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -3,7 +3,7 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 def location_for(place, fake_version = nil)
-  if place.is_a?(String) && place =~ /^(git:[^#]*)#(.*)/
+  if place.is_a?(String) && place =~ /^((?:git[:@]|https:)[^#]*)#(.*)/
     [fake_version, { :git => $1, :branch => $2, :require => false }].compact
   elsif place.is_a?(String) && place =~ /^file:\/\/(.*)/
     ['>= 0', { :path => File.expand_path($1), :require => false }]

--- a/acceptance/tests/face/loadable_from_modules.rb
+++ b/acceptance/tests/face/loadable_from_modules.rb
@@ -19,7 +19,7 @@ metadata_json_file = <<-FILE
   "author": "Puppet Labs",
   "summary": "Nginx Module",
   "license": "Apache Version 2.0",
-  "source": "git://github.com/puppetlabs/puppetlabs-nginx.git",
+  "source": "https://github.com/puppetlabs/puppetlabs-nginx",
   "project_page": "https://github.com/puppetlabs/puppetlabs-nginx",
   "issues_url": "https://github.com/puppetlabs/puppetlabs-nginx",
   "dependencies": [

--- a/acceptance/tests/modules/changes/missing_checksums_json.rb
+++ b/acceptance/tests/modules/changes/missing_checksums_json.rb
@@ -20,7 +20,7 @@ apply_manifest_on master, %Q{
   "author": "Puppet Labs",
   "summary": "Nginx Module",
   "license": "Apache Version 2.0",
-  "source": "git://github.com/puppetlabs/puppetlabs-nginx.git",
+  "source": "https://github.com/puppetlabs/puppetlabs-nginx",
   "project_page": "https://github.com/puppetlabs/puppetlabs-nginx",
   "issues_url": "https://github.com/puppetlabs/puppetlabs-nginx",
   "dependencies": [

--- a/spec/fixtures/unit/forge/bacula.json
+++ b/spec/fixtures/unit/forge/bacula.json
@@ -37,7 +37,7 @@
           "license": "Apache 2.0",
           "checksums": { },
           "version": "0.0.2",
-          "source": "git://github.com/puppetlabs/puppetlabs-bacula.git",
+          "source": "https://github.com/puppetlabs/puppetlabs-bacula",
           "project_page": "https://github.com/puppetlabs/puppetlabs-bacula",
           "summary": "bacula",
           "dependencies": [ ],

--- a/spec/unit/application/lookup_spec.rb
+++ b/spec/unit/application/lookup_spec.rb
@@ -631,6 +631,14 @@ Searching for "a"
             lookup.run_command
           }.to raise_error(/Incorrectly formatted data in .+ given via the --facts flag \(only accepts yaml and json files\)/)
         end
+
+        it "fails when a node doesn't have facts" do
+          lookup.options[:node] = "bad.node"
+          allow(lookup.command_line).to receive(:args).and_return(['c'])
+
+          expected_error = "No facts available for target node: #{lookup.options[:node]}"
+          expect { lookup.run_command }.to raise_error(RuntimeError, expected_error)
+        end
       end
     end
 

--- a/spec/unit/forge/module_release_spec.rb
+++ b/spec/unit/forge/module_release_spec.rb
@@ -90,7 +90,7 @@ describe Puppet::Forge::ModuleRelease do
         "checksums": { },
         "version": "#{module_version}",
         "description": "Standard Library for Puppet Modules",
-        "source": "git://github.com/puppetlabs/puppetlabs-stdlib.git",
+        "source": "https://github.com/puppetlabs/puppetlabs-stdlib",
         "project_page": "https://github.com/puppetlabs/puppetlabs-stdlib",
         "summary": "Puppet Module Standard Library",
         "dependencies": [
@@ -204,7 +204,7 @@ describe Puppet::Forge::ModuleRelease do
         "checksums": { },
         "version": "#{module_version}",
         "description": "Standard Library for Puppet Modules",
-        "source": "git://github.com/puppetlabs/puppetlabs-stdlib.git",
+        "source": "https://github.com/puppetlabs/puppetlabs-stdlib",
         "project_page": "https://github.com/puppetlabs/puppetlabs-stdlib",
         "summary": "Puppet Module Standard Library",
         "author": "#{module_author}",
@@ -279,7 +279,7 @@ describe Puppet::Forge::ModuleRelease do
         "checksums": { },
         "version": "#{module_version}",
         "description": "Standard Library for Puppet Modules",
-        "source": "git://github.com/puppetlabs/puppetlabs-stdlib.git",
+        "source": "https://github.com/puppetlabs/puppetlabs-stdlib",
         "project_page": "https://github.com/puppetlabs/puppetlabs-stdlib",
         "summary": "Puppet Module Standard Library",
         "dependencies": [


### PR DESCRIPTION
* commit 'fd0a86e23afa3c504d5645d117d2290da07f849b':
  (maint) update Gemfile locate_for
  (maint) Remove references to git scheme
  (packaging) Updating the puppet.pot file
  (PUP-7362) Fail fast if there are no facts for a node
  (packaging) Updating manpage file for 6.x
  (PUP-10435) Facts provided in a file can't be used for classification