### PR TITLE
(maint) ruby-openssl now sets store_context.error

### DIFF
--- a/lib/puppet/ssl/verifier.rb
+++ b/lib/puppet/ssl/verifier.rb
@@ -115,6 +115,12 @@ class Puppet::SSL::Verifier
         return false
       end
 
+    # ruby-openssl#74ef8c0cc56b840b772240f2ee2b0fc0aafa2743 now sets the
+    # store_context error when the cert is mismatched
+    when OpenSSL::X509::V_ERR_HOSTNAME_MISMATCH
+      @last_error = Puppet::SSL::CertMismatchError.new(peer_cert, @hostname)
+      return false
+
     when OpenSSL::X509::V_ERR_CRL_NOT_YET_VALID
       crl = store_context.current_crl
       if crl && crl.last_update && crl.last_update < Time.now + FIVE_MINUTES_AS_SECONDS

--- a/lib/puppet/util/monkey_patches.rb
+++ b/lib/puppet/util/monkey_patches.rb
@@ -39,6 +39,12 @@ unless Puppet::Util::Platform.jruby_fips?
     end
   end
 
+  unless defined?(OpenSSL::X509::V_ERR_HOSTNAME_MISMATCH)
+    module OpenSSL::X509
+      OpenSSL::X509::V_ERR_HOSTNAME_MISMATCH = 0x3E
+    end
+  end
+
   class OpenSSL::SSL::SSLContext
     if DEFAULT_PARAMS[:options]
       DEFAULT_PARAMS[:options] |= OpenSSL::SSL::OP_NO_SSLv2 | OpenSSL::SSL::OP_NO_SSLv3


### PR DESCRIPTION
Ruby now correctly sets the store_context.error when the cert is mismatched[1], [2]. So
in that case raise the expected CertMismatchError.

We also have to monkey patch the ruby constant, which was only recently added to
match openssl 1.1[3].

[1] https://github.com/ruby/openssl/issues/244
[2] https://github.com/ruby/openssl/commit/74ef8c0cc56b840b772240f2ee2b0fc0aafa2743
[3] https://github.com/ruby/openssl/commit/65ea09c403cc216d8e14d966b78fbc1bea16810d