### PR TITLE
(PUP-7479) Prioritize `--environment` flag over ENC for lookup

### DIFF
--- a/acceptance/tests/parser_functions/puppet_lookup_cmd.rb
+++ b/acceptance/tests/parser_functions/puppet_lookup_cmd.rb
@@ -2596,6 +2596,15 @@ with_puppet_running_on master, @master_opts, @coderoot do
     "lookup in ENC specified environment failed"
   )
 
+  step "--compile uses environment specified in --envrionment flag"
+  r = on(master, puppet('lookup', '--compile', "--node #{@node1}", "--confdir #{@confdir}", "--facts #{@coderoot}/facts.yaml", "--environment env1", 'environment_key'))
+  result = r.stdout
+  assert_match(
+    /env-env1 hiera provided value/,
+    result,
+    "env1 environment_key lookup failed, expected 'env-env1 hiera"
+  )
+
   step "without --compile does not use environment specified in ENC"
   r = on(master, puppet('lookup', "--node #{@node1}", "--confdir #{@confdir}", "--facts #{@coderoot}/facts.yaml", 'environment_key'))
   result = r.stdout


### PR DESCRIPTION
This commit changes the priority of the `--environment` option by
skipping the classification whenever the flag is specified. This allows
the user to bypass the ENC enforced environment with the cli option.