### PR TITLE
(maint) Update assert_not_match to refute_match

### DIFF
--- a/acceptance/tests/environment/enc_nonexistent_directory_environment.rb
+++ b/acceptance/tests/environment/enc_nonexistent_directory_environment.rb
@@ -72,7 +72,7 @@ file {
         unless agent['locale'] == 'ja'
           assert_match(/Could not find a directory environment named 'doesnotexist'/, result.stderr, "Errors when nonexistent environment is specified")
         end
-        assert_not_match(/In the production environment/, result.stdout, "Executed manifest from production environment")
+        refute_match(/In the production environment/, result.stdout, "Executed manifest from production environment")
       end
     end
   end

--- a/acceptance/tests/resource/package/yum.rb
+++ b/acceptance/tests/resource/package/yum.rb
@@ -82,7 +82,7 @@ test_name "test the yum package provider" do
     step 'Installing a non-existent version of a known package fails' do
       verify_absent agents, 'guid'
       apply_manifest_on(agents, 'package {"guid": ensure => "1.1"}') do |result|
-        assert_not_match(/Package\[guid\]\/ensure: created/, "#{result.host}: #{result.stdout}")
+        refute_match(/Package\[guid\]\/ensure: created/, "#{result.host}: #{result.stdout}")
         assert_match("Package[guid]/ensure: change from 'purged' to '1.1' failed", "#{result.host}: #{result.stderr}")
       end
       verify_absent agents, 'guid'
@@ -91,7 +91,7 @@ test_name "test the yum package provider" do
     step 'Installing a non-existent package fails' do
       verify_absent agents, 'not_a_package'
       apply_manifest_on(agents, 'package {"not_a_package": ensure => present}') do |result|
-        assert_not_match(/Package\[not_a_package\]\/ensure: created/, "#{result.host}: #{result.stdout}")
+        refute_match(/Package\[not_a_package\]\/ensure: created/, "#{result.host}: #{result.stdout}")
         assert_match("Package[not_a_package]/ensure: change from 'purged' to 'present' failed", "#{result.host}: #{result.stderr}")
       end
       verify_absent agents, 'not_a_package'
@@ -100,7 +100,7 @@ test_name "test the yum package provider" do
     step 'Removing a non-existent package succeeds' do
       verify_absent agents, 'not_a_package'
       apply_manifest_on(agents, 'package {"not_a_package": ensure => absent}') do |result|
-        assert_not_match(/Package\[not_a_package\]\/ensure/, "#{result.host}: #{result.stdout}")
+        refute_match(/Package\[not_a_package\]\/ensure/, "#{result.host}: #{result.stdout}")
         assert_match('Applied catalog', "#{result.host}: #{result.stdout}")
       end
       verify_absent agents, 'not_a_package'


### PR DESCRIPTION
In Beaker, the assert_not_match method was removed in commit voxpupuli/beaker@6282311 in favor of MiniTest::Assertions#refute_match. This change was released in Beaker 5.0.0.

This commit updates all instances of the assert_not_match with refute_match in preparation for a future switch to Beaker 5.