### PR TITLE
(PUP-11406) Update puppet rspec tests for Ruby 3.1.

### DIFF
--- a/spec/unit/http/service/compiler_spec.rb
+++ b/spec/unit/http/service/compiler_spec.rb
@@ -592,7 +592,7 @@ describe Puppet::HTTP::Service::Compiler do
       invalid_facts = Puppet::Node::Facts.new(certname, {'invalid_utf8_sequence' => "\xE2\x82".force_encoding('binary')})
       expect {
         subject.put_facts(certname, environment: 'production', facts: invalid_facts)
-      }.to raise_error(Puppet::HTTP::SerializationError, /Failed to serialize Puppet::Node::Facts to json: "\\xE2" from ASCII-8BIT to UTF-8/)
+      }.to raise_error(Puppet::HTTP::SerializationError, /Failed to serialize Puppet::Node::Facts to json: ("\\xE2" from ASCII-8BIT to UTF-8|partial character in source, but hit end)/)
     end
   end
 

--- a/spec/unit/network/formats_spec.rb
+++ b/spec/unit/network/formats_spec.rb
@@ -504,7 +504,7 @@ EOT
 
     context "when rendering face-related objects" do
       it "pretty prints facts" do
-        tm = Time.new("2016-01-27T19:30:00")
+        tm = Time.new(2016, 1, 27, 19, 30, 0)
         values = {
           "architecture" =>  "x86_64",
           "os" => {

--- a/spec/unit/reports/store_spec.rb
+++ b/spec/unit/reports/store_spec.rb
@@ -15,7 +15,11 @@ describe Puppet::Reports.report(:store) do
     end
 
     let(:report) do
-      report = YAML.load_file(File.join(PuppetSpec::FIXTURE_DIR, 'yaml/report2.6.x.yaml'))
+      if RUBY_VERSION < "3.0"
+        report = YAML.load_file(File.join(PuppetSpec::FIXTURE_DIR, 'yaml/report2.6.x.yaml'))
+      else
+        report = YAML.unsafe_load_file(File.join(PuppetSpec::FIXTURE_DIR, 'yaml/report2.6.x.yaml'))
+      end
       report.extend(described_class)
       report
     end

--- a/spec/unit/util/storage_spec.rb
+++ b/spec/unit/util/storage_spec.rb
@@ -170,7 +170,7 @@ describe Puppet::Util::Storage do
       it 'should load Time and Symbols' do
         state = {
           'File[/etc/puppetlabs/puppet]' =>
-          { :checked => Time.new('2018-08-08 15:28:25.546999000 -07:00') }
+          { :checked => Time.new(2018, 8, 8, 15, 28, 25, "-07:00") }
         }
         write_state_file(YAML.dump(state))
 

--- a/spec/unit/x509/cert_provider_spec.rb
+++ b/spec/unit/x509/cert_provider_spec.rb
@@ -135,7 +135,7 @@ describe Puppet::X509::CertProvider do
 
           expect {
             create_provider(crlpath: crl_path).load_crls
-          }.to raise_error(OpenSSL::X509::CRLError, 'nested asn1 error')
+          }.to raise_error(OpenSSL::X509::CRLError, /(PEM_read_bio_X509_CRL: bad base64 decode|nested asn1 error)/)
         end
 
         it 'raises if the input is empty' do


### PR DESCRIPTION
Currently, puppet rspec tests fail when run with ruby 3.1.2 and openssl@1.1.1. These failures are primarily due to a change in behavior with the YAML.load function, Ruby 3.1 no longer accepting certain Time strings as input, and some error messages being changed.