### PR TITLE
(maint) Merge 6.x to main

### DIFF
--- a/acceptance/tests/resource/file/handle_fifo_files_when_recursing.rb
+++ b/acceptance/tests/resource/file/handle_fifo_files_when_recursing.rb
@@ -1,0 +1,69 @@
+test_name "should be able to handle fifo files when recursing"
+tag 'audit:high',
+    'audit:acceptance'
+confine :except, :platform => /windows/
+
+def ensure_owner_recursively_manifest(path, owner_value)
+  return <<-MANIFEST
+  file { "#{path}":
+    ensure  => present,
+    recurse => true,
+    owner   => #{owner_value}
+  }
+  MANIFEST
+end
+
+agents.each do |agent|
+  initial_owner = ''
+  random_user = "pl#{rand(999).to_i}"
+
+  tmp_path = agent.tmpdir("tmpdir")
+  fifo_path = "#{tmp_path}/myfifo"
+
+  teardown do
+    agent.rm_rf(tmp_path)
+  end
+
+  step "create fifo file" do
+    on(agent, "mkfifo #{fifo_path}")
+    on(agent, puppet("resource user #{random_user} ensure=absent"))
+  end
+
+  step "check that fifo file got created" do
+    on(agent, "ls -l #{fifo_path}") do |result|
+      assert(result.stdout.start_with?('p'))
+      initial_owner = result.stdout.split[2]
+    end
+  end
+
+  step "create a new user" do
+    on(agent, puppet("resource user #{random_user} ensure=present"))
+  end
+
+  step "puppet ensures '#{random_user}' as owner of path" do
+    apply_manifest_on(agent, ensure_owner_recursively_manifest(tmp_path, random_user), :acceptable_exit_codes => [0]) do
+      assert_match(/#{tmp_path}\]\/owner: owner changed '#{initial_owner}' to '#{random_user}'/, stdout)
+      assert_no_match(/Error: .+ Failed to generate additional resources using ‘eval_generate’: Cannot manage files of type fifo/, stderr)
+    end
+  end
+
+  step "check that given file is still a fifo" do
+    on(agent, "ls -l #{fifo_path}") do |result|
+      assert(result.stdout.start_with?('p'))
+    end
+  end
+
+  step "check ownership of fifo file" do
+    on(agent, "ls -l #{fifo_path}") do |result|
+      user = result.stdout.split[2]
+      assert_equal(random_user, user)
+    end
+  end
+
+  step "check ownership of tmp folder" do
+    on(agent, "ls -ld #{tmp_path}") do |result|
+      user = result.stdout.split[2]
+      assert_equal(random_user, user)
+    end
+  end
+end

--- a/acceptance/tests/resource/user/should_correctly_ensure_depending_resources.rb
+++ b/acceptance/tests/resource/user/should_correctly_ensure_depending_resources.rb
@@ -1,0 +1,43 @@
+test_name 'should correctly ensure resource and dependant user' do
+  tag 'audit:high',
+      'audit:acceptance'
+
+  confine :to, :platform => /el-8-x86_64/
+
+  agents.each do |agent|
+    teardown do
+      apply_manifest_on(agent, <<-MANIFEST) do |result|
+        package { 'abrt':
+          ensure => 'purged',
+        }
+        -> user { 'abrt':
+          ensure => 'absent',
+        }
+        -> group { 'abrt':
+          ensure => 'absent'
+        }
+        MANIFEST
+      end
+    end
+
+    step "ensure desired state on package and desired information on dependant user and group" do
+      apply_manifest_on(agent, <<-MANIFEST, { :catch_failures => true, :debug => true }) do |result|
+        package { 'abrt':
+          ensure => 'present',
+        }
+        -> group { 'abrt':
+          ensure     => 'present',
+          gid        => '59998',
+          forcelocal => true,
+        }
+        -> user { 'abrt':
+          ensure     => 'present',
+          uid        => '59998',
+          gid        => '59998',
+          forcelocal => true,
+        }
+        MANIFEST
+      end
+    end
+  end
+end

--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -384,8 +384,11 @@ Copyright (c) 2015 Puppet Inc., LLC Licensed under the Apache 2.0 License
         session = service.create_session
         cert = session.route_to(:ca)
 
-        cert = cert.get_certificate(node)
-        trusted = Puppet::Context::TrustedInformation.new(true, node, cert)
+        _, x509 = cert.get_certificate(node)
+        cert = OpenSSL::X509::Certificate.new(x509)
+
+        Puppet::SSL::Oids.register_puppet_oids
+        trusted = Puppet::Context::TrustedInformation.remote(true, facts.values['certname'] || node, Puppet::SSL::Certificate.from_instance(cert))
 
         Puppet.override(trusted_information: trusted) do
           if tc == :plain || options[:compile]

--- a/lib/puppet/file_serving/metadata.rb
+++ b/lib/puppet/file_serving/metadata.rb
@@ -118,6 +118,9 @@ class Puppet::FileServing::Metadata < Puppet::FileServing::Base
     when "link"
       @destination = Puppet::FileSystem.readlink(real_path)
       @checksum = ("{#{@checksum_type}}") + send("#{@checksum_type}_file", real_path).to_s rescue nil
+    when "fifo", "socket"
+      @checksum_type = "none"
+      @checksum = ("{#{@checksum_type}}") + send("#{@checksum_type}_file", real_path).to_s
     else
       raise ArgumentError, _("Cannot manage files of type %{file_type}") % { file_type: stat.ftype }
     end

--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -66,7 +66,6 @@ module Puppet
     newproperty(:ensure, :parent => Puppet::Property::Ensure) do
       newvalue(:present, :event => :user_created) do
         provider.create
-        @resource.generate
       end
 
       newvalue(:absent, :event => :user_removed) do
@@ -693,9 +692,8 @@ module Puppet
       defaultto false
     end
 
-    def generate
+    def eval_generate
       if !self[:purge_ssh_keys].empty? && self[:purge_ssh_keys] != :false
-        return [] if self[:ensure] == :present && !provider.exists? 
         if Puppet::Type.type(:ssh_authorized_key).nil?
           warning _("Ssh_authorized_key type is not available. Cannot purge SSH keys.")
         else

--- a/spec/unit/transaction/additional_resource_generator_spec.rb
+++ b/spec/unit/transaction/additional_resource_generator_spec.rb
@@ -479,21 +479,6 @@ describe Puppet::Transaction::AdditionalResourceGenerator do
                          "Notify[goodbye]"))
     end
 
-    it "sets resources_failed_to_generate to true if resource#generate raises an exception" do
-      catalog = compile_to_ral(<<-MANIFEST)
-        user { 'foo':
-          ensure => present,
-        }
-      MANIFEST
-
-      allow(catalog.resource("User[foo]")).to receive(:generate).and_raise(RuntimeError)
-      relationship_graph = relationship_graph_for(catalog)
-      generator = Puppet::Transaction::AdditionalResourceGenerator.new(catalog, relationship_graph, prioritizer)
-      generator.generate_additional_resources(catalog.resource("User[foo]"))
-
-      expect(generator.resources_failed_to_generate).to be_truthy
-    end
-
     def relationships_after_generating(manifest, resource_to_generate)
       catalog = compile_to_ral(manifest)
       generate_resources_in(catalog, nil, resource_to_generate)


### PR DESCRIPTION
* commit '1675a6c677666f4a668ec144459ad286c5635439':
  (PUP-4045) Allow retrieval of attributes for fifo and socket files
  (PUP-8220) Override trusted certname if present
  (PUP-8094) Make lookup aware of certificate extensions
  (PUP-11320) Move `ssh_authorized_key` resources creation at the end

* Conflicts:
 	lib/puppet/type/user.rb

Supersedes PR #8833 

I verified this preserves the fixes in 6.x and main:

### Puppet can resolve a user created during the run (PUP-11320):
 
```
❯ cat PUP-11320.pp 
exec { '/sbin/luseradd -u 50080 -M myuser': }
-> user { 'myuser':
  uid        => 50081,
  forcelocal => true,
}

❯ sudo -u josh /home/josh/.rbenv/shims/bundle exec puppet apply --noop PUP-11320.pp 
Notice: Compiled catalog for localhost in environment production in 0.03 seconds
Notice: /Stage[main]/Main/Exec[/sbin/luseradd -u 50080 -M myuser]/returns: current_value 'notrun', should be ['0'] (noop)
Notice: /Stage[main]/Main/User[myuser]/ensure: current_value 'absent', should be 'present' (noop)
Notice: Class[Main]: Would have triggered 'refresh' from 2 events
Notice: Stage[main]: Would have triggered 'refresh' from 1 event
Notice: Applied catalog in 0.02 seconds
```

### Puppet can purge sshkeys for a user created during the run (PUP-11067):

```
❯ cat PUP-11067.pp
user { "test123":
  ensure => present,
  purge_ssh_keys => true
}

❯ sudo -u josh /home/josh/.rbenv/shims/bundle exec puppet apply --noop PUP-11067.pp
Notice: Compiled catalog for localhost in environment production in 0.01 seconds
Notice: /Stage[main]/Main/User[test123]/ensure: current_value 'absent', should be 'present' (noop)
Notice: Class[Main]: Would have triggered 'refresh' from 1 event
Notice: Stage[main]: Would have triggered 'refresh' from 1 event
Notice: Applied catalog in 0.03 seconds
```

### Puppet does not require the ssh_authorized_key type to exist when setting `purge_ssh_keys => false` (PUP-11131)

```
❯ bx puppet module uninstall puppetlabs-sshkeys_core
Notice: Preparing to uninstall 'puppetlabs-sshkeys_core' ...
Removed 'puppetlabs-sshkeys_core' (v2.3.0) from /home/josh/.puppetlabs/etc/code/environments/production/modules

❯ cat PUP-11131.pp                                  
$username = $facts['identity']['user']

user { $username:
  ensure => present,
  purge_ssh_keys => false,
}

❯ bx puppet apply PUP-11131.pp
Notice: Compiled catalog for localhost in environment production in 0.01 seconds
Notice: Applied catalog in 0.02 seconds
```