### PR TITLE
(maint) Merge 6.x to main

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # defaults
-* @puppetlabs/phoenix @puppetlabs/puppetserver-maintainers @puppetlabs/night-s-watch
+* @puppetlabs/phoenix @puppetlabs/puppetserver-maintainers
 
 # PAL
 /lib/puppet/pal @puppetlabs/bolt


### PR DESCRIPTION
Preserved the GH workflows in main, since all supported rubygems
support the `--silent` flag.
