### PR TITLE
(PUP-11522) Support mutual TLS when using an external CA

### DIFF
--- a/lib/puppet/http/client.rb
+++ b/lib/puppet/http/client.rb
@@ -426,7 +426,7 @@ class Puppet::HTTP::Client
     cacerts = cert_provider.load_cacerts || []
 
     ssl = Puppet::SSL::SSLProvider.new
-    @default_system_ssl_context = ssl.create_system_context(cacerts: cacerts)
+    @default_system_ssl_context = ssl.create_system_context(cacerts: cacerts, include_client_cert: true)
     ssl.print(@default_system_ssl_context)
     @default_system_ssl_context
   end

--- a/lib/puppet/ssl/ssl_provider.rb
+++ b/lib/puppet/ssl/ssl_provider.rb
@@ -77,7 +77,14 @@ class Puppet::SSL::SSLProvider
     if include_client_cert
       cert_provider = Puppet::X509::CertProvider.new
       private_key = cert_provider.load_private_key(Puppet[:certname], required: false)
+      unless private_key
+        Puppet.warning("Private key for '#{Puppet[:certname]}' does not exist")
+      end
+
       client_cert = cert_provider.load_client_cert(Puppet[:certname], required: false)
+      unless client_cert
+        Puppet.warning("Client certificate for '#{Puppet[:certname]}' does not exist")
+      end
 
       if private_key && client_cert
         client_chain = resolve_client_chain(store, client_cert, private_key)

--- a/spec/lib/puppet_spec/https.rb
+++ b/spec/lib/puppet_spec/https.rb
@@ -40,7 +40,7 @@ class PuppetSpec::HTTPSServer
 
     IO.pipe {|stop_pipe_r, stop_pipe_w|
       store = OpenSSL::X509::Store.new
-      store.add_cert(@ca_cert)
+      Array(@ca_cert).each { |c| store.add_cert(c) }
       store.purpose = OpenSSL::X509::PURPOSE_SSL_CLIENT
       ctx = OpenSSL::SSL::SSLContext.new
       ctx.cert_store = store

--- a/spec/unit/ssl/ssl_provider_spec.rb
+++ b/spec/unit/ssl/ssl_provider_spec.rb
@@ -159,6 +159,22 @@ describe Puppet::SSL::SSLProvider do
       expect(sslctx.private_key).to be_nil
     end
 
+    it 'warns if the client cert does not exist' do
+      Puppet[:certname] = 'missingcert'
+      Puppet[:hostprivkey] = fixtures('ssl/signed-key.pem')
+
+      expect(Puppet).to receive(:warning).with("Client certificate for 'missingcert' does not exist")
+      subject.create_system_context(cacerts: [], include_client_cert: true)
+    end
+
+    it 'warns if the private key does not exist' do
+      Puppet[:certname] = 'missingkey'
+      Puppet[:hostcert] = fixtures('ssl/signed.pem')
+
+      expect(Puppet).to receive(:warning).with("Private key for 'missingkey' does not exist")
+      subject.create_system_context(cacerts: [], include_client_cert: true)
+    end
+
     it 'raises if client cert and private key are mismatched' do
       Puppet[:hostcert] = fixtures('ssl/signed.pem')
       Puppet[:hostprivkey] = fixtures('ssl/127.0.0.1-key.pem')


### PR DESCRIPTION
Previously, the http client could trust additional CAs or include a client cert, but not both. However, when integrating with Vault, it's common for the Vault server to require a client cert to retrieve a token and for the Vault server's cert to be issued by an external CA. To make this simple, the following is now possible:

```ruby
client = Puppet.runtime[:http]
client.get(URI("https://server.example.com:8888"), options: {include_system_store: true})
```

If the client cert exists and the server requests mutual TLS (mTLS), then the cert will be used in the call above. If the client cert doesn't exist/yet, such as `puppet apply` prior to any certs being issued, then the call above will ignore the non-existent client cert, but fail to connect if the server requests mTLS. If the client cert exists, but doesn't match its private key, then the call above will error.

Note previously mTLS with an external CA was possible, but it meant the caller had to create a custom ssl context and pass that into the http client, e.g. `options: { ssl_context: ctx }`. That is still possible after this PR, but is no longer necessary.