### PR TITLE
(maint) Do not output raw serialization in acceptance

### DIFF
--- a/acceptance/tests/server_returns_pson_when_preferred_serialization_set.rb
+++ b/acceptance/tests/server_returns_pson_when_preferred_serialization_set.rb
@@ -10,9 +10,11 @@ test_name "C100532: Server returns expected format when --preferred_serializatio
     formats.each do |expected_format|
       step "Server returns #{expected_format} catalog when --preferred_serialization_format=#{expected_format}" do
         agents.each do |agent|
+          # We use :silent here to avoid raw http_debug bytes being printed to our CI logs
           on(agent, puppet('agent', '-t',
                            "--preferred_serialization_format #{expected_format}",
-                           '--http_debug'), :acceptable_exit_codes => [0,2]) do |res|
+                           '--http_debug'),
+                    :acceptable_exit_codes => [0,2], :silent => true) do |res|
             found_format = false
             started = false
             res.stderr.each_line do |line|


### PR DESCRIPTION
Previously, we would output the full content of an agent run using
http_debug when checking serialization formats. We require checking
the stdout of the http_debug command to validate the content-type
header was set correctly.

However, outputting the raw bytes from the http requests to the logs
can be problematic because in CI we will take each test's output and
place them into xml files for Jenkins to display. These raw bytes may
contain invalid xml content that causes the post-run CI actions to fail
the build.

This sets the command which uses http_debug to "silent" so that its
content will not be sent to stdout.