### PR TITLE
(maint) Fix usage of legacy fact in fqdn_rand

### DIFF
--- a/lib/puppet/parser/functions/fqdn_rand.rb
+++ b/lib/puppet/parser/functions/fqdn_rand.rb
@@ -23,7 +23,7 @@ Puppet::Parser::Functions::newfunction(:fqdn_rand, :arity => -2, :type => :rvalu
     initial_seed = args.shift
     downcase = !!args.shift
 
-    fqdn = self['::fqdn']
+    fqdn = self['facts'].dig('networking', 'fqdn')
     fqdn = fqdn.downcase if downcase
 
     # Puppet 5.4's fqdn_rand function produces a different value than earlier versions

--- a/spec/unit/parser/functions/fqdn_rand_spec.rb
+++ b/spec/unit/parser/functions/fqdn_rand_spec.rb
@@ -80,7 +80,7 @@ describe "the fqdn_rand function" do
     extra = args[:extra_identifier] || []
 
     scope = create_test_scope_for_node('localhost')
-    scope.compiler.topscope['fqdn'] = host.freeze
+    scope.set_facts({ 'networking' => { 'fqdn' => host }})
 
     scope.function_fqdn_rand([max] + extra)
   end


### PR DESCRIPTION
The `fqdn_rand` function rely on the `fqdn` legacy fact to operate.
When running Puppet with `--no-include_legacy_facts`, the behavior is
changed:

```sh-session
romain@zappy ~/Projects/puppetlabs/puppet % bundle exec puppet apply -e 'warning(fqdn_rand(100))' --include_legacy_facts
Warning: Scope(Class[main]): 4
Notice: Compiled catalog for zappy.blogreen.org in environment
production in 0.01 seconds
Notice: Applied catalog in 0.01 seconds
romain@zappy ~/Projects/puppetlabs/puppet % bundle exec puppet apply -e 'warning(fqdn_rand(100))' --no-include_legacy_facts
Warning: Undefined variable '::fqdn';
   (file & line not available)
Warning: Scope(Class[main]): 79
Notice: Compiled catalog for zappy.blogreen.org in environment
production in 0.01 seconds
Notice: Applied catalog in 0.01 seconds
```

Adjust the `fqdn_rand` function to use the `networking.fqdn` fact
instead of the old one to fix this issue.
