### PR TITLE
Support Ed25519 keys/certificates

### DIFF
--- a/lib/puppet/ssl/ssl_provider.rb
+++ b/lib/puppet/ssl/ssl_provider.rb
@@ -134,7 +134,7 @@ class Puppet::SSL::SSLProvider
   #
   # @param cacerts [Array<OpenSSL::X509::Certificate>] Array of trusted CA certs
   # @param crls [Array<OpenSSL::X509::CRL>] Array of CRLs
-  # @param private_key [OpenSSL::PKey::RSA, OpenSSL::PKey::EC] client's private key
+  # @param private_key [OpenSSL::PKey::PKey] client's private key
   # @param client_cert [OpenSSL::X509::Certificate] client's cert whose public
   #   key matches the `private_key`
   # @param revocation [:chain, :leaf, false] revocation mode
@@ -199,7 +199,7 @@ class Puppet::SSL::SSLProvider
   # of the private key, and that it hasn't been tampered with since.
   #
   # @param csr [OpenSSL::X509::Request] certificate signing request
-  # @param public_key [OpenSSL::PKey::RSA, OpenSSL::PKey::EC] public key
+  # @param public_key [OpenSSL::PKey::PKey] public key
   # @raise [Puppet::SSL:SSLError] The private_key for the given `public_key` was
   #   not used to sign the CSR.
   # @api private
@@ -281,7 +281,9 @@ class Puppet::SSL::SSLProvider
   def resolve_client_chain(store, client_cert, private_key)
     client_chain = verify_cert_with_store(store, client_cert)
 
-    if !private_key.is_a?(OpenSSL::PKey::RSA) && !private_key.is_a?(OpenSSL::PKey::EC)
+    if !private_key.is_a?(OpenSSL::PKey::RSA) && \
+       !private_key.is_a?(OpenSSL::PKey::EC) && \
+       !(private_key.is_a?(OpenSSL::PKey::PKey) && private_key.respond_to?(:oid) && private_key.oid == 'ED25519')
       raise Puppet::SSL::SSLError, _("Unsupported key '%{type}'") % { type: private_key.class.name }
     end
 

--- a/lib/puppet/x509/cert_provider.rb
+++ b/lib/puppet/x509/cert_provider.rb
@@ -176,7 +176,7 @@ class Puppet::X509::CertProvider
   # historical reasons, names are case insensitive.
   #
   # @param name [String] The private key identity
-  # @param key [OpenSSL::PKey::RSA] private key
+  # @param key [OpenSSL::PKey::PKey] private key
   # @param password [String, nil] If non-nil, derive an encryption key
   #   from the password, and use that to encrypt the private key. If nil,
   #   save the private key unencrypted.
@@ -227,7 +227,7 @@ class Puppet::X509::CertProvider
   # @param password [String, nil] If the private key is encrypted, decrypt
   #   it using the password. If the key is encrypted, but a password is
   #   not specified, then the key cannot be loaded.
-  # @return [OpenSSL::PKey::RSA, OpenSSL::PKey::EC] The private key
+  # @return [OpenSSL::PKey::PKey] The private key
   # @raise [OpenSSL::PKey::PKeyError] The `pem` text does not contain a valid key
   #
   # @api private
@@ -299,7 +299,7 @@ class Puppet::X509::CertProvider
   # Create a certificate signing request (CSR).
   #
   # @param name [String] the request identity
-  # @param private_key [OpenSSL::PKey::RSA] private key
+  # @param private_key [OpenSSL::PKey::PKey] private key
   # @return [Puppet::X509::Request] The request
   #
   # @api private

--- a/spec/lib/puppet/test_ca.rb
+++ b/spec/lib/puppet/test_ca.rb
@@ -129,7 +129,9 @@ module Puppet
     private
 
     def build_cert(name, issuer, opts = {})
-      key = if opts[:key_type] == :ec
+      key = if opts[:key_type] == :ed25519
+              key = OpenSSL::PKey.generate('ed25519')
+            elsif opts[:key_type] == :ec
               key = OpenSSL::PKey::EC.generate('prime256v1')
             elsif opts[:reuse_key]
               key = opts[:reuse_key]

--- a/spec/unit/x509/cert_provider_spec.rb
+++ b/spec/unit/x509/cert_provider_spec.rb
@@ -318,6 +318,32 @@ describe Puppet::X509::CertProvider do
           }.to raise_error(OpenSSL::PKey::PKeyError, /(unknown|invalid) curve name|Could not parse PKey: (no start line|bad decrypt)/)
         end
       end
+
+      context 'using Ed25519', if: RUBY_VERSION.to_f >= 3 && OpenSSL::OPENSSL_VERSION_NUMBER > 0x10101000 do
+        it 'returns a generic key' do
+          expect(provider.load_private_key('ed25519-key')).to be_a(OpenSSL::PKey::PKey)
+        end
+
+        it 'returns a generic key from PKCS#8 format' do
+          expect(provider.load_private_key('ed25519-key-pk8')).to be_a(OpenSSL::PKey::PKey)
+        end
+
+        it 'returns a generic key from openssl format' do
+          expect(provider.load_private_key('ed25519-key-openssl')).to be_a(OpenSSL::PKey::PKey)
+        end
+
+        it 'decrypts a generic key using the password' do
+          pkey = provider.load_private_key('encrypted-ed25519-key', password: password)
+          expect(pkey).to be_a(OpenSSL::PKey::PKey)
+        end
+
+        it 'raises without a password' do
+          # password is 74695716c8b6
+          expect {
+            provider.load_private_key('encrypted-ed25519-key')
+          }.to raise_error(OpenSSL::PKey::PKeyError, /(unknown|invalid) curve name|Could not parse PKey: no start line/)
+        end
+      end
     end
 
     context 'certs' do


### PR DESCRIPTION
The generic interface usage was added by 78712feb5dd54565d6a86be341410b0c3e04aab6, which improved key format support.
ruby-openssl 3.0, shipped in Ruby 3.0, supports Ed25519 keys using the generic interface and returns a OpenSSL::PKey::PKey.
The only thing preventing these from working is a simple type check. Remove it and update various type annotations to refer to OpenSSL::PKey::PKey, though the old types will still work.