### PR TITLE
(PUP-11428) Reload ssl context for each agent run

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -242,20 +242,7 @@ module Puppet
     {
       :environments => Puppet::Environments::Cached.new(Puppet::Environments::Combined.new(*loaders)),
       :http_pool => proc { Puppet.runtime[:http].pool },
-      :ssl_context => proc {
-        begin
-          cert = Puppet::X509::CertProvider.new
-          password = cert.load_private_key_password
-          ssl = Puppet::SSL::SSLProvider.new
-          ssl.load_context(certname: Puppet[:certname], password: password)
-        rescue => e
-          # TRANSLATORS: `message` is an already translated string of why SSL failed to initialize
-          Puppet.log_exception(e, _("Failed to initialize SSL: %{message}") % { message: e.message })
-          # TRANSLATORS: `puppet agent -t` is a command and should not be translated
-          Puppet.err(_("Run `puppet agent -t`"))
-          raise e
-        end
-      },
+      :ssl_context => proc { Puppet.runtime[:http].default_ssl_context },
       :ssl_host => proc { Puppet::SSL::Host.localhost(true) },
       :http_session => proc { Puppet.runtime[:http].create_session },
       :plugins => proc { Puppet::Plugins::Configuration.load_plugins },

--- a/lib/puppet/agent.rb
+++ b/lib/puppet/agent.rb
@@ -94,6 +94,8 @@ class Puppet::Agent
           rescue StandardError => detail
             Puppet.log_exception(detail, _("Could not run %{client_class}: %{detail}") % { client_class: client_class, detail: detail })
             nil
+          ensure
+            Puppet.runtime[:http].close
           end
         end
       end

--- a/lib/puppet/agent.rb
+++ b/lib/puppet/agent.rb
@@ -45,11 +45,19 @@ class Puppet::Agent
     result = nil
     wait_for_lock_deadline = nil
     block_run = Puppet::Application.controlled_run do
-      splay client_options.fetch :splay, Puppet[:splay]
+      # splay may sleep for awhile!
+      splay(client_options.fetch(:splay, Puppet[:splay]))
+
+      # waiting for certs may sleep for awhile depending on onetime, waitforcert and maxwaitforcert!
+      # this needs to happen before forking so that if we fail to obtain certs and try to exit, then
+      # we exit the main process and not the forked child.
+      ssl_context = wait_for_certificates(client_options)
+
       result = run_in_fork(should_fork) do
         with_client(client_options[:transaction_uuid], client_options[:job_id]) do |client|
           client_args = client_options.merge(:pluginsync => Puppet::Configurer.should_pluginsync?)
           begin
+            # lock may sleep for awhile depending on waitforlock and maxwaitforlock!
             lock do
               # NOTE: Timeout is pretty heinous as the location in which it
               # throws an error is entirely unpredictable, which means that
@@ -57,7 +65,9 @@ class Puppet::Agent
               # sanity. The only thing a Puppet agent should do after this
               # error is thrown is die with as much dignity as possible.
               Timeout.timeout(Puppet[:runtimeout], RunTimeoutError) do
-                client.run(client_args)
+                Puppet.override(ssl_context: ssl_context) do
+                  client.run(client_args)
+                end
               end
             end
           rescue Puppet::LockError
@@ -136,5 +146,11 @@ class Puppet::Agent
     yield @client
   ensure
     @client = nil
+  end
+
+  def wait_for_certificates(options)
+    waitforcert = options[:waitforcert] || (Puppet[:onetime] ? 0 : Puppet[:waitforcert])
+    sm = Puppet::SSL::StateMachine.new(waitforcert: waitforcert, onetime: Puppet[:onetime])
+    sm.ensure_client_certificate
   end
 end

--- a/lib/puppet/http/client.rb
+++ b/lib/puppet/http/client.rb
@@ -272,6 +272,8 @@ class Puppet::HTTP::Client
   #
   def close
     @pool.close
+    @default_ssl_context = nil
+    @default_system_ssl_context = nil
   end
 
   def default_ssl_context

--- a/lib/puppet/http/client.rb
+++ b/lib/puppet/http/client.rb
@@ -25,7 +25,7 @@ class Puppet::HTTP::Client
   #   used if :include_system_store is set to true
   # @param [Integer] redirect_limit default number of HTTP redirections to allow
   #   in a given request. Can also be specified per-request.
-  # @param [Integer] retry_limit number of HTTP reties allowed in a given
+  # @param [Integer] retry_limit number of HTTP retries allowed in a given
   #   request
   #
   def initialize(pool: Puppet::Network::HTTP::Pool.new(Puppet[:http_keepalive_timeout]), ssl_context: nil, system_ssl_context: nil, redirect_limit: 10, retry_limit: 100)
@@ -281,7 +281,9 @@ class Puppet::HTTP::Client
     password = cert.load_private_key_password
 
     ssl = Puppet::SSL::SSLProvider.new
-    ssl.load_context(certname: Puppet[:certname], password: password)
+    ctx = ssl.load_context(certname: Puppet[:certname], password: password)
+    ssl.print(ctx)
+    ctx
   rescue => e
     # TRANSLATORS: `message` is an already translated string of why SSL failed to initialize
     Puppet.log_exception(e, _("Failed to initialize SSL: %{message}") % { message: e.message })
@@ -425,6 +427,8 @@ class Puppet::HTTP::Client
 
     ssl = Puppet::SSL::SSLProvider.new
     @default_system_ssl_context = ssl.create_system_context(cacerts: cacerts)
+    ssl.print(@default_system_ssl_context)
+    @default_system_ssl_context
   end
 
   def apply_auth(request, basic_auth)

--- a/lib/puppet/http/client.rb
+++ b/lib/puppet/http/client.rb
@@ -274,6 +274,20 @@ class Puppet::HTTP::Client
     @pool.close
   end
 
+  def default_ssl_context
+    cert = Puppet::X509::CertProvider.new
+    password = cert.load_private_key_password
+
+    ssl = Puppet::SSL::SSLProvider.new
+    ssl.load_context(certname: Puppet[:certname], password: password)
+  rescue => e
+    # TRANSLATORS: `message` is an already translated string of why SSL failed to initialize
+    Puppet.log_exception(e, _("Failed to initialize SSL: %{message}") % { message: e.message })
+    # TRANSLATORS: `puppet agent -t` is a command and should not be translated
+    Puppet.err(_("Run `puppet agent -t`"))
+    raise e
+  end
+
   protected
 
   def encode_query(url, params)

--- a/lib/puppet/ssl/ssl_provider.rb
+++ b/lib/puppet/ssl/ssl_provider.rb
@@ -185,6 +185,12 @@ class Puppet::SSL::SSLProvider
           Puppet.debug(_("Verified CA certificate '%{subject}' fingerprint %{digest}") % {subject: cert.subject.to_utf8, digest: digest})
         end
       end
+      ssl_context.crls.each do |crl|
+        oid_values = Hash[crl.extensions.map { |ext| [ext.oid, ext.value] }]
+        crlNumber = oid_values['crlNumber'] || 'unknown'
+        authKeyId = (oid_values['authorityKeyIdentifier'] || 'unknown').chomp!
+        Puppet.debug("Using CRL '#{crl.issuer.to_utf8}' authorityKeyIdentifier '#{authKeyId}' crlNumber '#{crlNumber }'")
+      end
     end
   end
 

--- a/lib/puppet/ssl/ssl_provider.rb
+++ b/lib/puppet/ssl/ssl_provider.rb
@@ -173,6 +173,21 @@ class Puppet::SSL::SSLProvider
     csr
   end
 
+  def print(ssl_context, alg = 'SHA256')
+    if Puppet::Util::Log.sendlevel?(:debug)
+      chain = ssl_context.client_chain
+      # print from root to client
+      chain.reverse.each_with_index do |cert, i|
+        digest = Puppet::SSL::Digest.new(alg, cert.to_der)
+        if i == chain.length - 1
+          Puppet.debug(_("Verified client certificate '%{subject}' fingerprint %{digest}") % {subject: cert.subject.to_utf8, digest: digest})
+        else
+          Puppet.debug(_("Verified CA certificate '%{subject}' fingerprint %{digest}") % {subject: cert.subject.to_utf8, digest: digest})
+        end
+      end
+    end
+  end
+
   private
 
   def default_flags

--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -278,7 +278,7 @@ class Puppet::SSL::StateMachine
       else
         Puppet.info(_("Will try again in %{time} seconds.") % {time: time})
 
-        # close persistent connections and session state before sleeping
+        # close http/tls and session state before sleeping
         Puppet.runtime[:http].close
         @machine.session = Puppet.runtime[:http].create_session
 

--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -417,20 +417,7 @@ class Puppet::SSL::StateMachine
   def ensure_client_certificate
     final_state = run_machine(NeedLock.new(self), Done)
     ssl_context = final_state.ssl_context
-
-    if Puppet::Util::Log.sendlevel?(:debug)
-      chain = ssl_context.client_chain
-      # print from root to client
-      chain.reverse.each_with_index do |cert, i|
-        digest = Puppet::SSL::Digest.new(@digest, cert.to_der)
-        if i == chain.length - 1
-          Puppet.debug(_("Verified client certificate '%{subject}' fingerprint %{digest}") % {subject: cert.subject.to_utf8, digest: digest})
-        else
-          Puppet.debug(_("Verified CA certificate '%{subject}' fingerprint %{digest}") % {subject: cert.subject.to_utf8, digest: digest})
-        end
-      end
-    end
-
+    @ssl_provider.print(ssl_context, @digest)
     ssl_context
   end
 

--- a/spec/integration/application/agent_spec.rb
+++ b/spec/integration/application/agent_spec.rb
@@ -836,7 +836,6 @@ describe "puppet agent", unless: Puppet::Util::Platform.jruby? do
           instance.agent.run(splay: false)
         end
 
-        pending("PUP-11428: the second run should fail due to the revoked client cert")
         agent.command_line.args << '--verbose'
         expect {
           agent.run

--- a/spec/integration/application/agent_spec.rb
+++ b/spec/integration/application/agent_spec.rb
@@ -3,6 +3,7 @@ require 'puppet_spec/files'
 require 'puppet_spec/puppetserver'
 require 'puppet_spec/compiler'
 require 'puppet_spec/https'
+require 'puppet/application/agent'
 
 describe "puppet agent", unless: Puppet::Util::Platform.jruby? do
   include PuppetSpec::Files
@@ -734,6 +735,114 @@ describe "puppet agent", unless: Puppet::Util::Platform.jruby? do
         }.to exit_with(2)
          .and output(a_string_matching(%r{Notice: Local environment: 'production' doesn't match server specified environment 'newenv', restarting agent run with environment 'newenv'})
          .and matching(%r{defined 'message' as 'web'})).to_stdout
+      end
+    end
+  end
+
+  context "ssl" do
+    context "bootstrapping" do
+      before :each do
+        # reconfigure ssl to non-existent dir and files to force bootstrapping
+        dir = tmpdir('ssl')
+        Puppet[:ssldir] = dir
+        Puppet[:localcacert] = File.join(dir, 'ca.pem')
+        Puppet[:hostcrl] = File.join(dir, 'crl.pem')
+        Puppet[:hostprivkey] = File.join(dir, 'cert.pem')
+        Puppet[:hostcert] = File.join(dir, 'key.pem')
+
+        Puppet[:daemonize] = false
+        Puppet[:logdest] = 'console'
+        Puppet[:log_level] = 'info'
+      end
+
+      it "exits if the agent is not allowed to wait" do
+        Puppet[:waitforcert] = 0
+
+        server.start_server do |port|
+          Puppet[:serverport] = port
+          expect {
+            agent.run
+          }.to exit_with(1)
+           .and output(%r{Exiting now because the waitforcert setting is set to 0}).to_stdout
+           .and output(%r{Failed to submit the CSR, HTTP response was 404}).to_stderr
+        end
+      end
+
+      it "exits if the maxwaitforcert time is exceeded" do
+        Puppet[:waitforcert] = 1
+        Puppet[:maxwaitforcert] = 1
+
+        server.start_server do |port|
+          Puppet[:serverport] = port
+          expect {
+            agent.run
+          }.to exit_with(1)
+            .and output(%r{Couldn't fetch certificate from CA server; you might still need to sign this agent's certificate \(127.0.0.1\). Exiting now because the maxwaitforcert timeout has been exceeded.}).to_stdout
+            .and output(%r{Failed to submit the CSR, HTTP response was 404}).to_stderr
+        end
+      end
+    end
+
+    def copy_fixtures(sources, dest)
+      ssldir = File.join(PuppetSpec::FIXTURE_DIR, 'ssl')
+      File.open(dest, 'w') do |f|
+        sources.each do |s|
+          f.write(File.read(File.join(ssldir, s)))
+        end
+      end
+    end
+
+    it "reloads the CRL between runs" do
+      Puppet[:localcacert] = ca = tmpfile('ca')
+      Puppet[:hostcrl] = crl = tmpfile('crl')
+      Puppet[:hostcert] = cert = tmpfile('cert')
+      Puppet[:hostprivkey] = key = tmpfile('key')
+
+      copy_fixtures(%w[ca.pem intermediate.pem], ca)
+      copy_fixtures(%w[crl.pem intermediate-crl.pem], crl)
+      copy_fixtures(%w[127.0.0.1.pem], cert)
+      copy_fixtures(%w[127.0.0.1-key.pem], key)
+
+      revoked = cert_fixture('revoked.pem')
+      revoked_key = key_fixture('revoked-key.pem')
+
+      mounts = {}
+      mounts[:catalog] = -> (req, res) {
+        catalog = compile_to_catalog(<<~MANIFEST, node)
+          file { '#{cert}':
+            ensure => file,
+            content => '#{revoked}'
+          }
+          file { '#{key}':
+            ensure => file,
+            content => '#{revoked_key}'
+          }
+        MANIFEST
+
+        res.body = formatter.render(catalog)
+        res['Content-Type'] = formatter.mime
+      }
+
+      server.start_server(mounts: mounts) do |port|
+        Puppet[:serverport] = port
+        Puppet[:daemonize] = false
+        Puppet[:runinterval] = 1
+        Puppet[:waitforcert] = 1
+        Puppet[:maxwaitforcert] = 1
+
+        # simulate two runs of the agent, then return so we don't infinite loop
+        allow_any_instance_of(Puppet::Daemon).to receive(:run_event_loop) do |instance|
+          instance.agent.run(splay: false)
+          instance.agent.run(splay: false)
+        end
+
+        pending("PUP-11428: the second run should fail due to the revoked client cert")
+        agent.command_line.args << '--verbose'
+        expect {
+          agent.run
+        }.to exit_with(1)
+         .and output(%r{Exiting now because the maxwaitforcert timeout has been exceeded}).to_stdout
+         .and output(%r{Certificate 'CN=revoked' is revoked}).to_stderr
       end
     end
   end

--- a/spec/unit/agent_spec.rb
+++ b/spec/unit/agent_spec.rb
@@ -38,6 +38,10 @@ describe Puppet::Agent do
         end
       end
     end
+
+    ssl_context = Puppet::SSL::SSLContext.new
+    machine = instance_double("Puppet::SSL::StateMachine", ensure_client_certificate: ssl_context)
+    allow(Puppet::SSL::StateMachine).to receive(:new).and_return(machine)
   end
 
   after do
@@ -197,7 +201,7 @@ describe Puppet::Agent do
         @agent.run
       end
 
-      it "should inform that a run is already in progres and try to run every X seconds if waitforlock is used" do
+      it "should inform that a run is already in progress and try to run every X seconds if waitforlock is used" do
         # so the locked file exists
         allow(File).to receive(:file?).and_return(true)
         # so we don't have to wait again for the run to exit (default maxwaitforcert is 60)
@@ -226,7 +230,7 @@ describe Puppet::Agent do
         @agent.run
       end
     end
-    
+
     describe "when should_fork is true", :if => Puppet.features.posix? && RUBY_PLATFORM != 'java' do
       before do
         @agent = Puppet::Agent.new(AgentTestClient, true)

--- a/spec/unit/http/client_spec.rb
+++ b/spec/unit/http/client_spec.rb
@@ -120,6 +120,24 @@ describe Puppet::HTTP::Client do
 
       client.close
     end
+
+    it 'reloads the default ssl context' do
+      expect(client.pool).to receive(:with_connection) do |_, verifier|
+        expect(verifier.ssl_context).to_not equal(puppet_context)
+      end
+
+      client.close
+      client.connect(uri)
+    end
+
+    it 'reloads the default system ssl context' do
+      expect(client.pool).to receive(:with_connection) do |_, verifier|
+        expect(verifier.ssl_context).to_not equal(system_context)
+      end
+
+      client.close
+      client.connect(uri, options: {include_system_store: true})
+    end
   end
 
   context "for GET requests" do

--- a/spec/unit/ssl/state_machine_spec.rb
+++ b/spec/unit/ssl/state_machine_spec.rb
@@ -27,6 +27,7 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
   let(:refused_message) { %r{Connection refused|No connection could be made because the target machine actively refused it} }
 
   before(:each) do
+    Puppet[:daemonize] = false
     Puppet[:ssl_lockfile] = tmpfile('ssllock')
     allow(Kernel).to receive(:sleep)
   end

--- a/tasks/generate_cert_fixtures.rake
+++ b/tasks/generate_cert_fixtures.rake
@@ -37,14 +37,15 @@ task(:gen_cert_fixtures) do
   #                                   |   |
   # signed.pem                        |   +- /CN=signed
   # revoked.pem                       |   +- /CN=revoked
-  # 127.0.0.1.pem                     |   +- /CN=127.0.0.1 (with dns alt names)
   # tampered-cert.pem                 |   +- /CN=signed (with different public key)
   # ec.pem                            |   +- /CN=ec (with EC private key)
   # oid.pem                           |   +- /CN=oid (with custom oid)
   #                                   |
-  #                                   + /CN=Test CA Agent Subauthority
-  #                                   |  |
-  # pluto.pem                         |  +- /CN=pluto
+  # 127.0.0.1.pem                     +- /CN=127.0.0.1 (with dns alt names)
+  #                                   |
+  # intermediate-agent.pem            +- /CN=Test CA Agent Subauthority
+  #                                   |   |
+  # pluto.pem                         |   +- /CN=pluto
   #                                   |
   # bad-int-basic-constraints.pem     +- /CN=Test CA Subauthority (bad isCA constraint)
   #


### PR DESCRIPTION
* Agents never reloaded their ssl state, which prevented `crl_refresh_interval` from working as intended when `Puppet[:onetime]` was false. Now we reload ssl state prior to each run.
* Clear `default_*_ssl_context` for each run.
* Print CRL information at debug level along with CA and client certs.
* Daemonized agents never logged that they were exiting if they failed to get a cert.
* Added integration tests for bootstrapping SSL.