### PR TITLE
(maint) Update github actions to account for 7.x branch

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -3,9 +3,9 @@ name: Checks
 
 on:
   push:
-    branches: [main]
+    branches: [7.x]
   pull_request:
-    branches: [main]
+    branches: [7.x]
 
 permissions:
   contents: read

--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -3,9 +3,9 @@ name: RSpec tests
 
 on:
   push:
-    branches: [main]
+    branches: [7.x]
   pull_request:
-    branches: [main]
+    branches: [7.x]
 
 permissions:
   contents: read

--- a/.github/workflows/snyk_monitor.yaml
+++ b/.github/workflows/snyk_monitor.yaml
@@ -3,7 +3,7 @@ name: Snyk Monitor
 on:
   push:
     branches:
-      - main
+      - 7.x
 permissions:
   contents: read
 


### PR DESCRIPTION
This work is for [PA-4700](https://tickets.puppetlabs.com/browse/PA-4700)

Puppet 6.x will be end of life on February 28, 2023 and Puppet 7.x will become the long term support (LTS) branch. In preparation for this, a new Puppet 7.x branch will be created and Puppet's GitHub Actions & protection rules must be updated. This PR updates Puppet's GitHub Actions to account for 7.x being the new LTS branch.