### PR TITLE
(packaging) Add Artix to pacman.rb

### DIFF
--- a/lib/puppet/provider/package/pacman.rb
+++ b/lib/puppet/provider/package/pacman.rb
@@ -17,8 +17,8 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
   # Yaourt is a common AUR helper which, if installed, we can use to query the AUR
   commands :yaourt => "/usr/bin/yaourt" if yaourt?
 
-  confine     'os.name' => [:archlinux, :manjarolinux]
-  defaultfor  'os.name' => [:archlinux, :manjarolinux]
+  confine     'os.name' => [:archlinux, :manjarolinux, :artix]
+  defaultfor  'os.name' => [:archlinux, :manjarolinux, :artix]
   has_feature :install_options
   has_feature :uninstall_options
   has_feature :upgradeable


### PR DESCRIPTION
Add Artix to the list of Arch-based distros. This will greatly simplify the process of packaging Puppet for Artix.