### PR TITLE
(PUP-11631) Adds copy_metaparams method

### DIFF
--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -356,6 +356,16 @@ class Type
     param
   end
 
+  # Copies all of a resource's metaparameters (except `alias`) to a generated child resource
+  # @param parameters [Hash] of a resource's parameters
+  # @return [Void]
+  def copy_metaparams(parameters)
+    parameters.each do |name, param|
+      self[name] = param.value if param.metaparam? && !name == :alias
+    end
+    nil
+  end
+
   # Returns the list of parameters that comprise the composite key / "uniqueness key".
   # All parameters that return true from #isnamevar? or is named `:name` are included in the returned result.
   # @see uniqueness_key

--- a/lib/puppet/type/resources.rb
+++ b/lib/puppet/type/resources.rb
@@ -120,12 +120,7 @@ Puppet::Type.newtype(:resources) do
       select { |r| r.class.validproperty?(:ensure) }.
       select { |r| able_to_ensure_absent?(r) }.
       each { |resource|
-        @parameters.each do |name, param|
-          resource[name] = param.value if param.metaparam?
-        end
-
-        # Mark that we're purging, so transactions can handle relationships
-        # correctly
+        resource.copy_metaparams(@parameters)
         resource.purging
       }
   end

--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -811,9 +811,7 @@ module Puppet
         flatten.each do |res|
           res[:ensure] = :absent
           res[:user] = self[:name]
-          @parameters.each do |name, param|
-            res[name] = param.value if param.metaparam?
-          end
+          res.copy_metaparams(@parameters)
         end
     end
 

--- a/spec/unit/type/resources_spec.rb
+++ b/spec/unit/type/resources_spec.rb
@@ -270,6 +270,20 @@ describe resources do
       @catalog = Puppet::Resource::Catalog.new
     end
 
+    context "when the catalog contains a purging resource with an alias" do
+      before do
+        @resource = Puppet::Type.type(:resources).new(:name => "purgeable_test", :purge => true)
+        @catalog.add_resource @resource
+        @catalog.alias(@resource, "purgeable_test_alias")
+      end
+
+      it "should not copy the alias metaparameter" do
+        allow(Puppet::Type.type(:purgeable_test)).to receive(:instances).and_return([@purgee])
+        generated = @resource.generate.first
+        expect(generated[:alias]).to be_nil
+      end
+    end
+
     context "when dealing with non-purging resources" do
       before do
         @resources = Puppet::Type.type(:resources).new(:name => 'purgeable_test')


### PR DESCRIPTION
Some types (e.g. resources, user) generate child resources from parent resources and need to copy all metaparameters, except for :alias, to the newly-generated child resource.

This commit adds a new method, copy_metaparams, that enables types to do this.