### PR TITLE
(PUP-11717) Protect against facter returning a Hash subclass

### DIFF
--- a/lib/puppet/indirector/facts/facter.rb
+++ b/lib/puppet/indirector/facts/facter.rb
@@ -40,7 +40,10 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
                Puppet::Node::Facts.new(request.key, Puppet.runtime[:facter].to_hash)
              else
                # resolve does not return legacy facts unless requested
-               Puppet::Node::Facts.new(request.key, Puppet.runtime[:facter].resolve(''))
+               facts = Puppet.runtime[:facter].resolve('')
+               # some versions of Facter 4 return a Facter::FactCollection instead of
+               # a Hash, breaking API compatibility, so force a hash using `to_h`
+               Puppet::Node::Facts.new(request.key, facts.to_h)
              end
 
     result.add_local_facts unless request.options[:resolve_options]


### PR DESCRIPTION
Facter.resolve v4 returns a Facter::FactCollection Hash subclass unlilke Facter v3. This causes functions like `dig` to fail, since the function only accepts a Collection type, not a Runtime type:

    dig($facts, "ruby", "version")

Protect against this by calling `to_h`. If the object is a Hash, it will return `self`. If the object is derived from Hash, it will return a new Hash containing the contents of the object.