### PR TITLE
(docs) lib/puppet/type/exec.rb `unless` `grep(1)` anchors

### DIFF
--- a/lib/puppet/type/exec.rb
+++ b/lib/puppet/type/exec.rb
@@ -457,7 +457,7 @@ module Puppet
 
             exec { '/bin/echo root >> /usr/lib/cron/cron.allow':
               path   => '/usr/bin:/usr/sbin:/bin',
-              unless => 'grep root /usr/lib/cron/cron.allow 2>/dev/null',
+              unless => 'grep ^root$ /usr/lib/cron/cron.allow 2>/dev/null',
             }
 
         This would add `root` to the cron.allow file (on Solaris) unless


### PR DESCRIPTION
The shown `grep(1)` example is missing begin‑of‑line/end‑of‑line anchors.