### PR TITLE
(PUP-11751) Only raise strict errors when compiling

### DIFF
--- a/acceptance/tests/lookup/config5_interpolation.rb
+++ b/acceptance/tests/lookup/config5_interpolation.rb
@@ -10,9 +10,6 @@ tag 'audit:high',
                        # lookup in a masterless setup.
     'server'
 
-  pending_test('unexpected `::roles` returning undefined here, but the test passes when strict=warning')
-  # Should revisit this in PUP-11751
-
   app_type        = File.basename(__FILE__, '.*')
   tmp_environment = mk_tmp_environment_with_teardown(master, app_type + '1')
   fq_tmp_environmentpath  = "#{environmentpath}/#{tmp_environment}"

--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -531,11 +531,16 @@ class Puppet::Parser::Scope
       case Puppet[:strict]
       when :off
         # do nothing
-      when :warning
+      when :error
+        if Puppet.lookup(:avoid_hiera_lookup_errors){false} && Puppet.lookup(:during_compilation){false}
+          Puppet.warn_once(UNDEFINED_VARIABLES_KIND, _("Variable: %{name}") % { name: name },
+                           _("Undefined variable '%{name}' during hiera lookup; %{reason}") % { name: name, reason: reason } )
+        else
+          raise ArgumentError, _("Undefined variable '%{name}'; %{reason}") % { name: name, reason: reason }
+        end
+      else
         Puppet.warn_once(UNDEFINED_VARIABLES_KIND, _("Variable: %{name}") % { name: name },
         _("Undefined variable '%{name}'; %{reason}") % { name: name, reason: reason } )
-      when :error
-        raise ArgumentError, _("Undefined variable '%{name}'; %{reason}") % { name: name, reason: reason }
       end
     end
     nil

--- a/lib/puppet/pops/lookup/hiera_config.rb
+++ b/lib/puppet/pops/lookup/hiera_config.rb
@@ -249,16 +249,18 @@ class HieraConfig
     if @scope_interpolations.empty?
       true
     else
-      scope = lookup_invocation.scope
-      lookup_invocation.without_explain do
-        @scope_interpolations.all? do |key, root_key, segments, old_value|
-          value = scope[root_key]
-          unless value.nil? || segments.empty?
-            found = nil;
-            catch(:no_such_key) { found = sub_lookup(key, lookup_invocation, segments, value) }
-            value = found;
+      Puppet.override(avoid_hiera_lookup_errors: Puppet.lookup(:during_compilation){false}) do
+        scope = lookup_invocation.scope
+        lookup_invocation.without_explain do
+          @scope_interpolations.all? do |key, root_key, segments, old_value|
+            value = scope[root_key]
+            unless value.nil? || segments.empty?
+              found = nil;
+              catch(:no_such_key) { found = sub_lookup(key, lookup_invocation, segments, value) }
+              value = found;
+            end
+            old_value.eql?(value)
           end
-          old_value.eql?(value)
         end
       end
     end
@@ -633,23 +635,27 @@ class HieraConfigV5 < HieraConfig
       entry_datadir = @config_root + (he[KEY_DATADIR] || datadir)
       entry_datadir = Pathname(interpolate(entry_datadir.to_s, lookup_invocation, false))
       location_key = LOCATION_KEYS.find { |key| he.include?(key) }
-      locations = case location_key
-      when KEY_PATHS
-        resolve_paths(entry_datadir, he[location_key], lookup_invocation, @config_path.nil?)
-      when KEY_PATH
-        resolve_paths(entry_datadir, [he[location_key]], lookup_invocation, @config_path.nil?)
-      when KEY_GLOBS
-        expand_globs(entry_datadir, he[location_key], lookup_invocation)
-      when KEY_GLOB
-        expand_globs(entry_datadir, [he[location_key]], lookup_invocation)
-      when KEY_URIS
-        expand_uris(he[location_key], lookup_invocation)
-      when KEY_URI
-        expand_uris([he[location_key]], lookup_invocation)
-      when KEY_MAPPED_PATHS
-        expand_mapped_paths(entry_datadir, he[location_key], lookup_invocation)
-      else
-        nil
+      locations = nil
+      Puppet.override(avoid_hiera_lookup_errors: Puppet.lookup(:during_compilation){false}) do
+        locations = case location_key
+                    when KEY_PATHS
+                      resolve_paths(entry_datadir, he[location_key], lookup_invocation, @config_path.nil?)
+                    when KEY_PATH
+                      resolve_paths(entry_datadir, [he[location_key]], lookup_invocation, @config_path.nil?)
+                    when KEY_GLOBS
+                      expand_globs(entry_datadir, he[location_key], lookup_invocation)
+                    when KEY_GLOB
+                      expand_globs(entry_datadir, [he[location_key]], lookup_invocation)
+                    when KEY_URIS
+                      expand_uris(he[location_key], lookup_invocation)
+                    when KEY_URI
+                      expand_uris([he[location_key]], lookup_invocation)
+                    when KEY_MAPPED_PATHS
+                      expand_mapped_paths(entry_datadir, he[location_key], lookup_invocation)
+                    else
+                      nil
+                    end
+
       end
       next if @config_path.nil? && !locations.nil? && locations.empty? # Default config and no existing paths found
       options = he[KEY_OPTIONS] || defaults[KEY_OPTIONS]


### PR DESCRIPTION
Before this commit, strict unknown variable errors were raised outside of puppet compiles, notably during hiera lookups and interpolation. With this change, only undefined variables from a compile will raise. This way, we can allow hiera interpolation and lookups to succeed prior to a compile, even with :strict set to :error.