### PR TITLE
(maint) fix multiple misspellings of "satisfied"

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -2041,7 +2041,7 @@ EOT
       :type => :boolean,
       :desc => "Whether puppet should call deferred functions before applying
         the catalog. If set to `true`, then all prerequisites needed for the
-        deferred function must be satified prior to puppet running. If set to
+        deferred function must be satisfied prior to puppet running. If set to
         `false`, then deferred functions will follow puppet relationships and
         ordering. This allows puppet to install prerequisites needed for a
         deferred function and call the deferred function in the same run."

--- a/man/man5/puppet.conf.5
+++ b/man/man5/puppet.conf.5
@@ -1503,7 +1503,7 @@ The preferred means of serializing ruby instances for passing over the wire\. Th
 .IP "" 0
 .
 .SS "preprocess_deferred"
-Whether puppet should call deferred functions before applying the catalog\. If set to \fBtrue\fR, then all prerequisites needed for the deferred function must be satified prior to puppet running\. If set to \fBfalse\fR, then deferred functions will follow puppet relationships and ordering\. This allows puppet to install prerequisites needed for a deferred function and call the deferred function in the same run\.
+Whether puppet should call deferred functions before applying the catalog\. If set to \fBtrue\fR, then all prerequisites needed for the deferred function must be satisfied prior to puppet running\. If set to \fBfalse\fR, then deferred functions will follow puppet relationships and ordering\. This allows puppet to install prerequisites needed for a deferred function and call the deferred function in the same run\.
 .
 .IP "\(bu" 4
 \fIDefault\fR: \fBfalse\fR

--- a/spec/integration/application/agent_spec.rb
+++ b/spec/integration/application/agent_spec.rb
@@ -154,7 +154,7 @@ describe "puppet agent", unless: Puppet::Util::Platform.jruby? do
       end
     end
 
-    it "fails to apply a deferred function with an unsatified prerequisite" do
+    it "fails to apply a deferred function with an unsatisfied prerequisite" do
       Puppet[:preprocess_deferred] = true
 
       catalog_handler = -> (req, res) {

--- a/spec/integration/application/apply_spec.rb
+++ b/spec/integration/application/apply_spec.rb
@@ -454,7 +454,7 @@ class amod::bad_type {
 
     context 'and the file is not serialized with rich_data' do
       # do not want to stub out behavior in tests
-      before :each do 
+      before :each do
         Puppet[:strict] = :warning
       end
 
@@ -714,7 +714,7 @@ class amod::bad_type {
        .and output(%r{Notice: /Stage\[main\]/Main/Notify\[deferred4x\]/message: defined 'message' as 'I am deferred'}).to_stdout
     end
 
-    it "fails to apply a deferred function with an unsatified prerequisite" do
+    it "fails to apply a deferred function with an unsatisfied prerequisite" do
       Puppet[:preprocess_deferred] = true
 
       apply.command_line.args = ['-e', deferred_manifest]


### PR DESCRIPTION
This fixes several misspellings of the word "satisfied", which is written "satified", where an `s` is missing.

This misspelling was flagged by the Debian [Lintian tool](https://wiki.debian.org/Lintian).