### PR TITLE
(PUP-11379) Agent no longer calls local enc script

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -304,7 +304,7 @@ class Puppet::Configurer
         Puppet.debug(_("Environment not passed via CLI and no catalog was given, attempting to find out the last server-specified environment"))
         initial_environment, loaded_last_environment = last_server_specified_environment
 
-        unless loaded_last_environment
+        unless Puppet[:use_last_environment] && loaded_last_environment
           Puppet.debug(_("Requesting environment from the server"))
           initial_environment = current_server_specified_environment(@environment, configured_environment, options)
         end

--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -442,6 +442,17 @@ module Puppet
         <https://puppet.com/docs/puppet/latest/environments_about.html>",
       :type    => :path,
     },
+    :use_last_environment => {
+      :type     => :boolean,
+      :default  => true,
+      :desc     => <<-'EOT'
+      Puppet saves both the initial and converged environment in the last_run_summary file.
+      If they differ, and this setting is set to true, we will use the last converged
+      environment and skip the node request.
+
+      When set to false, we will do the node request and ignore the environment data from the last_run_summary file.
+    EOT
+    },
     :always_retry_plugins => {
         :type     => :boolean,
         :default  => true,

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -1128,88 +1128,120 @@ describe Puppet::Configurer do
           converged_environment: #{last_server_specified_environment}
           run_mode: agent
         SUMMARY
+      end
 
-        expect(Puppet::Node.indirection).not_to receive(:find)
+      describe "when the use_last_environment is set to true" do
+        before do
+          expect(Puppet::Node.indirection).not_to receive(:find)
           .with(anything, hash_including(:ignore_cache => true, :fail_on_404 => true))
-      end
+        end
 
-      it "prefers the environment set via cli" do
-        Puppet.settings.handlearg('--environment', 'usethis')
-        configurer.run
+        it "prefers the environment set via cli" do
+          Puppet.settings.handlearg('--environment', 'usethis')
+          configurer.run
 
-        expect(configurer.environment).to eq('usethis')
-      end
+          expect(configurer.environment).to eq('usethis')
+        end
 
-      it "prefers the environment set via lastrunfile over config" do
-        FileUtils.mkdir_p(Puppet[:confdir])
-        set_puppet_conf(Puppet[:confdir], <<~CONF)
-        [main]
-        environment = usethis
-        lastrunfile = #{Puppet[:lastrunfile]}
-        CONF
+        it "prefers the environment set via lastrunfile over config" do
+          FileUtils.mkdir_p(Puppet[:confdir])
+          set_puppet_conf(Puppet[:confdir], <<~CONF)
+          [main]
+          environment = usethis
+          lastrunfile = #{Puppet[:lastrunfile]}
+          CONF
 
-        Puppet.initialize_settings
-        configurer.run
-
-        expect(configurer.environment).to eq(last_server_specified_environment)
-      end
-
-      it "uses the environment from Puppet[:environment] if given a catalog" do
-        configurer.run(catalog: catalog)
-
-        expect(configurer.environment).to eq(Puppet[:environment])
-      end
-
-      it "uses the environment from Puppet[:environment] if use_cached_catalog = true" do
-        Puppet[:use_cached_catalog] = true
-        expects_cached_catalog_only(catalog)
-        configurer.run
-
-        expect(configurer.environment).to eq(Puppet[:environment])
-      end
-
-      describe "when the environment is not set via CLI" do
-        it "uses the environment found in lastrunfile if the key exists" do
+          Puppet.initialize_settings
           configurer.run
 
           expect(configurer.environment).to eq(last_server_specified_environment)
         end
 
-        it "pushes the converged environment found in lastrunfile over the existing context" do
-          initial_env = Puppet::Node::Environment.remote('production')
-          Puppet.push_context(
-            current_environment: initial_env,
-            loaders: Puppet::Pops::Loaders.new(initial_env, true))
+        it "uses the environment from Puppet[:environment] if given a catalog" do
+          configurer.run(catalog: catalog)
 
-          expect(Puppet).to receive(:push_context).with(
-            hash_including(:current_environment, :loaders),
-            "Local node environment #{last_server_specified_environment} for configurer transaction"
-          ).once.and_call_original
-
-          configurer.run
+          expect(configurer.environment).to eq(Puppet[:environment])
         end
 
-        it "uses the environment from Puppet[:environment] if strict_environment_mode is set" do
-          Puppet[:strict_environment_mode] = true
+        it "uses the environment from Puppet[:environment] if use_cached_catalog = true" do
+          Puppet[:use_cached_catalog] = true
+          expects_cached_catalog_only(catalog)
           configurer.run
 
           expect(configurer.environment).to eq(Puppet[:environment])
         end
 
-        it "uses the environment from Puppet[:environment] if initial_environment is the same as converged_environment" do
-          Puppet[:lastrunfile] = file_containing('last_run_summary.yaml', <<~SUMMARY)
-          ---
-          version:
-            config: 1624882680
-            puppet: 6.24.0
-          application:
-            initial_environment: development
-            converged_environment: development
-            run_mode: agent
-          SUMMARY
+        describe "when the environment is not set via CLI" do
+          it "uses the environment found in lastrunfile if the key exists" do
+            configurer.run
+
+            expect(configurer.environment).to eq(last_server_specified_environment)
+          end
+
+          it "pushes the converged environment found in lastrunfile over the existing context" do
+            initial_env = Puppet::Node::Environment.remote('production')
+            Puppet.push_context(
+              current_environment: initial_env,
+              loaders: Puppet::Pops::Loaders.new(initial_env, true))
+
+            expect(Puppet).to receive(:push_context).with(
+              hash_including(:current_environment, :loaders),
+              "Local node environment #{last_server_specified_environment} for configurer transaction"
+            ).once.and_call_original
+
+            configurer.run
+          end
+
+          it "uses the environment from Puppet[:environment] if strict_environment_mode is set" do
+            Puppet[:strict_environment_mode] = true
+            configurer.run
+
+            expect(configurer.environment).to eq(Puppet[:environment])
+          end
+
+          it "uses the environment from Puppet[:environment] if initial_environment is the same as converged_environment" do
+            Puppet[:lastrunfile] = file_containing('last_run_summary.yaml', <<~SUMMARY)
+            ---
+            version:
+              config: 1624882680
+              puppet: 6.24.0
+            application:
+              initial_environment: development
+              converged_environment: development
+              run_mode: agent
+            SUMMARY
+            configurer.run
+
+            expect(configurer.environment).to eq(Puppet[:environment])
+          end
+        end
+      end
+
+      describe "when the use_last_environment setting is set to false" do
+        let(:node_environment) { Puppet::Node::Environment.remote(:salam) }
+        let(:node) { Puppet::Node.new(Puppet[:node_name_value]) }
+
+        before do
+          Puppet[:use_last_environment] = false
+          node.environment = node_environment
+
+          allow(Puppet::Node.indirection).to receive(:find)
+          allow(Puppet::Node.indirection).to receive(:find)
+            .with(anything, hash_including(:ignore_cache => true, :fail_on_404 => true))
+            .and_return(node)
+        end
+
+        it "does a node request" do
+          expect(Puppet::Node.indirection).to receive(:find)
+          .with(anything, hash_including(:ignore_cache => true, :fail_on_404 => true))
+
+          configurer.run
+        end
+
+        it "uses the node environment from the node request" do
           configurer.run
 
-          expect(configurer.environment).to eq(Puppet[:environment])
+          expect(configurer.environment).to eq(node_environment.name.to_s)
         end
       end
     end


### PR DESCRIPTION
This commit adds a new setting that allows to choose between using the
environment data from the `last_run_summary.yaml` file or just do the node
request and ignore all the other environment data.

TO DO before merging:

- [x] Run jenkins tests.