### PR TITLE
(maint) Add more logic to a teardown stage in a test

### DIFF
--- a/acceptance/tests/resource/exec/should_run_command_in_cwd.rb
+++ b/acceptance/tests/resource/exec/should_run_command_in_cwd.rb
@@ -120,7 +120,10 @@ test_name "The Exec resource should run commands in the specified cwd" do
         # we need to create the user directory ourselves in order for deb users to successfully login
         on(agent, "mkdir /home/#{username} && chown -R #{username} /home/#{username}")
       end
-      teardown { agent.user_absent(username) }
+      teardown do
+        on(agent, "pkill -9 -u `id -u #{username}`") if agent.platform =~ /ubuntu-22\.04/
+        agent.user_absent(username)
+      end
     end
 
     tmpdir_noaccess = agent.tmpdir("mock_noaccess")


### PR DESCRIPTION
The should_run_command_in_cwd test on ubuntu2204 leaves behind a few
processes that take a few seconds to run. Those processes are associated
with the test user, and when we try to delete the test user and the processes
are still around the test fails.