### PR TITLE
(PUP-11629) Accept empty string with MultiJSON

### DIFF
--- a/lib/puppet/module/task.rb
+++ b/lib/puppet/module/task.rb
@@ -232,7 +232,12 @@ class Puppet::Module
     end
 
     def self.read_metadata(file)
-      Puppet::Util::Json.load(Puppet::FileSystem.read(file, :encoding => 'utf-8')) if file
+      # MultiJSON has a bug that improperly errors when loading an empty string
+      # so we handle it here for now. See: PUP-11629
+      if file
+        content = Puppet::FileSystem.read(file, :encoding => 'utf-8')
+        content.empty? ? {} : Puppet::Util::Json.load(content)
+      end
     rescue SystemCallError, IOError => err
       msg = _("Error reading metadata: %{message}" % {message: err.message})
       raise InvalidMetadata.new(msg, 'puppet.tasks/unreadable-metadata')

--- a/spec/unit/task_spec.rb
+++ b/spec/unit/task_spec.rb
@@ -235,6 +235,17 @@ describe Puppet::Module::Task do
         tasks[0].metadata
       }.to raise_error(Puppet::Module::Task::InvalidMetadata, /whoops/)
     end
+
+    it 'returns empty hash for metadata when json metadata file is empty' do
+      FileUtils.mkdir_p(tasks_path)
+      FileUtils.touch(File.join(tasks_path, 'task.json'))
+      FileUtils.touch(File.join(tasks_path, 'task'))
+
+      tasks = Puppet::Module::Task.tasks_in_module(mymod)
+
+      expect(tasks.count).to eq(1)
+      expect(tasks[0].metadata).to eq({})
+    end
   end
 
   describe :validate do


### PR DESCRIPTION
An empty string is valid JSON per the IETF standard, but MultiJSON raises an error when passed one. This commit updates our JSON load method to check for  empty strings and return nil, as the built-in JSON gem does.