### PR TITLE
(PUP-11649) Remove Ruby support for less then 2.7

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -16,9 +16,9 @@ jobs:
     strategy:
       matrix:
         cfg:
-          - {check: rubocop, os: ubuntu-latest, ruby: 2.5}
-          - {check: commits, os: ubuntu-latest, ruby: 2.5}
-          - {check: warnings, os: ubuntu-latest, ruby: 2.5}
+          - {check: rubocop, os: ubuntu-latest, ruby: 2.7}
+          - {check: commits, os: ubuntu-latest, ruby: 2.7}
+          - {check: warnings, os: ubuntu-latest, ruby: 2.7}
 
     runs-on: ${{ matrix.cfg.os }}
     steps:

--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -16,15 +16,11 @@ jobs:
     strategy:
       matrix:
         cfg:
-          - {os: ubuntu-latest, ruby: '2.5'}
-          - {os: ubuntu-latest, ruby: '2.6'}
           - {os: ubuntu-latest, ruby: '2.7'}
           - {os: ubuntu-latest, ruby: '3.0'}
           # Using ubuntu 20.04 to OpenSSL 1.1.1
           - {os: ubuntu-20.04, ruby: '3.2'}
           - {os: ubuntu-latest, ruby: 'jruby-9.2.21.0'}
-          - {os: windows-2019, ruby: '2.5'}
-          - {os: windows-2019, ruby: '2.6'}
           - {os: windows-2019, ruby: '2.7'}
           - {os: windows-2019, ruby: '3.0'}
 

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -15,7 +15,7 @@ gem_executables: 'puppet'
 gem_default_executables: 'puppet'
 gem_license: 'Apache-2.0'
 gem_forge_project: 'puppet'
-gem_required_ruby_version: '>= 2.5.0'
+gem_required_ruby_version: '>= 2.7.0'
 gem_required_rubygems_version: '> 1.3.1'
 gem_runtime_dependencies:
   facter: ['> 2.0.1', '< 5']

--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -1,11 +1,11 @@
 require_relative 'puppet/version'
 require_relative 'puppet/concurrent/synchronized'
 
-if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.5.0")
-  raise LoadError, "Puppet #{Puppet.version} requires Ruby 2.5.0 or greater, found Ruby #{RUBY_VERSION.dup}."
+if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.7.0")
+  raise LoadError, "Puppet #{Puppet.version} requires Ruby 2.7.0 or greater, found Ruby #{RUBY_VERSION.dup}."
 end
 
-Puppet::OLDEST_RECOMMENDED_RUBY_VERSION = '2.5.0'
+Puppet::OLDEST_RECOMMENDED_RUBY_VERSION = '2.7.0'
 
 $LOAD_PATH.extend(Puppet::Concurrent::Synchronized)
 


### PR DESCRIPTION
This PR removes the older version of Ruby that are no longer supported. We also remove the pinning of bundler since we are not on Ruby 2.5 anymore.