### PR TITLE
(maint) Update report format version in HTTP report doc

### DIFF
--- a/api/docs/http_report.md
+++ b/api/docs/http_report.md
@@ -1,7 +1,7 @@
 Report
 ======
 This document describes the Puppet master's report endpoint and the schema for
-Report Format 6 in technical term. Also see the
+Report Format 11 in technical terms. Also see the
 [documentation](https://puppet.com/docs/puppet/latest/format_report.html).
 
 The `report` endpoint allows clients to send reports to the master via `http`


### PR DESCRIPTION
Puppet 6's report format is version 11. It also changes the grammar.

This eacde2be0e23fa76902439d0c212db3b64d58f25 with a corrected version number.