### PR TITLE
(PUP-11472) Add source_ref to legacy function error

### DIFF
--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -606,7 +606,7 @@ describe 'loaders' do
     it "an illegal function is loaded" do
       expect {
         loader.load_typed(typed_name(:function, 'bad_func_load3')).value
-      }.to raise_error(SecurityError, /Illegal method definition of method 'bad_func_load3_illegal_method' on line 8 in legacy function/)
+      }.to raise_error(SecurityError, /Illegal method definition of method 'bad_func_load3_illegal_method' in source .*bad_func_load3.rb on line 8 in legacy function/)
     end
   end
 


### PR DESCRIPTION
Prior to the commit the illegal error message only included the method
name and line number, but this makes finding the source file difficult.

After this commit the source file name is included in the error message.