### PR TITLE
(PUP-9648) Use binary_file instead of file

### DIFF
--- a/acceptance/tests/catalog_with_binary_data.rb
+++ b/acceptance/tests/catalog_with_binary_data.rb
@@ -45,7 +45,7 @@ test_name "C100300: Catalog containing binary data is applied correctly" do
         \$test_path = \$facts['networking']['fqdn'] ? #{agent_tmp_dirs}
         file { '#{test_num}':
           path   => "\$test_path/#{test_num}",
-          content => file('#{test_num}/binary_data'),
+          content => binary_file('#{test_num}/binary_data'),
           ensure => present,
         }
       }


### PR DESCRIPTION
The `file` function returns a `String`, not `Binary`, so if the string contains data that is not valid UTF-8, then puppetserver will fail to serialize the catalog as `rich_data_json`. However as described in PUP-10928, puppet will fallback to either `rich_data_msgpack` (if msgpack is installed as a puppetserver gem) or fallback to `pson`.

Rich data support was added to agents in Puppet 6, so just use the `binary_file` function instead of relying on the fallback behavior.

I tested this using:

```
bundle exec rake ci:test:setup SHA=7eac0d839a56c765074bfc14df65768f3f00ecdf HOSTS=redhat7-64m-redhat7-64a
bundle exec beaker exec tests/catalog_with_binary_data.rb
```
