### PR TITLE
(maint) Merge up 6.x to main

### DIFF
--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -693,7 +693,7 @@ module Puppet
     end
 
     def generate
-      if !self[:purge_ssh_keys].empty? && self[:purge_ssh_keys] != :false
+      if !self[:purge_ssh_keys].empty?
         if Puppet::Type.type(:ssh_authorized_key).nil?
           warning _("Ssh_authorized_key type is not available. Cannot purge SSH keys.")
         else


### PR DESCRIPTION
* commit '2a7b3ad1e2ef20b19b910029994cfe1f78d39839':
  (PUP-11380) Ignore authorized key purging if home doesn't exist yet
  Revert "(PUP-11067) Prioritize user type `ensure` before `purge_ssh_keys`"
  Revert "(PUP-11320) Move `ssh_authorized_key` resources creation at the end"

* Conflicts:
  lib/puppet/type/user.rb