### PR TITLE
(maint) Skip tests that use test forge instance

### DIFF
--- a/acceptance/tests/modules/changes/module_with_modified_file.rb
+++ b/acceptance/tests/modules/changes/module_with_modified_file.rb
@@ -1,4 +1,5 @@
 test_name 'puppet module changes (on a module with a modified file)'
+skip_test "The test forge instance's SSL cert expired, see ITHELP-60681"
 
 tag 'audit:high',
     'audit:acceptance',

--- a/acceptance/tests/modules/changes/module_with_removed_file.rb
+++ b/acceptance/tests/modules/changes/module_with_removed_file.rb
@@ -1,4 +1,5 @@
 test_name 'puppet module changes (on a module with a removed file)'
+skip_test "The test forge instance's SSL cert expired, see ITHELP-60681"
 
 tag 'audit:high',
     'audit:acceptance',

--- a/acceptance/tests/modules/changes/unmodified_module.rb
+++ b/acceptance/tests/modules/changes/unmodified_module.rb
@@ -1,4 +1,5 @@
 test_name 'puppet module changes (on an unmodified module)'
+skip_test "The test forge instance's SSL cert expired, see ITHELP-60681"
 
 tag 'audit:high',
     'audit:acceptance',

--- a/acceptance/tests/modules/list/with_environment.rb
+++ b/acceptance/tests/modules/list/with_environment.rb
@@ -1,4 +1,5 @@
 test_name 'puppet module list (with environment)'
+skip_test "The test forge instance's SSL cert expired, see ITHELP-60681"
 
 tag 'server',
     'audit:high',


### PR DESCRIPTION
Currently, the test forge instance's SSL cert is expired. Due to this Puppet CI is blocked. This commit skips all tests that use a test forge instance.