### PR TITLE
(PUP-11330) Puppet::Node#environment_name may return the wrong value

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -513,17 +513,7 @@ class Puppet::Configurer
                                              :transaction_uuid => @transaction_uuid,
                                              :fail_on_404 => true)
 
-        # The :rest node terminus returns a node with an environment_name, but not an
-        # environment instance. Attempting to get the environment instance will load
-        # it from disk, which will likely fail. So create a remote environment.
-        #
-        # The :plain node terminus returns a node with an environment, but not an
-        # environment_name.
-        if !node.has_environment_instance? && node.environment_name
-          node.environment = Puppet::Node::Environment.remote(node.environment_name)
-        end
-
-        @server_specified_environment = node.environment.to_s
+        @server_specified_environment = node.environment_name.to_s
 
         if @server_specified_environment != @environment
           Puppet.notice _("Local environment: '%{local_env}' doesn't match server specified node environment '%{node_env}', switching agent to '%{node_env}'.") % { local_env: @environment, node_env: @server_specified_environment }

--- a/lib/puppet/node.rb
+++ b/lib/puppet/node.rb
@@ -89,7 +89,7 @@ class Puppet::Node
     unless @environment.nil?
       # always set the environment parameter. It becomes top scope $environment for a manifest during catalog compilation.
       @parameters[ENVIRONMENT] = @environment.name.to_s
-      self.environment_name = @environment.name if instance_variable_defined?(:@environment_name)
+      self.environment_name = @environment.name
     end
     @environment
   end

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -40,6 +40,12 @@ describe Puppet::Node do
         expect(node.environment.name).to eq(:bar)
       end
 
+      it "sets environment_name with the correct environment name" do
+        node = Puppet::Node.new("foo")
+        node.environment = Puppet::Node::Environment.remote('www123')
+        expect(node.environment_name).to eq(:www123)
+      end
+
       it "allows its environment to be set by parameters after initialization" do
         node = Puppet::Node.new("foo")
         node.parameters["environment"] = :bar


### PR DESCRIPTION
Previosuly, if an environment instance is set on a node, then the
`Node#environment_name` returns nil, but `Node#environment` returns the
instance whose name is the expected symbolic value.

This commit fixes this inconsistency, by removing the
`instance_variable_defined?` check, when setting the environment.