### PR TITLE
(PUP-11369) Add support for the system parameter to the pw provider

### DIFF
--- a/lib/puppet/provider/group/pw.rb
+++ b/lib/puppet/provider/group/pw.rb
@@ -4,12 +4,15 @@ Puppet::Type.type(:group).provide :pw, :parent => Puppet::Provider::NameService:
   desc "Group management via `pw` on FreeBSD and DragonFly BSD."
 
   commands :pw => "pw"
-  has_features :manages_members
+  has_features :manages_members, :system_groups
 
   defaultfor :operatingsystem => [:freebsd, :dragonfly]
   confine    :operatingsystem => [:freebsd, :dragonfly]
 
   options :members, :flag => "-M", :method => :mem
+
+  MAX_SYSTEM_GID = 999
+  MIN_SYSTEM_GID = 100
 
   verify :gid, _("GID must be an integer") do |value|
     value.is_a? Integer
@@ -23,6 +26,8 @@ Puppet::Type.type(:group).provide :pw, :parent => Puppet::Provider::NameService:
       unless gid == :absent
         cmd << flag(:gid) << gid
       end
+    elsif @resource.system?
+      cmd << flag(:gid) << next_system_gid
     end
 
     members = @resource.should(:members)
@@ -38,6 +43,17 @@ Puppet::Type.type(:group).provide :pw, :parent => Puppet::Provider::NameService:
     cmd << "-o" if @resource.allowdupe?
 
     cmd
+  end
+
+  def next_system_gid
+    used_gid = []
+    Etc.group { |group| used_gid << group.gid if (MIN_SYSTEM_GID..MAX_SYSTEM_GID).cover?(group.gid) }
+
+    gid = MAX_SYSTEM_GID
+    gid -= 1 while used_gid.include?(gid) && gid >= MIN_SYSTEM_GID
+    raise Puppet::Error.new("No free gid available for group resource '#{resource[:name]}'") if gid < MIN_SYSTEM_GID
+
+    return gid
   end
 
   def modifycmd(param, value)

--- a/spec/unit/provider/group/pw_spec.rb
+++ b/spec/unit/provider/group/pw_spec.rb
@@ -45,6 +45,13 @@ describe Puppet::Type.type(:group).provider(:pw) do
       expect(provider).to receive(:execute).with(include("-M") & include("user1,user2"), kind_of(Hash))
       provider.create
     end
+
+    it "should use -g when creating system users" do
+      allow(provider).to receive(:next_system_gid).and_return(123)
+      resource[:system] = true
+      expect(provider).to receive(:execute).with([described_class.command(:pw), "groupadd", "testgroup", "-g", 123], kind_of(Hash))
+      provider.create
+    end
   end
 
   describe "when deleting groups" do

--- a/spec/unit/provider/user/pw_spec.rb
+++ b/spec/unit/provider/user/pw_spec.rb
@@ -77,6 +77,13 @@ describe Puppet::Type.type(:user).provider(:pw) do
       provider.create
     end
 
+    it "should use -u when creating system users" do
+      allow(provider).to receive(:next_system_uid).and_return(123)
+      resource[:system] = true
+      expect(provider).to receive(:execute).with([described_class.command(:pw), "useradd", "testuser", "-u", 123], kind_of(Hash))
+      provider.create
+    end
+
     it "should call the password set function with the correct argument when the password property is set" do
       resource[:password] = "*"
       expect(provider).to receive(:execute)


### PR DESCRIPTION
While pw(8) says:

    In general, user and group ids less than 100 are reserved for use by
    the system, and numbers greater than 32000 may also be reserved for
    special purposes (used by some system daemons).

the ports manage UIDs / GIDs in the 1-999 range:

    https://cgit.freebsd.org/ports/tree/UIDs

So for consistency with other OSs, limit system users to the 100-999
range.
