### PR TITLE
(maint) update github actions windows environment

### DIFF
--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -19,9 +19,9 @@ jobs:
           - {os: ubuntu-18.04, ruby: 2.6}
           - {os: ubuntu-18.04, ruby: 2.7}
           - {os: ubuntu-18.04, ruby: jruby-9.2.9.0}
-          - {os: windows-2016, ruby: 2.4}
-          - {os: windows-2016, ruby: 2.5}
-          - {os: windows-2016, ruby: 2.6}
+          - {os: windows-2019, ruby: 2.4}
+          - {os: windows-2019, ruby: 2.5}
+          - {os: windows-2019, ruby: 2.6}
 
     runs-on: ${{ matrix.cfg.os }}
     steps:


### PR DESCRIPTION
Update Windows environment from windows-2106 to windows-2019

https://github.com/actions/virtual-environments/issues/4312