### PR TITLE
(PUP-11626) Update Ubuntu GitHub Action runners

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -13,9 +13,9 @@ jobs:
     strategy:
       matrix:
         cfg:
-          - {check: rubocop, os: ubuntu-18.04, ruby: 2.5}
-          - {check: commits, os: ubuntu-18.04, ruby: 2.5}
-          - {check: warnings, os: ubuntu-18.04, ruby: 2.5}
+          - {check: rubocop, os: ubuntu-latest, ruby: 2.5}
+          - {check: commits, os: ubuntu-latest, ruby: 2.5}
+          - {check: warnings, os: ubuntu-latest, ruby: 2.5}
 
     runs-on: ${{ matrix.cfg.os }}
     steps:

--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -13,12 +13,12 @@ jobs:
     strategy:
       matrix:
         cfg:
-          - {os: ubuntu-18.04, ruby: 2.3}
-          - {os: ubuntu-18.04, ruby: 2.4}
-          - {os: ubuntu-18.04, ruby: 2.5}
-          - {os: ubuntu-18.04, ruby: 2.6}
-          - {os: ubuntu-18.04, ruby: 2.7}
-          - {os: ubuntu-18.04, ruby: jruby-9.2.9.0}
+          - {os: ubuntu-latest, ruby: 2.3}
+          - {os: ubuntu-latest, ruby: 2.4}
+          - {os: ubuntu-latest, ruby: 2.5}
+          - {os: ubuntu-latest, ruby: 2.6}
+          - {os: ubuntu-latest, ruby: 2.7}
+          - {os: ubuntu-latest, ruby: jruby-9.2.9.0}
           - {os: windows-2019, ruby: 2.4}
           - {os: windows-2019, ruby: 2.5}
           - {os: windows-2019, ruby: 2.6}


### PR DESCRIPTION
GitHub is deprecating Ubuntu 18.04 runners on April 1, 2023. This commit switches all Ubuntu 18.04 used in GitHub Actions to `ubuntu-latest` (currently Ubuntu 20.04).