### PR TITLE
(PUP-11594) Handle misconfigured /proc filesystems in safe_posix_fork

### DIFF
--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -530,7 +530,7 @@ module Util
             IO::new(f.to_i).close rescue nil
           end
         end
-      rescue Errno::ENOENT # /proc/self/fd not found
+      rescue Errno::ENOENT, Errno::ENOTDIR # /proc/self/fd not found, /proc/self not a dir
         3.upto(256){|fd| IO::new(fd).close rescue nil}
       end
 

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -625,12 +625,22 @@ describe Puppet::Util do
       Puppet::Util.safe_posix_fork
     end
 
-    it "should close all open file descriptors except stdin/stdout/stderr when /proc/self/fd doesn't exists" do
+    it "should close all open file descriptors except stdin/stdout/stderr when /proc/self/fd doesn't exist" do
       # This is ugly, but I can't really think of a better way to do it without
       # letting it actually close fds, which seems risky
       (0..2).each {|n| expect(IO).not_to receive(:new).with(n)}
       (3..256).each {|n| expect(IO).to receive(:new).with(n).and_return(double('io', close: nil))  }
       allow(Dir).to receive(:foreach).with('/proc/self/fd').and_raise(Errno::ENOENT)
+
+      Puppet::Util.safe_posix_fork
+    end
+
+    it "should close all open file descriptors except stdin/stdout/stderr when /proc/self is not a directory" do
+      # This is ugly, but I can't really think of a better way to do it without
+      # letting it actually close fds, which seems risky
+      (0..2).each {|n| expect(IO).not_to receive(:new).with(n)}
+      (3..256).each {|n| expect(IO).to receive(:new).with(n).and_return(double('io', close: nil))  }
+      allow(Dir).to receive(:foreach).with('/proc/self/fd').and_raise(Errno::ENOTDIR)
 
       Puppet::Util.safe_posix_fork
     end


### PR DESCRIPTION
If `/proc/self` is not a directory, `safe_posix_fork` will raise an unhandled
`Errno::ENOTDIR`, which will cause all puppet executions to fail.

This adds `Errno::ENOTDIR` to the `rescue`, to handle this case.