### PR TITLE
(maint) Excludes RHEL9 from init_on_systemd test

### DIFF
--- a/acceptance/tests/resource/service/init_on_systemd.rb
+++ b/acceptance/tests/resource/service/init_on_systemd.rb
@@ -1,6 +1,6 @@
 test_name 'SysV on default Systemd Service Provider Validation' do
 
-  confine :to, :platform => /el-|centos|fedora-(2[0-9])/ do |h|
+  confine :to, :platform => /el-[6-8]|centos|fedora-(2[0-9])/ do |h|
     on h, 'which systemctl', :acceptable_exit_codes => [0, 1]
     stdout =~ /systemctl/
   end


### PR DESCRIPTION
Red Hat 9 does not ship with /etc/init.d, causing this test to fail. We have excluded it as a platform for this particular test.

See also: PA-4121