### PR TITLE
(PUP-11402) Puppet lookup fails when used locally

### DIFF
--- a/acceptance/tests/parser_functions/puppet_lookup_cmd.rb
+++ b/acceptance/tests/parser_functions/puppet_lookup_cmd.rb
@@ -2193,16 +2193,6 @@ apply_manifest_on(master, @manifest, :catch_failures => true)
 step 'start puppet server'
 with_puppet_running_on master, @master_opts, @coderoot do
 
-  step "handle certificate"
-  on(master, "puppetserver ca generate --certname #{@node1}")
-  on(master, "puppetserver ca generate --certname #{@node2}")
-  on(master, "mkdir -p #{@testroot}/puppet/ssl/certs")
-  on(master, "mkdir -p #{@testroot}/puppet/ssl/private_keys")
-  on(master, "cp -a /etc/puppetlabs/puppet/ssl/certs/ca.pem #{@testroot}/puppet/ssl/certs")
-  on(master, "cp -a /etc/puppetlabs/puppet/ssl/crl.pem #{@testroot}/puppet/ssl")
-  on(master, "cp -a /etc/puppetlabs/puppet/ssl/private_keys/#{master.connection.hostname}.pem #{@testroot}/puppet/ssl/private_keys")
-  on(master, "cp -a /etc/puppetlabs/puppet/ssl/certs/#{master.connection.hostname}.pem #{@testroot}/puppet/ssl/certs")
-
   step "global_key"
   rg = on(master, puppet('lookup', 'global_key'))
   result = rg.stdout
@@ -2586,6 +2576,25 @@ with_puppet_running_on master, @master_opts, @coderoot do
 
   step 'apply enc manifest'
   apply_manifest_on(master, @encmanifest, :catch_failures => true)
+
+  step "--compile uses environment specified in ENC"
+  r = on(master, puppet('lookup', '--compile', "--node #{@node1}", "--confdir #{@confdir}", "--facts #{@coderoot}/facts.yaml", 'environment_key'))
+  result = r.stdout
+  assert_match(
+    /CA is not available/,
+    result,
+    "lookup in ENC specified environment failed"
+  )
+
+  step "handle certificate"
+  on(master, "puppetserver ca generate --certname #{@node1}")
+  on(master, "puppetserver ca generate --certname #{@node2}")
+  on(master, "mkdir -p #{@testroot}/puppet/ssl/certs")
+  on(master, "mkdir -p #{@testroot}/puppet/ssl/private_keys")
+  on(master, "cp -a /etc/puppetlabs/puppet/ssl/certs/ca.pem #{@testroot}/puppet/ssl/certs")
+  on(master, "cp -a /etc/puppetlabs/puppet/ssl/crl.pem #{@testroot}/puppet/ssl")
+  on(master, "cp -a /etc/puppetlabs/puppet/ssl/private_keys/#{master.connection.hostname}.pem #{@testroot}/puppet/ssl/private_keys")
+  on(master, "cp -a /etc/puppetlabs/puppet/ssl/certs/#{master.connection.hostname}.pem #{@testroot}/puppet/ssl/certs")
 
   step "--compile uses environment specified in ENC"
   r = on(master, puppet('lookup', '--compile', "--node #{@node1}", "--confdir #{@confdir}", "--facts #{@coderoot}/facts.yaml", 'environment_key'))

--- a/spec/integration/application/lookup_spec.rb
+++ b/spec/integration/application/lookup_spec.rb
@@ -48,6 +48,7 @@ describe 'lookup' do
     let(:facts) { Puppet::Node::Facts.new("facts", {'my_fact' => 'my_fact_value'}) }
     let(:cert) { pem_content('oid.pem') }
 
+    let(:node) { Puppet::Node.new('testnode', :facts => facts, :environment => env) }
     let(:populated_env_dir) do
       dir_contained_in(env_dir, environment_files)
       env_dir
@@ -104,7 +105,9 @@ describe 'lookup' do
         certname: fqdn,
         extensions: { "1.3.6.1.4.1.34380.1.2.1.1" => "somevalue" }))
 
-      lookup('a')
+      Puppet.settings[:node_terminus] = 'exec'
+      expect_any_instance_of(Puppet::Node::Exec).to receive(:find).and_return(node)
+      lookup('a', :compile => true)
     end
 
     it 'loads external facts when running without --node' do


### PR DESCRIPTION
This commit moves the entire trusted information logic in the case where
we have the `compile` option enabled and we are not a `plain` terminus,
since any other case does not need the said `trusted_information`
context.