### PR TITLE
(PUP-11699) Run tests against Ruby 3.2 and OpenSSL 3

### DIFF
--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -20,8 +20,8 @@ jobs:
           - {os: ubuntu-latest, ruby: '2.6'}
           - {os: ubuntu-latest, ruby: '2.7'}
           - {os: ubuntu-latest, ruby: '3.0'}
-          # Using ubuntu 20.04 to OpenSSL 1.1.1
-          - {os: ubuntu-20.04, ruby: '3.2'}
+          - {os: ubuntu-20.04, ruby: '3.2'} # openssl 1.1.1
+          - {os: ubuntu-22.04, ruby: '3.2'} # openssl 3
           - {os: ubuntu-latest, ruby: 'jruby-9.2.21.0'}
           - {os: windows-2019, ruby: '2.5'}
           - {os: windows-2019, ruby: '2.6'}

--- a/lib/puppet/ssl/certificate_request.rb
+++ b/lib/puppet/ssl/certificate_request.rb
@@ -68,10 +68,7 @@ class Puppet::SSL::CertificateRequest < Puppet::SSL::Base
     csr.public_key = if key.is_a?(OpenSSL::PKey::EC)
                        # EC#public_key doesn't follow the PKey API,
                        # see https://github.com/ruby/openssl/issues/29
-                       point = key.public_key
-                       pubkey = OpenSSL::PKey::EC.new(point.group)
-                       pubkey.public_key = point
-                       pubkey
+                       key
                      else
                        key.public_key
                      end

--- a/spec/unit/ssl/certificate_request_spec.rb
+++ b/spec/unit/ssl/certificate_request_spec.rb
@@ -198,7 +198,7 @@ describe Puppet::SSL::CertificateRequest do
 
         expect do
           request.generate(key, :csr_attributes => csr_attributes)
-        end.to raise_error Puppet::Error, /Cannot create CSR with attribute thats\.no\.moon: first num too large/
+        end.to raise_error Puppet::Error, /Cannot create CSR with attribute thats\.no\.moon: /
       end
 
       it "should support old non-DER encoded extensions" do
@@ -271,7 +271,7 @@ describe Puppet::SSL::CertificateRequest do
         exts = {"thats.no.moon" => "death star"}
         expect do
           request.generate(key, :extension_requests => exts)
-        end.to raise_error Puppet::Error, /Cannot create CSR with extension request thats\.no\.moon.*: first num too large/
+        end.to raise_error Puppet::Error, /Cannot create CSR with extension request thats\.no\.moon.*: /
       end
     end
 
@@ -313,6 +313,7 @@ describe Puppet::SSL::CertificateRequest do
 
     it "should use SHA1 to sign the csr when SHA256 isn't available" do
       csr = OpenSSL::X509::Request.new
+      csr.public_key = key.public_key
       expect(OpenSSL::Digest).to receive(:const_defined?).with("SHA256").and_return(false)
       expect(OpenSSL::Digest).to receive(:const_defined?).with("SHA1").and_return(true)
       signer = Puppet::SSL::CertificateSigner.new
@@ -323,6 +324,7 @@ describe Puppet::SSL::CertificateRequest do
     it "should use SHA512 to sign the csr when SHA256 and SHA1 aren't available" do
       key = OpenSSL::PKey::RSA.new(2048)
       csr = OpenSSL::X509::Request.new
+      csr.public_key = key.public_key
       expect(OpenSSL::Digest).to receive(:const_defined?).with("SHA256").and_return(false)
       expect(OpenSSL::Digest).to receive(:const_defined?).with("SHA1").and_return(false)
       expect(OpenSSL::Digest).to receive(:const_defined?).with("SHA512").and_return(true)
@@ -334,6 +336,7 @@ describe Puppet::SSL::CertificateRequest do
     it "should use SHA384 to sign the csr when SHA256/SHA1/SHA512 aren't available" do
       key = OpenSSL::PKey::RSA.new(2048)
       csr = OpenSSL::X509::Request.new
+      csr.public_key = key.public_key
       expect(OpenSSL::Digest).to receive(:const_defined?).with("SHA256").and_return(false)
       expect(OpenSSL::Digest).to receive(:const_defined?).with("SHA1").and_return(false)
       expect(OpenSSL::Digest).to receive(:const_defined?).with("SHA512").and_return(false)
@@ -345,6 +348,7 @@ describe Puppet::SSL::CertificateRequest do
 
     it "should use SHA224 to sign the csr when SHA256/SHA1/SHA512/SHA384 aren't available" do
       csr = OpenSSL::X509::Request.new
+      csr.public_key = key.public_key
       expect(OpenSSL::Digest).to receive(:const_defined?).with("SHA256").and_return(false)
       expect(OpenSSL::Digest).to receive(:const_defined?).with("SHA1").and_return(false)
       expect(OpenSSL::Digest).to receive(:const_defined?).with("SHA512").and_return(false)

--- a/spec/unit/x509/cert_provider_spec.rb
+++ b/spec/unit/x509/cert_provider_spec.rb
@@ -280,7 +280,7 @@ describe Puppet::X509::CertProvider do
           # password is 74695716c8b6
           expect {
             provider.load_private_key('encrypted-key')
-          }.to raise_error(OpenSSL::PKey::PKeyError, /Could not parse PKey: no start line/)
+          }.to raise_error(OpenSSL::PKey::PKeyError, /Could not parse PKey: (no start line|bad decrypt)/)
         end
 
         it 'decrypts an RSA key previously saved using 3DES' do
@@ -315,7 +315,7 @@ describe Puppet::X509::CertProvider do
           # password is 74695716c8b6
           expect {
             provider.load_private_key('encrypted-ec-key')
-          }.to raise_error(OpenSSL::PKey::PKeyError, /(unknown|invalid) curve name|Could not parse PKey: no start line/)
+          }.to raise_error(OpenSSL::PKey::PKeyError, /(unknown|invalid) curve name|Could not parse PKey: (no start line|bad decrypt)/)
         end
       end
     end


### PR DESCRIPTION
* Update tests to work with openssl 3 native library
* Update code to work with ruby-openssl 3 bindings
* Add ubuntu 22.04, ruby 3.2. 0 and openssl 3 to CI