### PR TITLE
(PUP-11459) Always load Puppet::Util::Windows

### DIFF
--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -7,6 +7,7 @@ require 'uri'
 require 'pathname'
 require 'ostruct'
 require 'puppet/util/platform'
+require 'puppet/util/windows'
 require 'puppet/util/symbolic_file_mode'
 require 'puppet/file_system/uniquefile'
 require 'securerandom'
@@ -21,8 +22,6 @@ module Util
   # to be in Puppet::Util but have been moved into external modules.
   require 'puppet/util/posix'
   extend Puppet::Util::POSIX
-
-  require 'puppet/util/windows/process' if Puppet::Util::Platform.windows?
 
   extend Puppet::Util::SymbolicFileMode
 

--- a/lib/puppet/util/monkey_patches.rb
+++ b/lib/puppet/util/monkey_patches.rb
@@ -70,8 +70,6 @@ unless Puppet::Util::Platform.jruby_fips?
 end
 
 if Puppet::Util::Platform.windows?
-  require 'puppet/util/windows'
-
   class OpenSSL::X509::Store
     @puppet_certs_loaded = false
     alias __original_set_default_paths set_default_paths

--- a/spec/unit/util/windows_spec.rb
+++ b/spec/unit/util/windows_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Puppet::Util::Windows do
+  %w[
+    ADSI
+    ADSI::ADSIObject
+    ADSI::User
+    ADSI::UserProfile
+    ADSI::Group
+    EventLog
+    File
+    Process
+    Registry
+    Service
+    SID
+    ].each do |name|
+    it "defines Puppet::Util::Windows::#{name}" do
+      expect(described_class.const_get(name)).to be
+    end
+  end
+end


### PR DESCRIPTION
Previously, 'puppet/util/windows.rb' was loaded on Windows due to requiring
'puppet/file_system/uniquefile'[1]. The second require[2] was actually a noop,
since the file had already been required. And on non-Windows, the file was never
loaded.

Now we explicitly require 'puppet/util/windows' on all platforms. It must be
done after 'puppet/util/platform' so we can detect if we're actually on Windows.
We also remove the misleading requires that didn't do anything.

[1] https://github.com/puppetlabs/puppet/blob/6.26.0/lib/puppet/util.rb#L11
[2] https://github.com/puppetlabs/puppet/blob/6.26.0/lib/puppet/util.rb#L25