### PR TITLE
(PUP-11586) Add Documentation field to systemd unit

### DIFF
--- a/ext/systemd/puppet.service
+++ b/ext/systemd/puppet.service
@@ -10,6 +10,7 @@
 #
 [Unit]
 Description=Puppet agent
+Documentation=man:puppet-agent(8)
 Wants=basic.target
 After=basic.target network.target network-online.target
 


### PR DESCRIPTION
The addition of [this field](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Documentation=) allows calling [systemctl help](https://freedesktop.org/software/systemd/man/systemctl.html#help%20PATTERN%E2%80%A6%7CPID%E2%80%A6) puppet to display documentation for the service unit.