### PR TITLE
(maint) replace egrep with grep in acceptance/tests/resource/exec/should_run_bad_command.rb

### DIFF
--- a/acceptance/tests/resource/exec/should_run_bad_command.rb
+++ b/acceptance/tests/resource/exec/should_run_bad_command.rb
@@ -27,7 +27,7 @@ def stop_sleep_process(targets, accept_no_pid_found = false)
     when /osx/
       command = "ps -e -o pid,comm | grep sleep | sed 's/^[^0-9]*//g' | cut -d\\  -f1"
     when /win/
-      command = "cmd.exe /C WMIC path win32_process WHERE Name=\\\"PING.EXE\\\" get ProcessId | egrep -o '[0-9]+\\s*$'"
+      command = "cmd.exe /C WMIC path win32_process WHERE Name=\\\"PING.EXE\\\" get ProcessId | grep -o '[0-9]+\\s*$'"
     else
       command = "ps -ef | grep 'bin/sleep ' | grep -v 'grep' | grep -v 'true' | sed 's/^[^0-9]*//g' | cut -d\\  -f1"
     end


### PR DESCRIPTION
As according to: https://www.phoronix.com/news/GNU-Grep-3.8-Stop-egrep-fgrep
We should stop using egrep since it has been deprecated since 2007. This command comes with a warning also in the acceptance test.

`warning: egrep is obsolescent; using grep -E`

I saw this in puppet code while cleaning up another project by running the Grep -ir in one directory level higher than I should have had.

Cheers