### PR TITLE
(maint) replace legacy facts in service provider

### DIFF
--- a/lib/puppet/provider/service/init.rb
+++ b/lib/puppet/provider/service/init.rb
@@ -4,7 +4,7 @@ Puppet::Type.type(:service).provide :init, :parent => :base do
   desc "Standard `init`-style service management."
 
   def self.defpath
-    case Puppet.runtime[:facter].value(:operatingsystem)
+    case Puppet.runtime[:facter].value(:os)['name']
     when "FreeBSD", "DragonFly"
       ["/etc/rc.d", "/usr/local/etc/rc.d"]
     when "HP-UX"
@@ -21,8 +21,8 @@ Puppet::Type.type(:service).provide :init, :parent => :base do
   # Debian and Ubuntu should use the Debian provider.
   # RedHat systems should use the RedHat provider.
   confine :true => begin
-      os = Puppet.runtime[:facter].value(:operatingsystem).downcase
-      family = Puppet.runtime[:facter].value(:osfamily).downcase
+      os = Puppet.runtime[:facter].value(:os)['name'].downcase
+      family = Puppet.runtime[:facter].value(:os)['family'].downcase
       !(os == 'debian' || os == 'ubuntu' || family == 'redhat')
   end
 


### PR DESCRIPTION
This causes issues with spec testing puppet modules on a regular basis.
It's not guaranteed that new factsets from facterdb have legacy facts
because, well, Puppet Inc declared them legacy and in many places they
are opt-in. We (Vox Pupuli) spent alot of time adding some legacy facts
back to some factsets, but it's inconsistent. I think they shouldn't be
used anymore.