### PR TITLE
(maint) Update to newer ruby

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -13,9 +13,9 @@ jobs:
     strategy:
       matrix:
         cfg:
-          - {check: rubocop, os: ubuntu-18.04, ruby: 2.5}
-          - {check: commits, os: ubuntu-18.04, ruby: 2.5}
-          - {check: warnings, os: ubuntu-18.04, ruby: 2.5}
+          - {check: rubocop, os: ubuntu-18.04, ruby: 2.7}
+          - {check: commits, os: ubuntu-18.04, ruby: 2.7}
+          - {check: warnings, os: ubuntu-18.04, ruby: 2.7}
 
     runs-on: ${{ matrix.cfg.os }}
     steps:


### PR DESCRIPTION
The rubocop check was failing in GH because it used 2.5 which includes
an older Bundler which doesn't handle `required_ruby_version` correctly.

Just use ruby 2.7 to run the checks to avoid future 2.5 issues.