### PR TITLE
(maint) Handle case where agent and server are on the same host

### DIFF
--- a/acceptance/tests/agent/agent_fails_with_unknown_resource.rb
+++ b/acceptance/tests/agent/agent_fails_with_unknown_resource.rb
@@ -68,7 +68,9 @@ test_name "agent run should fail if it finds an unknown resource type" do
           agent.rm_rf(vendor_modules_path)
         end
 
-        on(agent, puppet('agent', '-t', '--environment', tmp_environment), acceptable_exit_codes: [1]) do |result|  
+        # override vendormoduledir in case agent and server are on the same host
+        agent_dir = get_test_file_path(agent, 'vendormodulepath')
+        on(agent, puppet('agent', '-t', '--environment', tmp_environment, '--vendormoduledir', agent_dir), acceptable_exit_codes: [1]) do |result|
           assert_match(/Error: Failed to apply catalog: Resource type 'Mycustomtype' was not found/, result.stderr)
         end
       end


### PR DESCRIPTION
The test sets the vendormoduledir so that compilation succeeds and expects the agent to fail, since the customtype was never pluginsynced. Override vendormoduledir on the agent so the test works in either case.

Verified this passes using single and multi host configs:

```
bx rake ci:test:setup SHA=fa212183fac8cfb125d5bf4bdf89d23e0793b161 HOSTS=redhat7-64a-redhat7-64m
bx rake ci:test:setup SHA=fa212183fac8cfb125d5bf4bdf89d23e0793b161 HOSTS=redhat7-64ma           
```

