### PR TITLE
(PUP-11684) Default to exclude unchanged resources

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1452,7 +1452,7 @@ EOT
         To turn off reports entirely, set this to `none`",
     },
     :exclude_unchanged_resources => {
-      :default => false,
+      :default => true,
       :type => :boolean,
       :desc => 'When set to true, resources that have had no changes after catalog application
         will not have corresponding unchanged resource status updates listed in the report.'


### PR DESCRIPTION
In PUP-11654, we gave the option to exclude unchanged resources from reports.

In this commit, we make that option the default behavior.