### PR TITLE
(PUP-11454) Enforce salt requirements for macOS versions 10.15+

### DIFF
--- a/acceptance/tests/resource/user/should_allow_managed_macos_users_to_login.rb
+++ b/acceptance/tests/resource/user/should_allow_managed_macos_users_to_login.rb
@@ -35,8 +35,8 @@ test_name "should allow managed macOS users to login" do
       on(agent, "dscl /Local/Default -authonly testuser helloworld", :acceptable_exit_codes => 0)
     end
 
-    unless agent['platform'] =~ /osx-11/
-      skip_test "AuthenticationAuthority field fix test is not valid for macOS older than Big Sur (11.0)"
+    unless agent['platform'] =~ /^osx-1[1-9]/
+      skip_test "AuthenticationAuthority field fix test is not valid for macOS before Big Sur (11.0)"
     end
 
     # Setting up environment to mimic situation on macOS 11 BigSur

--- a/lib/puppet/provider/user/directoryservice.rb
+++ b/lib/puppet/provider/user/directoryservice.rb
@@ -401,6 +401,11 @@ Puppet::Type.type(:user).provide :directoryservice do
   # we have to treat the ds cache just like you would in the password=
   # method.
   def salt=(value)
+    if (Puppet::Util::Package.versioncmp(self.class.get_os_version, '10.15') >= 0)
+      if value.length != 64
+        self.fail "macOS versions 10.15 and higher require the salt to be 32-bytes. Since Puppet's user resource requires the value to be hex encoded, the length of the salt's string must be 64. Please check your salt and try again."
+      end
+    end
     if (Puppet::Util::Package.versioncmp(self.class.get_os_version, '10.7') > 0)
       assert_full_pbkdf2_password
 

--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -227,6 +227,9 @@ module Puppet
         * OS X 10.8 and higher use salted SHA512 PBKDF2 hashes. When managing passwords
           on these systems, the `salt` and `iterations` attributes need to be specified as
           well as the password.
+        * macOS 10.15 and higher require the salt to be 32-bytes. Since Puppet's user 
+          resource requires the value to be hex encoded, the length of the salt's
+          string must be 64. 
         * Windows passwords can be managed only in cleartext, because there is no Windows
           API for setting the password hash.
 


### PR DESCRIPTION
macOS 10.15+ require the salt to be 32 bytes