### PR TITLE
(PUP-8094) Make lookup aware of certificate extensions

### DIFF
--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -378,7 +378,7 @@ Copyright (c) 2015 Puppet Inc., LLC Licensed under the Apache 2.0 License
         cert = OpenSSL::X509::Certificate.new(x509)
 
         Puppet::SSL::Oids.register_puppet_oids
-        trusted = Puppet::Context::TrustedInformation.remote(true, node, Puppet::SSL::Certificate.from_instance(cert))
+        trusted = Puppet::Context::TrustedInformation.remote(true, facts.values['certname'] || node, Puppet::SSL::Certificate.from_instance(cert))
 
         Puppet.override(trusted_information: trusted) do
           if tc == :plain || options[:compile]

--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -374,8 +374,11 @@ Copyright (c) 2015 Puppet Inc., LLC Licensed under the Apache 2.0 License
         session = service.create_session
         cert = session.route_to(:ca)
 
-        cert = cert.get_certificate(node)
-        trusted = Puppet::Context::TrustedInformation.new(true, node, cert)
+        _, x509 = cert.get_certificate(node)
+        cert = OpenSSL::X509::Certificate.new(x509)
+
+        Puppet::SSL::Oids.register_puppet_oids
+        trusted = Puppet::Context::TrustedInformation.remote(true, node, Puppet::SSL::Certificate.from_instance(cert))
 
         Puppet.override(trusted_information: trusted) do
           if tc == :plain || options[:compile]


### PR DESCRIPTION
d48d683 added the ability to classify nodes based on trusted facts (certname, fqdn, domain). However, this didn't apply to custom extensions.

Register Puppet OIDs inside the lookup application, then parse the certificate and create a trusted information object to get the correct list of custom extensions.

If a value for `certname` is provided in a fact file for the lookup application, use it when creating the trusted information object. This makes it possible to override `trusted.certname` for classification.