### PR TITLE
(PUP-7126) use selabel_lookup instead of matchpathcon

### DIFF
--- a/lib/puppet/provider/file/posix.rb
+++ b/lib/puppet/provider/file/posix.rb
@@ -8,11 +8,6 @@ Puppet::Type.type(:file).provide :posix do
   include Puppet::Util::Warnings
 
   require 'etc'
-  require_relative '../../../puppet/util/selinux'
-
-  def self.post_resource_eval
-    Selinux.matchpathcon_fini if Puppet::Util::SELinux.selinux_support?
-  end
 
   def uid2name(id)
     return id.to_s if id.is_a?(Symbol) or id.is_a?(String)

--- a/lib/puppet/type/file/selcontext.rb
+++ b/lib/puppet/type/file/selcontext.rb
@@ -83,7 +83,7 @@ module Puppet
   end
 
   Puppet::Type.type(:file).newparam(:selinux_ignore_defaults) do
-    desc "If this is set then Puppet will not ask SELinux (via matchpathcon) to
+    desc "If this is set then Puppet will not ask SELinux (via selabel_lookup) to
       supply defaults for the SELinux attributes (seluser, selrole,
       seltype, and selrange). In general, you should leave this set at its
       default and only set it to true when you need Puppet to not try to fix
@@ -96,7 +96,7 @@ module Puppet
   Puppet::Type.type(:file).newproperty(:seluser, :parent => Puppet::SELFileContext) do
     desc "What the SELinux user component of the context of the file should be.
       Any valid SELinux user component is accepted.  For example `user_u`.
-      If not specified it defaults to the value returned by matchpathcon for
+      If not specified it defaults to the value returned by selabel_lookup for
       the file, if any exists.  Only valid on systems with SELinux support
       enabled."
 
@@ -107,7 +107,7 @@ module Puppet
   Puppet::Type.type(:file).newproperty(:selrole, :parent => Puppet::SELFileContext) do
     desc "What the SELinux role component of the context of the file should be.
       Any valid SELinux role component is accepted.  For example `role_r`.
-      If not specified it defaults to the value returned by matchpathcon for
+      If not specified it defaults to the value returned by selabel_lookup for
       the file, if any exists.  Only valid on systems with SELinux support
       enabled."
 
@@ -118,7 +118,7 @@ module Puppet
   Puppet::Type.type(:file).newproperty(:seltype, :parent => Puppet::SELFileContext) do
     desc "What the SELinux type component of the context of the file should be.
       Any valid SELinux type component is accepted.  For example `tmp_t`.
-      If not specified it defaults to the value returned by matchpathcon for
+      If not specified it defaults to the value returned by selabel_lookup for
       the file, if any exists.  Only valid on systems with SELinux support
       enabled."
 
@@ -130,7 +130,7 @@ module Puppet
     desc "What the SELinux range component of the context of the file should be.
       Any valid SELinux range component is accepted.  For example `s0` or
       `SystemHigh`.  If not specified it defaults to the value returned by
-      matchpathcon for the file, if any exists.  Only valid on systems with
+      selabel_lookup for the file, if any exists.  Only valid on systems with
       SELinux support enabled and that have support for MCS (Multi-Category
       Security)."
 

--- a/spec/unit/transaction_spec.rb
+++ b/spec/unit/transaction_spec.rb
@@ -758,20 +758,6 @@ describe Puppet::Transaction do
       transaction.evaluate
     end
 
-    it "should call Selinux.matchpathcon_fini in case Selinux is enabled ", :if => Puppet.features.posix? do
-      selinux = double('selinux', is_selinux_enabled: true, matchpathcon_fini: nil)
-      stub_const('Selinux', selinux)
-
-      resource = Puppet::Type.type(:file).new(:path => make_absolute("/tmp/foo"))
-      transaction = transaction_with_resource(resource)
-
-      expect(Selinux).to receive(:matchpathcon_fini)
-      expect(Puppet::Util::SELinux).to receive(:selinux_support?).and_return(true)
-
-      transaction.evaluate
-    end
-  end
-
   describe 'when checking application run state' do
     before do
       @catalog = Puppet::Resource::Catalog.new

--- a/spec/unit/type/file/selinux_spec.rb
+++ b/spec/unit/type/file/selinux_spec.rb
@@ -54,7 +54,7 @@ require 'spec_helper'
       expect(@sel.default).to be_nil
     end
 
-    it "should be able to detect matchpathcon defaults" do
+    it "should be able to detect default context" do
       allow(@sel).to receive(:debug)
       expect(@sel).to receive(:get_selinux_default_context).with(@path, :file).and_return("user_u:role_r:type_t:s0")
       expectedresult = case param

--- a/spec/unit/util/selinux_spec.rb
+++ b/spec/unit/util/selinux_spec.rb
@@ -142,8 +142,11 @@ describe Puppet::Util::SELinux do
         fstat = double('File::Stat', :mode => 0)
         expect(Puppet::FileSystem).to receive(:lstat).with('/foo').and_return(fstat)
         expect(self).to receive(:find_fs).with("/foo").and_return("ext3")
-        expect(Selinux).to receive(:matchpathcon).with("/foo", 0).and_return([0, "user_u:role_r:type_t:s0"])
+        hnd = double("SWIG::TYPE_p_selabel_handle")
+        expect(Selinux).to receive(:selabel_open).with(0, nil, 0).and_return(hnd)
+        expect(Selinux).to receive(:selabel_lookup).with(hnd, '/foo', 0).and_return([0, "user_u:role_r:type_t:s0"])
 
+        expect(Selinux).to receive(:selabel_close).with(hnd)
         expect(get_selinux_default_context("/foo")).to eq("user_u:role_r:type_t:s0")
       end
     end
@@ -152,9 +155,12 @@ describe Puppet::Util::SELinux do
       without_partial_double_verification do
         allow(self).to receive(:selinux_support?).and_return(true)
         allow(self).to receive(:selinux_label_support?).and_return(true)
-        allow(Selinux).to receive(:matchpathcon).with("/root/chuj", 0).and_return(-1)
+        hnd = double("SWIG::TYPE_p_selabel_handle")
+        allow(Selinux).to receive(:selabel_open).with(0, nil, 0).and_return(hnd)
+        allow(Selinux).to receive(:selabel_lookup).with(hnd, "/root/chuj", 0).and_return(-1)
         allow(self).to receive(:file_lstat).with("/root/chuj").and_raise(Errno::EACCES, "/root/chuj")
 
+        expect(Selinux).to receive(:selabel_close).with(hnd)
         expect(get_selinux_default_context("/root/chuj")).to be_nil
       end
     end
@@ -163,9 +169,12 @@ describe Puppet::Util::SELinux do
       without_partial_double_verification do
         allow(self).to receive(:selinux_support?).and_return(true)
         allow(self).to receive(:selinux_label_support?).and_return(true)
-        allow(Selinux).to receive(:matchpathcon).with("/root/chuj", 0).and_return(-1)
+        hnd = double("SWIG::TYPE_p_selabel_handle")
+        allow(Selinux).to receive(:selabel_open).with(0, nil, 0).and_return(hnd)
+        allow(Selinux).to receive(:selabel_lookup).with(hnd, "/root/chuj", 0).and_return(-1)
         allow(self).to receive(:file_lstat).with("/root/chuj").and_raise(Errno::ENOENT, "/root/chuj")
 
+        expect(Selinux).to receive(:selabel_close).with(hnd)
         expect(get_selinux_default_context("/root/chuj")).to be_nil
       end
     end
@@ -174,9 +183,12 @@ describe Puppet::Util::SELinux do
       without_partial_double_verification do
         allow(self).to receive(:selinux_support?).and_return(true)
         allow(self).to receive(:selinux_label_support?).and_return(true)
-        allow(Selinux).to receive(:matchpathcon).with("/root/chuj", 32768).and_return(-1)
+        hnd = double("SWIG::TYPE_p_selabel_handle")
+        allow(Selinux).to receive(:selabel_open).with(0, nil, 0).and_return(hnd)
+        allow(Selinux).to receive(:selabel_lookup).with(hnd, "/root/chuj", 32768).and_return(-1)
         allow(self).to receive(:file_lstat).with("/root/chuj").and_raise(Errno::ENOENT, "/root/chuj")
 
+        expect(Selinux).to receive(:selabel_close).twice.with(hnd)
         expect(get_selinux_default_context("/root/chuj", :present)).to be_nil
         expect(get_selinux_default_context("/root/chuj", :file)).to be_nil
       end
@@ -186,8 +198,11 @@ describe Puppet::Util::SELinux do
       without_partial_double_verification do
         allow(self).to receive(:selinux_support?).and_return(true)
         allow(self).to receive(:selinux_label_support?).and_return(true)
-        allow(Selinux).to receive(:matchpathcon).with("/root/chuj", 16384).and_return(-1)
+        hnd = double("SWIG::TYPE_p_selabel_handle")
+        allow(Selinux).to receive(:selabel_open).with(0, nil, 0).and_return(hnd)
+        allow(Selinux).to receive(:selabel_lookup).with(hnd, "/root/chuj", 16384).and_return(-1)
         allow(self).to receive(:file_lstat).with("/root/chuj").and_raise(Errno::ENOENT, "/root/chuj")
+        allow(Selinux).to receive(:selabel_close).with(hnd)
 
         expect(get_selinux_default_context("/root/chuj", :directory)).to be_nil
       end
@@ -197,9 +212,12 @@ describe Puppet::Util::SELinux do
       without_partial_double_verification do
         allow(self).to receive(:selinux_support?).and_return(true)
         allow(self).to receive(:selinux_label_support?).and_return(true)
-        allow(Selinux).to receive(:matchpathcon).with("/root/chuj", 40960).and_return(-1)
+        hnd = double("SWIG::TYPE_p_selabel_handle")
+        allow(Selinux).to receive(:selabel_open).with(0, nil, 0).and_return(hnd)
+        allow(Selinux).to receive(:selabel_lookup).with(hnd, "/root/chuj", 40960).and_return(-1)
         allow(self).to receive(:file_lstat).with("/root/chuj").and_raise(Errno::ENOENT, "/root/chuj")
 
+        expect(Selinux).to receive(:selabel_close).with(hnd)
         expect(get_selinux_default_context("/root/chuj", :link)).to be_nil
       end
     end
@@ -208,21 +226,27 @@ describe Puppet::Util::SELinux do
       without_partial_double_verification do
         allow(self).to receive(:selinux_support?).and_return(true)
         allow(self).to receive(:selinux_label_support?).and_return(true)
-        allow(Selinux).to receive(:matchpathcon).with("/root/chuj", 0).and_return(-1)
+        hnd = double("SWIG::TYPE_p_selabel_handle")
+        allow(Selinux).to receive(:selabel_open).with(0, nil, 0).and_return(hnd)
+        allow(Selinux).to receive(:selabel_lookup).with(hnd, "/root/chuj", 0).and_return(-1)
         allow(self).to receive(:file_lstat).with("/root/chuj").and_raise(Errno::ENOENT, "/root/chuj")
 
+        expect(Selinux).to receive(:selabel_close).with(hnd)
         expect(get_selinux_default_context("/root/chuj", "unknown")).to be_nil
       end
     end
 
-    it "should return nil if matchpathcon returns failure" do
+    it "should close handle and return nil if selabel_lookup returns failure" do
       without_partial_double_verification do
         expect(self).to receive(:selinux_support?).and_return(true)
         fstat = double('File::Stat', :mode => 0)
         expect(Puppet::FileSystem).to receive(:lstat).with('/foo').and_return(fstat)
         expect(self).to receive(:find_fs).with("/foo").and_return("ext3")
-        expect(Selinux).to receive(:matchpathcon).with("/foo", 0).and_return(-1)
+        hnd = double("SWIG::TYPE_p_selabel_handle")
+        expect(Selinux).to receive(:selabel_open).with(0, nil, 0).and_return(hnd)
+        expect(Selinux).to receive(:selabel_lookup).with(hnd, '/foo', 0).and_return(-1)
 
+        expect(Selinux).to receive(:selabel_close).with(hnd)
         expect(get_selinux_default_context("/foo")).to be_nil
       end
     end


### PR DESCRIPTION
    (PUP-7126) Use selabel_lookup instead of matchpathcon
    
    Matchpatchon is deprecated. Since ruby bindings are
    available in libselinux-ruby, selabel_open should be used instead to
    create an open handler, from which context can be retrieved with
    selabel_lookup. At completion, the handler is closed with selabel_close,
    releasing its resources back to the system.

    Do not call matchpathcon_fini in post_resource_eval for file posix provider.
    
    Resources are released back to the system when the handle is closed with
    selabel_close, so matchpathcon_fini is no longer necessary.