### PR TITLE
(maint) Remove spurious space between method name & args

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -194,7 +194,7 @@ Layout/SpaceAroundKeyword:
   Enabled: false
 
 Layout/SpaceAfterMethodName:
-  Enabled: false
+  Enabled: true
 
 Layout/SpaceAfterNot:
   Enabled: false

--- a/lib/puppet/pops/evaluator/relationship_operator.rb
+++ b/lib/puppet/pops/evaluator/relationship_operator.rb
@@ -119,7 +119,7 @@ class RelationshipOperator
   # To implement this, the general evaluator needs to be able to track each evaluation result and associate
   # it with a corresponding expression. This structure should then be passed to the relationship operator.
   #
-  def evaluate (left_right_evaluated, relationship_expression, scope)
+  def evaluate(left_right_evaluated, relationship_expression, scope)
     # assert operator (should have been validated, but this logic makes assumptions which would
     # screw things up royally). Better safe than sorry.
     unless RELATIONSHIP_OPERATORS.include?(relationship_expression.operator)


### PR DESCRIPTION
JRuby 9.4 will warn that this will be interpreted as a method's argument list not a destructuring. That is the desired behavior but we do not want the warning.