### PR TITLE
(PUP-11321) Allow loading of safe classes from the persistence store

### DIFF
--- a/lib/puppet/pops/serialization/to_data_converter.rb
+++ b/lib/puppet/pops/serialization/to_data_converter.rb
@@ -14,8 +14,6 @@ module Serialization
     # @option options [Boolean] :local_reference use local references instead of duplicating complex entries
     # @option options [Boolean] :type_by_reference `true` if Object types are converted to references rather than embedded.
     # @option options [Boolean] :symbol_as_string `true` if Symbols should be converted to strings (with type loss)
-    # @option options [Boolean] :force_symbol `false` if Symbols should not be converted (rich_data and symbol_as_string must be false)
-    # @option options [Boolean] :silence_warnings `false` if warnings should be silenced
     # @option options [String] :message_prefix String to prepend to in warnings and errors
     # @return [Data] the processed result. An object assignable to `Data`.
     #
@@ -42,12 +40,6 @@ module Serialization
 
       @symbol_as_string = options[:symbol_as_string]
       @symbol_as_string = false if @symbol_as_string.nil?
-
-      @force_symbol = options[:force_symbol]
-      @force_symbol = false if @force_symbol.nil?
-
-      @silence_warnings = options[:silence_warnings]
-      @silence_warnings = false if @silence_warnings.nil?
 
       @rich_data = options[:rich_data]
       @rich_data = false if @rich_data.nil?
@@ -100,11 +92,7 @@ module Serialization
         elsif @rich_data
           { PCORE_TYPE_KEY => PCORE_TYPE_SYMBOL, PCORE_VALUE_KEY => value.to_s }
         else
-          if @force_symbol
-            value
-          else
-            @silence_warnings ? unknown_to_string(value) : unknown_to_string_with_warning(value)
-          end
+          unknown_to_string_with_warning(value)
         end
       elsif value.instance_of?(Array)
         process(value) do
@@ -129,11 +117,7 @@ module Serialization
           { PCORE_TYPE_KEY => PCORE_TYPE_SENSITIVE, PCORE_VALUE_KEY => to_data(value.unwrap) }
         end
       else
-        if @rich_data
-          value_to_data_hash(value)
-        else
-          @silence_warnings ? unknown_to_string(value) : unknown_to_string_with_warning(value)
-        end
+        unknown_to_data(value)
       end
     end
 
@@ -205,6 +189,10 @@ module Serialization
       v = yield
       @recursive_lock.delete(id)
       v
+    end
+
+    def unknown_to_data(value)
+      @rich_data ? value_to_data_hash(value) : unknown_to_string_with_warning(value)
     end
 
     def unknown_key_to_string_with_warning(value)

--- a/lib/puppet/transaction/persistence.rb
+++ b/lib/puppet/transaction/persistence.rb
@@ -87,17 +87,7 @@ class Puppet::Transaction::Persistence
 
   # Save data from internal class to persistence store on disk.
   def save
-    converted_data = Puppet::Pops::Serialization::ToDataConverter.convert(
-      @new_data, {
-        symbol_as_string: false,
-        local_reference: false,
-        type_by_reference: true,
-        force_symbol: true,
-        silence_warnings: true,
-        message_prefix: to_s
-      }
-    )
-    Puppet::Util::Yaml.dump(converted_data, Puppet[:transactionstorefile])
+    Puppet::Util::Yaml.dump(@new_data, Puppet[:transactionstorefile])
   end
 
   # Use the catalog and run_mode to determine if persistence should be enabled or not

--- a/spec/unit/pops/serialization/to_from_hr_spec.rb
+++ b/spec/unit/pops/serialization/to_from_hr_spec.rb
@@ -559,29 +559,6 @@ module Serialization
         expect(warnings).to eql(["['key'] contains the special value default. It will be converted to the String 'default'"])
       end
     end
-    context 'and force_symbol set to true' do
-      let(:to_converter) { ToDataConverter.new(:rich_data => false, :force_symbol => true) }
-
-      it 'A Hash with Symbol values is converted to hash with Symbol values' do
-        val = { 'one' => :one, 'two' => :two }
-        Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
-
-          # write and read methods does not work here as we cannot force Symbols in Json.
-          # and a hash with symbol values cannot be an instance of Types::TypeFactory.data.
-          # Using YAML for this instead
-          io.reopen
-          value = to_converter.convert(val)
-          io << [value].to_yaml
-          io.rewind
-
-          val2 = from_converter.convert(YAML::load(io.read)[0])
-
-          expect(val2).to be_a(Hash)
-          expect(val2).to eql({ 'one' => :one, 'two' => :two })
-        end
-        expect(warnings).to be_empty
-      end
-    end
   end
 
   context 'with rich_data is set to true' do
@@ -653,41 +630,6 @@ module Serialization
       expect do
         from_converter.convert({ '__ptype' => { '__ptype' => 'Pcore::TimestampType', '__pvalue' => 12345 }})
       end.to raise_error(/Cannot create a Pcore::TimestampType from a (Fixnum|Integer)/)
-    end
-  end
-
-  context 'when data is unknown' do
-    let(:to_converter) { ToDataConverter.new(:message_prefix => 'Test Hash') }
-    let(:logs) { [] }
-    let(:warnings) { logs.select { |log| log.level == :warning }.map { |log| log.message } }
-    let(:val) { Class.new }
-
-    context 'and :silence_warnings undefined or set to false' do
-      it 'convert the unknown data to string with warnings' do
-        Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
-          write(val)
-          val2 = read
-          expect(val2).to be_a(String)
-          expect(val2).to match(/Class/)
-        end
-        expect(warnings).to eql([
-          "Test Hash contains a #{val.class} value. It will be converted to the String '#{val.to_s}'"])
-      end
-    end
-
-    context 'and :silence_warnings undefined or set to true' do
-      let(:to_converter) { ToDataConverter.new(:message_prefix => 'Test Hash', :silence_warnings => true) }
-
-      it 'convert the unknown data to string without warnings if silence_warnings set to true' do
-        val = Class.new
-        Puppet::Util::Log.with_destination(Puppet::Test::LogCollector.new(logs)) do
-          write(val)
-          val2 = read
-          expect(val2).to be_a(String)
-          expect(val2).to match(/Class/)
-        end
-        expect(warnings).to be_empty
-      end
     end
   end
 end

--- a/spec/unit/transaction/persistence_spec.rb
+++ b/spec/unit/transaction/persistence_spec.rb
@@ -138,6 +138,57 @@ describe Puppet::Transaction::Persistence do
         persistence = Puppet::Transaction::Persistence.new
         expect(persistence.load.dig("File[/tmp/audit]", "parameters", "mtime", "system_value")).to contain_exactly(be_a(Time))
       end
+
+      it 'should load Regexp' do
+        write_state_file(<<~END)
+          system_value:
+            - !ruby/regexp /regexp/
+        END
+
+        persistence = Puppet::Transaction::Persistence.new
+        expect(persistence.load.dig("system_value")).to contain_exactly(be_a(Regexp))
+      end
+
+      it 'should load semantic puppet version' do
+        write_state_file(<<~END)
+          system_value:
+            - !ruby/object:SemanticPuppet::Version
+              major: 1
+              minor: 0
+              patch: 0
+              prerelease: 
+              build: 
+        END
+
+        persistence = Puppet::Transaction::Persistence.new
+        expect(persistence.load.dig("system_value")).to contain_exactly(be_a(SemanticPuppet::Version))
+      end
+
+      it 'should load puppet time related objects' do
+        write_state_file(<<~END)
+          system_value:
+            - !ruby/object:Puppet::Pops::Time::Timestamp
+              nsecs: 1638316135955087259
+            - !ruby/object:Puppet::Pops::Time::TimeData
+              nsecs: 1495789430910161286
+            - !ruby/object:Puppet::Pops::Time::Timespan
+              nsecs: 1495789430910161286
+        END
+
+        persistence = Puppet::Transaction::Persistence.new
+        expect(persistence.load.dig("system_value")).to contain_exactly(be_a(Puppet::Pops::Time::Timestamp), be_a(Puppet::Pops::Time::TimeData), be_a(Puppet::Pops::Time::Timespan))
+      end
+
+      it 'should load binary objects' do
+        write_state_file(<<~END)
+          system_value:
+            - !ruby/object:Puppet::Pops::Types::PBinaryType::Binary
+              binary_buffer: ''
+        END
+
+        persistence = Puppet::Transaction::Persistence.new
+        expect(persistence.load.dig("system_value")).to contain_exactly(be_a(Puppet::Pops::Types::PBinaryType::Binary))
+      end
     end
   end
 


### PR DESCRIPTION
Revert changes introduced for PUP-10820 and fix binary values in the persistence store a different way