### PR TITLE
(PUP-11602) Defaults crl_refresh_interval to 1 day

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1198,12 +1198,13 @@ EOT
       #{AS_DURATION}",
     },
     :crl_refresh_interval => {
+      :default    => "1d",
       :type       => :duration,
       :desc       => "How often the Puppet agent refreshes its local CRL. By
-         default the CRL is only downloaded once, and never refreshed. If a
-         duration is specified, then the agent will refresh its CRL whenever it
-         next runs and the elapsed time since the CRL was last refreshed exceeds
-         the duration.
+         default the CRL is refreshed once every 24 hours. If a different
+         duration is specified, then the agent will refresh its CRL whenever
+         it next runs and the elapsed time since the CRL was last refreshed
+         exceeds the duration.
 
          In general, the duration should be greater than the `runinterval`.
          Setting it to an equal or lesser value will cause the CRL to be

--- a/spec/unit/ssl/state_machine_spec.rb
+++ b/spec/unit/ssl/state_machine_spec.rb
@@ -30,6 +30,7 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
     Puppet[:daemonize] = false
     Puppet[:ssl_lockfile] = tmpfile('ssllock')
     allow(Kernel).to receive(:sleep)
+    allow_any_instance_of(Puppet::X509::CertProvider).to receive(:crl_last_update).and_return(Time.now + (5 * 60))
   end
 
   def expected_digest(name, content)
@@ -524,12 +525,6 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
       state.next_state
 
       expect(File).to_not exist(Puppet[:hostcrl])
-    end
-
-    it 'skips CRL refresh by default' do
-      allow_any_instance_of(Puppet::X509::CertProvider).to receive(:load_crls).and_return(crls)
-
-      state.next_state
     end
 
     it 'skips CRL refresh if it has not expired' do


### PR DESCRIPTION
This commit changes the crl_refresh_interval from defaulting to "never" to 1 day.