### PR TITLE
(maint) Update doc generation with default domain

### DIFF
--- a/lib/puppet/reference/configuration.rb
+++ b/lib/puppet/reference/configuration.rb
@@ -38,6 +38,8 @@ config = Puppet::Util::Reference.newreference(:configuration, :depth => 1, :doc 
       val = '$confdir/hiera.yaml. However, for backwards compatibility, if a file exists at $codedir/hiera.yaml, Puppet uses that instead.'
     elsif name.to_s == 'certname'
       val = "the Host's fully qualified domain name, as determined by Facter"
+    elsif name.to_s == 'srv_domain'
+      val = 'example.com'
     end
 
     # Leave out the section information; it was apparently confusing people.


### PR DESCRIPTION
In line with other values, this commit sets a default value for
`srv_domain` for consistency.

See also: 5b954fdf12ef3ae9e4276269a1eab9097ea489de