### PR TITLE
(PUP-11593) Gentoo: Fix systemd service provider

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -19,6 +19,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   defaultfor 'os.family' => :redhat, 'os.name' => :fedora
   defaultfor 'os.family' => :suse
   defaultfor 'os.family' => :coreos
+  defaultfor 'os.family' => :gentoo
   defaultfor 'os.name' => :amazon, 'os.release.major' => ["2", "2023"]
   defaultfor 'os.name' => :debian
   notdefaultfor 'os.name' => :debian, 'os.release.major' => ["5", "6", "7"] # These are using the "debian" method

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -18,7 +18,7 @@ describe 'Puppet::Type::Service::Provider::Systemd',
     Puppet::Util::Execution::ProcessOutput.new('', 0)
   end
 
-  osfamilies = [ 'archlinux', 'coreos' ]
+  osfamilies = [ 'archlinux', 'coreos', 'gentoo' ]
 
   osfamilies.each do |osfamily|
     it "should be the default provider on #{osfamily}" do


### PR DESCRIPTION
Systemd is available on Gentoo since a long time (although Gentoo supports multiple init systems). This change marks the provider as default for Gentoo.