### PR TITLE
Stop checking encoding names

### DIFF
--- a/lib/puppet/pops/types/p_binary_type.rb
+++ b/lib/puppet/pops/types/p_binary_type.rb
@@ -72,13 +72,13 @@ class PBinaryType < PAnyType
     # @api public
     #
     def self.from_string(encoded_string)
-      enc = encoded_string.encoding.name
+      enc = encoded_string.encoding
       unless encoded_string.valid_encoding?
-        raise ArgumentError, _("The given string in encoding '%{enc}' is invalid. Cannot create a Binary UTF-8 representation") % { enc: enc }
+        raise ArgumentError, _("The given string in encoding '%{enc}' is invalid. Cannot create a Binary UTF-8 representation") % { enc: enc.name }
       end
       # Convert to UTF-8 (if not already UTF-8), and then to binary
-      encoded_string = (enc == "UTF-8") ? encoded_string.dup : encoded_string.encode('UTF-8')
-      encoded_string.force_encoding("ASCII-8BIT")
+      encoded_string = (enc == Encoding::UTF_8) ? encoded_string.dup : encoded_string.encode(Encoding::UTF_8)
+      encoded_string.force_encoding(Encoding::BINARY)
       new(encoded_string)
     end
 
@@ -91,7 +91,7 @@ class PBinaryType < PAnyType
     # @api private
     #
     def initialize(bin)
-      @binary_buffer = (bin.encoding.name == "ASCII-8BIT" ? bin : bin.b).freeze
+      @binary_buffer = (bin.encoding == Encoding::BINARY ? bin : bin.b).freeze
     end
 
     # Presents the binary content as a string base64 encoded string (without line breaks).


### PR DESCRIPTION
Comparing the names is much less efficient than comparing the instance directly.
    
It may also change in the future: https://bugs.ruby-lang.org/issues/18576