### PR TITLE
(PUP-11725) Turn on strict mode by default

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -188,7 +188,7 @@ module Puppet
         ",
     },
     :strict => {
-      :default    => :warning,
+      :default    => :error,
       :type       => :symbolic_enum,
       :values     => [:off, :warning, :error],
       :desc       => "The strictness level of puppet. Allowed values are:

--- a/spec/integration/parser/compiler_spec.rb
+++ b/spec/integration/parser/compiler_spec.rb
@@ -158,7 +158,7 @@ describe Puppet::Parser::Compiler do
     it 'makes $settings::strict available as string' do
       node = Puppet::Node.new("testing")
       catalog = compile_to_catalog(<<-MANIFEST, node)
-          notify { 'test': message => $settings::strict == 'warning' }
+          notify { 'test': message => $settings::strict == 'error' }
       MANIFEST
       expect(catalog).to have_resource("Notify[test]").with_parameter(:message, true)
     end
@@ -174,7 +174,7 @@ describe Puppet::Parser::Compiler do
     it 'makes all server settings available as $settings::all_local hash' do
       node = Puppet::Node.new("testing")
       catalog = compile_to_catalog(<<-MANIFEST, node)
-          notify { 'test': message => $settings::all_local['strict'] == 'warning' }
+          notify { 'test': message => $settings::all_local['strict'] == 'error' }
       MANIFEST
       expect(catalog).to have_resource("Notify[test]").with_parameter(:message, true)
     end
@@ -694,7 +694,7 @@ describe Puppet::Parser::Compiler do
       end
 
       it 'a missing variable as default causes an evaluation error' do
-        # when strict variables not on
+        # strict mode on by default for 8.x
         expect {
           compile_to_catalog(<<-MANIFEST)
           class a ($b=$x) { notify {test: message=>"yes ${undef == $b}" } }
@@ -703,9 +703,9 @@ describe Puppet::Parser::Compiler do
         }.to raise_error(/Evaluation Error: Unknown variable: 'x'/)
       end
 
-      it 'a missing variable as default value becomes undef when strict_variables is off' do
-        # strict variables on by default for 8.x
+      it 'a missing variable as default value becomes undef when strict mode is off' do
         Puppet[:strict_variables] = false
+        Puppet[:strict] = :warning
         catalog = compile_to_catalog(<<-MANIFEST)
         class a ($b=$x) { notify {test: message=>"yes ${undef == $b}" } }
           include a

--- a/spec/integration/parser/conditionals_spec.rb
+++ b/spec/integration/parser/conditionals_spec.rb
@@ -68,8 +68,9 @@ describe "Evaluation of Conditionals" do
     end
 
     it "evaluates undefined variables as false" do
-      # strict_variables is off so behavior this test is trying to check isn't stubbed out
+      # strict mode is off so behavior this test is trying to check isn't stubbed out
       Puppet[:strict_variables] = false
+      Puppet[:strict] = :warning
       catalog = compile_to_catalog(<<-CODE)
       if $undef_var {
       } else {

--- a/spec/integration/parser/scope_spec.rb
+++ b/spec/integration/parser/scope_spec.rb
@@ -276,8 +276,9 @@ describe "Two step scoping for variables" do
 
     ['a:.b', '::a::b'].each do |ref|
       it "does not resolve a qualified name on the form #{ref} against top scope" do
-        # strict_variables is off so behavior this test is trying to check isn't stubbed out
+        # strict mode is off so behavior this test is trying to check isn't stubbed out
         Puppet[:strict_variables] = false
+        Puppet[:strict] = :warning
         expect_the_message_not_to_be("from topscope") do <<-"MANIFEST"
               class c {
                 notify { 'something': message => "$#{ref}" }
@@ -299,8 +300,9 @@ describe "Two step scoping for variables" do
 
     ['a:.b', '::a::b'].each do |ref|
       it "does not resolve a qualified name on the form #{ref} against node scope" do
-        # strict_variables is off so behavior this test is trying to check isn't stubbed out
+        # strict mode is off so behavior this test is trying to check isn't stubbed out
         Puppet[:strict_variables] = false
+        Puppet[:strict] = :warning
         expect_the_message_not_to_be("from node") do <<-MANIFEST
               class c {
                 notify { 'something': message => "$a::b" }

--- a/spec/unit/application/lookup_spec.rb
+++ b/spec/unit/application/lookup_spec.rb
@@ -503,6 +503,9 @@ Searching for "a"
       include PuppetSpec::Files
 
       it "is unaffected by global variables unless '--compile' is used" do
+        # strict mode is off so behavior this test is trying to check isn't stubbed out
+        Puppet[:strict_variables] = false
+        Puppet[:strict] = :warning
         lookup.options[:node] = node
         lookup.options[:render_as] = :s
         allow(lookup.command_line).to receive(:args).and_return(['c'])
@@ -673,8 +676,9 @@ Searching for "a"
       let(:node) { Puppet::Node.new("testnode", :facts => facts, :environment => 'puppet_func_provider') }
 
       it "works OK in the absense of '--compile'" do
-        # strict_variables is off so behavior this test is trying to check isn't stubbed out
+        # strict mode is off so behavior this test is trying to check isn't stubbed out
         Puppet[:strict_variables] = false
+        Puppet[:strict] = :warning
         lookup.options[:node] = node
         allow(lookup.command_line).to receive(:args).and_return(['c'])
         lookup.options[:render_as] = :s

--- a/spec/unit/data_providers/hiera_data_provider_spec.rb
+++ b/spec/unit/data_providers/hiera_data_provider_spec.rb
@@ -35,6 +35,7 @@ describe "when using a hiera data provider" do
     node = Puppet::Node.new("testnode", :facts => facts, :environment => environment)
     compiler = Puppet::Parser::Compiler.new(node)
     compiler.topscope['domain'] = 'example.com'
+    compiler.topscope['my_fact'] = 'server3'
     block_given? ? compiler.compile { |catalog| yield(compiler); catalog } : compiler.compile
   end
 
@@ -164,6 +165,7 @@ describe "when using a hiera data provider" do
     expect(extract_notifications(compiler.compile)).to include('server2')
 
     compiler = Puppet::Parser::Compiler.new(node)
+    compiler.topscope['my_fact'] = 'server3'
     expect(extract_notifications(compiler.compile)).to include('In name.yaml')
   end
 

--- a/spec/unit/functions/epp_spec.rb
+++ b/spec/unit/functions/epp_spec.rb
@@ -22,8 +22,9 @@ describe "the epp function" do
       expect { eval_template("<%= $kryptonite == undef %>")}.to raise_error(/Evaluation Error: Unknown variable: 'kryptonite'./)
     end
 
-    it "get nil accessing a variable that does not exist when strict_variables is off" do
+    it "get nil accessing a variable that does not exist when strict mode is off" do
       Puppet[:strict_variables] = false
+      Puppet[:strict] = :warning
       expect(eval_template("<%= $kryptonite == undef %>")).to eq("true")
     end
 

--- a/spec/unit/functions/inline_epp_spec.rb
+++ b/spec/unit/functions/inline_epp_spec.rb
@@ -20,8 +20,9 @@ describe "the inline_epp function" do
       expect { eval_template("<%= $kryptonite == undef %>")}.to raise_error(/Evaluation Error: Unknown variable: 'kryptonite'./)
     end
 
-    it "get nil accessing a variable that does not exist when strict_variables is off" do
+    it "get nil accessing a variable that does not exist when strict mode is off" do
       Puppet[:strict_variables] = false
+      Puppet[:strict] = :warning
       expect(eval_template("<%= $kryptonite == undef %>")).to eq("true")
     end
 

--- a/spec/unit/functions/return_spec.rb
+++ b/spec/unit/functions/return_spec.rb
@@ -19,8 +19,10 @@ describe 'the return function' do
     end
 
     it 'with undef value as function result when not given an argument' do
-      # strict_variables is off so behavior this test is trying to check isn't stubbed out
+      # strict mode is off so behavior this test is trying to check isn't stubbed out
       Puppet[:strict_variables] = false
+      Puppet[:strict] = :warning
+
       expect(compile_to_catalog(<<-CODE)).to have_resource('Notify[xy]')
           function please_return() {
             [1,2,3].map |$x| { if $x == 1 { return() } 200 }

--- a/spec/unit/hiera/scope_spec.rb
+++ b/spec/unit/hiera/scope_spec.rb
@@ -16,8 +16,13 @@ describe Hiera::Scope do
   end
 
   describe "#[]" do
-    it "should return nil when no value is found" do
+    it "should return nil when no value is found and strict mode is off" do
+      Puppet[:strict] = :warning
       expect(scope["foo"]).to eq(nil)
+    end
+
+    it "should raise error by default when no value is found" do
+      expect { scope["foo"] }.to raise_error(/Undefined variable 'foo'/)
     end
 
     it "should treat '' as nil" do

--- a/spec/unit/module_spec.rb
+++ b/spec/unit/module_spec.rb
@@ -773,12 +773,14 @@ describe Puppet::Module do
   end
 
   it "should not have metadata if it has a metadata file and its data is empty" do
+    Puppet[:strict] = :warning
     allow(File).to receive(:read).with(mymod_metadata, {:encoding => 'utf-8'}).and_return("")
 
     expect(mymod).not_to be_has_metadata
   end
 
   it "should not have metadata if has a metadata file and its data is invalid" do
+    Puppet[:strict] = :warning
     allow(File).to receive(:read).with(mymod_metadata, {:encoding => 'utf-8'}).and_return("This is some invalid json.\n")
     expect(mymod).not_to be_has_metadata
   end
@@ -797,12 +799,6 @@ describe Puppet::Module do
     expect_any_instance_of(Puppet::Module).to receive(:load_metadata)
 
     Puppet::Module.new("yay", "/path", double("env"))
-  end
-
-  it "should tolerate failure to parse" do
-    allow(File).to receive(:read).with(mymod_metadata, {:encoding => 'utf-8'}).and_return(my_fixture('trailing-comma.json'))
-
-    expect(mymod.has_metadata?).to be_falsey
   end
 
   describe 'when --strict is warning' do

--- a/spec/unit/parser/scope_spec.rb
+++ b/spec/unit/parser/scope_spec.rb
@@ -162,6 +162,10 @@ describe Puppet::Parser::Scope do
   end
 
   describe "when looking up a variable" do
+    before :each do
+      Puppet[:strict] = :warning
+    end
+
     it "should support :lookupvar and :setvar for backward compatibility" do
       @scope.setvar("var", "yep")
       expect(@scope.lookupvar("var")).to eq("yep")

--- a/spec/unit/pops/evaluator/arithmetic_ops_spec.rb
+++ b/spec/unit/pops/evaluator/arithmetic_ops_spec.rb
@@ -94,6 +94,9 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
     end
 
     context "on strings requiring boxing to Numeric" do
+      before :each do
+        Puppet[:strict] = :off
+      end
       it "'2' + '2'        ==  4" do
         expect(evaluate(literal('2') + literal('2'))).to eq(4)
       end
@@ -124,6 +127,11 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
 
       it "'012.3' + '010'  ==  20.3 (not error, floats can start with 0)" do
         expect(evaluate(literal('012.3') + literal('010'))).to eq(20.3)
+      end
+
+      it "raises an error when coercing string to numerical by default" do
+        Puppet[:strict] = :error
+        expect { evaluate(literal('2') + literal('2')) }.to raise_error(/Evaluation Error: The string '2' was automatically coerced to the numerical value 2/)
       end
     end
 

--- a/spec/unit/pops/evaluator/evaluating_parser_spec.rb
+++ b/spec/unit/pops/evaluator/evaluating_parser_spec.rb
@@ -439,6 +439,10 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
     end
 
     context "on strings requiring boxing to Numeric" do
+      # turn strict mode off so behavior is not stubbed out
+      before :each do
+        Puppet[:strict] = :off
+      end
       let(:logs) { [] }
       let(:notices) { logs.select { |log| log.level == :notice }.map { |log| log.message } }
       let(:warnings) { logs.select { |log| log.level == :warning }.map { |log| log.message } }
@@ -851,6 +855,7 @@ describe 'Puppet::Pops::Evaluator::EvaluatorImpl' do
       "[1,2][1, -1.0]"              => "An Array[] cannot use Float where Integer is expected",
     }.each do |source, result|
       it "should parse and evaluate the expression '#{source}' to #{result}" do
+        Puppet[:strict] = :off
         expect { parser.evaluate_string(scope, source, __FILE__)}.to raise_error(Regexp.new(Regexp.quote(result)))
       end
     end

--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -246,6 +246,7 @@ describe 'loaders' do
     end
 
     it 'loader allows loading a function more than once' do
+      pending('See PUP-11751')
       allow(File).to receive(:read).with(user_metadata_path, {:encoding => 'utf-8'}).and_return('')
       allow(File).to receive(:read).with(usee_metadata_path, {:encoding => 'utf-8'}).and_raise(Errno::ENOENT)
       allow(File).to receive(:read).with(usee2_metadata_path, {:encoding => 'utf-8'}).and_raise(Errno::ENOENT)

--- a/spec/unit/pops/validator/validator_spec.rb
+++ b/spec/unit/pops/validator/validator_spec.rb
@@ -142,10 +142,9 @@ describe "validating 4x" do
   end
 
   context 'with the default settings for --strict' do
-    it 'produces a warning for duplicate keys in a literal hash' do
+    it 'produces an error for duplicate keys in a literal hash' do
       acceptor = validate(parse('{ a => 1, a => 2 }'))
-      expect(acceptor.warning_count).to eql(1)
-      expect(acceptor.error_count).to eql(0)
+      expect(acceptor.error_count).to eql(1)
       expect(acceptor).to have_issue(Puppet::Pops::Issues::DUPLICATE_KEY)
     end
 


### PR DESCRIPTION
To start moving towards enabling strict mode by default, in [PUP-11689](https://tickets.puppetlabs.com/browse/PUP-11689) strict_variables was turned on. This commit continues that by setting strict to default to error instead of warning. 

Additionally, rspec tests that failed after the change were updated. I came across some unexpected behavior after setting strict to error so I set those tests to pending and created a ticket, [PUP-11751](https://tickets.puppetlabs.com/browse/PUP-11751), so those could be looked into later.