### PR TITLE
(maint) Update rubygems and remove unnecessary step

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -29,9 +29,9 @@ jobs:
         with:
           ruby-version: ${{ matrix.cfg.ruby }}
 
-      - name: Install bundler and gems
+      - name: Update rubygems and install gems
         run: |
-          gem install bundler
+          gem update --system --no-document
           bundle config set without packaging documentation
           bundle install --jobs 4 --retry 3
 

--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -33,9 +33,9 @@ jobs:
         with:
           ruby-version: ${{ matrix.cfg.ruby }}
 
-      - name: Install bundler and gems
+      - name: Update rubygems and install gems
         run: |
-          gem install bundler
+          gem update --system --no-document
           bundle config set without packaging documentation
           bundle install --jobs 4 --retry 3
 


### PR DESCRIPTION
This commit updates rubygems to latest version to avoid the following
error: ``` Your RubyGems version (2.5.2.3)) has a bug that prevents
`required_ruby_version` from working for Bundler. Any scripts that use
`gem install bundler` will break as soon as Bundler drops support for
your Ruby version. Please upgrade RubyGems...  ```

This commit also removes an unnecessary step that installed `bundler` a
second time since the `ruby/setup-ruby@v1` action now also installs
bundler.

(cherry picked from commit 8f9992704fc353d5639108bd63761b1736d4d3d2)