### PR TITLE
(PUP-11649) Drop MRI < 2.7

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.version = mdata ? mdata[1] : version
 
   s.required_rubygems_version = Gem::Requirement.new("> 1.3.1")
+  # Bump this in PUP-11716
   s.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
   s.authors = ["Puppet Labs"]
   s.date = "2012-08-17"

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -16,9 +16,9 @@ jobs:
     strategy:
       matrix:
         cfg:
-          - {check: rubocop, os: ubuntu-latest, ruby: 2.5}
-          - {check: commits, os: ubuntu-latest, ruby: 2.5}
-          - {check: warnings, os: ubuntu-latest, ruby: 2.5}
+          - {check: rubocop, os: ubuntu-latest, ruby: 2.7}
+          - {check: commits, os: ubuntu-latest, ruby: 2.7}
+          - {check: warnings, os: ubuntu-latest, ruby: 2.7}
 
     runs-on: ${{ matrix.cfg.os }}
     steps:

--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -16,15 +16,11 @@ jobs:
     strategy:
       matrix:
         cfg:
-          - {os: ubuntu-latest, ruby: '2.5'}
-          - {os: ubuntu-latest, ruby: '2.6'}
           - {os: ubuntu-latest, ruby: '2.7'}
           - {os: ubuntu-latest, ruby: '3.0'}
           # Using ubuntu 20.04 to OpenSSL 1.1.1
           - {os: ubuntu-20.04, ruby: '3.2'}
           - {os: ubuntu-latest, ruby: 'jruby-9.2.21.0'}
-          - {os: windows-2019, ruby: '2.5'}
-          - {os: windows-2019, ruby: '2.6'}
           - {os: windows-2019, ruby: '2.7'}
           - {os: windows-2019, ruby: '3.0'}
 

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -15,7 +15,7 @@ gem_executables: 'puppet'
 gem_default_executables: 'puppet'
 gem_license: 'Apache-2.0'
 gem_forge_project: 'puppet'
-gem_required_ruby_version: '>= 2.5.0'
+gem_required_ruby_version: '>= 2.7.0'
 gem_required_rubygems_version: '> 1.3.1'
 gem_runtime_dependencies:
   facter: ['> 2.0.1', '< 5']

--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -1,11 +1,12 @@
 require_relative 'puppet/version'
 require_relative 'puppet/concurrent/synchronized'
 
-if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.5.0")
-  raise LoadError, "Puppet #{Puppet.version} requires Ruby 2.5.0 or greater, found Ruby #{RUBY_VERSION.dup}."
+# Update JRuby version constraints in PUP-11716
+if !defined?(JRUBY_VERSION) && Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.7.0")
+  raise LoadError, "Puppet #{Puppet.version} requires Ruby 2.7.0 or greater, found Ruby #{RUBY_VERSION.dup}."
 end
 
-Puppet::OLDEST_RECOMMENDED_RUBY_VERSION = '2.5.0'
+Puppet::OLDEST_RECOMMENDED_RUBY_VERSION = '2.7.0'
 
 $LOAD_PATH.extend(Puppet::Concurrent::Synchronized)
 
@@ -130,6 +131,7 @@ module Puppet
 
   # Now that settings are loaded we have the code loaded to be able to issue
   # deprecation warnings. Warn if we're on a deprecated ruby version.
+  # Update JRuby version constraints in PUP-11716
   if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new(Puppet::OLDEST_RECOMMENDED_RUBY_VERSION)
     Puppet.deprecation_warning(_("Support for ruby version %{version} is deprecated and will be removed in a future release. See https://puppet.com/docs/puppet/latest/system_requirements.html for a list of supported ruby versions.") % { version: RUBY_VERSION })
   end


### PR DESCRIPTION
We still have to support JRuby 9.2, which implements the MRI 2.5.x language feature set. See 065e2ef1544c7c38095a46afb147107703a528f7 for details.