### PR TITLE
(docs) Add example for next()

### DIFF
--- a/lib/puppet/functions/next.rb
+++ b/lib/puppet/functions/next.rb
@@ -1,8 +1,25 @@
 # Makes iteration continue with the next value, optionally with a given value for this iteration.
 # If a value is not given it defaults to `undef`
+# 
+# @example Using the `next()` function
+#
+# ```puppet
+# $data = ['a','b','c']
+# $data.each |Integer $index, String $value| {
+#   if $index == 1 {
+#     next()
+#   }
+#   notice ("${index} = ${value}")
+# }
+# ```
+#
+# Would notice:
+# ```
+# Notice: Scope(Class[main]): 0 = a
+# Notice: Scope(Class[main]): 2 = c
+# ```
 #
 # @since 4.7.0
-#
 Puppet::Functions.create_function(:next) do
   dispatch :next_impl do
     optional_param 'Any', :value


### PR DESCRIPTION
Pretty self-explanatory. We don't have a good example for using this in the docs, and I want to link to it from other pages. 

(Please merge this up to main)