### PR TITLE
(maint) Require vcr 6.1 - 6.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ group(:test) do
   gem "rspec", "~> 3.1", require: false
   gem "rspec-expectations", ["~> 3.9", "!= 3.9.3"]
   gem "rspec-its", "~> 1.1", require: false
-  gem 'vcr', '~> 5.0', require: false
+  gem 'vcr', RUBY_VERSION.to_f >= 3.2 ? '~> 6.1' : '~> 5.0', require: false
   gem 'webmock', '~> 3.0', require: false
   gem 'webrick', '~> 1.7', require: false if RUBY_VERSION.to_f >= 3.0
   gem 'yard', require: false


### PR DESCRIPTION
Specs generated a warning due to an issue with vcr < 6.1 on Ruby 3.1+. See https://github.com/vcr/vcr/commit/98cc00b57369dfd671c227be6aa3f03d7475cb6c

```
/usr/local/bin/bundle: warning: Exception in finalizer #<Proc:0x00007f8c2990fbe8 /usr/local/lib/ruby/gems/3.2.0/gems/vcr-5.1.0/lib/vcr/library_hooks/webmock.rb:36 (lambda)>
/usr/local/lib/ruby/gems/3.2.0/gems/vcr-5.1.0/lib/vcr/library_hooks/webmock.rb:36:in `block in global_hook_disabled_requests': wrong number of arguments (given 1, expected 0) (ArgumentError)
```