### PR TITLE
(PUP-11713) Update beaker tests to use structured facts

### DIFF
--- a/acceptance/tests/catalog_with_binary_data.rb
+++ b/acceptance/tests/catalog_with_binary_data.rb
@@ -42,7 +42,7 @@ test_name "C100300: Catalog containing binary data is applied correctly" do
     manifest = <<-MANIFEST
       class #{test_num}(
       ) {
-        \$test_path = \$::fqdn ? #{agent_tmp_dirs}
+        \$test_path = \$facts['networking']['fqdn'] ? #{agent_tmp_dirs}
         file { '#{test_num}':
           path   => "\$test_path/#{test_num}",
           content => file('#{test_num}/binary_data'),

--- a/acceptance/tests/direct_puppet/supports_utf8.rb
+++ b/acceptance/tests/direct_puppet/supports_utf8.rb
@@ -41,7 +41,7 @@ test_name "C97172: static catalogs support utf8" do
 file { '#{environmentpath}/#{tmp_environment}/manifests/site.pp':
   ensure => file,
   content => '
-\$test_path = \$::fqdn ? #{tmp_file}
+\$test_path = \$facts["networking"]["fqdn"] ? #{tmp_file}
 file { \$test_path:
   content => @(UTF8)
     #{file_contents}

--- a/acceptance/tests/parser_functions/hiera_in_templates.rb
+++ b/acceptance/tests/parser_functions/hiera_in_templates.rb
@@ -100,7 +100,7 @@ node default {
   \\$msgs = hiera_array('message')
   notify {\\$msgs:}
   class {'#{@module_name}':
-    result_dir => hiera('result_dir')[\\$::hostname],
+    result_dir => hiera('result_dir')[\\$facts['networking']['hostname']],
   }
 }
 ",
@@ -119,7 +119,7 @@ file {"#{@coderoot}/hiera.yaml":
 :hierarchy:
   - \\"%{clientcert}\\"
   - \\"%{environment}\\"
-  - \\"%{osfamily}\\"
+  - \\"%{os.family}\\"
   - \\"default\\"
 "
 }
@@ -188,7 +188,7 @@ class #{@module_name} (
 file { "#{moduledir}/manifests/mod_default.pp":
   content => "
 class #{@module_name}::mod_default {
-  \\$result_dir = hiera('result_dir')[\\$::hostname]
+  \\$result_dir = hiera('result_dir')[\\$facts['networking']['hostname']]
   notify{\\"module mod_default invoked.\\\\n\\":}
   file {\\\"\\\${result_dir}/mod_default\\\":
     ensure  => 'file',
@@ -202,7 +202,7 @@ class #{@module_name}::mod_default {
 file { "#{moduledir}/manifests/mod_osfamily.pp":
   content => "
 class #{@module_name}::mod_osfamily {
-  \\$result_dir = hiera('result_dir')[\\$::hostname]
+  \\$result_dir = hiera('result_dir')[\\$facts['networking']['hostname']]
   notify{\\"module mod_osfamily invoked.\\\\n\\":}
   file {\\\"\\\${result_dir}/mod_osfamily\\\":
     ensure  => 'file',
@@ -216,7 +216,7 @@ class #{@module_name}::mod_osfamily {
 file { "#{moduledir}/manifests/mod_production.pp":
   content => "
 class #{@module_name}::mod_production {
-  \\$result_dir = hiera('result_dir')[\\$::hostname]
+  \\$result_dir = hiera('result_dir')[\\$facts['networking']['hostname']]
   notify{\\"module mod_production invoked.\\\\n\\":}
   file {\\\"\\\${result_dir}/mod_production\\\":
     ensure  => 'file',
@@ -230,7 +230,7 @@ class #{@module_name}::mod_production {
 file { "#{moduledir}/manifests/mod_fqdn.pp":
   content => "
 class #{@module_name}::mod_fqdn {
-  \\$result_dir = hiera('result_dir')[\\$::hostname]
+  \\$result_dir = hiera('result_dir')[\\$facts['networking']['hostname']]
   notify{\\"module mod_fqdn invoked.\\\\n\\":}
   file {\\\"\\\${result_dir}/mod_fqdn\\\":
     ensure  => 'file',
@@ -271,7 +271,7 @@ end
 def find_osfamilies
   family_hash = {}
   agents.each do |agent|
-    res = on(agent, facter("osfamily"))
+    res = on(agent, facter("os.family"))
     osf = res.stdout.chomp
     family_hash[osf] = 1
   end
@@ -282,7 +282,7 @@ def find_tmp_dirs
   tmp_dirs = ""
   host_to_result_dir = {}
   agents.each do |agent|
-    h = on(agent, facter("hostname")).stdout.chomp
+    h = on(agent, facter("networking.hostname")).stdout.chomp
     t = agent.tmpdir("#{@module_name}_results")
     tmp_dirs += "  #{h}: '#{t}'\n"
     host_to_result_dir[h] = t
@@ -304,7 +304,7 @@ with_puppet_running_on master, @master_opts, @coderoot do
   env_manifest = create_environment(find_osfamilies, tmp_dirs)
   apply_manifest_on(master, env_manifest, :catch_failures => true)
   agents.each do |agent|
-    resultdir = host_to_result_dir[on(agent, facter("hostname")).stdout.chomp]
+    resultdir = host_to_result_dir[on(agent, facter("networking.hostname")).stdout.chomp]
     step "Applying catalog to agent: #{agent}. result files in #{resultdir}"
     on(
       agent,

--- a/acceptance/tests/reports/corrective_change_new_resource.rb
+++ b/acceptance/tests/reports/corrective_change_new_resource.rb
@@ -41,7 +41,7 @@ test_name "C98092 - a new resource should not be reported as a corrective change
     file { '#{environmentpath}/#{tmp_environment}/manifests/site.pp':
       ensure => file,
       content => '
-    \$test_path = \$::fqdn ? #{tmp_file}
+    \$test_path = \$facts["networking"]["fqdn"] ? #{tmp_file}
     file { \$test_path:
       content => @(UTF8)
         #{file_contents}

--- a/acceptance/tests/reports/corrective_change_outside_puppet.rb
+++ b/acceptance/tests/reports/corrective_change_outside_puppet.rb
@@ -41,7 +41,7 @@ test_name "C98093 - a resource changed outside of Puppet will be reported as a c
       file { '#{environmentpath}/#{tmp_environment}/manifests/site.pp':
         ensure => file,
         content => '
-      \$test_path = \$::fqdn ? #{tmp_file}
+      \$test_path = \$facts["networking"]["fqdn"] ? #{tmp_file}
       file { \$test_path:
         content => @(UTF8)
           #{file_contents}

--- a/acceptance/tests/reports/corrective_change_via_puppet.rb
+++ b/acceptance/tests/reports/corrective_change_via_puppet.rb
@@ -46,7 +46,7 @@ test_name "C98094 - a resource changed via Puppet manifest will not be reported 
       file { '#{environmentpath}/#{environment_name}/manifests/site.pp':
         ensure => file,
         content => '
-      \$test_path = \$::fqdn ? #{file_resource}
+      \$test_path = \$facts["networking"]["fqdn"] ? #{file_resource}
       file { \$test_path:
         content => @(UTF8)
           #{file_contents}

--- a/acceptance/tests/resource/file/ticket_6448_file_with_utf8_source.rb
+++ b/acceptance/tests/resource/file/ticket_6448_file_with_utf8_source.rb
@@ -54,7 +54,7 @@ test_name 'Ensure a file resource can have a UTF-8 source attribute, content, an
 
   step 'create a site.pp on master containing a unicode file resource' do
     site_pp_contents = <<-SITE_PP
-      \$test_path = \$::fqdn ? #{agent_tmp_dirs}
+      \$test_path = \$facts['networking']['fqdn'] ? #{agent_tmp_dirs}
       file { "\$test_path/\uff72\uff67\u30d5\u30eb":
         ensure => present,
         source => "puppet:///modules/utf8_file_module/\u9759\u7684",


### PR DESCRIPTION
Update manifests and hiera config to use structure facts.

Passed on base linux: https://jenkins-platform.delivery.puppetlabs.net/job/platform_puppet-agent-extra_puppet-agent-integration-suite_pr/2405/