### PR TITLE
(maint) For ruby 2.5, pin to older version of rubygems-update

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Update rubygems and install gems
         run: |
-          gem update --system --no-document
+          gem update --system 3.3.26 --no-document
           bundle config set without packaging documentation
           bundle install --jobs 4 --retry 3
 

--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Update rubygems and install gems
         run: |
-          gem update --system --no-document
+          gem update --system 3.3.26 --no-document
           bundle config set without packaging documentation
           bundle install --jobs 4 --retry 3
 


### PR DESCRIPTION
The latest version of rubygems-update does not support ruby 2.5. This breaks spec testing on the 6.x so we're going to pin to the last supported version of that gem.