### PR TITLE
(maint) Merge 6.x to main

### DIFF
--- a/lib/puppet/util/yaml.rb
+++ b/lib/puppet/util/yaml.rb
@@ -24,7 +24,11 @@ module Puppet::Util::Yaml
   # @raise [YamlLoadException] If deserialization fails.
   # @return The parsed YAML, which can be Hash, Array or scalar types.
   def self.safe_load(yaml, allowed_classes = [], filename = nil)
-    data = YAML.safe_load(yaml, allowed_classes, [], true, filename)
+    if Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0')
+      data = YAML.safe_load(yaml, permitted_classes: allowed_classes, aliases: true, filename: filename)
+    else
+      data = YAML.safe_load(yaml, allowed_classes, [], true, filename)
+    end
     data = false if data.nil?
     data
   rescue ::Psych::DisallowedClass => detail


### PR DESCRIPTION
Pins rdoc to < 6.4.0 to avoid pulling in psych >= 4 which dropped Ruby 2.5

Psych 4 removed methods that accept positional arguments, but older Psych versions don't take keyword arguments. To ensure compatibility, use keyword arguments for psych >= 3.1.0 or fallback to positional arguments.