### PR TITLE
(PUP-11526) Evaluate deferred functions lazily by default

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -2037,7 +2037,7 @@ EOT
         what is being done.",
     },
     :preprocess_deferred => {
-      :default => true,
+      :default => false,
       :type => :boolean,
       :desc => "Whether puppet should call deferred functions before applying
         the catalog. If set to `true`, then all prerequisites needed for the

--- a/spec/integration/application/agent_spec.rb
+++ b/spec/integration/application/agent_spec.rb
@@ -155,6 +155,8 @@ describe "puppet agent", unless: Puppet::Util::Platform.jruby? do
     end
 
     it "fails to apply a deferred function with an unsatified prerequisite" do
+      Puppet[:preprocess_deferred] = true
+
       catalog_handler = -> (req, res) {
         catalog = compile_to_catalog(deferred_manifest, node)
         res.body = formatter.render(catalog)
@@ -173,8 +175,6 @@ describe "puppet agent", unless: Puppet::Util::Platform.jruby? do
     end
 
     it "applies a deferred function and its prerequisite in the same run" do
-      Puppet[:preprocess_deferred] = false
-
       catalog_handler = -> (req, res) {
         catalog = compile_to_catalog(deferred_manifest, node)
         res.body = formatter.render(catalog)

--- a/spec/integration/application/apply_spec.rb
+++ b/spec/integration/application/apply_spec.rb
@@ -695,6 +695,8 @@ class amod::bad_type {
     end
 
     it "fails to apply a deferred function with an unsatified prerequisite" do
+      Puppet[:preprocess_deferred] = true
+
       apply.command_line.args = ['-e', deferred_manifest]
       expect {
         apply.run
@@ -704,8 +706,6 @@ class amod::bad_type {
     end
 
     it "applies a deferred function and its prerequisite in the same run" do
-      Puppet[:preprocess_deferred] = false
-
       apply.command_line.args = ['-e', deferred_manifest]
       expect {
         apply.run
@@ -714,6 +714,7 @@ class amod::bad_type {
     end
 
     it "validates the deferred resource before applying any resources" do
+      Puppet[:preprocess_deferred] = true
       undeferred_file = tmpfile('undeferred')
 
       manifest = <<~END
@@ -738,8 +739,6 @@ class amod::bad_type {
     end
 
     it "evaluates resources before validating the deferred resource" do
-      Puppet[:preprocess_deferred] = false
-
       manifest = <<~END
         notify { 'runs before file': } ->
         file { '#{deferred_file}':


### PR DESCRIPTION
This commit changes the default value of preprocess_deferred setting from true to false. This change will ensure deferred functions are not preprocessed by default and are instead evaluated during catalog application. Additionally, some tests were updated to accommodate this change.

This work is a follow up to [PUP-9323](https://tickets.puppetlabs.com/browse/PUP-9323).