### PR TITLE
(maint) Skip should_query_all.rb test for macos-12-arm64

### DIFF
--- a/acceptance/tests/resource/group/should_query_all.rb
+++ b/acceptance/tests/resource/group/should_query_all.rb
@@ -1,5 +1,7 @@
 test_name "should query all groups"
 confine :except, :platform => /^cisco_/ # See PUP-5828
+skip_test if agents.any? {|agent| agent['platform'] =~ /osx-12-arm64/ } # See PA-4555
+
 tag 'audit:high',
     'audit:refactor',   # Use block style `test_name`
     'audit:integration' # Does not modify system running test


### PR DESCRIPTION
Our new macos 12 arm64 hardware has something a bit off with the configuration
that causes this test to fail. Rather then holding up the release of the puppet
release we are going to skip the test and fix the hardware issue at a later point.