### PR TITLE
(PUP-11552) Pass ERB arguments as keywords

### DIFF
--- a/lib/puppet/face/help.rb
+++ b/lib/puppet/face/help.rb
@@ -140,7 +140,7 @@ Puppet::Face.define(:help, '0.0.1') do
 
   def erb(name)
     template = (Pathname(__FILE__).dirname + "help" + name)
-    erb = ERB.new(template.read, nil, '-')
+    erb = Puppet::Util.create_erb(template.read)
     erb.filename = template.to_s
     return erb
   end

--- a/lib/puppet/generate/type.rb
+++ b/lib/puppet/generate/type.rb
@@ -167,7 +167,7 @@ module Puppet
         templates = {}
         templates.default_proc = lambda { |hash, key|
           raise _("template was not found at '%{key}'.") % { key: key } unless Puppet::FileSystem.file?(key)
-          template = ERB.new(File.read(key), nil, '-')
+          template = Puppet::Util.create_erb(File.read(key))
           template.filename = key
           template
         }

--- a/lib/puppet/parser/templatewrapper.rb
+++ b/lib/puppet/parser/templatewrapper.rb
@@ -90,7 +90,7 @@ class Puppet::Parser::TemplateWrapper
 
     result = nil
     benchmark(:debug, _("Interpolated template %{template_source} in %%{seconds} seconds") % { template_source: escaped_template_source }) do
-      template = ERB.new(string, 0, "-")
+      template = Puppet::Util.create_erb(string)
       template.filename = @__file__
       result = template.result(binding)
     end

--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -34,6 +34,17 @@ module Util
   end
   module_function :default_env
 
+  if RUBY_VERSION >= "2.6"
+    def create_erb(content)
+      ERB.new(content, trim_mode: '-')
+    end
+  else
+    def create_erb(content)
+      ERB.new(content, 0, '-')
+    end
+  end
+  module_function :create_erb
+
   # @param name [String] The name of the environment variable to retrieve
   # @param mode [Symbol] Which operating system mode to use e.g. :posix or :windows.  Use nil to autodetect
   # @return [String] Value of the specified environment variable.  nil if it does not exist

--- a/lib/puppet/util/resource_template.rb
+++ b/lib/puppet/util/resource_template.rb
@@ -40,7 +40,7 @@ class Puppet::Util::ResourceTemplate
 
   def evaluate
     set_resource_variables
-    ERB.new(Puppet::FileSystem.read(@file, :encoding => 'utf-8'), 0, "-").result(binding)
+    Puppet::Util.create_erb(Puppet::FileSystem.read(@file, :encoding => 'utf-8')).result(binding)
   end
 
   def initialize(file, resource)

--- a/spec/unit/util/resource_template_spec.rb
+++ b/spec/unit/util/resource_template_spec.rb
@@ -39,7 +39,7 @@ describe Puppet::Util::ResourceTemplate do
 
     it "should create a template instance with the contents of the file" do
       expect(Puppet::FileSystem).to receive(:read).with("/my/template", :encoding => 'utf-8').and_return("yay")
-      expect(ERB).to receive(:new).with("yay", 0, "-").and_return(@template)
+      expect(Puppet::Util).to receive(:create_erb).with("yay").and_return(@template)
 
       allow(@wrapper).to receive(:set_resource_variables)
 


### PR DESCRIPTION
On Ruby 3.1 passing the arguments as positional arguments raises warnings:

```
warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
```

However, on Ruby < 2.7 passing as keyword arguments is not allowed. This is why a conditional with RUBY_VERSION is used.

I must admit I have not tested my changes yet and am relying on CI to tell me now.