### PR TITLE
(PUP-11433) Use systemd by default in CentOS/RHEL

### DIFF
--- a/lib/puppet/provider/service/redhat.rb
+++ b/lib/puppet/provider/service/redhat.rb
@@ -8,7 +8,8 @@ Puppet::Type.type(:service).provide :redhat, :parent => :init, :source => :init 
 
   commands :chkconfig => "/sbin/chkconfig", :service => "/sbin/service"
 
-  defaultfor :osfamily => :redhat
+  defaultfor :osfamily => :redhat, :operatingsystemmajrelease => (4..6).to_a
+  defaultfor :operatingsystem => :amazon, :operatingsystemmajrelease => ["2017"]
   defaultfor :osfamily => :suse, :operatingsystemmajrelease => ["10", "11"]
 
   # Remove the symlinks

--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -14,11 +14,13 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   confine :true => Puppet::FileSystem.exist?('/proc/1/comm') && Puppet::FileSystem.read('/proc/1/comm').include?('systemd')
 
   defaultfor :osfamily => [:archlinux]
-  defaultfor :osfamily => :redhat, :operatingsystemmajrelease => ["7", "8", "9"]
+  defaultfor :osfamily => :redhat
+  notdefaultfor :osfamily => :redhat, :operatingsystemmajrelease => (4..6).to_a
   defaultfor :osfamily => :redhat, :operatingsystem => :fedora
   defaultfor :osfamily => :suse
   defaultfor :osfamily => :coreos
   defaultfor :operatingsystem => :amazon, :operatingsystemmajrelease => ["2"]
+  notdefaultfor :operatingsystem => :amazon, :operatingsystemmajrelease => ["2017"]
   defaultfor :operatingsystem => :debian
   notdefaultfor :operatingsystem => :debian, :operatingsystemmajrelease => ["5", "6", "7"] # These are using the "debian" method
   defaultfor :operatingsystem => :LinuxMint

--- a/spec/unit/provider/service/redhat_spec.rb
+++ b/spec/unit/provider/service/redhat_spec.rb
@@ -19,11 +19,9 @@ describe 'Puppet::Type::Service::Provider::Redhat',
     allow(Facter).to receive(:value).with(:osfamily).and_return('RedHat')
   end
 
-  osfamilies = [ 'RedHat' ]
-
-  osfamilies.each do |osfamily|
-    it "should be the default provider on #{osfamily}" do
-      expect(Facter).to receive(:value).with(:osfamily).and_return(osfamily)
+  [4, 5, 6].each do |ver|
+    it "should be the default provider on rhel#{ver}" do
+      allow(Facter).to receive(:value).with(:operatingsystemmajrelease).and_return(ver)
       expect(provider_class.default?).to be_truthy
     end
   end


### PR DESCRIPTION
Since CentOS7/RHEL7, systemd is used to manage services. This change
changes the default provider in CentOS/RHEL from the old redhat
provider based on init, to the systemd provider, so that we no longer
need to update the provider code when adding support for a new version
of CentOS/RHEL.

The old redhat provider is still used for CentOS/RHEL<7 which are using
init to manage services.