### PR TITLE
(PUP-11754) Empty metadata files should be treated as though they don't exist

### DIFF
--- a/lib/puppet/module.rb
+++ b/lib/puppet/module.rb
@@ -214,7 +214,9 @@ class Puppet::Module
 
   def read_metadata
     md_file = metadata_file
-    md_file.nil? ? {} : Puppet::Util::Json.load(File.read(md_file, :encoding => 'utf-8'))
+    return {} if md_file.nil?
+    content = File.read(md_file, :encoding => 'utf-8')
+    content.empty? ? {} : Puppet::Util::Json.load(content)
   rescue Errno::ENOENT
     {}
   rescue Puppet::Util::Json::ParseError => e

--- a/lib/puppet/module/task.rb
+++ b/lib/puppet/module/task.rb
@@ -232,8 +232,6 @@ class Puppet::Module
     end
 
     def self.read_metadata(file)
-      # MultiJSON has a bug that improperly errors when loading an empty string
-      # so we handle it here for now. See: PUP-11629
       if file
         content = Puppet::FileSystem.read(file, :encoding => 'utf-8')
         content.empty? ? {} : Puppet::Util::Json.load(content)

--- a/spec/unit/pops/loaders/loaders_spec.rb
+++ b/spec/unit/pops/loaders/loaders_spec.rb
@@ -246,7 +246,6 @@ describe 'loaders' do
     end
 
     it 'loader allows loading a function more than once' do
-      pending('See PUP-11754')
       allow(File).to receive(:read).with(user_metadata_path, {:encoding => 'utf-8'}).and_return('')
       allow(File).to receive(:read).with(usee_metadata_path, {:encoding => 'utf-8'}).and_raise(Errno::ENOENT)
       allow(File).to receive(:read).with(usee2_metadata_path, {:encoding => 'utf-8'}).and_raise(Errno::ENOENT)


### PR DESCRIPTION
This commit has Puppet::Util::Json.load check if an empty string is passed in and returns nil if an empty string is passed in. More work may be necessary to ensure Puppet::Util::Json.load behaves as expected.