### PR TITLE
(maint) Sync gemspec and packaging file

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -10,6 +10,9 @@
 # Please see the [packaging
 # repository](https://github.com/puppetlabs/packaging) for information on how
 # to build the Puppet gem package.
+#
+# Make sure these gem requirements are in sync with ext/project_data.yaml and
+# the Gemfile
 
 Gem::Specification.new do |s|
   s.name = "puppet"
@@ -37,6 +40,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency(%q<fast_gettext>, ">= 2.1", "< 3")
   s.add_runtime_dependency(%q<locale>, "~> 2.1")
   s.add_runtime_dependency(%q<multi_json>, "~> 1.13")
+  s.add_runtime_dependency(%q<puppet-resource_api>, "~> 1.5")
   s.add_runtime_dependency(%q<concurrent-ruby>, ["~> 1.0", "< 1.2.0"])
   s.add_runtime_dependency(%q<deep_merge>, "~> 1.0")
   s.add_runtime_dependency(%q<scanf>, "~> 1.0")

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@ def location_for(place, fake_version = nil)
   end
 end
 
+# Make sure these gem requirements are in sync with the gempspec and ext/project_data.yaml
+
 gem "facter", *location_for(ENV['FACTER_LOCATION'] || ["~> 4.3"])
 gem "semantic_puppet", *location_for(ENV['SEMANTIC_PUPPET_LOCATION'] || ["~> 1.0"])
 gem "puppet-resource_api", *location_for(ENV['RESOURCE_API_LOCATION'] || ["~> 1.5"])

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -8,7 +8,7 @@ description: 'Puppet, an automated configuration management tool'
 version_file: 'lib/puppet/version.rb'
 # files and gem_files are space separated lists
 files: '[A-Z]* install.rb bin lib conf man examples ext tasks spec locales'
-# The gem specification bits only work on Puppet >= 3.0rc, NOT 2.7.x and earlier
+# Make sure these gem requirements are in sync with the gempspec and Gemfile
 gem_files: '[A-Z]* install.rb bin lib conf man examples ext tasks spec locales'
 gem_test_files: 'spec/**/*'
 gem_executables: 'puppet'
@@ -20,9 +20,9 @@ gem_required_rubygems_version: '> 1.3.1'
 gem_runtime_dependencies:
   facter: ['>= 4.3.0', '< 5']
   semantic_puppet: '~> 1.0'
-  fast_gettext: ['>= 1.1', '< 3']
+  fast_gettext: ['>= 2.1', '< 3']
   locale: '~> 2.1'
-  multi_json: '~> 1.10'
+  multi_json: '~> 1.13'
   puppet-resource_api: '~>1.5'
   concurrent-ruby: ["~> 1.0", "< 1.2.0"]
   deep_merge: '~> 1.0'


### PR DESCRIPTION
Puppet's gemspec and the project_data.yaml file used by our packaging utility had gotten out of sync in terms of Puppet's gem dependencies.

This commit syncs up the dependencies in both the gemspec and project_data.yaml, which includes changing our dependency on fast_gettext to >= 2.1 < 3, which allows us to use fast_gettext that's compatible with Ruby > 3.2 (i.e., does not include removed Object#taint methods).