### PR TITLE
(maint) Update Facter dependency

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -18,7 +18,7 @@ gem_forge_project: 'puppet'
 gem_required_ruby_version: '>= 2.7.0'
 gem_required_rubygems_version: '> 1.3.1'
 gem_runtime_dependencies:
-  facter: ['> 4.3.0', '< 5']
+  facter: ['>= 4.3.0', '< 5']
   semantic_puppet: '~> 1.0'
   fast_gettext: ['>= 1.1', '< 3']
   locale: '~> 2.1'


### PR DESCRIPTION
Prior to this commit, Puppet's runtime dependency on Facter was '> 4.3.0', '< 5'. The most recent release of Facter is 4.3.0, so nightly gems of Puppet 8 could not satisfy their runtime dependencies.

This commit updates the lower bound of Puppet's Facter runtime dependency to '>= 4.3.0'.