### PR TITLE
(PUP-11756) Update facter dependency

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.summary = "Puppet, an automated configuration management tool"
   s.specification_version = 3
-  s.add_runtime_dependency(%q<facter>, [">= 2.4.0", "< 5"])
+  s.add_runtime_dependency(%q<facter>, [">= 4.3.0", "< 5"])
   s.add_runtime_dependency(%q<semantic_puppet>, "~> 1.0")
   s.add_runtime_dependency(%q<fast_gettext>, ">= 2.1", "< 3")
   s.add_runtime_dependency(%q<locale>, "~> 2.1")

--- a/Gemfile
+++ b/Gemfile
@@ -12,8 +12,7 @@ def location_for(place, fake_version = nil)
   end
 end
 
-# override .gemspec deps - may issue warning depending on Bundler version
-gem "facter", :git => 'https://github.com/puppetlabs/facter'
+gem "facter", *location_for(ENV['FACTER_LOCATION'] || ["~> 4.3"])
 gem "semantic_puppet", *location_for(ENV['SEMANTIC_PUPPET_LOCATION'] || ["~> 1.0"])
 gem "puppet-resource_api", *location_for(ENV['RESOURCE_API_LOCATION'] || ["~> 1.5"])
 

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -18,7 +18,7 @@ gem_forge_project: 'puppet'
 gem_required_ruby_version: '>= 2.7.0'
 gem_required_rubygems_version: '> 1.3.1'
 gem_runtime_dependencies:
-  facter: ['> 2.0.1', '< 5']
+  facter: ['> 4.3.0', '< 5']
   semantic_puppet: '~> 1.0'
   fast_gettext: ['>= 1.1', '< 3']
   locale: '~> 2.1'


### PR DESCRIPTION
With the release of facter 4.3.0 we no longer need to point to facter's github repo.