### PR TITLE
(PUP-11540) Update task_info_service to return private/description

### DIFF
--- a/lib/puppet/info_service/task_information_service.rb
+++ b/lib/puppet/info_service/task_information_service.rb
@@ -6,7 +6,7 @@ class Puppet::InfoService::TaskInformationService
     env = Puppet.lookup(:environments).get!(environment_name)
     env.modules.map do |mod|
       mod.tasks.map do |task|
-        {:module => {:name => task.module.name}, :name => task.name}
+        {:module => {:name => task.module.name}, :name => task.name, :metadata => task.metadata}
       end
     end.flatten
   end

--- a/spec/unit/info_service_spec.rb
+++ b/spec/unit/info_service_spec.rb
@@ -11,6 +11,9 @@ describe "Puppet::InfoService" do
 
   context 'task information service' do
     let(:mod_name) { 'test1' }
+    let(:metadata) {
+      { "private" => true,
+        "description" => "a task that does a thing" } }
     let(:task_name) { "#{mod_name}::thingtask" }
     let(:modpath) { tmpdir('modpath') }
     let(:env_name) { 'testing' }
@@ -20,8 +23,13 @@ describe "Puppet::InfoService" do
     context 'tasks_per_environment method' do
       it "returns task data for the tasks in an environment" do
         Puppet.override(:environments => env_loader) do
-          PuppetSpec::Modules.create(mod_name, modpath, {:environment => env, :tasks => [['thingtask']]})
-          expect(Puppet::InfoService.tasks_per_environment(env_name)).to eq([{:name => task_name, :module => {:name => mod_name}}])
+          PuppetSpec::Modules.create(mod_name, modpath, {:environment => env,
+                                                         :tasks => [['thingtask',
+                                                                     {:name => 'thingtask.json',
+                                                                      :content => metadata.to_json}]]})
+          expect(Puppet::InfoService.tasks_per_environment(env_name)).to eq([{:name => task_name,
+                                                                              :module => {:name => mod_name},
+                                                                              :metadata => metadata}  ])
         end
       end
 
@@ -207,7 +215,7 @@ describe "Puppet::InfoService" do
       end
     end
   end
-  
+
   context 'plan information service' do
     let(:mod_name) { 'test1' }
     let(:plan_name) { "#{mod_name}::thingplan" }


### PR DESCRIPTION
Updates the task_info_service implementation to return all task metadata
for each task when tasks_for_environment is called. This requires
reading metadata json files for each task.

Testing was done to ensure the additional file reads for metadata json
files would not impact performance of puppetserver. In tests with an
environment with > 3000 tasks, the difference in total time to process
all task data was only any increase of 0.5 - 1 second..