### PR TITLE
(PUP-11437) Fix bug on lookup when environment is supplied

### DIFF
--- a/acceptance/tests/parser_functions/puppet_lookup_cmd.rb
+++ b/acceptance/tests/parser_functions/puppet_lookup_cmd.rb
@@ -2605,15 +2605,6 @@ with_puppet_running_on master, @master_opts, @coderoot do
     "lookup in ENC specified environment failed"
   )
 
-  step "--compile uses environment specified in --envrionment flag"
-  r = on(master, puppet('lookup', '--compile', "--node #{@node1}", "--confdir #{@confdir}", "--facts #{@coderoot}/facts.yaml", "--environment env1", 'environment_key'))
-  result = r.stdout
-  assert_match(
-    /env-env1 hiera provided value/,
-    result,
-    "env1 environment_key lookup failed, expected 'env-env1 hiera"
-  )
-
   step "without --compile does not use environment specified in ENC"
   r = on(master, puppet('lookup', "--node #{@node1}", "--confdir #{@confdir}", "--facts #{@coderoot}/facts.yaml", 'environment_key'))
   result = r.stdout

--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -373,38 +373,34 @@ Copyright (c) 2015 Puppet Inc., LLC Licensed under the Apache 2.0 License
     end
 
     unless node.is_a?(Puppet::Node) # to allow unit tests to pass a node instance
-      facts = retrieve_node_facts(node, given_facts) 
-      if Puppet.settings.set_by_cli?('environment')
-        node = Puppet::Node.new(node, :classes => nil, :parameters => nil, :facts => facts, :environment => Puppet.settings.value('environment'))
-      else
-        ni = Puppet::Node.indirection
-        tc = ni.terminus_class
-        if options[:compile]
-          if tc == :plain
-            node = ni.find(node, facts: facts)
-          else
-            begin
-              service = Puppet.runtime[:http]
-              session = service.create_session
-              cert = session.route_to(:ca)
+      facts = retrieve_node_facts(node, given_facts)
+      ni = Puppet::Node.indirection
+      tc = ni.terminus_class
+      if options[:compile] && !Puppet.settings.set_by_cli?('environment')
+        if tc == :plain
+          node = ni.find(node, facts: facts)
+        else
+          begin
+            service = Puppet.runtime[:http]
+            session = service.create_session
+            cert = session.route_to(:ca)
 
-              _, x509 = cert.get_certificate(node)
-              cert = OpenSSL::X509::Certificate.new(x509)
-              Puppet::SSL::Oids.register_puppet_oids
-              trusted = Puppet::Context::TrustedInformation.remote(true, facts.values['certname'] || node, Puppet::SSL::Certificate.from_instance(cert))
-              Puppet.override(trusted_information: trusted) do
-                node = ni.find(node, facts: facts)
-              end
-            rescue
-              Puppet.warning _("CA is not available, the operation will continue without using trusted facts.")
+            _, x509 = cert.get_certificate(node)
+            cert = OpenSSL::X509::Certificate.new(x509)
+            Puppet::SSL::Oids.register_puppet_oids
+            trusted = Puppet::Context::TrustedInformation.remote(true, facts.values['certname'] || node, Puppet::SSL::Certificate.from_instance(cert))
+            Puppet.override(trusted_information: trusted) do
               node = ni.find(node, facts: facts)
             end
+          rescue
+            Puppet.warning _("CA is not available, the operation will continue without using trusted facts.")
+            node = ni.find(node, facts: facts)
           end
-        else
-          ni.terminus_class = :plain
-          node = ni.find(node, facts: facts)
-          ni.terminus_class = tc
         end
+      else
+        ni.terminus_class = :plain
+        node = ni.find(node, facts: facts, environment: Puppet[:environment])
+        ni.terminus_class = tc
       end
     else
       node.add_extra_facts(given_facts) if given_facts

--- a/spec/integration/application/lookup_spec.rb
+++ b/spec/integration/application/lookup_spec.rb
@@ -72,6 +72,25 @@ describe 'lookup' do
       expect_lookup_with_output(0, /value a/)
     end
 
+    it "resolves hiera data using a top-level node parameter" do
+      File.write(File.join(env_dir, env_name, 'hiera.yaml'), <<~YAML)
+        ---
+        version: 5
+        hierarchy:
+          - name: "Per Node"
+            data_hash: yaml_data
+            path: "%{my_fact}.yaml"
+      YAML
+
+      File.write(File.join(env_dir, env_name, 'data', "my_fact_value.yaml"), <<~YAML)
+        ---
+        a: value from per node data
+      YAML
+
+      app.command_line.args << 'a'
+      expect_lookup_with_output(0, /--- value from per node data/)
+    end
+
     it 'loads trusted information from the node certificate' do
       Puppet.settings[:node_terminus] = 'exec'
       expect_any_instance_of(Puppet::Node::Exec).to receive(:find) do |args|


### PR DESCRIPTION
Topscope variables were not being resolved on lookup when an environment was supplied. This PR fixes that.