### PR TITLE
(PUP-11722) Pin ruby concurrent to 1.1.x

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency(%q<locale>, "~> 2.1")
   s.add_runtime_dependency(%q<multi_json>, "~> 1.13")
   s.add_runtime_dependency(%q<httpclient>, "~> 2.8")
-  s.add_runtime_dependency(%q<concurrent-ruby>, "~> 1.0")
+  s.add_runtime_dependency(%q<concurrent-ruby>, ["~> 1.0", "< 1.2.0"])
   s.add_runtime_dependency(%q<deep_merge>, "~> 1.0")
 
   # loads platform specific gems like ffi, win32 platform gems

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -26,7 +26,7 @@ gem_runtime_dependencies:
   multi_json: '~> 1.10'
   httpclient: '~> 2.8'
   puppet-resource_api: '~>1.5'
-  concurrent-ruby: '~> 1.0'
+  concurrent-ruby: ["~> 1.0", "< 1.2.0"]
   deep_merge: '~> 1.0'
 gem_rdoc_options:
   - --title


### PR DESCRIPTION
concurrent 1.2 deleted Concurrent::RubyThreadLocalVar, so pin for now.

We have to update two places, because .gemspec is used when running puppet from source using bundler and ext/project_data.yaml is used when building the puppet gem.