### PR TITLE
(PUP-11763) Converts ctime/mtime to string

### DIFF
--- a/lib/puppet/type/file/ctime.rb
+++ b/lib/puppet/type/file/ctime.rb
@@ -10,7 +10,7 @@ module Puppet
       if stat
         current_value = stat.ctime
       end
-      current_value
+      current_value.to_s
     end
 
     validate do |val|

--- a/lib/puppet/type/file/mtime.rb
+++ b/lib/puppet/type/file/mtime.rb
@@ -9,7 +9,7 @@ module Puppet
       if stat
         current_value = stat.mtime
       end
-      current_value
+      current_value.to_s
     end
 
     validate do |val|

--- a/spec/unit/type/file/ctime_spec.rb
+++ b/spec/unit/type/file/ctime_spec.rb
@@ -15,7 +15,7 @@ describe Puppet::Type.type(:file).attrclass(:ctime) do
     @resource[:audit] = [:ctime]
 
     # this .to_resource audit behavior is magical :-(
-    expect(@resource.to_resource[:ctime]).to eq(Puppet::FileSystem.stat(@filename).ctime)
+    expect(@resource.to_resource[:ctime]).to eq(Puppet::FileSystem.stat(@filename).ctime.to_s)
   end
 
   it "should return absent if auditing an absent file" do

--- a/spec/unit/type/file/mtime_spec.rb
+++ b/spec/unit/type/file/mtime_spec.rb
@@ -15,7 +15,7 @@ describe Puppet::Type.type(:file).attrclass(:mtime) do
     @resource[:audit] = [:mtime]
 
     # this .to_resource audit behavior is magical :-(
-    expect(@resource.to_resource[:mtime]).to eq(Puppet::FileSystem.stat(@filename).mtime)
+    expect(@resource.to_resource[:mtime]).to eq(Puppet::FileSystem.stat(@filename).mtime.to_s)
   end
 
   it "should return absent if auditing an absent file" do


### PR DESCRIPTION
Prior to this commit, Puppet's file type returned a file's ctime and mtime (created and modified times) as Time objects. This commit converts those to Strings instead to alleviate issues when those values needed to be used in formats that don't understand Time objects (e.g. YAML).