### PR TITLE
(PUP-11666) Mark resources type as valid for hosts and devices

### DIFF
--- a/lib/puppet/type/resources.rb
+++ b/lib/puppet/type/resources.rb
@@ -7,6 +7,7 @@ Puppet::Type.newtype(:resources) do
     so you can purge unmanaged resources but set `noop` to true so the
     purging is only logged and does not actually happen."
 
+  apply_to_all
 
   newparam(:name) do
     desc "The name of the type to be managed."


### PR DESCRIPTION
The resources type is useful on both hosts and devices and is compatible as is in both modes.