### PR TITLE
(PUP-11634) Eliminate deprecated methods in preparation for Ruby 3.2

### DIFF
--- a/Guardfile.example
+++ b/Guardfile.example
@@ -16,7 +16,7 @@ notification(:terminal_notifier, app_name: "Puppet ::", group: `pwd`.chomp) if `
 
 ## Uncomment and set this to only include directories you want to watch
 # directories %w(app lib config test spec features) \
-#  .select{|d| Dir.exists?(d) ? d : UI.warning("Directory #{d} does not exist")}
+#  .select{|d| Dir.exist?(d) ? d : UI.warning("Directory #{d} does not exist")}
 
 ## Note: if you are using the `directories` clause above and you are not
 ## watching the project directory ('.'), then you will want to move

--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -30,6 +30,6 @@ group(:test) do
   gem "mocha", "~> 0.10.5", :require => false
 end
 
-if File.exists? "#{__FILE__}.local"
+if File.exist? "#{__FILE__}.local"
   eval(File.read("#{__FILE__}.local"), binding)
 end

--- a/acceptance/tests/environment/custom_type_provider_from_same_environment.rb
+++ b/acceptance/tests/environment/custom_type_provider_from_same_environment.rb
@@ -53,7 +53,7 @@ TYPE
             File.unlink(@resource[:name])
           end
           def exists?
-            File.exists?(@resource[:name])
+            File.exist?(@resource[:name])
           end
         end
 PROVIDER

--- a/ext/windows/service/daemon.rb
+++ b/ext/windows/service/daemon.rb
@@ -48,7 +48,7 @@ class WindowsDaemon < Puppet::Util::Windows::Daemon
     #
     # Example code to register an event source;
     # eventlogdll =  File.expand_path(File.join(basedir, 'puppet', 'ext', 'windows', 'eventlog', 'puppetres.dll'))
-    # if (File.exists?(eventlogdll))
+    # if (File.exist?(eventlogdll))
     #   Win32::EventLog.add_event_source(
     #      'source' => "Application",
     #      'key_name' => "Puppet Agent",

--- a/spec/integration/application/agent_spec.rb
+++ b/spec/integration/application/agent_spec.rb
@@ -527,7 +527,7 @@ describe "puppet agent", unless: Puppet::Util::Platform.jruby? do
       }
 
       # ensure file is written before yielding
-      until File.exists?(path) && File.size(path) > 0 do
+      until File.exist?(path) && File.size(path) > 0 do
         sleep 0.1
       end
 

--- a/spec/unit/application/agent_spec.rb
+++ b/spec/unit/application/agent_spec.rb
@@ -524,7 +524,7 @@ describe Puppet::Application::Agent do
       end
 
       it "should stop the daemon" do
-        expect(@daemon).to receive(:stop).with(:exit => false)
+        expect(@daemon).to receive(:stop).with({:exit => false})
 
         expect { execute_agent }.to exit_with 0
       end

--- a/spec/unit/application/device_spec.rb
+++ b/spec/unit/application/device_spec.rb
@@ -535,7 +535,7 @@ describe Puppet::Application::Device do
         end
 
         it "makes the Puppet::Pops::Loaders available" do
-          expect(configurer).to receive(:run).with(:network_device => true, :pluginsync => false) do
+          expect(configurer).to receive(:run).with({:network_device => true, :pluginsync => false}) do
             fail('Loaders not available') unless Puppet.lookup(:loaders) { nil }.is_a?(Puppet::Pops::Loaders)
             true
           end.and_return(6, 2)

--- a/spec/unit/application/resource_spec.rb
+++ b/spec/unit/application/resource_spec.rb
@@ -122,7 +122,7 @@ describe Puppet::Application::Resource do
       allow(@resource_app.command_line).to receive(:args).and_return(['type','name','param=temp'])
 
       expect(Puppet::Resource.indirection).to receive(:save).with(@res, 'type/name').and_return([@res, @report])
-      expect(Puppet::Resource).to receive(:new).with('type', 'name', :parameters => {'param' => 'temp'}).and_return(@res)
+      expect(Puppet::Resource).to receive(:new).with('type', 'name', {:parameters => {'param' => 'temp'}}).and_return(@res)
 
       @resource_app.main
     end

--- a/spec/unit/daemon_spec.rb
+++ b/spec/unit/daemon_spec.rb
@@ -180,7 +180,7 @@ describe Puppet::Daemon, :unless => Puppet::Util::Platform.windows? do
 
     it "should shut down without exiting" do
       daemon.argv = %w{foo}
-      expect(daemon).to receive(:stop).with(:exit => false)
+      expect(daemon).to receive(:stop).with({:exit => false})
       daemon.reexec
     end
 

--- a/spec/unit/file_bucket/dipper_spec.rb
+++ b/spec/unit/file_bucket/dipper_spec.rb
@@ -322,7 +322,7 @@ describe Puppet::FileBucket::Dipper, :uses_checksums => true do
         file = make_tmp_file(plaintext)
 
         expect(Puppet::FileBucket::File.indirection).to receive(:head).with(
-          %r{#{digest_algorithm}/#{checksum}}, :bucket_path => "/my/bucket"
+          %r{#{digest_algorithm}/#{checksum}}, {:bucket_path => "/my/bucket"}
         ).and_return(true)
         expect(Puppet::FileBucket::File.indirection).not_to receive(:save)
         expect(@dipper.backup(file)).to eq(checksum)

--- a/spec/unit/file_serving/fileset_spec.rb
+++ b/spec/unit/file_serving/fileset_spec.rb
@@ -153,12 +153,12 @@ describe Puppet::FileServing::Fileset do
       top_names = %w{one two .svn CVS}
       sub_names = %w{file1 file2 .svn CVS 0 false}
 
-      allow(Dir).to receive(:entries).with(path, encoding: Encoding::UTF_8).and_return(top_names)
+      allow(Dir).to receive(:entries).with(path, {encoding: Encoding::UTF_8}).and_return(top_names)
       top_names.each do |subdir|
         @files << subdir # relative path
         subpath = File.join(path, subdir)
         allow(Puppet::FileSystem).to receive(stat_method).with(subpath).and_return(@dirstat)
-        allow(Dir).to receive(:entries).with(subpath, encoding: Encoding::UTF_8).and_return(sub_names)
+        allow(Dir).to receive(:entries).with(subpath, {encoding: Encoding::UTF_8}).and_return(sub_names)
         sub_names.each do |file|
           @files << File.join(subdir, file) # relative path
           subfile_path = File.join(subpath, file)
@@ -176,12 +176,12 @@ describe Puppet::FileServing::Fileset do
       top_names = (1..10).map {|i| "dir_#{i}" }
       sub_names = (1..100).map {|i| "file__#{i}" }
 
-      allow(Dir).to receive(:entries).with(path, encoding: Encoding::UTF_8).and_return(top_names)
+      allow(Dir).to receive(:entries).with(path, {encoding: Encoding::UTF_8}).and_return(top_names)
       top_names.each do |subdir|
         @files << subdir # relative path
         subpath = File.join(path, subdir)
         allow(Puppet::FileSystem).to receive(stat_method).with(subpath).and_return(@dirstat)
-        allow(Dir).to receive(:entries).with(subpath, encoding: Encoding::UTF_8).and_return(sub_names)
+        allow(Dir).to receive(:entries).with(subpath, {encoding: Encoding::UTF_8}).and_return(sub_names)
         sub_names.each do |file|
           @files << File.join(subdir, file) # relative path
           subfile_path = File.join(subpath, file)
@@ -193,7 +193,7 @@ describe Puppet::FileServing::Fileset do
     def setup_mocks_for_dir(mock_dir, base_path)
       path = File.join(base_path, mock_dir.name)
       allow(Puppet::FileSystem).to receive(:lstat).with(path).and_return(MockStat.new(path, true))
-      allow(Dir).to receive(:entries).with(path, encoding: Encoding::UTF_8).and_return(['.', '..'] + mock_dir.entries.map(&:name))
+      allow(Dir).to receive(:entries).with(path, {encoding: Encoding::UTF_8}).and_return(['.', '..'] + mock_dir.entries.map(&:name))
       mock_dir.entries.each do |entry|
         setup_mocks_for_entry(entry, path)
       end
@@ -360,7 +360,7 @@ describe Puppet::FileServing::Fileset do
     link_path = File.join(path, "mylink")
     expect(Puppet::FileSystem).to receive(:stat).with(link_path).and_raise(Errno::ENOENT)
 
-    allow(Dir).to receive(:entries).with(path, encoding: Encoding::UTF_8).and_return(["mylink"])
+    allow(Dir).to receive(:entries).with(path, {encoding: Encoding::UTF_8}).and_return(["mylink"])
 
     fileset = Puppet::FileServing::Fileset.new(path)
 
@@ -377,16 +377,16 @@ describe Puppet::FileServing::Fileset do
 
       @filesets = @paths.collect do |path|
         allow(Puppet::FileSystem).to receive(:lstat).with(path).and_return(double('stat', :directory? => true))
-        Puppet::FileServing::Fileset.new(path, :recurse => true)
+        Puppet::FileServing::Fileset.new(path, {:recurse => true})
       end
 
       allow(Dir).to receive(:entries).and_return([])
     end
 
     it "returns a hash of all files in each fileset with the value being the base path" do
-      expect(Dir).to receive(:entries).with(make_absolute("/first/path"), encoding: Encoding::UTF_8).and_return(%w{one uno})
-      expect(Dir).to receive(:entries).with(make_absolute("/second/path"), encoding: Encoding::UTF_8).and_return(%w{two dos})
-      expect(Dir).to receive(:entries).with(make_absolute("/third/path"), encoding: Encoding::UTF_8).and_return(%w{three tres})
+      expect(Dir).to receive(:entries).with(make_absolute("/first/path"), {encoding: Encoding::UTF_8}).and_return(%w{one uno})
+      expect(Dir).to receive(:entries).with(make_absolute("/second/path"), {encoding: Encoding::UTF_8}).and_return(%w{two dos})
+      expect(Dir).to receive(:entries).with(make_absolute("/third/path"), {encoding: Encoding::UTF_8}).and_return(%w{three tres})
 
       expect(Puppet::FileServing::Fileset.merge(*@filesets)).to eq({
         "." => make_absolute("/first/path"),
@@ -400,15 +400,15 @@ describe Puppet::FileServing::Fileset do
     end
 
     it "includes the base directory from the first fileset" do
-      expect(Dir).to receive(:entries).with(make_absolute("/first/path"), encoding: Encoding::UTF_8).and_return(%w{one})
-      expect(Dir).to receive(:entries).with(make_absolute("/second/path"), encoding: Encoding::UTF_8).and_return(%w{two})
+      expect(Dir).to receive(:entries).with(make_absolute("/first/path"), {encoding: Encoding::UTF_8}).and_return(%w{one})
+      expect(Dir).to receive(:entries).with(make_absolute("/second/path"), {encoding: Encoding::UTF_8}).and_return(%w{two})
 
       expect(Puppet::FileServing::Fileset.merge(*@filesets)["."]).to eq(make_absolute("/first/path"))
     end
 
     it "uses the base path of the first found file when relative file paths conflict" do
-      expect(Dir).to receive(:entries).with(make_absolute("/first/path"), encoding: Encoding::UTF_8).and_return(%w{one})
-      expect(Dir).to receive(:entries).with(make_absolute("/second/path"), encoding: Encoding::UTF_8).and_return(%w{one})
+      expect(Dir).to receive(:entries).with(make_absolute("/first/path"), {encoding: Encoding::UTF_8}).and_return(%w{one})
+      expect(Dir).to receive(:entries).with(make_absolute("/second/path"), {encoding: Encoding::UTF_8}).and_return(%w{one})
 
       expect(Puppet::FileServing::Fileset.merge(*@filesets)["one"]).to eq(make_absolute("/first/path"))
     end

--- a/spec/unit/graph/simple_graph_spec.rb
+++ b/spec/unit/graph/simple_graph_spec.rb
@@ -475,7 +475,7 @@ describe Puppet::Graph::SimpleGraph do
 
     it "should write a dot file based on the passed name" do
       expect(File).to receive(:open).with(@file, "w:UTF-8").and_yield(double("file", :puts => nil))
-      expect(@graph).to receive(:to_dot).with("name" => @name.to_s.capitalize)
+      expect(@graph).to receive(:to_dot).with({"name" => @name.to_s.capitalize})
       Puppet[:graph] = true
       @graph.write_graph(@name)
     end

--- a/spec/unit/indirector/file_server_spec.rb
+++ b/spec/unit/indirector/file_server_spec.rb
@@ -183,10 +183,10 @@ describe Puppet::Indirector::FileServer do
       expect(Puppet::FileServing::Fileset).to receive(:merge).and_return("one" => "/one", "two" => "/two")
 
       one = double('one', :collect => nil)
-      expect(model).to receive(:new).with("/one", :relative_path => "one").and_return(one)
+      expect(model).to receive(:new).with("/one", {:relative_path => "one"}).and_return(one)
 
       two = double('two', :collect => nil)
-      expect(model).to receive(:new).with("/two", :relative_path => "two").and_return(two)
+      expect(model).to receive(:new).with("/two", {:relative_path => "two"}).and_return(two)
 
       # order can't be guaranteed
       result = indirection.search(uri)
@@ -205,7 +205,7 @@ describe Puppet::Indirector::FileServer do
       expect(Puppet::FileServing::Fileset).to receive(:merge).and_return("one" => "/one")
 
       one = double('one', :collect => nil)
-      expect(model).to receive(:new).with("/one", :relative_path => "one").and_return(one)
+      expect(model).to receive(:new).with("/one", {:relative_path => "one"}).and_return(one)
       expect(one).to receive(:links=).with(true)
 
       indirection.search(uri, links: true)
@@ -221,7 +221,7 @@ describe Puppet::Indirector::FileServer do
       expect(Puppet::FileServing::Fileset).to receive(:merge).and_return("one" => "/one")
 
       one = double('one', :collect => nil)
-      expect(model).to receive(:new).with("/one", :relative_path => "one").and_return(one)
+      expect(model).to receive(:new).with("/one", {:relative_path => "one"}).and_return(one)
 
       expect(one).to receive(:checksum_type=).with(:checksum)
 
@@ -238,7 +238,7 @@ describe Puppet::Indirector::FileServer do
       expect(Puppet::FileServing::Fileset).to receive(:merge).and_return("one" => "/one")
 
       one = double('one')
-      expect(model).to receive(:new).with("/one", :relative_path => "one").and_return(one)
+      expect(model).to receive(:new).with("/one", {:relative_path => "one"}).and_return(one)
       expect(one).to receive(:collect)
 
       indirection.search(uri)

--- a/spec/unit/indirector/node/plain_spec.rb
+++ b/spec/unit/indirector/node/plain_spec.rb
@@ -21,7 +21,7 @@ describe Puppet::Node::Plain do
   end
 
   it "should find facts if none are supplied" do
-    expect(Puppet::Node::Facts.indirection).to receive(:find).with(nodename, :environment => environment).and_return(indirection_facts)
+    expect(Puppet::Node::Facts.indirection).to receive(:find).with(nodename, {:environment => environment}).and_return(indirection_facts)
     request.options.delete(:facts)
     node = node_indirection.find(request)
     expect(node.parameters).to include(indirection_fact_values)

--- a/spec/unit/provider/file/posix_spec.rb
+++ b/spec/unit/provider/file/posix_spec.rb
@@ -39,7 +39,7 @@ describe Puppet::Type.type(:file).provider(:posix), :if => Puppet.features.posix
 
   describe "#uid2name" do
     it "should return the name of the user identified by the id" do
-      allow(Etc).to receive(:getpwuid).with(501).and_return(Struct::Passwd.new('jilluser', nil, 501))
+      allow(Etc).to receive(:getpwuid).with(501).and_return(Etc::Passwd.new('jilluser', nil, 501))
 
       expect(provider.uid2name(501)).to eq('jilluser')
     end
@@ -61,7 +61,7 @@ describe Puppet::Type.type(:file).provider(:posix), :if => Puppet.features.posix
 
   describe "#name2uid" do
     it "should return the id of the user if it exists" do
-      passwd = Struct::Passwd.new('bobbo', nil, 502)
+      passwd = Etc::Passwd.new('bobbo', nil, 502)
 
       allow(Etc).to receive(:getpwnam).with('bobbo').and_return(passwd)
       allow(Etc).to receive(:getpwuid).with(502).and_return(passwd)
@@ -131,7 +131,7 @@ describe Puppet::Type.type(:file).provider(:posix), :if => Puppet.features.posix
 
   describe "#gid2name" do
     it "should return the name of the group identified by the id" do
-      allow(Etc).to receive(:getgrgid).with(501).and_return(Struct::Passwd.new('unicorns', nil, nil, 501))
+      allow(Etc).to receive(:getgrgid).with(501).and_return(Etc::Passwd.new('unicorns', nil, nil, 501))
 
       expect(provider.gid2name(501)).to eq('unicorns')
     end
@@ -153,7 +153,7 @@ describe Puppet::Type.type(:file).provider(:posix), :if => Puppet.features.posix
 
   describe "#name2gid" do
     it "should return the id of the group if it exists" do
-      passwd = Struct::Passwd.new('penguins', nil, nil, 502)
+      passwd = Etc::Passwd.new('penguins', nil, nil, 502)
 
       allow(Etc).to receive(:getgrnam).with('penguins').and_return(passwd)
       allow(Etc).to receive(:getgrgid).with(502).and_return(passwd)

--- a/spec/unit/provider/ldap_spec.rb
+++ b/spec/unit/provider/ldap_spec.rb
@@ -73,7 +73,7 @@ describe Puppet::Provider::Ldap do
       it "should create a provider with :ensure => :absent" do
         expect(@manager).to receive(:find).with("one").and_return(nil)
 
-        expect(@class).to receive(:new).with(:ensure => :absent).and_return("myprovider")
+        expect(@class).to receive(:new).with({:ensure => :absent}).and_return("myprovider")
 
         expect(@resource).to receive(:provider=).with("myprovider")
 

--- a/spec/unit/provider/nameservice_spec.rb
+++ b/spec/unit/provider/nameservice_spec.rb
@@ -30,8 +30,8 @@ describe Puppet::Provider::NameService do
   # These are values getpwent might give you
   let :users do
     [
-      Struct::Passwd.new('root', 'x', 0, 0),
-      Struct::Passwd.new('foo', 'x', 1000, 2000),
+      Etc::Passwd.new('root', 'x', 0, 0),
+      Etc::Passwd.new('foo', 'x', 1000, 2000),
       nil
     ]
   end
@@ -39,13 +39,13 @@ describe Puppet::Provider::NameService do
   # These are values getgrent might give you
   let :groups do
     [
-      Struct::Group.new('root', 'x', 0, %w{root}),
-      Struct::Group.new('bin', 'x', 1, %w{root bin daemon}),
+      Etc::Group.new('root', 'x', 0, %w{root}),
+      Etc::Group.new('bin', 'x', 1, %w{root bin daemon}),
       nil
     ]
   end
 
-  # A fake struct besides Struct::Group and Struct::Passwd
+  # A fake struct besides Etc::Group and Etc::Passwd
   let :fakestruct do
     Struct.new(:foo, :bar)
   end
@@ -82,11 +82,11 @@ describe Puppet::Provider::NameService do
 
   let(:utf_8_mixed_users) {
     [
-      Struct::Passwd.new('root', 'x', 0, 0),
-      Struct::Passwd.new('foo', 'x', 1000, 2000),
-      Struct::Passwd.new(utf_8_jose, utf_8_jose, 1001, 2000), # UTF-8 character
+      Etc::Passwd.new('root', 'x', 0, 0),
+      Etc::Passwd.new('foo', 'x', 1000, 2000),
+      Etc::Passwd.new(utf_8_jose, utf_8_jose, 1001, 2000), # UTF-8 character
       # In a UTF-8 environment, ruby will return strings labeled as UTF-8 even if they're not valid in UTF-8
-      Struct::Passwd.new(invalid_utf_8_jose, invalid_utf_8_jose, 1002, 2000),
+      Etc::Passwd.new(invalid_utf_8_jose, invalid_utf_8_jose, 1002, 2000),
       nil
     ]
   }
@@ -94,10 +94,10 @@ describe Puppet::Provider::NameService do
   let(:latin_1_mixed_users) {
     [
       # In a LATIN-1 environment, ruby will return *all* strings labeled as LATIN-1
-      Struct::Passwd.new('root'.force_encoding(Encoding::ISO_8859_1), 'x', 0, 0),
-      Struct::Passwd.new('foo'.force_encoding(Encoding::ISO_8859_1), 'x', 1000, 2000),
-      Struct::Passwd.new(utf_8_labeled_as_latin_1_jose, utf_8_labeled_as_latin_1_jose, 1002, 2000),
-      Struct::Passwd.new(valid_latin1_jose, valid_latin1_jose, 1001, 2000), # UTF-8 character
+      Etc::Passwd.new('root'.force_encoding(Encoding::ISO_8859_1), 'x', 0, 0),
+      Etc::Passwd.new('foo'.force_encoding(Encoding::ISO_8859_1), 'x', 1000, 2000),
+      Etc::Passwd.new(utf_8_labeled_as_latin_1_jose, utf_8_labeled_as_latin_1_jose, 1002, 2000),
+      Etc::Passwd.new(valid_latin1_jose, valid_latin1_jose, 1001, 2000), # UTF-8 character
       nil
     ]
   }
@@ -197,7 +197,7 @@ describe Puppet::Provider::NameService do
     end
 
     it "should pass the Puppet::Etc :canonical_name Struct member to the constructor" do
-      users = [ Struct::Passwd.new(invalid_utf_8_jose, invalid_utf_8_jose, 1002, 2000), nil ]
+      users = [ Etc::Passwd.new(invalid_utf_8_jose, invalid_utf_8_jose, 1002, 2000), nil ]
       allow(Etc).to receive(:getpwent).and_return(*users)
       expect(provider.class).to receive(:new).with({:name => escaped_utf_8_jose, :canonical_name => invalid_utf_8_jose, :ensure => :present})
       provider.class.instances

--- a/spec/unit/provider/nameservice_spec.rb
+++ b/spec/unit/provider/nameservice_spec.rb
@@ -199,7 +199,7 @@ describe Puppet::Provider::NameService do
     it "should pass the Puppet::Etc :canonical_name Struct member to the constructor" do
       users = [ Struct::Passwd.new(invalid_utf_8_jose, invalid_utf_8_jose, 1002, 2000), nil ]
       allow(Etc).to receive(:getpwent).and_return(*users)
-      expect(provider.class).to receive(:new).with(:name => escaped_utf_8_jose, :canonical_name => invalid_utf_8_jose, :ensure => :present)
+      expect(provider.class).to receive(:new).with({:name => escaped_utf_8_jose, :canonical_name => invalid_utf_8_jose, :ensure => :present})
       provider.class.instances
     end
   end

--- a/spec/unit/provider/package/aix_spec.rb
+++ b/spec/unit/provider/package/aix_spec.rb
@@ -16,7 +16,7 @@ describe Puppet::Type.type(:package).provider(:aix) do
 
   it "should uninstall a package" do
     expect(@provider).to receive(:installp).with('-gu', 'mypackage')
-    expect(@provider.class).to receive(:pkglist).with(:pkgname => 'mypackage').and_return(nil)
+    expect(@provider.class).to receive(:pkglist).with({:pkgname => 'mypackage'}).and_return(nil)
     @provider.uninstall
   end
 

--- a/spec/unit/provider/package/nim_spec.rb
+++ b/spec/unit/provider/package/nim_spec.rb
@@ -158,14 +158,14 @@ OUTPUT
     it "should call installp to uninstall a bff package" do
       expect(@provider).to receive(:lslpp).with("-qLc", "mypackage.foo").and_return("#bos.atm:bos.atm.atmle:7.1.2.0: : :C: :ATM LAN Emulation Client Support : : : : : : :0:0:/:1241")
       expect(@provider).to receive(:installp).with("-gu", "mypackage.foo")
-      expect(@provider.class).to receive(:pkglist).with(:pkgname => 'mypackage.foo').and_return(nil)
+      expect(@provider.class).to receive(:pkglist).with({:pkgname => 'mypackage.foo'}).and_return(nil)
       @provider.uninstall
     end
 
     it "should call rpm to uninstall an rpm package" do
       expect(@provider).to receive(:lslpp).with("-qLc", "mypackage.foo").and_return("cdrecord:cdrecord-1.9-6:1.9-6: : :C:R:A command line CD/DVD recording program.: :/bin/rpm -e cdrecord: : : : :0: :/opt/freeware:Wed Jun 29 09:41:32 PDT 2005")
       expect(@provider).to receive(:rpm).with("-e", "mypackage.foo")
-      expect(@provider.class).to receive(:pkglist).with(:pkgname => 'mypackage.foo').and_return(nil)
+      expect(@provider.class).to receive(:pkglist).with({:pkgname => 'mypackage.foo'}).and_return(nil)
       @provider.uninstall
     end
   end

--- a/spec/unit/provider/service/bsd_spec.rb
+++ b/spec/unit/provider/service/bsd_spec.rb
@@ -94,13 +94,13 @@ describe 'Puppet::Type::Service::Provider::Bsd',
 
     it "should use the supplied start command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :start => '/bin/foo'))
-      expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).to receive(:execute).with(['/bin/foo'], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
       provider.start
     end
 
     it "should start the serviced directly otherwise" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
-      expect(provider).to receive(:execute).with(['/etc/rc.d/sshd', :onestart], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).to receive(:execute).with(['/etc/rc.d/sshd', :onestart], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
       expect(provider).to receive(:search).with('sshd').and_return('/etc/rc.d/sshd')
       provider.start
     end
@@ -113,13 +113,13 @@ describe 'Puppet::Type::Service::Provider::Bsd',
 
     it "should use the supplied stop command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :stop => '/bin/foo'))
-      expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).to receive(:execute).with(['/bin/foo'], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
       provider.stop
     end
 
     it "should stop the serviced directly otherwise" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
-      expect(provider).to receive(:execute).with(['/etc/rc.d/sshd', :onestop], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).to receive(:execute).with(['/etc/rc.d/sshd', :onestop], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
       expect(provider).to receive(:search).with('sshd').and_return('/etc/rc.d/sshd')
       provider.stop
     end

--- a/spec/unit/provider/service/debian_spec.rb
+++ b/spec/unit/provider/service/debian_spec.rb
@@ -87,7 +87,7 @@ describe 'Puppet::Type::Service::Provider::Debian',
 
   context "when checking whether it is enabled" do
     it "should execute the query command" do
-      expect(@provider).to receive(:execute).with(["/usr/sbin/invoke-rc.d", "--quiet", "--query", @resource[:name], "start"], :failonfail => false)
+      expect(@provider).to receive(:execute).with(["/usr/sbin/invoke-rc.d", "--quiet", "--query", @resource[:name], "start"], {:failonfail => false})
                              .and_return(Puppet::Util::Execution::ProcessOutput.new('', 0))
       @provider.enabled?
     end
@@ -104,7 +104,7 @@ describe 'Puppet::Type::Service::Provider::Debian',
 
     it "should consider nonexistent services to be disabled" do
       @provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'doesnotexist'))
-      expect(@provider).to receive(:execute).with(["/usr/sbin/invoke-rc.d", "--quiet", "--query", "doesnotexist", "start"], :failonfail => false)
+      expect(@provider).to receive(:execute).with(["/usr/sbin/invoke-rc.d", "--quiet", "--query", "doesnotexist", "start"], {:failonfail => false})
                              .and_return(Puppet::Util::Execution::ProcessOutput.new("", 1))
       expect(@provider.enabled?).to be(:false)
     end

--- a/spec/unit/provider/service/gentoo_spec.rb
+++ b/spec/unit/provider/service/gentoo_spec.rb
@@ -79,13 +79,13 @@ describe 'Puppet::Type::Service::Provider::Gentoo',
   describe "#start" do
     it "should use the supplied start command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :start => '/bin/foo'))
-      expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).to receive(:execute).with(['/bin/foo'], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
       provider.start
     end
 
     it "should start the service with <initscript> start otherwise" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
-      expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:start], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:start], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
       expect(provider).to receive(:search).with('sshd').and_return('/etc/init.d/sshd')
       provider.start
     end
@@ -94,13 +94,13 @@ describe 'Puppet::Type::Service::Provider::Gentoo',
   describe "#stop" do
     it "should use the supplied stop command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :stop => '/bin/foo'))
-      expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).to receive(:execute).with(['/bin/foo'], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
       provider.stop
     end
 
     it "should stop the service with <initscript> stop otherwise" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
-      expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:stop], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:stop], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
       expect(provider).to receive(:search).with('sshd').and_return('/etc/init.d/sshd')
       provider.stop
     end
@@ -160,27 +160,27 @@ describe 'Puppet::Type::Service::Provider::Gentoo',
     describe "when a special status command is specified" do
       it "should use the status command from the resource" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :status => '/bin/foo'))
-        expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:status], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+        expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:status], {:failonfail => false, :override_locale => false, :squelch => false, :combine => true})
         expect(provider).to receive(:execute)
-          .with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+          .with(['/bin/foo'], {:failonfail => false, :override_locale => false, :squelch => false, :combine => true})
           .and_return(process_output)
         provider.status
       end
 
       it "should return :stopped when the status command returns with a non-zero exitcode" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :status => '/bin/foo'))
-        expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:status], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+        expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:status], {:failonfail => false, :override_locale => false, :squelch => false, :combine => true})
         expect(provider).to receive(:execute)
-          .with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+          .with(['/bin/foo'], {:failonfail => false, :override_locale => false, :squelch => false, :combine => true})
           .and_return(Puppet::Util::Execution::ProcessOutput.new('', 3))
         expect(provider.status).to eq(:stopped)
       end
 
       it "should return :running when the status command returns with a zero exitcode" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :status => '/bin/foo'))
-        expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:status], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+        expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:status], {:failonfail => false, :override_locale => false, :squelch => false, :combine => true})
         expect(provider).to receive(:execute)
-          .with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+          .with(['/bin/foo'], {:failonfail => false, :override_locale => false, :squelch => false, :combine => true})
           .and_return(process_output)
         expect(provider.status).to eq(:running)
       end
@@ -189,14 +189,14 @@ describe 'Puppet::Type::Service::Provider::Gentoo',
     describe "when hasstatus is false" do
       it "should return running if a pid can be found" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasstatus => false))
-        expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:status], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+        expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:status], {:failonfail => false, :override_locale => false, :squelch => false, :combine => true})
         expect(provider).to receive(:getpid).and_return(1000)
         expect(provider.status).to eq(:running)
       end
 
       it "should return stopped if no pid can be found" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasstatus => false))
-        expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:status], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+        expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:status], {:failonfail => false, :override_locale => false, :squelch => false, :combine => true})
         expect(provider).to receive(:getpid).and_return(nil)
         expect(provider.status).to eq(:stopped)
       end
@@ -207,7 +207,7 @@ describe 'Puppet::Type::Service::Provider::Gentoo',
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasstatus => true))
         expect(provider).to receive(:search).with('sshd').and_return('/etc/init.d/sshd')
         expect(provider).to receive(:execute)
-          .with(['/etc/init.d/sshd',:status], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+          .with(['/etc/init.d/sshd',:status], {:failonfail => false, :override_locale => false, :squelch => false, :combine => true})
           .and_return(process_output)
         expect(provider.status).to eq(:running)
       end
@@ -216,7 +216,7 @@ describe 'Puppet::Type::Service::Provider::Gentoo',
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasstatus => true))
         expect(provider).to receive(:search).with('sshd').and_return('/etc/init.d/sshd')
         expect(provider).to receive(:execute)
-          .with(['/etc/init.d/sshd',:status], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+          .with(['/etc/init.d/sshd',:status], {:failonfail => false, :override_locale => false, :squelch => false, :combine => true})
           .and_return(Puppet::Util::Execution::ProcessOutput.new('', 3))
         expect(provider.status).to eq(:stopped)
       end
@@ -226,24 +226,24 @@ describe 'Puppet::Type::Service::Provider::Gentoo',
   describe "#restart" do
     it "should use the supplied restart command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :restart => '/bin/foo'))
-      expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:restart], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
-      expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:restart], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
+      expect(provider).to receive(:execute).with(['/bin/foo'], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
       provider.restart
     end
 
     it "should restart the service with <initscript> restart if hasrestart is true" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasrestart => true))
       expect(provider).to receive(:search).with('sshd').and_return('/etc/init.d/sshd')
-      expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:restart], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:restart], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
       provider.restart
     end
 
     it "should restart the service with <initscript> stop/start if hasrestart is false" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasrestart => false))
       expect(provider).to receive(:search).with('sshd').and_return('/etc/init.d/sshd')
-      expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:restart], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
-      expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:stop], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
-      expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:start], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).not_to receive(:execute).with(['/etc/init.d/sshd',:restart], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
+      expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:stop], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
+      expect(provider).to receive(:execute).with(['/etc/init.d/sshd',:start], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
       provider.restart
     end
   end

--- a/spec/unit/provider/service/openbsd_spec.rb
+++ b/spec/unit/provider/service/openbsd_spec.rb
@@ -28,7 +28,7 @@ describe 'Puppet::Type::Service::Provider::Openbsd',
   context "#start" do
     it "should use the supplied start command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :start => '/bin/foo'))
-      expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).to receive(:execute).with(['/bin/foo'], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
       provider.start
     end
 
@@ -42,7 +42,7 @@ describe 'Puppet::Type::Service::Provider::Openbsd',
   context "#stop" do
     it "should use the supplied stop command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :stop => '/bin/foo'))
-      expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).to receive(:execute).with(['/bin/foo'], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
       provider.stop
     end
 
@@ -56,27 +56,27 @@ describe 'Puppet::Type::Service::Provider::Openbsd',
   context "#status" do
     it "should use the status command from the resource" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :status => '/bin/foo'))
-      expect(provider).not_to receive(:execute).with(['/usr/sbin/rcctl', :get, 'sshd', :status], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).not_to receive(:execute).with(['/usr/sbin/rcctl', :get, 'sshd', :status], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
       expect(provider).to receive(:execute)
-       .with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+       .with(['/bin/foo'], {:failonfail => false, :override_locale => false, :squelch => false, :combine => true})
        .and_return(Puppet::Util::Execution::ProcessOutput.new('', 0))
       provider.status
     end
 
     it "should return :stopped when status command returns with a non-zero exitcode" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :status => '/bin/foo'))
-      expect(provider).not_to receive(:execute).with(['/usr/sbin/rcctl', :get, 'sshd', :status], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).not_to receive(:execute).with(['/usr/sbin/rcctl', :get, 'sshd', :status], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
       expect(provider).to receive(:execute)
-        .with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+        .with(['/bin/foo'], {:failonfail => false, :override_locale => false, :squelch => false, :combine => true})
         .and_return(Puppet::Util::Execution::ProcessOutput.new('', 3))
       expect(provider.status).to eq(:stopped)
     end
 
     it "should return :running when status command returns with a zero exitcode" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :status => '/bin/foo'))
-      expect(provider).not_to receive(:execute).with(['/usr/sbin/rcctl', :get, 'sshd', :status], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).not_to receive(:execute).with(['/usr/sbin/rcctl', :get, 'sshd', :status], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
       expect(provider).to receive(:execute)
-        .with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+        .with(['/bin/foo'], {:failonfail => false, :override_locale => false, :squelch => false, :combine => true})
         .and_return(Puppet::Util::Execution::ProcessOutput.new('', 0))
       expect(provider.status).to eq(:running)
     end
@@ -85,9 +85,9 @@ describe 'Puppet::Type::Service::Provider::Openbsd',
   context "#restart" do
     it "should use the supplied restart command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :restart => '/bin/foo'))
-      expect(provider).not_to receive(:execute).with(['/usr/sbin/rcctl', '-f', :restart, 'sshd'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).not_to receive(:execute).with(['/usr/sbin/rcctl', '-f', :restart, 'sshd'], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
       expect(provider).to receive(:execute)
-        .with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+        .with(['/bin/foo'], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
         .and_return(Puppet::Util::Execution::ProcessOutput.new('', 0))
       provider.restart
     end
@@ -110,13 +110,13 @@ describe 'Puppet::Type::Service::Provider::Openbsd',
   context "#enabled?" do
     it "should return :true if the service is enabled" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
-      expect(provider).to receive(:execute).with(['/usr/sbin/rcctl', 'get', 'sshd', 'status'], :failonfail => false, :combine => false, :squelch => false).and_return(double(:exitstatus => 0))
+      expect(provider).to receive(:execute).with(['/usr/sbin/rcctl', 'get', 'sshd', 'status'], {:failonfail => false, :combine => false, :squelch => false}).and_return(double(:exitstatus => 0))
       expect(provider.enabled?).to eq(:true)
     end
 
     it "should return :false if the service is disabled" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
-      expect(provider).to receive(:execute).with(['/usr/sbin/rcctl', 'get', 'sshd', 'status'], :failonfail => false, :combine => false, :squelch => false).and_return(Puppet::Util::Execution::ProcessOutput.new('NO', 1))
+      expect(provider).to receive(:execute).with(['/usr/sbin/rcctl', 'get', 'sshd', 'status'], {:failonfail => false, :combine => false, :squelch => false}).and_return(Puppet::Util::Execution::ProcessOutput.new('NO', 1))
       expect(provider.enabled?).to eq(:false)
     end
   end
@@ -147,19 +147,19 @@ describe 'Puppet::Type::Service::Provider::Openbsd',
   context "#running?" do
     it "should run rcctl check to check the service" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
-      expect(provider).to receive(:execute).with(['/usr/sbin/rcctl', 'check', 'sshd'], :failonfail => false, :combine => false, :squelch => false).and_return('sshd(ok)')
+      expect(provider).to receive(:execute).with(['/usr/sbin/rcctl', 'check', 'sshd'], {:failonfail => false, :combine => false, :squelch => false}).and_return('sshd(ok)')
       expect(provider.running?).to be_truthy
     end
 
     it "should return true if the service is running" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
-      expect(provider).to receive(:execute).with(['/usr/sbin/rcctl', 'check', 'sshd'], :failonfail => false, :combine => false, :squelch => false).and_return('sshd(ok)')
+      expect(provider).to receive(:execute).with(['/usr/sbin/rcctl', 'check', 'sshd'], {:failonfail => false, :combine => false, :squelch => false}).and_return('sshd(ok)')
       expect(provider.running?).to be_truthy
     end
 
     it "should return nil if the service is not running" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
-      expect(provider).to receive(:execute).with(['/usr/sbin/rcctl', 'check', 'sshd'], :failonfail => false, :combine => false, :squelch => false).and_return('sshd(failed)')
+      expect(provider).to receive(:execute).with(['/usr/sbin/rcctl', 'check', 'sshd'], {:failonfail => false, :combine => false, :squelch => false}).and_return('sshd(failed)')
       expect(provider.running?).to be_nil
     end
   end
@@ -167,19 +167,19 @@ describe 'Puppet::Type::Service::Provider::Openbsd',
   context "#flags" do
     it "should return flags when set" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :flags => '-6'))
-      expect(provider).to receive(:execute).with(['/usr/sbin/rcctl', 'get', 'sshd', 'flags'], :failonfail => false, :combine => false, :squelch => false).and_return('-6')
+      expect(provider).to receive(:execute).with(['/usr/sbin/rcctl', 'get', 'sshd', 'flags'], {:failonfail => false, :combine => false, :squelch => false}).and_return('-6')
       provider.flags
     end
 
     it "should return empty flags" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
-      expect(provider).to receive(:execute).with(['/usr/sbin/rcctl', 'get', 'sshd', 'flags'], :failonfail => false, :combine => false, :squelch => false).and_return('')
+      expect(provider).to receive(:execute).with(['/usr/sbin/rcctl', 'get', 'sshd', 'flags'], {:failonfail => false, :combine => false, :squelch => false}).and_return('')
       provider.flags
     end
 
     it "should return flags for special services" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'pf'))
-      expect(provider).to receive(:execute).with(['/usr/sbin/rcctl', 'get', 'pf', 'flags'], :failonfail => false, :combine => false, :squelch => false).and_return('YES')
+      expect(provider).to receive(:execute).with(['/usr/sbin/rcctl', 'get', 'pf', 'flags'], {:failonfail => false, :combine => false, :squelch => false}).and_return('YES')
       provider.flags
     end
   end

--- a/spec/unit/provider/service/openrc_spec.rb
+++ b/spec/unit/provider/service/openrc_spec.rb
@@ -37,13 +37,13 @@ describe 'Puppet::Type::Service::Provider::Openrc',
   describe "#start" do
     it "should use the supplied start command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :start => '/bin/foo'))
-      expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).to receive(:execute).with(['/bin/foo'], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
       provider.start
     end
 
     it "should start the service with rc-service start otherwise" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
-      expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:start], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:start], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
       provider.start
     end
   end
@@ -51,13 +51,13 @@ describe 'Puppet::Type::Service::Provider::Openrc',
   describe "#stop" do
     it "should use the supplied stop command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :stop => '/bin/foo'))
-      expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).to receive(:execute).with(['/bin/foo'], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
       provider.stop
     end
 
     it "should stop the service with rc-service stop otherwise" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd'))
-      expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:stop], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:stop], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
       provider.stop
     end
   end
@@ -147,25 +147,25 @@ describe 'Puppet::Type::Service::Provider::Openrc',
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :status => '/bin/foo'))
         expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:status], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
         expect(provider).to receive(:execute)
-          .with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+          .with(['/bin/foo'], {:failonfail => false, :override_locale => false, :squelch => false, :combine => true})
           .and_return(Puppet::Util::Execution::ProcessOutput.new('', 0))
         provider.status
       end
 
       it "should return :stopped when status command returns with a non-zero exitcode" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :status => '/bin/foo'))
-        expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:status], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+        expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:status], {:failonfail => false, :override_locale => false, :squelch => false, :combine => true})
         expect(provider).to receive(:execute)
-          .with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+          .with(['/bin/foo'], {:failonfail => false, :override_locale => false, :squelch => false, :combine => true})
           .and_return(Puppet::Util::Execution::ProcessOutput.new('', 3))
         expect(provider.status).to eq(:stopped)
       end
 
       it "should return :running when status command returns with a zero exitcode" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :status => '/bin/foo'))
-        expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:status], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+        expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:status], {:failonfail => false, :override_locale => false, :squelch => false, :combine => true})
         expect(provider).to receive(:execute)
-          .with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+          .with(['/bin/foo'], {:failonfail => false, :override_locale => false, :squelch => false, :combine => true})
           .and_return(Puppet::Util::Execution::ProcessOutput.new('', 0))
         expect(provider.status).to eq(:running)
       end
@@ -174,14 +174,14 @@ describe 'Puppet::Type::Service::Provider::Openrc',
     describe "when hasstatus is false" do
       it "should return running if a pid can be found" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasstatus => false))
-        expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:status], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+        expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:status], {:failonfail => false, :override_locale => false, :squelch => false, :combine => true})
         expect(provider).to receive(:getpid).and_return(1000)
         expect(provider.status).to eq(:running)
       end
 
       it "should return stopped if no pid can be found" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasstatus => false))
-        expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:status], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+        expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:status], {:failonfail => false, :override_locale => false, :squelch => false, :combine => true})
         expect(provider).to receive(:getpid).and_return(nil)
         expect(provider.status).to eq(:stopped)
       end
@@ -191,7 +191,7 @@ describe 'Puppet::Type::Service::Provider::Openrc',
       it "should return running if rc-service status exits with a zero exitcode" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasstatus => true))
         expect(provider).to receive(:execute)
-          .with(['/sbin/rc-service','sshd',:status], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+          .with(['/sbin/rc-service','sshd',:status], {:failonfail => false, :override_locale => false, :squelch => false, :combine => true})
           .and_return(Puppet::Util::Execution::ProcessOutput.new('', 0))
         expect(provider.status).to eq(:running)
       end
@@ -199,7 +199,7 @@ describe 'Puppet::Type::Service::Provider::Openrc',
       it "should return stopped if rc-service status exits with a non-zero exitcode" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasstatus => true))
         expect(provider).to receive(:execute)
-          .with(['/sbin/rc-service','sshd',:status], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+          .with(['/sbin/rc-service','sshd',:status], {:failonfail => false, :override_locale => false, :squelch => false, :combine => true})
           .and_return(Puppet::Util::Execution::ProcessOutput.new('', 3))
         expect(provider.status).to eq(:stopped)
       end
@@ -209,22 +209,22 @@ describe 'Puppet::Type::Service::Provider::Openrc',
   describe "#restart" do
     it "should use the supplied restart command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :restart => '/bin/foo'))
-      expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:restart], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
-      expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:restart], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
+      expect(provider).to receive(:execute).with(['/bin/foo'], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
       provider.restart
     end
 
     it "should restart the service with rc-service restart if hasrestart is true" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasrestart => true))
-      expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:restart], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:restart], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
       provider.restart
     end
 
     it "should restart the service with rc-service stop/start if hasrestart is false" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :hasrestart => false))
-      expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:restart], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
-      expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:stop], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
-      expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:start], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).not_to receive(:execute).with(['/sbin/rc-service','sshd',:restart], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
+      expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:stop], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
+      expect(provider).to receive(:execute).with(['/sbin/rc-service','sshd',:start], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
       provider.restart
     end
   end

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -217,7 +217,7 @@ describe 'Puppet::Type::Service::Provider::Systemd',
     it "should use the supplied start command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service', :start => '/bin/foo'))
       expect(provider).to receive(:daemon_reload?).and_return('no')
-      expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).to receive(:execute).with(['/bin/foo'], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
       provider.start
     end
 
@@ -249,13 +249,13 @@ Jun 14 21:43:23 foo.example.com systemd[1]: sshd.service lacks both ExecStart= a
   describe "#stop" do
     it "should use the supplied stop command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service', :stop => '/bin/foo'))
-      expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).to receive(:execute).with(['/bin/foo'], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
       provider.stop
     end
 
     it "should stop the service with systemctl stop otherwise" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      expect(provider).to receive(:execute).with(['/bin/systemctl','stop', '--', 'sshd.service'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).to receive(:execute).with(['/bin/systemctl','stop', '--', 'sshd.service'], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
       provider.stop
     end
 
@@ -277,13 +277,13 @@ Jun 14 21:43:23 foo.example.com systemd[1]: sshd.service lacks both ExecStart= a
   describe "#daemon_reload?" do
     it "should skip the systemctl daemon_reload if not required by the service" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      expect(provider).to receive(:execute).with(['/bin/systemctl', 'show', '--property=NeedDaemonReload', '--', 'sshd.service'], :failonfail => false).and_return("no")
+      expect(provider).to receive(:execute).with(['/bin/systemctl', 'show', '--property=NeedDaemonReload', '--', 'sshd.service'], {:failonfail => false}).and_return("no")
       provider.daemon_reload?
     end
     it "should run a systemctl daemon_reload if the service has been modified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      expect(provider).to receive(:execute).with(['/bin/systemctl', 'show', '--property=NeedDaemonReload', '--', 'sshd.service'], :failonfail => false).and_return("yes")
-      expect(provider).to receive(:execute).with(['/bin/systemctl', 'daemon-reload'], :failonfail => false)
+      expect(provider).to receive(:execute).with(['/bin/systemctl', 'show', '--property=NeedDaemonReload', '--', 'sshd.service'], {:failonfail => false}).and_return("yes")
+      expect(provider).to receive(:execute).with(['/bin/systemctl', 'daemon-reload'], {:failonfail => false})
       provider.daemon_reload?
     end
   end
@@ -291,51 +291,51 @@ Jun 14 21:43:23 foo.example.com systemd[1]: sshd.service lacks both ExecStart= a
   describe "#enabled?" do
     it "should return :true if the service is enabled" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled', '--', 'sshd.service'], :failonfail => false).
+      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled', '--', 'sshd.service'], {:failonfail => false}).
                             and_return(Puppet::Util::Execution::ProcessOutput.new("enabled\n", 0))
       expect(provider.enabled?).to eq(:true)
     end
 
     it "should return :true if the service is static" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled','--', 'sshd.service'], :failonfail => false).
+      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled','--', 'sshd.service'], {:failonfail => false}).
                             and_return(Puppet::Util::Execution::ProcessOutput.new("static\n", 0))
       expect(provider.enabled?).to eq(:true)
     end
 
     it "should return :false if the service is disabled" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled', '--', 'sshd.service'], :failonfail => false).
+      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled', '--', 'sshd.service'], {:failonfail => false}).
                             and_return(Puppet::Util::Execution::ProcessOutput.new("disabled\n", 1))
       expect(provider.enabled?).to eq(:false)
     end
 
     it "should return :false if the service is indirect" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
-      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled', '--', 'sshd.service'], :failonfail => false).
+      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled', '--', 'sshd.service'], {:failonfail => false}).
                             and_return(Puppet::Util::Execution::ProcessOutput.new("indirect\n", 0))
       expect(provider.enabled?).to eq(:false)
     end
 
     it "should return :false if the service is masked and the resource is attempting to be disabled" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service', :enable => false))
-      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled', '--', 'sshd.service'], :failonfail => false).
+      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled', '--', 'sshd.service'], {:failonfail => false}).
                             and_return(Puppet::Util::Execution::ProcessOutput.new("masked\n", 1))
       expect(provider.enabled?).to eq(:false)
     end
 
     it "should return :mask if the service is masked and the resource is attempting to be masked" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service', :enable => 'mask'))
-      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled', '--', 'sshd.service'], :failonfail => false).
+      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled', '--', 'sshd.service'], {:failonfail => false}).
                             and_return(Puppet::Util::Execution::ProcessOutput.new("masked\n", 1))
       expect(provider.enabled?).to eq(:mask)
     end
 
     it "should consider nonexistent services to be disabled" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'doesnotexist'))
-      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled', '--', 'doesnotexist'], :failonfail => false)
+      expect(provider).to receive(:execute).with(['/bin/systemctl','is-enabled', '--', 'doesnotexist'], {:failonfail => false})
                             .and_return(Puppet::Util::Execution::ProcessOutput.new("", 1))
-      expect(provider).to receive(:execute).with(["/usr/sbin/invoke-rc.d", "--quiet", "--query", "doesnotexist", "start"], :failonfail => false)
+      expect(provider).to receive(:execute).with(["/usr/sbin/invoke-rc.d", "--quiet", "--query", "doesnotexist", "start"], {:failonfail => false})
                             .and_return(Puppet::Util::Execution::ProcessOutput.new("", 1))
 
       expect(provider.enabled?).to be(:false)
@@ -363,7 +363,7 @@ Jun 14 21:43:23 foo.example.com systemd[1]: sshd.service lacks both ExecStart= a
     it "should run systemctl to disable and mask a service" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
       expect(provider).to receive(:execute).
-                            with(['/bin/systemctl','cat', '--', 'sshd.service'], :failonfail => false).
+                            with(['/bin/systemctl','cat', '--', 'sshd.service'], {:failonfail => false}).
                             and_return(Puppet::Util::Execution::ProcessOutput.new("# /lib/systemd/system/sshd.service\n...", 0))
       # :disable is the only call in the provider that uses a symbol instead of
       # a string.
@@ -376,7 +376,7 @@ Jun 14 21:43:23 foo.example.com systemd[1]: sshd.service lacks both ExecStart= a
     it "masks a service that doesn't exist" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'doesnotexist.service'))
       expect(provider).to receive(:execute).
-                            with(['/bin/systemctl','cat', '--', 'doesnotexist.service'], :failonfail => false).
+                            with(['/bin/systemctl','cat', '--', 'doesnotexist.service'], {:failonfail => false}).
                             and_return(Puppet::Util::Execution::ProcessOutput.new("No files found for doesnotexist.service.\n", 1))
       expect(provider).to receive(:systemctl).with(:mask, '--', 'doesnotexist.service')
       provider.mask
@@ -389,7 +389,7 @@ Jun 14 21:43:23 foo.example.com systemd[1]: sshd.service lacks both ExecStart= a
     it "should return running if the command returns 0" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
       expect(provider).to receive(:execute)
-        .with(['/bin/systemctl','is-active', '--', 'sshd.service'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+        .with(['/bin/systemctl','is-active', '--', 'sshd.service'], {:failonfail => false, :override_locale => false, :squelch => false, :combine => true})
         .and_return(Puppet::Util::Execution::ProcessOutput.new("active\n", 0))
       expect(provider.status).to eq(:running)
     end
@@ -398,7 +398,7 @@ Jun 14 21:43:23 foo.example.com systemd[1]: sshd.service lacks both ExecStart= a
       it "should return stopped if the command returns something non-0" do
         provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
         expect(provider).to receive(:execute)
-          .with(['/bin/systemctl','is-active', '--', 'sshd.service'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+          .with(['/bin/systemctl','is-active', '--', 'sshd.service'], {:failonfail => false, :override_locale => false, :squelch => false, :combine => true})
           .and_return(Puppet::Util::Execution::ProcessOutput.new("inactive\n", ec))
         expect(provider.status).to eq(:stopped)
       end
@@ -407,7 +407,7 @@ Jun 14 21:43:23 foo.example.com systemd[1]: sshd.service lacks both ExecStart= a
     it "should use the supplied status command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service', :status => '/bin/foo'))
       expect(provider).to receive(:execute)
-        .with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+        .with(['/bin/foo'], {:failonfail => false, :override_locale => false, :squelch => false, :combine => true})
         .and_return(process_output)
       provider.status
     end
@@ -419,15 +419,15 @@ Jun 14 21:43:23 foo.example.com systemd[1]: sshd.service lacks both ExecStart= a
     it "should use the supplied restart command if specified" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd', :restart => '/bin/foo'))
       expect(provider).to receive(:daemon_reload?).and_return('no')
-      expect(provider).to receive(:execute).with(['/bin/systemctl','restart', '--', 'sshd.service'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true).never
-      expect(provider).to receive(:execute).with(['/bin/foo'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).to receive(:execute).with(['/bin/systemctl','restart', '--', 'sshd.service'], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true}).never
+      expect(provider).to receive(:execute).with(['/bin/foo'], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
       provider.restart
     end
 
     it "should restart the service with systemctl restart" do
       provider = provider_class.new(Puppet::Type.type(:service).new(:name => 'sshd.service'))
       expect(provider).to receive(:daemon_reload?).and_return('no')
-      expect(provider).to receive(:execute).with(['/bin/systemctl','restart','--','sshd.service'], :failonfail => true, :override_locale => false, :squelch => false, :combine => true)
+      expect(provider).to receive(:execute).with(['/bin/systemctl','restart','--','sshd.service'], {:failonfail => true, :override_locale => false, :squelch => false, :combine => true})
       provider.restart
     end
 

--- a/spec/unit/provider/service/upstart_spec.rb
+++ b/spec/unit/provider/service/upstart_spec.rb
@@ -132,7 +132,7 @@ describe 'Puppet::Type::Service::Provider::Upstart',
 
         expect(provider).not_to receive(:status_exec).with(['foo'])
         expect(provider).to receive(:execute)
-          .with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+          .with(['/bin/foo'], {:failonfail => false, :override_locale => false, :squelch => false, :combine => true})
           .and_return(process_output)
         provider.status
       end
@@ -144,7 +144,7 @@ describe 'Puppet::Type::Service::Provider::Upstart',
 
         expect(provider).not_to receive(:status_exec).with(['foo'])
         expect(provider).to receive(:execute)
-          .with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+          .with(['/bin/foo'], {:failonfail => false, :override_locale => false, :squelch => false, :combine => true})
           .and_return(Puppet::Util::Execution::ProcessOutput.new('', 1))
         expect(provider.status).to eq(:stopped)
       end
@@ -156,7 +156,7 @@ describe 'Puppet::Type::Service::Provider::Upstart',
 
         expect(provider).not_to receive(:status_exec).with(['foo'])
         expect(provider).to receive(:execute)
-          .with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+          .with(['/bin/foo'], {:failonfail => false, :override_locale => false, :squelch => false, :combine => true})
           .and_return(process_output)
         expect(provider.status).to eq(:running)
       end
@@ -192,7 +192,7 @@ describe 'Puppet::Type::Service::Provider::Upstart',
 
         expect(provider).not_to receive(:status_exec).with(['foo'])
         expect(provider).to receive(:execute)
-          .with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+          .with(['/bin/foo'], {:failonfail => false, :override_locale => false, :squelch => false, :combine => true})
           .and_return(process_output)
         provider.status
       end
@@ -204,7 +204,7 @@ describe 'Puppet::Type::Service::Provider::Upstart',
 
         expect(provider).not_to receive(:status_exec).with(['foo'])
         expect(provider).to receive(:execute)
-          .with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+          .with(['/bin/foo'], {:failonfail => false, :override_locale => false, :squelch => false, :combine => true})
           .and_return(Puppet::Util::Execution::ProcessOutput.new('', 1))
         expect(provider.status).to eq(:stopped)
       end
@@ -216,7 +216,7 @@ describe 'Puppet::Type::Service::Provider::Upstart',
 
         expect(provider).not_to receive(:status_exec).with(['foo'])
         expect(provider).to receive(:execute)
-          .with(['/bin/foo'], :failonfail => false, :override_locale => false, :squelch => false, :combine => true)
+          .with(['/bin/foo'], {:failonfail => false, :override_locale => false, :squelch => false, :combine => true})
           .and_return(process_output)
         expect(provider.status).to eq(:running)
       end

--- a/spec/unit/provider/user/aix_spec.rb
+++ b/spec/unit/provider/user/aix_spec.rb
@@ -165,7 +165,7 @@ describe 'Puppet::Type::User::Provider::Aix' do
       allow(mock_tempfile_obj).to receive(:path).and_return('tempfile_path')
 
       allow(Tempfile).to receive(:new)
-        .with("puppet_#{provider.name}_pw", :encoding => Encoding::ASCII)
+        .with("puppet_#{provider.name}_pw", {:encoding => Encoding::ASCII})
         .and_return(mock_tempfile_obj)
 
       mock_tempfile_obj

--- a/spec/unit/provider/user/hpux_spec.rb
+++ b/spec/unit/provider/user/hpux_spec.rb
@@ -27,7 +27,7 @@ describe Puppet::Type.type(:user).provider(:hpuxuseradd),
 
   context "managing passwords" do
     let :pwent do
-      Struct::Passwd.new("testuser", "foopassword")
+      Etc::Passwd.new("testuser", "foopassword")
     end
 
     before :each do

--- a/spec/unit/provider/user/openbsd_spec.rb
+++ b/spec/unit/provider/user/openbsd_spec.rb
@@ -22,7 +22,7 @@ describe Puppet::Type.type(:user).provider(:openbsd) do
 
   let(:shadow_entry) {
     return unless Puppet.features.libshadow?
-    entry = Struct::PasswdEntry.new
+    entry = Etc::PasswdEntry.new
     entry[:sp_namp]   = 'myuser' # login name
     entry[:sp_loginclass] = 'staff' # login class
     entry

--- a/spec/unit/provider/user/useradd_spec.rb
+++ b/spec/unit/provider/user/useradd_spec.rb
@@ -29,7 +29,7 @@ describe Puppet::Type.type(:user).provider(:useradd) do
 
   let(:shadow_entry) {
     return unless Puppet.features.libshadow?
-    entry = Struct::PasswdEntry.new
+    entry = Etc::PasswdEntry.new
     entry[:sp_namp]   = 'myuser' # login name
     entry[:sp_pwdp]   = '$6$FvW8Ib8h$qQMI/CR9m.QzIicZKutLpBgCBBdrch1IX0rTnxuI32K1pD9.RXZrmeKQlaC.RzODNuoUtPPIyQDufunvLOQWF0' # encrypted password
     entry[:sp_lstchg] = 15573    # date of last password change

--- a/spec/unit/resource/type_spec.rb
+++ b/spec/unit/resource/type_spec.rb
@@ -521,7 +521,7 @@ describe Puppet::Resource::Type do
       allow(@type).to receive(:code).and_return(code)
 
       subscope = double('subscope', :compiler => @compiler)
-      expect(@scope).to receive(:newscope).with(:source => @type, :resource => @resource).and_return(subscope)
+      expect(@scope).to receive(:newscope).with({:source => @type, :resource => @resource}).and_return(subscope)
 
       expect(subscope).to receive(:with_guarded_scope).and_yield
       expect(subscope).to receive(:ephemeral_from).with(match, nil, nil).and_return(subscope)
@@ -546,7 +546,7 @@ describe Puppet::Resource::Type do
 
     it "should set all of its parameters in a subscope" do
       subscope = double('subscope', :compiler => @compiler)
-      expect(@scope).to receive(:newscope).with(:source => @type, :resource => @resource).and_return(subscope)
+      expect(@scope).to receive(:newscope).with({:source => @type, :resource => @resource}).and_return(subscope)
       expect(@type).to receive(:set_resource_parameters).with(@resource, subscope)
 
       @type.evaluate_code(@resource)

--- a/spec/unit/ssl/base_spec.rb
+++ b/spec/unit/ssl/base_spec.rb
@@ -46,7 +46,7 @@ describe Puppet::SSL::Certificate do
   describe "when initializing wrapped class from a file with #read" do
     it "should open the file with ASCII encoding" do
       path = '/foo/bar/cert'
-      expect(Puppet::FileSystem).to receive(:read).with(path, :encoding => Encoding::ASCII).and_return("bar")
+      expect(Puppet::FileSystem).to receive(:read).with(path, {:encoding => Encoding::ASCII}).and_return("bar")
       @base.read(path)
     end
   end

--- a/spec/unit/ssl/certificate_request_spec.rb
+++ b/spec/unit/ssl/certificate_request_spec.rb
@@ -45,7 +45,7 @@ describe Puppet::SSL::CertificateRequest do
 
     it "should be able to read requests from disk" do
       path = "/my/path"
-      expect(Puppet::FileSystem).to receive(:read).with(path, :encoding => Encoding::ASCII).and_return("my request")
+      expect(Puppet::FileSystem).to receive(:read).with(path, {:encoding => Encoding::ASCII}).and_return("my request")
       my_req = double('request')
       expect(OpenSSL::X509::Request).to receive(:new).with("my request").and_return(my_req)
       expect(request.read(path)).to equal(my_req)

--- a/spec/unit/ssl/certificate_spec.rb
+++ b/spec/unit/ssl/certificate_spec.rb
@@ -156,7 +156,7 @@ describe Puppet::SSL::Certificate do
 
     it "should be able to read certificates from disk" do
       path = "/my/path"
-      expect(Puppet::FileSystem).to receive(:read).with(path, :encoding => Encoding::ASCII).and_return("my certificate")
+      expect(Puppet::FileSystem).to receive(:read).with(path, {:encoding => Encoding::ASCII}).and_return("my certificate")
       certificate = double('certificate')
       expect(OpenSSL::X509::Certificate).to receive(:new).with("my certificate").and_return(certificate)
       expect(@certificate.read(path)).to equal(certificate)

--- a/spec/unit/transaction/event_manager_spec.rb
+++ b/spec/unit/transaction/event_manager_spec.rb
@@ -247,7 +247,7 @@ describe Puppet::Transaction::EventManager do
 
       it "should queue a new noop event generated from the resource" do
         event = Puppet::Transaction::Event.new
-        expect(@resource).to receive(:event).with(:status => "noop", :name => :noop_restart).and_return(event)
+        expect(@resource).to receive(:event).with({:status => "noop", :name => :noop_restart}).and_return(event)
         expect(@manager).to receive(:queue_events).with(@resource, [event])
 
         @manager.process_events(@resource)
@@ -277,7 +277,7 @@ describe Puppet::Transaction::EventManager do
 
       it "should queue a new noop event generated from the resource" do
         event = Puppet::Transaction::Event.new
-        expect(@resource).to receive(:event).with(:status => "noop", :name => :noop_restart).and_return(event)
+        expect(@resource).to receive(:event).with({:status => "noop", :name => :noop_restart}).and_return(event)
         expect(@manager).to receive(:queue_events).with(@resource, [event])
 
         @manager.process_events(@resource)

--- a/spec/unit/type/exec_spec.rb
+++ b/spec/unit/type/exec_spec.rb
@@ -295,7 +295,7 @@ RSpec.describe Puppet::Type.type(:exec) do
 
       it "accepts the current user" do
         allow(Puppet.features).to receive(:root?).and_return(false)
-        allow(Etc).to receive(:getpwuid).and_return(Struct::Passwd.new('input'))
+        allow(Etc).to receive(:getpwuid).and_return(Etc::Passwd.new('input'))
 
         type = Puppet::Type.type(:exec).new(:name => '/bin/true whatever', :user => 'input')
 

--- a/spec/unit/util/backups_spec.rb
+++ b/spec/unit/util/backups_spec.rb
@@ -80,7 +80,7 @@ describe Puppet::Util::Backups do
       end
 
       it "a copy should be created in the local directory" do
-        expect(FileUtils).to receive(:cp_r).with(path, backup, :preserve => true)
+        expect(FileUtils).to receive(:cp_r).with(path, backup, {:preserve => true})
         allow(Puppet::FileSystem).to receive(:exist?).with(path).and_return(true)
 
         expect(file.perform_backup).to be_truthy

--- a/spec/unit/util/filetype_spec.rb
+++ b/spec/unit/util/filetype_spec.rb
@@ -16,7 +16,7 @@ describe Puppet::Util::FileType do
     describe "when the file already exists" do
       it "should return the file's contents when asked to read it" do
         expect(Puppet::FileSystem).to receive(:exist?).with(path).and_return(true)
-        expect(Puppet::FileSystem).to receive(:read).with(path, :encoding => Encoding.default_external).and_return("my text")
+        expect(Puppet::FileSystem).to receive(:read).with(path, {:encoding => Encoding.default_external}).and_return("my text")
 
         expect(file.read).to eq("my text")
       end
@@ -46,7 +46,7 @@ describe Puppet::Util::FileType do
       end
 
       it "should first create a temp file and copy its contents over to the file location" do
-        expect(Tempfile).to receive(:new).with("puppet", :encoding => Encoding.default_external).and_return(tempfile)
+        expect(Tempfile).to receive(:new).with("puppet", {:encoding => Encoding.default_external}).and_return(tempfile)
         expect(tempfile).to receive(:print).with("my text")
         expect(tempfile).to receive(:flush)
         expect(tempfile).to receive(:close)
@@ -163,7 +163,7 @@ describe Puppet::Util::FileType do
         @tmp_cron = Tempfile.new("puppet_crontab_spec")
         @tmp_cron_path = @tmp_cron.path
         allow(Puppet::Util).to receive(:uid).with(uid).and_return(9000)
-        expect(Tempfile).to receive(:new).with("puppet_#{name}", :encoding => Encoding.default_external).and_return(@tmp_cron)
+        expect(Tempfile).to receive(:new).with("puppet_#{name}", {:encoding => Encoding.default_external}).and_return(@tmp_cron)
       end
 
       after :each do

--- a/spec/unit/util/resource_template_spec.rb
+++ b/spec/unit/util/resource_template_spec.rb
@@ -38,7 +38,7 @@ describe Puppet::Util::ResourceTemplate do
     end
 
     it "should create a template instance with the contents of the file" do
-      expect(Puppet::FileSystem).to receive(:read).with("/my/template", :encoding => 'utf-8').and_return("yay")
+      expect(Puppet::FileSystem).to receive(:read).with("/my/template", {:encoding => 'utf-8'}).and_return("yay")
       expect(Puppet::Util).to receive(:create_erb).with("yay").and_return(@template)
 
       allow(@wrapper).to receive(:set_resource_variables)


### PR DESCRIPTION
This eliminates deprecated method calls and constants which are removed in Ruby 3.2. These changes are compatible with Ruby 2.5 and up, so I'm targeting 7.x This will also reduce the chances of merge conflicts between 7.x and main as we move forward.