### PR TITLE
(PUP-11078) Puppet generate should return non-zero when failing

### DIFF
--- a/lib/puppet/face/generate.rb
+++ b/lib/puppet/face/generate.rb
@@ -58,6 +58,8 @@ Puppet::Face.define(:generate, '0.1.0') do
       Puppet::FileSystem::mkpath(outputdir)
 
       generator.generate(inputs, outputdir, options[:force])
+
+      exit(1) if generator.bad_input?
       nil
     end
   end


### PR DESCRIPTION
Previously, puppet generate would return an exit code with the value of
0 even when failing to generate a new custom type.
```
> puppet generate types
Notice: Generating Puppet resource types.
Error: <envpath>/modules/my_module/lib/puppet/type/my_module.rb: title patterns that use procs are not supported.
> echo $?
0
```
This commit fixes this issue by creating a new Puppet::Generate method
that checks whether a type has raised an error or not. Since we want to
continue checking inputs even if one has failed, this comes in handy
since we can exit at the end of the run, keeping the functionality the
same.