### PR TITLE
(PUP-11662) Allow legacy facts to be excluded

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1712,6 +1712,14 @@ EOT
         new configurations, where you want to fix the broken configuration
         rather than reverting to a known-good one.",
     },
+    :include_legacy_facts => {
+      :type       => :boolean,
+      :default    => true,
+      :desc       => "Whether to include legacy facts when requesting a catalog. This
+        option can be set to false provided all puppet manifests, hiera.yaml and hiera
+        configuration layers no longer access legacy facts, such as `$osfamily`, and
+        instead access structured facts, such as `$facts['os']['family']`."
+    },
     :fact_name_length_soft_limit => {
       :default    => 2560,
       :type       => :integer,

--- a/lib/puppet/indirector/facts/facter.rb
+++ b/lib/puppet/indirector/facts/facter.rb
@@ -35,8 +35,12 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
     result = if request.options[:resolve_options]
                raise(Puppet::Error, _("puppet facts show requires version 4.0.40 or greater of Facter.")) unless Facter.respond_to?(:resolve)
                find_with_options(request)
-             else
+             elsif Puppet[:include_legacy_facts]
+               # to_hash returns both structured and legacy facts
                Puppet::Node::Facts.new(request.key, Puppet.runtime[:facter].to_hash)
+             else
+               # resolve does not return legacy facts unless requested
+               Puppet::Node::Facts.new(request.key, Puppet.runtime[:facter].resolve(''))
              end
 
     result.add_local_facts unless request.options[:resolve_options]

--- a/spec/unit/indirector/facts/facter_spec.rb
+++ b/spec/unit/indirector/facts/facter_spec.rb
@@ -83,6 +83,16 @@ describe Puppet::Node::Facts::Facter do
 
       @facter.find(@request)
     end
+
+    it "can exclude legacy facts" do
+      Puppet[:include_legacy_facts] = false
+
+      facts = Puppet::Node::Facts.new("foo")
+      expect(Puppet::Node::Facts).to receive(:new).and_return(facts)
+      expect(Puppet.runtime[:facter]).to receive(:resolve).with('')
+
+      @facter.find(@request)
+    end
   end
 
   it 'should fail when saving facts' do


### PR DESCRIPTION
Adds a puppet setting `include_legacy_facts`. If set to false, then legacy facts will not be sent to puppetserver and will not be available during `puppet apply` compilation.

This commit doesn't cause legacy facts to be blocked, so they are still available via `Facter.value(:osfamily)` for example. This is important to maintain compatibility with `defaultfor`, `confine`, etc statements used to select the most suitable provider.