### PR TITLE
(PUP-11634) bump fast_gettext due to removed Object#taint method

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency(%q<facter>, [">= 2.4.0", "< 5"])
   s.add_runtime_dependency(%q<hiera>, [">= 3.2.1", "< 4"])
   s.add_runtime_dependency(%q<semantic_puppet>, "~> 1.0")
-  s.add_runtime_dependency(%q<fast_gettext>, ">= 1.1", "< 3")
+  s.add_runtime_dependency(%q<fast_gettext>, ">= 2.1", "< 3")
   s.add_runtime_dependency(%q<locale>, "~> 2.1")
   s.add_runtime_dependency(%q<multi_json>, "~> 1.13")
   s.add_runtime_dependency(%q<concurrent-ruby>, "~> 1.0")

--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ group(:packaging) do
 end
 
 group(:documentation, optional: true) do
-  gem 'gettext-setup', '~> 0.28', require: false, platforms: [:ruby]
+  gem 'gettext-setup', '~> 1.0', require: false, platforms: [:ruby]
   gem 'ronn', '~> 0.7.3', require: false, platforms: [:ruby]
 end
 


### PR DESCRIPTION
fast_gettext < 2.1 calls Object#taint (removed in Ruby 3.2) which prevented puppet from loading. Bump our runtime dependency for fast_gettext. Also bump gettext-setup to 1.x, as it has a transitive dependency on fast_gettext.