### PR TITLE
(PUP-11119) Removes "extra" CLI option

### DIFF
--- a/lib/puppet/face/help/action.erb
+++ b/lib/puppet/face/help/action.erb
@@ -54,7 +54,6 @@ undocumented option
 	end
 	unless action.options.empty?
       action.options.sort.each do |name|
-        next if name == :extra
         option = action.get_option name -%>
 <%= "  " + option.optparse.join(" | ")[0,(optionroom - 1)].ljust(optionroom) + ' - ' -%>
 <%     if !(option.summary) -%>

--- a/lib/puppet/face/help/face.erb
+++ b/lib/puppet/face/help/face.erb
@@ -49,7 +49,6 @@ undocumented option
 	end
  	unless face.options.empty?
       face.options.sort.each do |name|
-        next if name == :extra
         option = face.get_option name -%>
 <%= "  " + option.optparse.join(" | ")[0,(optionroom - 1)].ljust(optionroom) + ' - ' -%>
 <%     if !(option.summary) -%>

--- a/lib/puppet/indirector/face.rb
+++ b/lib/puppet/indirector/face.rb
@@ -54,20 +54,10 @@ class Puppet::Indirector::Face < Puppet::Face
     return result
   end
 
-  option "--extra " + _("HASH") do
-    summary _("Extra arguments to pass to the indirection request")
-    description <<-EOT
-      A terminus can take additional arguments to refine the operation, which
-      are passed as an arbitrary hash to the back-end.  Anything passed as
-      the extra value is just send direct to the back-end.
-    EOT
-    default_to do Hash.new end
-  end
-
   action :destroy do
     summary _("Delete an object.")
     arguments _("<key>")
-    when_invoked {|key, options| call_indirection_method :destroy, key, options[:extra] }
+    when_invoked {|key, options| call_indirection_method :destroy, key, {} }
   end
 
   action :find do
@@ -77,11 +67,10 @@ class Puppet::Indirector::Face < Puppet::Face
       # Default the key to Puppet[:certname] if none is supplied
       if args.length == 1
         key = Puppet[:certname]
-        options = args.last
       else
-        key, options = *args
+        key = args.first
       end
-      call_indirection_method :find, key, options[:extra]
+      call_indirection_method :find, key, {}
     end
   end
 
@@ -93,13 +82,13 @@ class Puppet::Indirector::Face < Puppet::Face
       currently accept data from STDIN, save actions cannot currently be invoked
       from the command line.
     EOT
-    when_invoked {|key, options| call_indirection_method :save, key, options[:extra] }
+    when_invoked {|key, options| call_indirection_method :save, key, {} }
   end
 
   action :search do
     summary _("Search for an object or retrieve multiple objects.")
     arguments _("<query>")
-    when_invoked {|key, options| call_indirection_method :search, key, options[:extra] }
+    when_invoked {|key, options| call_indirection_method :search, key, {} }
   end
 
   # Print the configuration for the current terminus class

--- a/lib/puppet/interface/documentation.rb
+++ b/lib/puppet/interface/documentation.rb
@@ -76,7 +76,6 @@ class Puppet::Interface
         s.text(" ")
 
         options.each do |option|
-          next if option == :extra
           option = get_option(option)
           wrap = option.required? ? %w{ < > } : %w{ [ ] }
 

--- a/spec/unit/indirector/face_spec.rb
+++ b/spec/unit/indirector/face_spec.rb
@@ -11,8 +11,6 @@ describe Puppet::Indirector::Face do
     instance
   end
 
-  it { is_expected.to be_option :extra }
-
   it "should be able to return a list of indirections" do
     expect(Puppet::Indirector::Face.indirections).to be_include("catalog")
   end
@@ -56,14 +54,14 @@ describe Puppet::Indirector::Face do
     end
 
     it "should forward passed options" do
-      expect(subject.indirection).to receive(method).with(:test, *params(method, {'one'=>'1'}))
-      subject.send(method, :test, :extra => {'one'=>'1'})
+      expect(subject.indirection).to receive(method).with(:test, *params(method, {}))
+      subject.send(method, :test, {})
     end
   end
 
   it "should default key to certname for find action" do
-    expect(subject.indirection).to receive(:find).with(Puppet[:certname], {'one'=>'1'})
-    subject.send(:find, :extra => {'one'=>'1'})
+    expect(subject.indirection).to receive(:find).with(Puppet[:certname], {})
+    subject.send(:find, {})
   end
 
   it "should be able to override its indirection name" do


### PR DESCRIPTION
The "extra" CLI option has been a part of Puppet since 2011, but has never worked properly and was hidden in 2021.

This commit entirely removes the "extra" CLI option.