### PR TITLE
(maint) Merge 7.x to main

### DIFF
--- a/lib/puppet/indirector/facts/facter.rb
+++ b/lib/puppet/indirector/facts/facter.rb
@@ -40,7 +40,10 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
                Puppet::Node::Facts.new(request.key, Puppet.runtime[:facter].to_hash)
              else
                # resolve does not return legacy facts unless requested
-               Puppet::Node::Facts.new(request.key, Puppet.runtime[:facter].resolve(''))
+               facts = Puppet.runtime[:facter].resolve('')
+               # some versions of Facter 4 return a Facter::FactCollection instead of
+               # a Hash, breaking API compatibility, so force a hash using `to_h`
+               Puppet::Node::Facts.new(request.key, facts.to_h)
              end
 
     result.add_local_facts unless request.options[:resolve_options]

--- a/spec/integration/node/facts_spec.rb
+++ b/spec/integration/node/facts_spec.rb
@@ -30,9 +30,9 @@ describe Puppet::Node::Facts do
     it "should be able to delegate to the :facter terminus" do
       allow(Puppet::Node::Facts.indirection).to receive(:terminus_class).and_return(:facter)
 
-      expect(Facter).to receive(:resolve).and_return("facter_hash")
+      expect(Facter).to receive(:resolve).and_return({1 => 2})
       facts = Puppet::Node::Facts.new("me")
-      expect(Puppet::Node::Facts).to receive(:new).with("me", "facter_hash").and_return(facts)
+      expect(Puppet::Node::Facts).to receive(:new).with("me", {1 => 2}).and_return(facts)
 
       expect(Puppet::Node::Facts.indirection.find("me")).to equal(facts)
     end


### PR DESCRIPTION
Manually merging up due to CI issues.

The test failed in main, because we changed the default for `ignore_legacy_facts` (so `Facter.resolve` is called, not `Facter.to_hash`)