### PR TITLE
(maint) Updates OpenSSL errors in spec

### DIFF
--- a/spec/integration/application/apply_spec.rb
+++ b/spec/integration/application/apply_spec.rb
@@ -629,7 +629,7 @@ class amod::bad_type {
           apply.run
         }.to exit_with(0)
          .and output(/Applied catalog/).to_stdout
-         .and output(/Report processor failed: certificate verify failed \[self signed certificate in certificate chain for CN=Unknown CA\]/).to_stderr
+         .and output(/Report processor failed: certificate verify failed \[self.signed certificate in certificate chain for CN=Unknown CA\]/).to_stderr
       end
     end
 

--- a/spec/integration/http/client_spec.rb
+++ b/spec/integration/http/client_spec.rb
@@ -53,7 +53,7 @@ describe Puppet::HTTP::Client, unless: Puppet::Util::Platform.jruby? do
         expect {
           client.get(URI("https://127.0.0.1:#{port}"), options: {ssl_context: alt_context})
         }.to raise_error(Puppet::SSL::CertVerifyError,
-                         %r{certificate verify failed.* .self signed certificate in certificate chain for CN=Test CA.})
+                         %r{certificate verify failed.* .self.signed certificate in certificate chain for CN=Test CA.})
       end
     end
 
@@ -170,7 +170,7 @@ describe Puppet::HTTP::Client, unless: Puppet::Util::Platform.jruby? do
         expect {
           client.get(URI("https://127.0.0.1:#{port}"), options: {ssl_context: system_context})
         }.to raise_error(Puppet::SSL::CertVerifyError,
-                         %r{certificate verify failed.* .self signed certificate in certificate chain for CN=Test CA.})
+                         %r{certificate verify failed.* .self.signed certificate in certificate chain for CN=Test CA.})
       end
     end
   end

--- a/spec/integration/network/http_pool_spec.rb
+++ b/spec/integration/network/http_pool_spec.rb
@@ -77,7 +77,7 @@ describe Puppet::Network::HttpPool, unless: Puppet::Util::Platform.jruby? do
           expect {
             http.get('/')
           }.to raise_error(Puppet::Error,
-                           %r{certificate verify failed.* .self signed certificate in certificate chain for CN=Test CA.})
+                           %r{certificate verify failed.* .self.signed certificate in certificate chain for CN=Test CA.})
         end
       end
 
@@ -219,7 +219,7 @@ describe Puppet::Network::HttpPool, unless: Puppet::Util::Platform.jruby? do
         expect {
           http.get('/')
         }.to raise_error(Puppet::Error,
-                         %r{certificate verify failed.* .self signed certificate in certificate chain for CN=Test CA.})
+                         %r{certificate verify failed.* .self.signed certificate in certificate chain for CN=Test CA.})
       end
     end
 


### PR DESCRIPTION
Between OpenSSL 1.1 and 3, errors about self-signed certificates changed from "self signed" (no hyphen) to "self-signed" (with a hyphen). This change caused regex for these errors in our spec tests to fail.

This commit relaxes the regex so it matches both OpenSSL 1.1 and 3 errors.