### PR TITLE
(PUP-11440) If no env found, and strict env mode cancel puppet run

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -330,7 +330,7 @@ class Puppet::Configurer
       temp_value = options[:pluginsync]
 
       # only validate server environment if pluginsync is requested
-      options[:pluginsync] = valid_server_environment? if options[:pluginsync] == true
+      options[:pluginsync] = valid_server_environment? if options[:pluginsync]
 
       query_options, facts = get_facts(options) unless query_options
       options[:pluginsync] = temp_value
@@ -443,7 +443,11 @@ class Puppet::Configurer
       true
     rescue Puppet::HTTP::ResponseError => detail
       if detail.response.code == 404
-        Puppet.notice(_("Environment '%{environment}' not found on server, skipping initial pluginsync.") % { environment: @environment })
+        if Puppet[:strict_environment_mode]
+          raise Puppet::Error.new(_("Environment '%{environment}' not found on server, aborting run.") % { environment: @environment })
+        else
+          Puppet.notice(_("Environment '%{environment}' not found on server, skipping initial pluginsync.") % { environment: @environment })
+        end
       else
         Puppet.log_exception(detail, detail.message)
       end


### PR DESCRIPTION
Previously if you were running the puppet agent with strict enviroment mode
and the given enviroment was not found, puppet would then default to the production
environment.
This can produce unexpected results, so now we are going to fail early when
the environment is not found and strict environment mode is on.