### PR TITLE
(PUP-5800) Don't file expand uniquefile's prefix

### DIFF
--- a/lib/puppet/file_system/uniquefile.rb
+++ b/lib/puppet/file_system/uniquefile.rb
@@ -127,7 +127,7 @@ class Puppet::FileSystem::Uniquefile < DelegateClass(File)
     tmpdir ||= tmpdir()
     n = nil
     begin
-      path = File.expand_path(make_tmpname(basename, n), tmpdir)
+      path = File.join(tmpdir, make_tmpname(basename, n))
       yield(path, n, *opts)
     rescue Errno::EEXIST
       n ||= 0

--- a/spec/unit/file_system/uniquefile_spec.rb
+++ b/spec/unit/file_system/uniquefile_spec.rb
@@ -80,7 +80,7 @@ describe Puppet::FileSystem::Uniquefile do
     lock = File.join(dir, 'path', 'to', 'lock')
 
     expect {
-      Puppet::FileSystem::Uniquefile.open_tmp(lock) { |tmp| }
+      Puppet::FileSystem::Uniquefile.new('foo', lock) { |tmp| }
     }.to raise_error(Errno::ENOENT, %r{No such file or directory - A directory component in .* does not exist or is a dangling symbolic link})
   end
 

--- a/spec/unit/file_system/uniquefile_spec.rb
+++ b/spec/unit/file_system/uniquefile_spec.rb
@@ -102,6 +102,12 @@ describe Puppet::FileSystem::Uniquefile do
     expect(filename).to eq(temp_rune_utf8)
   end
 
+  it "preserves tilde characters" do
+    Puppet::FileSystem::Uniquefile.open_tmp('~foo') do |file|
+      expect(File.basename(file.path)).to start_with('~foo')
+    end
+  end
+
   context "Ruby 1.9.3 Tempfile tests" do
     # the remaining tests in this file are ported directly from the ruby 1.9.3 source,
     # since most of this file was ported from there


### PR DESCRIPTION
Uniquefile is based on Ruby's Tempfile and it was already fixed in Ruby[1]

[1] https://github.com/ruby/ruby/commit/6f8bce9eff15b527c87e1b13312db2fbf0b504f4