### PR TITLE
(PUP-11320) Move `ssh_authorized_key` resources creation at the end

### DIFF
--- a/acceptance/tests/resource/user/should_correctly_ensure_depending_resources.rb
+++ b/acceptance/tests/resource/user/should_correctly_ensure_depending_resources.rb
@@ -1,0 +1,43 @@
+test_name 'should correctly ensure resource and dependant user' do
+  tag 'audit:high',
+      'audit:acceptance'
+
+  confine :to, :platform => /el-8-x86_64/
+
+  agents.each do |agent|
+    teardown do
+      apply_manifest_on(agent, <<-MANIFEST) do |result|
+        package { 'abrt':
+          ensure => 'purged',
+        }
+        -> user { 'abrt':
+          ensure => 'absent',
+        }
+        -> group { 'abrt':
+          ensure => 'absent'
+        }
+        MANIFEST
+      end
+    end
+
+    step "ensure desired state on package and desired information on dependant user and group" do
+      apply_manifest_on(agent, <<-MANIFEST, { :catch_failures => true, :debug => true }) do |result|
+        package { 'abrt':
+          ensure => 'present',
+        }
+        -> group { 'abrt':
+          ensure     => 'present',
+          gid        => '59998',
+          forcelocal => true,
+        }
+        -> user { 'abrt':
+          ensure     => 'present',
+          uid        => '59998',
+          gid        => '59998',
+          forcelocal => true,
+        }
+        MANIFEST
+      end
+    end
+  end
+end

--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -66,7 +66,6 @@ module Puppet
     newproperty(:ensure, :parent => Puppet::Property::Ensure) do
       newvalue(:present, :event => :user_created) do
         provider.create
-        @resource.generate
       end
 
       newvalue(:absent, :event => :user_removed) do
@@ -693,9 +692,8 @@ module Puppet
       defaultto false
     end
 
-    def generate
+    def eval_generate
       if !self[:purge_ssh_keys].empty?
-        return [] if self[:ensure] == :present && !provider.exists? 
         if Puppet::Type.type(:ssh_authorized_key).nil?
           warning _("Ssh_authorized_key type is not available. Cannot purge SSH keys.")
         else

--- a/spec/unit/transaction/additional_resource_generator_spec.rb
+++ b/spec/unit/transaction/additional_resource_generator_spec.rb
@@ -479,21 +479,6 @@ describe Puppet::Transaction::AdditionalResourceGenerator do
                          "Notify[goodbye]"))
     end
 
-    it "sets resources_failed_to_generate to true if resource#generate raises an exception" do
-      catalog = compile_to_ral(<<-MANIFEST)
-        user { 'foo':
-          ensure => present,
-        }
-      MANIFEST
-
-      allow(catalog.resource("User[foo]")).to receive(:generate).and_raise(RuntimeError)
-      relationship_graph = relationship_graph_for(catalog)
-      generator = Puppet::Transaction::AdditionalResourceGenerator.new(catalog, relationship_graph, prioritizer)
-      generator.generate_additional_resources(catalog.resource("User[foo]"))
-
-      expect(generator.resources_failed_to_generate).to be_truthy
-    end
-
     def relationships_after_generating(manifest, resource_to_generate)
       catalog = compile_to_ral(manifest)
       generate_resources_in(catalog, nil, resource_to_generate)


### PR DESCRIPTION
This commit moves the moment when `ssh_authorized_key` resources are created from the beginning of the user type evaluation, to the end of it to avoid order dependency issues.

PUP-11067 fixed the case where a user gets created and at the same time any ssh keys associated are removed in the same manifest. To achieve this, the ensure property gained priority over generating the ssh key removal resources as these depend on the user home location.

PUP-11320 allows once again natural priority of the user properties and parameters but moves the `ssh_authorized_key` resources creation at the end of the user type flow, after all user properties and parameters were resolved.