### PR TITLE
(PUP-11345) Assert path in Puppet::FileSystem.chmod

### DIFF
--- a/lib/puppet/file_system.rb
+++ b/lib/puppet/file_system.rb
@@ -396,7 +396,7 @@ module Puppet::FileSystem
   # @api public
   #
   def self.chmod(mode, path)
-    @impl.chmod(mode, path)
+    @impl.chmod(mode, assert_path(path))
   end
 
   # Replace the contents of a file atomically, creating the file if necessary.

--- a/lib/puppet/file_system/file_impl.rb
+++ b/lib/puppet/file_system/file_impl.rb
@@ -130,23 +130,23 @@ class Puppet::FileSystem::FileImpl
   end
 
   def symlink?(path)
-    File.symlink?(path)
+    ::File.symlink?(path)
   end
 
   def readlink(path)
-    File.readlink(path)
+    ::File.readlink(path)
   end
 
   def unlink(*paths)
-    File.unlink(*paths)
+    ::File.unlink(*paths)
   end
 
   def stat(path)
-    File.stat(path)
+    ::File.stat(path)
   end
 
   def lstat(path)
-    File.lstat(path)
+    ::File.lstat(path)
   end
 
   def compare_stream(path, stream)
@@ -180,7 +180,7 @@ class Puppet::FileSystem::FileImpl
       tempfile_path = tempfile.path
       FileUtils.chown(uid, gid, tempfile_path) if uid && gid
       chmod(mode, tempfile_path)
-      File.rename(tempfile_path, path_string(path))
+      ::File.rename(tempfile_path, path_string(path))
     ensure
       tempfile.close!
     end

--- a/lib/puppet/file_system/file_impl.rb
+++ b/lib/puppet/file_system/file_impl.rb
@@ -159,7 +159,7 @@ class Puppet::FileSystem::FileImpl
 
   def replace_file(path, mode = nil)
     begin
-      stat = Puppet::FileSystem.lstat(path)
+      stat = lstat(path)
       gid = stat.gid
       uid = stat.uid
       mode ||= stat.mode & 07777
@@ -180,7 +180,7 @@ class Puppet::FileSystem::FileImpl
       tempfile_path = tempfile.path
       FileUtils.chown(uid, gid, tempfile_path) if uid && gid
       chmod(mode, tempfile_path)
-      File.rename(tempfile_path, Puppet::FileSystem.path_string(path))
+      File.rename(tempfile_path, path_string(path))
     ensure
       tempfile.close!
     end

--- a/lib/puppet/file_system/jruby.rb
+++ b/lib/puppet/file_system/jruby.rb
@@ -14,7 +14,7 @@ class Puppet::FileSystem::JRuby < Puppet::FileSystem::Posix
   def replace_file(path, mode = nil, &block)
     # MRI Ruby rename checks if destination is a directory and raises, while
     # JRuby removes the directory and replaces the file.
-    if Puppet::FileSystem.directory?(path)
+    if directory?(path)
       raise Errno::EISDIR, _("Is a directory: %{directory}") % { directory: path }
     end
 

--- a/lib/puppet/file_system/windows.rb
+++ b/lib/puppet/file_system/windows.rb
@@ -159,7 +159,7 @@ class Puppet::FileSystem::Windows < Puppet::FileSystem::Posix
       end
 
       set_dacl(tempfile.path, dacl) if dacl
-      File.rename(tempfile.path, path_string(path))
+      ::File.rename(tempfile.path, path_string(path))
     ensure
       tempfile.close!
     end

--- a/lib/puppet/file_system/windows.rb
+++ b/lib/puppet/file_system/windows.rb
@@ -123,7 +123,7 @@ class Puppet::FileSystem::Windows < Puppet::FileSystem::Posix
   LOCK_VIOLATION = 33
 
   def replace_file(path, mode = nil)
-    if Puppet::FileSystem.directory?(path)
+    if directory?(path)
       raise Errno::EISDIR, _("Is a directory: %{directory}") % { directory: path }
     end
 
@@ -159,14 +159,14 @@ class Puppet::FileSystem::Windows < Puppet::FileSystem::Posix
       end
 
       set_dacl(tempfile.path, dacl) if dacl
-      File.rename(tempfile.path, Puppet::FileSystem.path_string(path))
+      File.rename(tempfile.path, path_string(path))
     ensure
       tempfile.close!
     end
   rescue Puppet::Util::Windows::Error => e
     case e.code
     when ACCESS_DENIED, SHARING_VIOLATION, LOCK_VIOLATION
-      raise Errno::EACCES.new(Puppet::FileSystem.path_string(path), e)
+      raise Errno::EACCES.new(path_string(path), e)
     else
       raise SystemCallError.new(e.message)
     end
@@ -193,7 +193,7 @@ class Puppet::FileSystem::Windows < Puppet::FileSystem::Posix
   end
 
   def get_dacl_from_file(path)
-    sd = Puppet::Util::Windows::Security.get_security_descriptor(Puppet::FileSystem.path_string(path))
+    sd = Puppet::Util::Windows::Security.get_security_descriptor(path_string(path))
     sd.dacl
   rescue Puppet::Util::Windows::Error => e
     raise e unless e.code == FILE_NOT_FOUND


### PR DESCRIPTION
Raise ArgumentError if passed an invalid path as is done for other Puppet::FileSystem methods.

Eliminate some Pathname copying when calling `Puppet::FileSystem.replace_file`