### PR TITLE
(PUP-11787) Warn if we fail to serialize and fallback

### DIFF
--- a/spec/unit/network/http/api/indirected_routes_spec.rb
+++ b/spec/unit/network/http/api/indirected_routes_spec.rb
@@ -182,6 +182,7 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
       indirection.save(data, "my data")
       request = a_request_that_finds(data, :accept_header => "application/json, text/pson")
       allow(data).to receive(:to_json).and_raise(Puppet::Network::FormatHandler::FormatError, 'Could not render to Puppet::Network::Format[json]: source sequence is illegal/malformed utf-8')
+      expect(Puppet).to receive(:warning).with(/Failed to serialize Puppet::IndirectorTesting for 'my data': Could not render to Puppet::Network::Format\[json\]/)
 
       handler.call(request, response)
 
@@ -228,6 +229,7 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
       indirection.save(data, "my data")
       request = a_request_that_searches(Puppet::IndirectorTesting.new("my"), :accept_header => "application/json, text/pson")
       allow(data).to receive(:to_json).and_raise(Puppet::Network::FormatHandler::FormatError, 'Could not render to Puppet::Network::Format[json]: source sequence is illegal/malformed utf-8')
+      expect(Puppet).to receive(:warning).with(/Failed to serialize Puppet::IndirectorTesting for 'my': Could not render_multiple to Puppet::Network::Format\[json\]/)
 
       handler.call(request, response)
 


### PR DESCRIPTION
If puppetserver falls back to PSON when serializing a catalog, then conversion of rich data will be lossy, but the problem won't be noticed until the catalog is applied on the agent.

This converts the debug message to a warning to assist troubleshooting. This affects both `find` and `search` operations for all indirected types.