### PR TITLE
(PUP-11502) Windows exe packages can be sourced from URL

### DIFF
--- a/lib/puppet/provider/package/windows/package.rb
+++ b/lib/puppet/provider/package/windows/package.rb
@@ -67,7 +67,8 @@ class Puppet::Provider::Package::Windows
         # REMIND: what about msp, etc
         MsiPackage
       when /\.exe"?\Z/i
-        fail(_("The source does not exist: '%{source}'") % { source: resource[:source] }) unless Puppet::FileSystem.exist?(resource[:source])
+        fail(_("The source does not exist: '%{source}'") % { source: resource[:source] }) unless
+          Puppet::FileSystem.exist?(resource[:source]) || resource[:source].start_with?('http://', 'https://')
         ExePackage
       else
         fail(_("Don't know how to install '%{source}'") % { source: resource[:source] })


### PR DESCRIPTION
Windows exe packages can now be install from a URL source.

It downloads the package locally, and runs the file with the command
options.

(cherry picked form commit 159b06614b52fd32a58f3f2a6d3eed64a9a0cd9b)