### PR TITLE
(maint) Simplify pson loading

### DIFF
--- a/lib/puppet/feature/pson.rb
+++ b/lib/puppet/feature/pson.rb
@@ -1,4 +1,4 @@
 require_relative '../../puppet/util/feature'
 
 # PSON is deprecated, use JSON instead
-Puppet.features.add(:pson, :libs => ['puppet/external/pson/common','puppet/external/pson/version', 'puppet/external/pson/pure'])
+Puppet.features.add(:pson, :libs => ['puppet/external/pson'])


### PR DESCRIPTION
Load puppet-pson entry-point instead of individual files, see

https://github.com/puppetlabs/puppet-pson/blob/main/lib/puppet/external/pson.rb