### PR TITLE
(maint) Bump to jruby 9.2.21.0

### DIFF
--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -20,7 +20,7 @@ jobs:
           - {os: ubuntu-latest, ruby: '2.6'}
           - {os: ubuntu-latest, ruby: '2.7'}
           - {os: ubuntu-latest, ruby: '3.0'}
-          - {os: ubuntu-latest, ruby: 'jruby-9.2.17.0'}
+          - {os: ubuntu-latest, ruby: 'jruby-9.2.21.0'}
           - {os: windows-2019, ruby: '2.5'}
           - {os: windows-2019, ruby: '2.6'}
           - {os: windows-2019, ruby: '2.7'}

--- a/spec/unit/file_system_spec.rb
+++ b/spec/unit/file_system_spec.rb
@@ -819,9 +819,11 @@ describe "Puppet::FileSystem" do
         mode = Puppet::FileSystem.stat(dir).mode
         Puppet::FileSystem.chmod(0, dir)
         begin
+          # JRuby 9.2.21.0 drops the path from the message..
+          message = Puppet::Util::Platform.jruby? ? /^Permission denied/ : /^Permission denied .* #{path}/
           expect {
             Puppet::FileSystem.unlink(path)
-          }.to raise_error(Errno::EACCES, /^Permission denied .* #{path}/)
+          }.to raise_error(Errno::EACCES, message)
         ensure
           Puppet::FileSystem.chmod(mode, dir)
         end


### PR DESCRIPTION
The setup action is failing to install 9.2.17.0, so update to the latest in the 9.2 series.