### PR TITLE
(PUP-10688) Allow tidy to pass on metaparameters

### DIFF
--- a/lib/puppet/type.rb
+++ b/lib/puppet/type.rb
@@ -361,7 +361,7 @@ class Type
   # @return [Void]
   def copy_metaparams(parameters)
     parameters.each do |name, param|
-      self[name] = param.value if param.metaparam? && !name == :alias
+      self[name] = param.value if param.metaparam? && name != :alias
     end
     nil
   end

--- a/lib/puppet/type/tidy.rb
+++ b/lib/puppet/type/tidy.rb
@@ -247,9 +247,10 @@ Puppet::Type.newtype(:tidy) do
       :ensure => :absent, :force => true
     }
 
-    parameters[:noop] = self[:noop] unless self[:noop].nil?
+    new_file = Puppet::Type.type(:file).new(parameters)
+    new_file.copy_metaparams(@parameters)
 
-    Puppet::Type.type(:file).new(parameters)
+    new_file
   end
 
   def retrieve


### PR DESCRIPTION
This PR allows tidy to properly pass on its metaparameters to generated child file resources.

While working on this ticket, we also discovered a bug in `copy_metaparams` that has been addressed.