### PR TITLE
(PUP-11751) Handle interpolation errors from hiera_config

### DIFF
--- a/acceptance/tests/lookup/config5_interpolation.rb
+++ b/acceptance/tests/lookup/config5_interpolation.rb
@@ -10,7 +10,7 @@ tag 'audit:high',
                        # lookup in a masterless setup.
     'server'
 
-  pending_test('unexpected `::roles` returning undefined here, but the test passes when strict=warning')
+  # pending_test('unexpected `::roles` returning undefined here, but the test passes when strict=warning')
   # Should revisit this in PUP-11751
 
   app_type        = File.basename(__FILE__, '.*')

--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -535,7 +535,12 @@ class Puppet::Parser::Scope
         Puppet.warn_once(UNDEFINED_VARIABLES_KIND, _("Variable: %{name}") % { name: name },
         _("Undefined variable '%{name}'; %{reason}") % { name: name, reason: reason } )
       when :error
-        raise ArgumentError, _("Undefined variable '%{name}'; %{reason}") % { name: name, reason: reason }
+        if Puppet.lookup(:avoid_hiera_interpolation_errors){false}
+          Puppet.warn_once(UNDEFINED_VARIABLES_KIND, _("Variable: %{name}") % { name: name },
+          _("Interpolation failed with '%{name}', but compilation continuing; %{reason}") % { name: name, reason: reason } )
+        else
+          raise ArgumentError, _("Undefined variable '%{name}'; %{reason}") % { name: name, reason: reason }
+        end
       end
     end
     nil

--- a/spec/unit/functions/lookup_spec.rb
+++ b/spec/unit/functions/lookup_spec.rb
@@ -286,7 +286,6 @@ describe "The lookup function" do
             YAML
 
           it 'fails and reports error' do
-            Puppet[:strict] = :error
             expect { lookup('a') }.to raise_error(
               "'default_hierarchy' is only allowed in the module layer (file: #{code_dir}/hiera.yaml, line: 5)")
           end
@@ -302,8 +301,7 @@ describe "The lookup function" do
             YAML
 
           it 'fails and reports errors when strict == error' do
-            Puppet[:strict] = :error
-            expect { lookup('a') }.to raise_error("Undefined variable '::nonesuch' (file: #{code_dir}/hiera.yaml, line: 4)")
+            expect { lookup('a') }.to raise_error("Function lookup() did not find a value for the name 'a'")
           end
         end
 
@@ -316,7 +314,6 @@ describe "The lookup function" do
             YAML
 
           it 'fails and reports errors when strict == error' do
-            Puppet[:strict] = :error
             expect { lookup('a') }.to raise_error("Interpolation using method syntax is not allowed in this context (file: #{code_dir}/hiera.yaml)")
           end
         end
@@ -604,9 +601,9 @@ describe "The lookup function" do
       context 'using global variable reference' do
         let(:data_path) { 'x%{::var.sub}.yaml' }
 
-        it 'raises an error when reloads the configuration if interpolating undefined values' do
+        it 'does not raise an error when reloads the configuration if interpolating undefined values' do
           collect_notices("notice('success')") do |scope|
-            expect { lookup_func.call(scope, 'y') }.to raise_error(/Undefined variable '::var'/)
+            expect { lookup_func.call(scope, 'y') }.to_not raise_error
           end
         end
 


### PR DESCRIPTION
With Puppet[:strict], hiera interpolation errors prevented compilations because variables were not yet initialized. With this change, the hiera_config class adds a context for the Puppet::Parser::Scope to consider when raising errors.