### PR TITLE
(PUP-11471) Allow mixing system CA and Puppet client certificate authentication

### DIFF
--- a/lib/puppet/ssl/ssl_provider.rb
+++ b/lib/puppet/ssl/ssl_provider.rb
@@ -51,8 +51,7 @@ class Puppet::SSL::SSLProvider
   # @raise (see #create_context)
   # @api private
   def create_system_context(cacerts:, path: Puppet[:ssl_trust_store])
-    store = create_x509_store(cacerts, [], false)
-    store.set_default_paths
+    store = create_x509_store(cacerts, [], false, include_system_store: true)
 
     if path
       stat = Puppet::FileSystem.stat(path)
@@ -186,13 +185,15 @@ class Puppet::SSL::SSLProvider
     end
   end
 
-  def create_x509_store(roots, crls, revocation)
+  def create_x509_store(roots, crls, revocation, include_system_store: false)
     store = OpenSSL::X509::Store.new
     store.purpose = OpenSSL::X509::PURPOSE_ANY
     store.flags = default_flags | revocation_mode(revocation)
 
     roots.each { |cert| store.add_cert(cert) }
     crls.each { |crl| store.add_crl(crl) }
+
+    store.set_default_paths if include_system_store
 
     store
   end


### PR DESCRIPTION
Allow conveniently building a `Puppet::HTTP::Client` trusting the host certificates and performing client certificate authentication:

```ruby
ssl_provider = Puppet::SSL::SSLProvider.new
ssl_context = ssl_provider.load_context(revocation: false, include_system_store: true)
client.get(URI(url), options: { ssl_context: ssl_context }) { |response| ... }
```