### PR TITLE
(maint) Install hiera v3 gem during beaker test

### DIFF
--- a/acceptance/tests/lookup/hiera3_custom_backend.rb
+++ b/acceptance/tests/lookup/hiera3_custom_backend.rb
@@ -26,6 +26,8 @@ tag 'audit:high',
     step 'delete custom backend, restore default hiera config' do
       on(master, "rm #{existing_loadpath}/hiera/backend/custom_backend.rb", :acceptable_exit_codes => [0,1])
       on(master, "mv #{hiera_conf_backup} #{confdir}/hiera.yaml", :acceptable_exit_codes => [0,1])
+      on(master, "/opt/puppetlabs/server/bin/puppetserver gem uninstall --executables --force hiera")
+      on(master, "/opt/puppetlabs/puppet/bin/gem uninstall --executables --force hiera")
     end
 
     agents.each do |agent|
@@ -33,6 +35,13 @@ tag 'audit:high',
         agent.rm_rf(command_result.stdout)
       end
     end
+  end
+
+  step "install hiera v3 gem" do
+    # for puppet agent <-> server, hiera must be installed using puppetserver's gem command
+    on(master, "/opt/puppetlabs/server/bin/puppetserver gem install --no-document hiera")
+    # for puppet lookup, hiera must be installed using puppet's gem command
+    on(master, "/opt/puppetlabs/puppet/bin/gem install --no-document hiera")
   end
 
   step "create hiera v5 config and v3 custom backend" do


### PR DESCRIPTION
The hiera gem is no longer bundled in puppet-agent, so install it during the hiera3_custom_backend test.

This is a follow up to the change in PA-4646

I manually verified this passes the following tests:

```
$ bundle exec rake ci:test:setup SHA=ed3ec05c794d111add2126cc4d3008b0adf64ab3 HOSTS=redhat7-64ma SERVER_VERSION=7.9.5.SNAPSHOT.2023.01.31T1920
...
$ bundle exec beaker exec tests/parser_functions/,tests/lookup,tests/utf8/utf8-in-function-args.rb,tests/ticket_5592_hiera_lookup_when_param_undef.rb
```

where the list of tests came from:

```
$ git grep -l hiera tests/
tests/lookup/config3_interpolation.rb
tests/lookup/config5_interpolation.rb
tests/lookup/hiera3_custom_backend.rb
tests/lookup/lookup.rb
tests/lookup/lookup_rich_values.rb
tests/lookup/merge_strategies.rb
tests/lookup/v3_config_and_data.rb
tests/lookup/v4_hieradata_with_v5_configs.rb
tests/parser_functions/calling_all_functions.rb
tests/parser_functions/hiera/lookup_data.rb
tests/parser_functions/hiera_array/lookup_data.rb
tests/parser_functions/hiera_hash/lookup_data.rb
tests/parser_functions/hiera_in_templates.rb
tests/parser_functions/puppet_lookup_cmd.rb
tests/ticket_5592_hiera_lookup_when_param_undef.rb
tests/utf8/utf8-in-function-args.rb
```
