### PR TITLE
(PUP-3907) Don't require the file owner/group to exist in noop

### DIFF
--- a/lib/puppet/type/file/group.rb
+++ b/lib/puppet/type/file/group.rb
@@ -23,7 +23,14 @@ module Puppet
       # evaluate this property, because they might be added during the catalog
       # apply.
       @should.map! do |val|
-        provider.name2gid(val) or raise "Could not find group #{val}"
+        gid = provider.name2gid(val)
+        if gid
+          gid
+        elsif provider.resource.noop?
+          return false
+        else
+          raise "Could not find group #{val}"
+        end
       end
 
       @should.include?(current)

--- a/lib/puppet/type/file/owner.rb
+++ b/lib/puppet/type/file/owner.rb
@@ -18,7 +18,14 @@ module Puppet
       # evaluate this property, because they might be added during the catalog
       # apply.
       @should.map! do |val|
-        provider.name2uid(val) or raise "Could not find user #{val}"
+        uid = provider.name2uid(val)
+        if uid
+          uid
+        elsif provider.resource.noop?
+          return false
+        else
+          raise "Could not find user #{val}"
+        end
       end
 
       return true if @should.include?(current)

--- a/spec/unit/type/file/group_spec.rb
+++ b/spec/unit/type/file/group_spec.rb
@@ -27,6 +27,13 @@ describe Puppet::Type.type(:file).attrclass(:group) do
       expect { group.insync?(5) }.to raise_error(/Could not find group foos/)
     end
 
+    it "should return false if a group's id can't be found by name in noop" do
+      Puppet[:noop] = true
+      allow(resource.provider).to receive(:name2gid).and_return(nil)
+
+      expect(group.insync?('notcreatedyet')).to eq(false)
+    end
+
     it "should use the id for comparisons, not the name" do
       expect(group.insync?('foos')).to be_falsey
     end

--- a/spec/unit/type/file/owner_spec.rb
+++ b/spec/unit/type/file/owner_spec.rb
@@ -25,6 +25,13 @@ describe Puppet::Type.type(:file).attrclass(:owner) do
       expect { owner.insync?(5) }.to raise_error(/Could not find user foo/)
     end
 
+    it "should return false if an owner's id can't be found by name in noop" do
+      Puppet[:noop] = true
+      allow(resource.provider).to receive(:name2uid).and_return(nil)
+
+      expect(owner.insync?('notcreatedyet')).to eq(false)
+    end
+
     it "should use the id for comparisons, not the name" do
       expect(owner.insync?('foo')).to be_falsey
     end


### PR DESCRIPTION
If the file owner or group can't be resolved and we're running in noop, then
return false, so puppet knows the properties' current and desired states don't
match.