### PR TITLE
(PUP-5800) Don't shell expand uniquefile prefix

### DIFF
--- a/spec/unit/file_system/uniquefile_spec.rb
+++ b/spec/unit/file_system/uniquefile_spec.rb
@@ -80,7 +80,7 @@ describe Puppet::FileSystem::Uniquefile do
     lock = File.join(dir, 'path', 'to', 'lock')
 
     expect {
-      Puppet::FileSystem::Uniquefile.open_tmp(lock) { |tmp| }
+      Puppet::FileSystem::Uniquefile.new('uniquefile', lock)
     }.to raise_error(Errno::ENOENT, %r{No such file or directory - A directory component in .* does not exist or is a dangling symbolic link})
   end
 

--- a/spec/unit/file_system/uniquefile_spec.rb
+++ b/spec/unit/file_system/uniquefile_spec.rb
@@ -84,15 +84,19 @@ describe Puppet::FileSystem::Uniquefile do
     }.to raise_error(Errno::ENOENT, %r{No such file or directory - A directory component in .* does not exist or is a dangling symbolic link})
   end
 
-  it "should use UTF8 characters in TMP,TEMP,TMPDIR environment variable", :if => Puppet::Util::Platform.windows? do
+  it "should use UTF8 characters in TMP,TEMP,TMPDIR environment variable" do
     rune_utf8 = "\u16A0\u16C7\u16BB\u16EB\u16D2\u16E6\u16A6\u16EB\u16A0\u16B1\u16A9\u16A0\u16A2\u16B1\u16EB\u16A0\u16C1\u16B1\u16AA\u16EB\u16B7\u16D6\u16BB\u16B9\u16E6\u16DA\u16B3\u16A2\u16D7"
     temp_rune_utf8 = File.join(Dir.tmpdir, rune_utf8)
     Puppet::FileSystem.mkpath(temp_rune_utf8)
 
     # Set the temporary environment variables to the UTF8 temp path
-    Puppet::Util::Windows::Process.set_environment_variable('TMPDIR', temp_rune_utf8)
-    Puppet::Util::Windows::Process.set_environment_variable('TMP', temp_rune_utf8)
-    Puppet::Util::Windows::Process.set_environment_variable('TEMP', temp_rune_utf8)
+    ['TMPDIR', 'TMP', 'TEMP'].each do |name|
+      if Puppet::Util::Platform.windows?
+        Puppet::Util::Windows::Process.set_environment_variable(name, temp_rune_utf8)
+      else
+        ENV[name] = temp_rune_utf8
+      end
+    end
 
     # Create a unique file
     filename = Puppet::FileSystem::Uniquefile.open_tmp('foo') do |file|


### PR DESCRIPTION
Update our `Uniquefile` implementation to be based off of newer `Tempfile` which doesn't call `File.expand_path` on the prefix.