### PR TITLE
(PUP-11405) Replace deprecated/changed Psych YAML methods, pin rdoc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ group(:features) do
   #gem 'ruby-shadow', '~> 2.5', require: false, platforms: [:ruby]
   gem 'minitar', '~> 0.9', require: false
   gem 'msgpack', '~> 1.2', require: false
-  gem 'rdoc', '~> 6.0', require: false, platforms: [:ruby]
+  gem 'rdoc', ['~> 6.0', '< 6.4.0'], require: false, platforms: [:ruby]
   # requires native augeas headers/libs
   # gem 'ruby-augeas', require: false, platforms: [:ruby]
   # requires native ldap headers/libs


### PR DESCRIPTION
The non-keyword argument variant was deprecated in Psych 3.1.0 and has been
removed in 4.0.0 (https://github.com/ruby/psych/commit/0767227051dbddf1f949eef512c174deabf22891).

Encountered this in a downstream custom Debian packaging of Puppet server with Psych 4.0.3 and manifested as an error regarding too many arguments (1 vs 5) during global `lookup_options` lookup resulting in catalog compilation failure.