### PR TITLE
(maint) Expect `with` hash arguments instead of kwargs

### DIFF
--- a/spec/unit/agent_spec.rb
+++ b/spec/unit/agent_spec.rb
@@ -173,7 +173,7 @@ describe Puppet::Agent do
       client = AgentTestClient.new
       expect(AgentTestClient).to receive(:new).and_return(client)
 
-      expect(client).to receive(:run).with(:pluginsync => true, :other => :options)
+      expect(client).to receive(:run).with({:pluginsync => true, :other => :options})
       @agent.run(:other => :options)
     end
 

--- a/spec/unit/confiner_spec.rb
+++ b/spec/unit/confiner_spec.rb
@@ -24,7 +24,7 @@ describe Puppet::Confiner do
 
   it "should delegate its confine method to its confine collection" do
     allow(@object).to receive(:confine_collection).and_return(coll)
-    expect(coll).to receive(:confine).with(:foo => :bar, :bee => :baz)
+    expect(coll).to receive(:confine).with({:foo => :bar, :bee => :baz})
     @object.confine(:foo => :bar, :bee => :baz)
   end
 

--- a/spec/unit/indirector/indirection_spec.rb
+++ b/spec/unit/indirector/indirection_spec.rb
@@ -6,7 +6,7 @@ shared_examples_for "Indirection Delegator" do
   it "should create a request object with the appropriate method name and all of the passed arguments" do
     request = Puppet::Indirector::Request.new(:indirection, :find, "me", nil)
 
-    expect(@indirection).to receive(:request).with(@method, "mystuff", nil, :one => :two).and_return(request)
+    expect(@indirection).to receive(:request).with(@method, "mystuff", nil, {:one => :two}).and_return(request)
 
     allow(@terminus).to receive(@method)
 

--- a/spec/unit/module_tool/tar/mini_spec.rb
+++ b/spec/unit/module_tool/tar/mini_spec.rb
@@ -82,7 +82,7 @@ describe Puppet::ModuleTool::Tar::Mini, :if => (Puppet.features.minitar? and Pup
     expect(Zlib::GzipReader).to receive(:open).with(sourcefile).and_yield(reader)
     expect(minitar).to receive(:find_valid_files).with(reader).and_return([name])
     entry = MockFileStatEntry.new(mode)
-    expect(Archive::Tar::Minitar).to receive(:unpack).with(reader, destdir, [name], :fsync => false).
+    expect(Archive::Tar::Minitar).to receive(:unpack).with(reader, destdir, [name], {:fsync => false}).
         and_yield(type, name, {:entry => entry})
     entry
   end

--- a/spec/unit/provider/ldap_spec.rb
+++ b/spec/unit/provider/ldap_spec.rb
@@ -85,7 +85,7 @@ describe Puppet::Provider::Ldap do
       it "should create a provider with the results of the find" do
         expect(@manager).to receive(:find).with("one").and_return("one" => "two")
 
-        expect(@class).to receive(:new).with("one" => "two", :ensure => :present).and_return("myprovider")
+        expect(@class).to receive(:new).with({"one" => "two", :ensure => :present}).and_return("myprovider")
 
         expect(@resource).to receive(:provider=).with("myprovider")
 
@@ -95,7 +95,7 @@ describe Puppet::Provider::Ldap do
       it "should set :ensure to :present in the returned values" do
         expect(@manager).to receive(:find).with("one").and_return("one" => "two")
 
-        expect(@class).to receive(:new).with("one" => "two", :ensure => :present).and_return("myprovider")
+        expect(@class).to receive(:new).with({"one" => "two", :ensure => :present}).and_return("myprovider")
 
         expect(@resource).to receive(:provider=).with("myprovider")
 

--- a/spec/unit/provider/package/dpkg_spec.rb
+++ b/spec/unit/provider/package/dpkg_spec.rb
@@ -32,7 +32,7 @@ describe Puppet::Type.type(:package).provider(:dpkg), unless: Puppet::Util::Plat
       expect(Puppet::Util::Execution).to receive(:execpipe).with(execpipe_args).and_yield(bash_installed_io)
 
       installed = double('bash')
-      expect(described_class).to receive(:new).with(:ensure => "4.2-5ubuntu3", :error => "ok", :desired => "install", :name => "bash", :mark => :none, :status => "installed", :provider => :dpkg).and_return(installed)
+      expect(described_class).to receive(:new).with({:ensure => "4.2-5ubuntu3", :error => "ok", :desired => "install", :name => "bash", :mark => :none, :status => "installed", :provider => :dpkg}).and_return(installed)
 
       expect(described_class.instances).to eq([installed])
     end
@@ -41,9 +41,9 @@ describe Puppet::Type.type(:package).provider(:dpkg), unless: Puppet::Util::Plat
       expect(Puppet::Util::Execution).to receive(:execpipe).with(execpipe_args).and_yield(all_installed_io)
 
       bash = double('bash')
-      expect(described_class).to receive(:new).with(:ensure => "4.2-5ubuntu3", :error => "ok", :desired => "install", :name => "bash", :mark => :none, :status => "installed", :provider => :dpkg).and_return(bash)
+      expect(described_class).to receive(:new).with({:ensure => "4.2-5ubuntu3", :error => "ok", :desired => "install", :name => "bash", :mark => :none, :status => "installed", :provider => :dpkg}).and_return(bash)
       vim = double('vim')
-      expect(described_class).to receive(:new).with(:ensure => "2:7.3.547-6ubuntu5", :error => "ok", :desired => "install", :name => "vim", :mark => :none, :status => "installed", :provider => :dpkg).and_return(vim)
+      expect(described_class).to receive(:new).with({:ensure => "2:7.3.547-6ubuntu5", :error => "ok", :desired => "install", :name => "vim", :mark => :none, :status => "installed", :provider => :dpkg}).and_return(vim)
 
       expect(described_class.instances).to eq([bash, vim])
     end

--- a/spec/unit/provider/package/pkgutil_spec.rb
+++ b/spec/unit/provider/package/pkgutil_spec.rb
@@ -195,7 +195,7 @@ Not in catalog"
       expect(described_class).to receive(:pkguti).with(['-c']).and_return(fake_data)
 
       testpkg = double('pkg1')
-      expect(described_class).to receive(:new).with(:ensure => "1.4.5,REV=2007.11.18", :name => "TESTpkg", :provider => :pkgutil).and_return(testpkg)
+      expect(described_class).to receive(:new).with({:ensure => "1.4.5,REV=2007.11.18", :name => "TESTpkg", :provider => :pkgutil}).and_return(testpkg)
       expect(described_class.instances).to eq([testpkg])
     end
 
@@ -207,10 +207,10 @@ Not in catalog"
       expect(described_class).to receive(:pkguti).with(['-c']).and_return(fake_data)
 
       testpkg = double('pkg1')
-      expect(described_class).to receive(:new).with(:ensure => "1.4.5,REV=2007.11.18", :name => "TESTpkg", :provider => :pkgutil).and_return(testpkg)
+      expect(described_class).to receive(:new).with({:ensure => "1.4.5,REV=2007.11.18", :name => "TESTpkg", :provider => :pkgutil}).and_return(testpkg)
 
       aliaspkg = double('pkg2')
-      expect(described_class).to receive(:new).with(:ensure => "1.4.5,REV=2007.11.18", :name => "mypkg", :provider => :pkgutil).and_return(aliaspkg)
+      expect(described_class).to receive(:new).with({:ensure => "1.4.5,REV=2007.11.18", :name => "mypkg", :provider => :pkgutil}).and_return(aliaspkg)
 
       expect(described_class.instances).to eq([testpkg,aliaspkg])
     end
@@ -223,7 +223,7 @@ Not in catalog"
       expect(described_class).to receive(:pkguti).with(['-c']).and_return(fake_data)
 
       testpkg = double('pkg1')
-      expect(described_class).to receive(:new).with(:ensure => "1.4.5,REV=2007.11.18", :name => "TESTpkg", :provider => :pkgutil).and_return(testpkg)
+      expect(described_class).to receive(:new).with({:ensure => "1.4.5,REV=2007.11.18", :name => "TESTpkg", :provider => :pkgutil}).and_return(testpkg)
 
       expect(described_class.instances).to eq([testpkg])
     end

--- a/spec/unit/provider/parsedfile_spec.rb
+++ b/spec/unit/provider/parsedfile_spec.rb
@@ -59,10 +59,10 @@ describe Puppet::Provider::ParsedFile do
         {:name => 'target3_record2'}
       ])
       expect(Puppet).to receive(:err).with('Could not prefetch parsedfile_type provider \'parsedfile_provider\' target \'/two\': some error. Treating as empty')
-      expect(provider).to receive(:new).with(:name => 'target1_record1', :on_disk => true, :target => '/one', :ensure => :present).and_return('r1')
-      expect(provider).to receive(:new).with(:name => 'target1_record2', :on_disk => true, :target => '/one', :ensure => :present).and_return('r2')
-      expect(provider).to receive(:new).with(:name => 'target3_record1', :on_disk => true, :target => '/three', :ensure => :present).and_return('r3')
-      expect(provider).to receive(:new).with(:name => 'target3_record2', :on_disk => true, :target => '/three', :ensure => :present).and_return('r4')
+      expect(provider).to receive(:new).with({:name => 'target1_record1', :on_disk => true, :target => '/one', :ensure => :present}).and_return('r1')
+      expect(provider).to receive(:new).with({:name => 'target1_record2', :on_disk => true, :target => '/one', :ensure => :present}).and_return('r2')
+      expect(provider).to receive(:new).with({:name => 'target3_record1', :on_disk => true, :target => '/three', :ensure => :present}).and_return('r3')
+      expect(provider).to receive(:new).with({:name => 'target3_record2', :on_disk => true, :target => '/three', :ensure => :present}).and_return('r4')
 
       expect(provider.instances).to eq(%w{r1 r2 r3 r4})
     end

--- a/spec/unit/transaction/event_manager_spec.rb
+++ b/spec/unit/transaction/event_manager_spec.rb
@@ -191,8 +191,8 @@ describe Puppet::Transaction::EventManager do
 
       allow(@resource).to receive(:callback1)
 
-      expect(@resource).to receive(:event).with(:message => "Triggered 'callback1' from 1 event", :status => 'success', :name => 'callback1')
-      expect(@resource).to receive(:event).with(:name => :restarted, :status => "success").and_return("myevent")
+      expect(@resource).to receive(:event).with({:message => "Triggered 'callback1' from 1 event", :status => 'success', :name => 'callback1'})
+      expect(@resource).to receive(:event).with({:name => :restarted, :status => "success"}).and_return("myevent")
       expect(@manager).to receive(:queue_events).with(@resource, ["myevent"])
 
       @manager.process_events(@resource)

--- a/spec/unit/transaction_spec.rb
+++ b/spec/unit/transaction_spec.rb
@@ -570,7 +570,7 @@ describe Puppet::Transaction do
     end
 
     it "should match resources by name, not title" do
-      expect(resource.provider.class).to receive(:prefetch).with("bar" => resource)
+      expect(resource.provider.class).to receive(:prefetch).with({"bar" => resource})
 
       transaction.prefetch_if_necessary(resource)
     end
@@ -598,7 +598,7 @@ describe Puppet::Transaction do
       catalog.add_resource other
 
       allow(resource.class).to receive(:defaultprovider).and_return(resource.provider.class)
-      expect(resource.provider.class).to receive(:prefetch).with('bar' => resource, 'other' => other)
+      expect(resource.provider.class).to receive(:prefetch).with({'bar' => resource, 'other' => other})
 
       transaction.prefetch_if_necessary(resource)
     end

--- a/spec/unit/type/file_spec.rb
+++ b/spec/unit/type/file_spec.rb
@@ -516,8 +516,8 @@ describe Puppet::Type.type(:file) do
       it "should pass the already-discovered resources to recurse_remote" do
         file[:source] = File.expand_path(__FILE__)
         allow(child).to receive(:[]).with(:path).and_return(name)
-        allow(file).to receive(:recurse_local).and_return(name => child)
-        expect(file).to receive(:recurse_remote).with(name => child).and_return([])
+        allow(file).to receive(:recurse_local).and_return({name => child})
+        expect(file).to receive(:recurse_remote).with({name => child}).and_return([])
         file.recurse
       end
     end
@@ -526,8 +526,8 @@ describe Puppet::Type.type(:file) do
       it "should use recurse_link" do
         file[:target] = File.expand_path(__FILE__)
         allow(child).to receive(:[]).with(:path).and_return(name)
-        allow(file).to receive(:recurse_local).and_return(name => child)
-        expect(file).to receive(:recurse_link).with(name => child).and_return([])
+        allow(file).to receive(:recurse_local).and_return({name => child})
+        expect(file).to receive(:recurse_link).with({name => child}).and_return([])
         file.recurse
       end
     end

--- a/spec/unit/type/filebucket_spec.rb
+++ b/spec/unit/type/filebucket_spec.rb
@@ -82,20 +82,20 @@ describe Puppet::Type.type(:filebucket) do
     it "should use any provided path" do
       path = make_absolute("/foo/bar")
       bucket = Puppet::Type.type(:filebucket).new :name => "main", :path => path
-      expect(Puppet::FileBucket::Dipper).to receive(:new).with(:Path => path).and_return(@bucket)
+      expect(Puppet::FileBucket::Dipper).to receive(:new).with({:Path => path}).and_return(@bucket)
       bucket.bucket
     end
 
     it "should use any provided server and port" do
       bucket = Puppet::Type.type(:filebucket).new :name => "main", :server => "myserv", :port => "myport", :path => false
-      expect(Puppet::FileBucket::Dipper).to receive(:new).with(:Server => "myserv", :Port => "myport").and_return(@bucket)
+      expect(Puppet::FileBucket::Dipper).to receive(:new).with({:Server => "myserv", :Port => "myport"}).and_return(@bucket)
       bucket.bucket
     end
 
     it "should not try to guess server or port if the path is unset and no server is provided" do
       Puppet.settings[:server] = "myserv"
       Puppet.settings[:server_list] = ['server_list_0', 'server_list_1']
-      expect(Puppet::FileBucket::Dipper).to receive(:new).with(:Server => nil, :Port => nil).and_return(@bucket)
+      expect(Puppet::FileBucket::Dipper).to receive(:new).with({:Server => nil, :Port => nil}).and_return(@bucket)
 
       bucket = Puppet::Type.type(:filebucket).new :name => "main", :path => false
       bucket.bucket

--- a/spec/unit/type/tidy_spec.rb
+++ b/spec/unit/type/tidy_spec.rb
@@ -196,7 +196,7 @@ describe tidy do
       end
 
       it "should use a Fileset with default max_files for infinite recursion" do
-        expect(Puppet::FileServing::Fileset).to receive(:new).with(@basepath, :recurse => true, :max_files=>0).and_return(@fileset)
+        expect(Puppet::FileServing::Fileset).to receive(:new).with(@basepath, {:recurse => true, :max_files=>0}).and_return(@fileset)
         expect(@fileset).to receive(:files).and_return(%w{. one two})
         allow(@tidy).to receive(:tidy?).and_return(false)
 
@@ -205,7 +205,7 @@ describe tidy do
 
       it "should use a Fileset with default max_files for limited recursion" do
         @tidy[:recurse] = 42
-        expect(Puppet::FileServing::Fileset).to receive(:new).with(@basepath, :recurse => true, :recurselimit => 42, :max_files=>0).and_return(@fileset)
+        expect(Puppet::FileServing::Fileset).to receive(:new).with(@basepath, {:recurse => true, :recurselimit => 42, :max_files=>0}).and_return(@fileset)
         expect(@fileset).to receive(:files).and_return(%w{. one two})
         allow(@tidy).to receive(:tidy?).and_return(false)
 
@@ -215,7 +215,7 @@ describe tidy do
       it "should use a Fileset with max_files for limited recursion" do
         @tidy[:recurse] = 42
         @tidy[:max_files] = 9876
-        expect(Puppet::FileServing::Fileset).to receive(:new).with(@basepath, :recurse => true, :recurselimit => 42, :max_files=>9876).and_return(@fileset)
+        expect(Puppet::FileServing::Fileset).to receive(:new).with(@basepath, {:recurse => true, :recurselimit => 42, :max_files=>9876}).and_return(@fileset)
         expect(@fileset).to receive(:files).and_return(%w{. one two})
         allow(@tidy).to receive(:tidy?).and_return(false)
 
@@ -428,7 +428,7 @@ describe tidy do
       @tidy[:recurse] = true
       @tidy[:rmdirs] = true
       fileset = double('fileset')
-      expect(Puppet::FileServing::Fileset).to receive(:new).with(@basepath, :recurse => true, :max_files=>0).and_return(fileset)
+      expect(Puppet::FileServing::Fileset).to receive(:new).with(@basepath, {:recurse => true, :max_files=>0}).and_return(fileset)
       expect(fileset).to receive(:files).and_return(%w{. one two one/subone two/subtwo one/subone/ssone})
       allow(@tidy).to receive(:tidy?).and_return(true)
 
@@ -450,7 +450,7 @@ describe tidy do
       @tidy[:recurse] = true
       @tidy[:rmdirs] = true
       fileset = double('fileset')
-      expect(Puppet::FileServing::Fileset).to receive(:new).with(@basepath, :recurse => true, :max_files=>0).and_return(fileset)
+      expect(Puppet::FileServing::Fileset).to receive(:new).with(@basepath, {:recurse => true, :max_files=>0}).and_return(fileset)
       expect(fileset).to receive(:files).and_return(%w{. a a/2 a/1 a/3})
       allow(@tidy).to receive(:tidy?).and_return(true)
 
@@ -463,7 +463,7 @@ describe tidy do
       @tidy[:noop] = true
 
       fileset = double('fileset')
-      expect(Puppet::FileServing::Fileset).to receive(:new).with(@basepath, :recurse => true, :max_files=>0).and_return(fileset)
+      expect(Puppet::FileServing::Fileset).to receive(:new).with(@basepath, {:recurse => true, :max_files=>0}).and_return(fileset)
       expect(fileset).to receive(:files).and_return(%w{. a a/2 a/1 a/3})
       allow(@tidy).to receive(:tidy?).and_return(true)
 

--- a/spec/unit/util/execution_spec.rb
+++ b/spec/unit/util/execution_spec.rb
@@ -153,11 +153,11 @@ describe Puppet::Util::Execution, if: !Puppet::Util::Platform.jruby? do
       end
 
       it "should create a new process for the command" do
-        expect(Process).to receive(:create).with(
+        expect(Process).to receive(:create).with({
           :command_line => "test command",
           :startup_info => {:stdin => @stdin, :stdout => @stdout, :stderr => @stderr},
           :close_handles => false
-        ).and_return(proc_info_stub)
+        }).and_return(proc_info_stub)
 
         call_exec_windows('test command', {}, @stdin, @stdout, @stderr)
       end
@@ -165,7 +165,7 @@ describe Puppet::Util::Execution, if: !Puppet::Util::Platform.jruby? do
       context 'cwd option' do
         let(:cwd) { 'cwd' }
         it "should execute the command in the specified working directory" do
-          expect(Process).to receive(:create).with(
+          expect(Process).to receive(:create).with({
             :command_line => "test command",
             :startup_info => {
               :stdin => @stdin,
@@ -174,7 +174,7 @@ describe Puppet::Util::Execution, if: !Puppet::Util::Platform.jruby? do
             },
             :close_handles => false,
             :cwd => cwd
-          )
+          })
 
           call_exec_windows('test command', { :cwd => cwd }, @stdin, @stdout, @stderr)
         end
@@ -192,7 +192,7 @@ describe Puppet::Util::Execution, if: !Puppet::Util::Platform.jruby? do
       context 'suppress_window option' do
         let(:cwd) { 'cwd' }
         it "should execute the command in the specified working directory" do
-          expect(Process).to receive(:create).with(
+          expect(Process).to receive(:create).with({
             :command_line => "test command",
             :startup_info => {
               :stdin => @stdin,
@@ -201,7 +201,7 @@ describe Puppet::Util::Execution, if: !Puppet::Util::Platform.jruby? do
             },
             :close_handles => false,
             :creation_flags => Puppet::Util::Windows::Process::CREATE_NO_WINDOW
-          )
+          })
 
           call_exec_windows('test command', { :suppress_window => true }, @stdin, @stdout, @stderr)
         end

--- a/spec/unit/util/network_device_spec.rb
+++ b/spec/unit/util/network_device_spec.rb
@@ -20,14 +20,9 @@ describe Puppet::Util::NetworkDevice do
   end
 
   describe "when initializing the remote network device singleton" do
-    it "should load the network device code" do
-      expect(Puppet::Util::NetworkDevice).to receive(:require)
-      Puppet::Util::NetworkDevice.init(@device)
-    end
-
     it "should create a network device instance" do
       allow(Puppet::Util::NetworkDevice).to receive(:require)
-      expect(Puppet::Util::NetworkDevice::Test::Device).to receive(:new).with("telnet://admin:password@127.0.0.1", :debug => false)
+      expect(Puppet::Util::NetworkDevice::Test::Device).to receive(:new).with("telnet://admin:password@127.0.0.1", {:debug => false})
       Puppet::Util::NetworkDevice.init(@device)
     end
 


### PR DESCRIPTION
Puppet verifies partial doubles so arguments are checked against the original method and to ensure methods that don't exist can't be stubbed. RSpec 3.11.2 changes how keyword arguments are verified[1].

So previously you could write `expect(:m).with(a: true)` and it would pass if the method was called with a hash or keyword arguments. But now the expectation must expect a hash, not keyword arguments.

[1] https://github.com/rspec/rspec-mocks/commit/bc1a68725d57e167c885763e7f3edc236f92b7b5