### PR TITLE
(PUP-4045) Allow retrieval of attributes for fifo and socket files

### DIFF
--- a/acceptance/tests/resource/file/handle_fifo_files_when_recursing.rb
+++ b/acceptance/tests/resource/file/handle_fifo_files_when_recursing.rb
@@ -1,0 +1,69 @@
+test_name "should be able to handle fifo files when recursing"
+tag 'audit:high',
+    'audit:acceptance'
+confine :except, :platform => /windows/
+
+def ensure_owner_recursively_manifest(path, owner_value)
+  return <<-MANIFEST
+  file { "#{path}":
+    ensure  => present,
+    recurse => true,
+    owner   => #{owner_value}
+  }
+  MANIFEST
+end
+
+agents.each do |agent|
+  initial_owner = ''
+  random_user = "pl#{rand(999).to_i}"
+
+  tmp_path = agent.tmpdir("tmpdir")
+  fifo_path = "#{tmp_path}/myfifo"
+
+  teardown do
+    agent.rm_rf(tmp_path)
+  end
+
+  step "create fifo file" do
+    on(agent, "mkfifo #{fifo_path}")
+    on(agent, puppet("resource user #{random_user} ensure=absent"))
+  end
+
+  step "check that fifo file got created" do
+    on(agent, "ls -l #{fifo_path}") do |result|
+      assert(result.stdout.start_with?('p'))
+      initial_owner = result.stdout.split[2]
+    end
+  end
+
+  step "create a new user" do
+    on(agent, puppet("resource user #{random_user} ensure=present"))
+  end
+
+  step "puppet ensures '#{random_user}' as owner of path" do
+    apply_manifest_on(agent, ensure_owner_recursively_manifest(tmp_path, random_user), :acceptable_exit_codes => [0]) do
+      assert_match(/#{tmp_path}\]\/owner: owner changed '#{initial_owner}' to '#{random_user}'/, stdout)
+      assert_no_match(/Error: .+ Failed to generate additional resources using ‘eval_generate’: Cannot manage files of type fifo/, stderr)
+    end
+  end
+
+  step "check that given file is still a fifo" do
+    on(agent, "ls -l #{fifo_path}") do |result|
+      assert(result.stdout.start_with?('p'))
+    end
+  end
+
+  step "check ownership of fifo file" do
+    on(agent, "ls -l #{fifo_path}") do |result|
+      user = result.stdout.split[2]
+      assert_equal(random_user, user)
+    end
+  end
+
+  step "check ownership of tmp folder" do
+    on(agent, "ls -ld #{tmp_path}") do |result|
+      user = result.stdout.split[2]
+      assert_equal(random_user, user)
+    end
+  end
+end

--- a/lib/puppet/file_serving/metadata.rb
+++ b/lib/puppet/file_serving/metadata.rb
@@ -118,6 +118,9 @@ class Puppet::FileServing::Metadata < Puppet::FileServing::Base
     when "link"
       @destination = Puppet::FileSystem.readlink(real_path)
       @checksum = ("{#{@checksum_type}}") + send("#{@checksum_type}_file", real_path).to_s rescue nil
+    when "fifo", "socket"
+      @checksum_type = "none"
+      @checksum = ("{#{@checksum_type}}") + send("#{@checksum_type}_file", real_path).to_s
     else
       raise ArgumentError, _("Cannot manage files of type %{file_type}") % { file_type: stat.ftype }
     end


### PR DESCRIPTION
This commit allows retrieval of attributes for fifo and socket files when recursing over given path from a `file` resource. This avoids below error:
```sh-session
Error: /Stage[main]/Main/File[/given_folder_path]: Failed to generate additional resources using ‘eval_generate’: Cannot manage files of type fifo
```
When applying:
```puppet
file { "/given_folder_path":
  ensure  => present,
  recurse => true,
  owner   => Luchi
}
```
Same behaviour and fix applies to `socket` files.