### PR TITLE
(PUP-11716) Revert ruby version changes to .gemspec and lib/puppet.rb

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -21,7 +21,8 @@ Gem::Specification.new do |s|
   s.version = mdata ? mdata[1] : version
 
   s.required_rubygems_version = Gem::Requirement.new("> 1.3.1")
-  s.required_ruby_version = Gem::Requirement.new(">= 3.1.0")
+  # Bump this in PUP-11716
+  s.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
   s.authors = ["Puppet Labs"]
   s.date = "2012-08-17"
   s.description = "Puppet, an automated configuration management tool"

--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -1,11 +1,12 @@
 require_relative 'puppet/version'
 require_relative 'puppet/concurrent/synchronized'
 
-Puppet::OLDEST_RECOMMENDED_RUBY_VERSION = '3.1.0'
-if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new(Puppet::OLDEST_RECOMMENDED_RUBY_VERSION)
-  raise LoadError, "Puppet #{Puppet.version} requires Ruby #{Puppet::OLDEST_RECOMMENDED_RUBY_VERSION} or greater, found Ruby #{RUBY_VERSION.dup}."
+# Update JRuby version constraints in PUP-11716
+if !defined?(JRUBY_VERSION) && Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("2.7.0")
+  raise LoadError, "Puppet #{Puppet.version} requires Ruby 2.7.0 or greater, found Ruby #{RUBY_VERSION.dup}."
 end
 
+Puppet::OLDEST_RECOMMENDED_RUBY_VERSION = '2.7.0'
 
 $LOAD_PATH.extend(Puppet::Concurrent::Synchronized)
 


### PR DESCRIPTION
This reverts commit a4d7b3ff3ab6f0e2e5d7eaae1b3607bd6651dcc5.