### PR TITLE
(maint) Update github action branches for main

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -3,9 +3,9 @@ name: Checks
 
 on:
   push:
-    branches: [7.x]
+    branches: [main]
   pull_request:
-    branches: [7.x]
+    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -3,9 +3,9 @@ name: RSpec tests
 
 on:
   push:
-    branches: [7.x]
+    branches: [main]
   pull_request:
-    branches: [7.x]
+    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
The promotion from 7.x overwrote our changes. Revert back to main. This change will ensure the file conflicts in any future merge.