### PR TITLE
(maint) Mark some tests as pending for Windows 11

### DIFF
--- a/acceptance/tests/agent/agent_fails_with_unknown_resource.rb
+++ b/acceptance/tests/agent/agent_fails_with_unknown_resource.rb
@@ -9,7 +9,9 @@ test_name "agent run should fail if it finds an unknown resource type" do
 
   require 'puppet/acceptance/temp_file_utils'
   extend Puppet::Acceptance::TempFileUtils
-  
+
+  pending_test("Windows 11 not sure why this fails") if agents.any? { |host| host['platform'] =~ /windows-11/ }
+
   step "agent should fail when it can't find a resource" do
     vendor_modules_path = master.tmpdir('vendor_modules')
     tmp_environment = mk_tmp_environment_with_teardown(master, 'tmp')

--- a/acceptance/tests/modulepath.rb
+++ b/acceptance/tests/modulepath.rb
@@ -1,6 +1,8 @@
 test_name 'Supports vendored modules' do
   tag 'risk:high'
 
+  pending_test("Windows 11 scp seems to crash sshd") if agents.any? { |host| host['platform'] =~ /windows-11/ }
+
   # beacon custom type emits a message so we can tell where the
   # type was loaded from, e.g. vendored, global, and whether the
   # type was loaded locally or pluginsynced from the master.

--- a/acceptance/tests/resource/file/ticket_6448_file_with_utf8_source.rb
+++ b/acceptance/tests/resource/file/ticket_6448_file_with_utf8_source.rb
@@ -14,6 +14,8 @@ test_name 'Ensure a file resource can have a UTF-8 source attribute, content, an
   agent_tmp_dirs  = {}
 
   agents.each do |agent|
+    pending_test("Windows 11 UTF-8 file paths") if agent['platform'] =~ /windows-11/
+
     agent_tmp_dirs[agent_to_fqdn(agent)] = agent.tmpdir(tmp_environment)
   end
 

--- a/acceptance/tests/resource/file/ticket_7680-follow-symlinks.rb
+++ b/acceptance/tests/resource/file/ticket_7680-follow-symlinks.rb
@@ -5,12 +5,7 @@ tag 'audit:high',
     'audit:acceptance'
 
 agents.each do |agent|
-  if agent.platform.variant == 'windows'
-    # symlinks are supported only on Vista+ (version 6.0 and higher)
-    on agent, facter('kernelmajversion') do
-      skip_test "Test not supported on this platform" if stdout.chomp.to_f < 6.0
-    end
-  end
+  pending_test("Windows 11 backslashes") if agent['platform'] =~ /windows-11/
 
   step "Create file content"
   real_source = agent.tmpfile('follow_links_source')

--- a/acceptance/tests/resource/service/windows_mixed_utf8.rb
+++ b/acceptance/tests/resource/service/windows_mixed_utf8.rb
@@ -38,6 +38,8 @@ MANIFEST
     }
   ].each do |mock_service|
     agents.each do |agent|
+      pending_test("Windows 11 UTF-8 file paths") if agent['platform'] =~ /windows-11/
+
       setup_service(agent, mock_service, 'MockService.cs')
 
       step 'Verify that enable = false disables the service' do

--- a/acceptance/tests/resource/user/should_modify_when_not_managing_home.rb
+++ b/acceptance/tests/resource/user/should_modify_when_not_managing_home.rb
@@ -26,6 +26,8 @@ agents.each do |agent|
   home_prop = nil
   case agent['platform']
   when /windows/
+    pending_test("Windows 11 backslashes") if agent['platform'] =~ /windows-11/
+
     # Sadly Windows ADSI won't tell us the default home directory
     # for a user. You can get it via WMI Win32_UserProfile, but that
     # doesn't exist in a base 2003 install. So we simply specify an

--- a/acceptance/tests/utf8/utf8-in-catalog.rb
+++ b/acceptance/tests/utf8/utf8-in-catalog.rb
@@ -11,6 +11,7 @@ test_name 'utf-8 characters in cached catalog' do
   on(master, "rm -rf '#{codedir}'")
   env_dir = "#{codedir}/environments"
   agents.each do |agent|
+    pending_test("Windows 11 UTF-8 file paths") if agent['platform'] =~ /windows-11/
 
     step "agent name: #{agent.hostname}, platform: #{agent.platform}"
     agent_vardir = agent.tmpdir("agent_vardir")

--- a/acceptance/tests/utf8/utf8-recursive-copy.rb
+++ b/acceptance/tests/utf8/utf8-recursive-copy.rb
@@ -18,6 +18,8 @@ test_name "PUP-8735: UTF-8 characters are preserved after recursively copying di
   extend Puppet::Acceptance::I18nUtils
 
   agents.each do |host|
+    pending_test("Windows 11 UTF-8 file paths") if host['platform'] =~ /windows-11/
+
     filename = "Fișier"
     content = <<-CONTENT
 閑けさや


### PR DESCRIPTION
https://github.com/voxpupuli/beaker/pull/1744, https://github.com/voxpupuli/beaker/pull/1745 must be merged first in order to test Windows 11.

Added `pending_test` for tests that fail on Windows 11. Also dropped 2003 logic
in the symlink test since we don't support it anymore.

Filed https://tickets.puppetlabs.com/browse/PUP-11582 so that we investigate why these failure are occurring.