### PR TITLE
(PUP-110603) Mark ZFS as an SELinux-Capable Filesystem

### DIFF
--- a/lib/puppet/util/selinux.rb
+++ b/lib/puppet/util/selinux.rb
@@ -204,7 +204,7 @@ module Puppet::Util::SELinux
   def selinux_label_support?(file)
     fstype = find_fs(file)
     return false if fstype.nil?
-    filesystems = ['ext2', 'ext3', 'ext4', 'gfs', 'gfs2', 'xfs', 'jfs', 'btrfs', 'tmpfs']
+    filesystems = ['ext2', 'ext3', 'ext4', 'gfs', 'gfs2', 'xfs', 'jfs', 'btrfs', 'tmpfs', 'zfs']
     filesystems.include?(fstype)
   end
 

--- a/spec/unit/util/selinux_spec.rb
+++ b/spec/unit/util/selinux_spec.rb
@@ -65,6 +65,7 @@ describe Puppet::Util::SELinux do
         '/'        => 'ext3',
         '/sys'     => 'sysfs',
         '/mnt/nfs' => 'nfs',
+        '/mnt/zfs' => 'zfs',
         '/proc'    => 'proc',
         '/dev'     => 'tmpfs' })
     end
@@ -83,6 +84,10 @@ describe Puppet::Util::SELinux do
 
     it "should return true if tmpfs" do
       expect(selinux_label_support?('/dev/shm/testfile')).to be_truthy
+    end
+
+    it "should return true if zfs" do
+      expect(selinux_label_support?('/mnt/zfs/testfile')).to be_truthy
     end
 
     it "should return false for a noncapable filesystem" do


### PR DESCRIPTION
Since OpenZFS 0.6.3, ZFS can handle SELinux labels. We should therefore allow Puppet to set labels for files on ZFS filesystems.

Adding the test here is probably excessive, and whilst I did consider adding a check to make sure the version of ZFS in use was recent enough, I couldn't see a way to do so without linking this package to `zfs_core`. Additionally, Puppet 7 only supports back to CentOS 6, which has OpenZFS 0.8.5 builds in the official repos.
