### PR TITLE
(PUP-10928) Add allow_pson_serialization setting

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1711,6 +1711,15 @@ EOT
       can be guaranteed to support this format, but it will be used for all
       classes that support it.",
     },
+    :allow_pson_serialization => {
+      :default    => true,
+      :type       => :boolean,
+      :desc       => "Whether when unable to serialize to JSON or other formats,
+        Puppet falls back to PSON. This option affects both puppetserver's
+        configuration management service responses and when the agent saves its
+        cached catalog. This option is useful in preventing the loss of data because
+        rich data cannot be serialized via PSON.",
+    },
     :agent_catalog_run_lockfile => {
       :default    => "$statedir/agent_catalog_run.lock",
       :type       => :string, # (#2888) Ensure this file is not added to the settings catalog.

--- a/lib/puppet/indirector/catalog/json.rb
+++ b/lib/puppet/indirector/catalog/json.rb
@@ -18,9 +18,14 @@ class Puppet::Resource::Catalog::Json < Puppet::Indirector::JSON
   def to_json(object)
     object.render(json_format)
   rescue Puppet::Network::FormatHandler::FormatError => err
-    Puppet.info(_("Unable to serialize catalog to json, retrying with pson"))
-    Puppet.log_exception(err, err.message, level: :debug)
-    object.render('pson').force_encoding(Encoding::BINARY)
+    if Puppet[allow_pson_serialization]
+      Puppet.info(_("Unable to serialize catalog to json, retrying with pson. PSON is deprecated and will be removed in a future release"))
+      Puppet.log_exception(err, err.message, level: :debug)
+      object.render('pson').force_encoding(Encoding::BINARY)
+    else
+      Puppet.info(_("Unable to serialize catalog to json, no other acceptable format"))
+      Puppet.log_exception(err, err.message, level: :err)
+    end
   end
 
   private

--- a/lib/puppet/network/http/api/indirected_routes.rb
+++ b/lib/puppet/network/http/api/indirected_routes.rb
@@ -192,8 +192,13 @@ class Puppet::Network::HTTP::API::IndirectedRoutes
         yield format
         true
       rescue Puppet::Network::FormatHandler::FormatError => err
-        Puppet.warning(_("Failed to serialize %{model} for '%{key}': %{detail}") %
-          {model: model, key: key, detail: err})
+        msg = _("Failed to serialize %{model} for '%{key}': %{detail}") %
+        {model: model, key: key, detail: err}
+        if Puppet[:allow_pson_serialization]
+          Puppet.warning(msg)
+        else
+          raise Puppet::Network::FormatHandler::FormatError.new(msg)
+        end
         false
       end
     end


### PR DESCRIPTION
Currently, Puppet will fall back to PSON when unable to serialize to JSON. This
can cause issues since rich data types cannot be serialized via PSON. Due to
this, PSON will eventually be depreceated and removed in future releases. This
commit adds a setting, :allow_pson_serialization, which defaults to false in
Puppet 7 and will default to true in Puppet 8. When set to false, a warning
will be raised when falling back to PSON and when set to true, an error will be
raised instead. This option affects both puppetserver's configuration management
service responses and when the agent saves its cached catalog.