### PR TITLE
(PUP-11348) Use ENV directly on Windows

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -369,11 +369,12 @@ module Puppet
           be set in `[server]`, `[agent]`, or an environment config section.",
         :call_hook => :on_define_and_write,
         :hook             => proc do |value|
-          Puppet::Util.set_env('PATH', '') if Puppet::Util.get_env('PATH').nil?
-          Puppet::Util.set_env('PATH', value) unless value == 'none'
-          paths = Puppet::Util.get_env('PATH').split(File::PATH_SEPARATOR)
+          ENV['PATH'] = '' if ENV['PATH'].nil?
+          ENV['PATH'] = value unless value == 'none'
+          paths = ENV['PATH'].split(File::PATH_SEPARATOR)
           Puppet::Util::Platform.default_paths.each do |path|
-            Puppet::Util.set_env('PATH', Puppet::Util.get_env('PATH') + File::PATH_SEPARATOR + path) unless paths.include?(path)
+            next if paths.include?(path)
+            ENV['PATH'] = ENV['PATH'] + File::PATH_SEPARATOR + path
           end
           value
         end

--- a/lib/puppet/file_system/uniquefile.rb
+++ b/lib/puppet/file_system/uniquefile.rb
@@ -150,7 +150,7 @@ class Puppet::FileSystem::Uniquefile < DelegateClass(File)
 
   def tmpdir
     tmp = '.'
-    for dir in [ Puppet::Util.get_env('TMPDIR'), Puppet::Util.get_env('TMP'), Puppet::Util.get_env('TEMP'), @@systmpdir, '/tmp']
+    for dir in [ ENV['TMPDIR'], ENV['TMP'], ENV['TEMP'], @@systmpdir, '/tmp']
       stat = File.stat(dir) if dir
       if stat && stat.directory? && stat.writable?
         tmp = dir

--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -549,8 +549,8 @@ class Puppet::Node::Environment
 
   # not private so it can be called in tests
   def self.extralibs()
-    if Puppet::Util.get_env('PUPPETLIB')
-      split_path(Puppet::Util.get_env('PUPPETLIB'))
+    if ENV['PUPPETLIB']
+      split_path(ENV['PUPPETLIB'])
     else
       []
     end

--- a/lib/puppet/provider/exec/windows.rb
+++ b/lib/puppet/provider/exec/windows.rb
@@ -45,7 +45,7 @@ Puppet::Type.type(:exec).provide :windows, :parent => Puppet::Provider::Exec do
     end
 
     if resource[:path]
-      Puppet::Util.withenv( {'PATH' => resource[:path].join(File::PATH_SEPARATOR)}, :windows) do
+      Puppet::Util.withenv('PATH' => resource[:path].join(File::PATH_SEPARATOR)) do
         return if which(exe)
       end
     end

--- a/lib/puppet/provider/package/gem.rb
+++ b/lib/puppet/provider/package/gem.rb
@@ -55,9 +55,9 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package::
   # that contains the content of PATH but without puppet/bin dir.
   # This is used to pass a custom PATH and execute commands in a controlled environment
   def self.windows_path_without_puppet_bin
-    @path ||= Puppet::Util.get_env('PATH').split(File::PATH_SEPARATOR)
-                                          .reject { |dir| dir =~ /puppet\\bin$/ }
-                                          .join(File::PATH_SEPARATOR)
+    @path ||= ENV['PATH'].split(File::PATH_SEPARATOR)
+                         .reject { |dir| dir =~ /puppet\\bin$/ }
+                         .join(File::PATH_SEPARATOR)
   end
 
   private_class_method :windows_path_without_puppet_bin
@@ -73,7 +73,7 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package::
     validate_command(command)
     cmd = [command] << command_options
 
-    custom_environment = {'HOME'=>Puppet::Util.get_env('HOME')}.merge(custom_environment)
+    custom_environment = {'HOME'=>ENV['HOME']}.merge(custom_environment)
 
     if Puppet::Util::Platform.windows?
       custom_environment[:PATH] = windows_path_without_puppet_bin

--- a/lib/puppet/provider/package/puppet_gem.rb
+++ b/lib/puppet/provider/package/puppet_gem.rb
@@ -7,9 +7,9 @@ Puppet::Type.type(:package).provide :puppet_gem, :parent => :gem do
   confine :true => Puppet.runtime[:facter].value(:aio_agent_version)
 
   def self.windows_gemcmd
-    puppet_dir = Puppet::Util.get_env('PUPPET_DIR')
+    puppet_dir = ENV['PUPPET_DIR']
     if puppet_dir
-      File.join(Puppet::Util.get_env('PUPPET_DIR').to_s, 'bin', 'gem.bat')
+      File.join(ENV['PUPPET_DIR'].to_s, 'bin', 'gem.bat')
     else
       File.join(Gem.default_bindir, 'gem.bat')
     end

--- a/lib/puppet/test/test_helper.rb
+++ b/lib/puppet/test/test_helper.rb
@@ -182,13 +182,8 @@ module Puppet::Test
       end
       $saved_indirection_state = nil
 
-      # Restore the global process environment.  Can't just assign because this
-      # is a magic variable, sadly, and doesn't do that™.  It is sufficiently
-      # faster to use the compare-then-set model to avoid excessive work that it
-      # justifies the complexity.  --daniel 2012-03-15
-      if ENV.to_hash != $old_env
-        ENV.replace($old_env)
-      end
+      # Restore the global process environment.
+      ENV.replace($old_env)
 
       # Clear all environments
       Puppet.lookup(:environments).clear_all

--- a/lib/puppet/test/test_helper.rb
+++ b/lib/puppet/test/test_helper.rb
@@ -69,13 +69,7 @@ module Puppet::Test
     # @return nil
     def self.before_all_tests()
       # The process environment is a shared, persistent resource.
-      # Can't use Puppet.features.microsoft_windows? as it may be mocked out in a test.  This can cause test recurring test failures
-      if (!!File::ALT_SEPARATOR)
-        mode = :windows
-      else
-        mode = :posix
-      end
-      $old_env = Puppet::Util.get_environment(mode)
+      $old_env = ENV.to_hash
     end
 
     # Call this method once, at the end of a test run, when no more tests
@@ -188,19 +182,12 @@ module Puppet::Test
       end
       $saved_indirection_state = nil
 
-      # Can't use Puppet.features.microsoft_windows? as it may be mocked out in a test.  This can cause test recurring test failures
-      if (!!File::ALT_SEPARATOR)
-        mode = :windows
-      else
-        mode = :posix
-      end
       # Restore the global process environment.  Can't just assign because this
       # is a magic variable, sadly, and doesn't do that™.  It is sufficiently
       # faster to use the compare-then-set model to avoid excessive work that it
       # justifies the complexity.  --daniel 2012-03-15
-      unless Puppet::Util.get_environment(mode) == $old_env
-        Puppet::Util.clear_environment(mode)
-        $old_env.each {|k, v| Puppet::Util.set_env(k, v, mode) }
+      if ENV.to_hash != $old_env
+        ENV.replace($old_env)
       end
 
       # Clear all environments

--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -37,7 +37,6 @@ module Util
   def create_erb(content)
     ERB.new(content, trim_mode: '-')
   end
-
   module_function :create_erb
 
   # @param name [String] The name of the environment variable to retrieve
@@ -258,16 +257,16 @@ module Util
     if absolute_path?(bin)
       return bin if FileTest.file? bin and FileTest.executable? bin
     else
-      exts = Puppet::Util.get_env('PATHEXT')
+      exts = ENV['PATHEXT']
       exts = exts ? exts.split(File::PATH_SEPARATOR) : %w[.COM .EXE .BAT .CMD]
-      Puppet::Util.get_env('PATH').split(File::PATH_SEPARATOR).each do |dir|
+      ENV['PATH'].split(File::PATH_SEPARATOR).each do |dir|
         begin
           dest = File.expand_path(File.join(dir, bin))
         rescue ArgumentError => e
           # if the user's PATH contains a literal tilde (~) character and HOME is not set, we may get
           # an ArgumentError here.  Let's check to see if that is the case; if not, re-raise whatever error
           # was thrown.
-          if e.to_s =~ /HOME/ and (Puppet::Util.get_env('HOME').nil? || Puppet::Util.get_env('HOME') == "")
+          if e.to_s =~ /HOME/ and (ENV['HOME'].nil? || ENV['HOME'] == "")
             # if we get here they have a tilde in their PATH.  We'll issue a single warning about this and then
             # ignore this path element and carry on with our lives.
             #TRANSLATORS PATH and HOME are environment variables and should not be translated

--- a/lib/puppet/util/execution.rb
+++ b/lib/puppet/util/execution.rb
@@ -379,7 +379,7 @@ module Puppet::Util::Execution
     end.join(" ") if command.is_a?(Array)
 
     options[:custom_environment] ||= {}
-    Puppet::Util.withenv(options[:custom_environment], :windows) do
+    Puppet::Util.withenv(options[:custom_environment]) do
       Puppet::Util::Windows::Process.execute(command, options, stdin, stdout, stderr)
     end
   end

--- a/spec/integration/defaults_spec.rb
+++ b/spec/integration/defaults_spec.rb
@@ -148,7 +148,7 @@ describe "Puppet defaults" do
       Puppet::Util.withenv( {"PATH" => path }, :windows) do
         Puppet.settings[:path] = "none" # this causes it to ignore the setting
 
-        expect(Puppet::Util.get_env('Path')).to eq(path)
+        expect(ENV['Path']).to eq(path)
       end
     end
   end

--- a/spec/integration/defaults_spec.rb
+++ b/spec/integration/defaults_spec.rb
@@ -137,7 +137,7 @@ describe "Puppet defaults" do
 
     it "path should not add anything" do
       path = "c:\\windows\\system32#{File::PATH_SEPARATOR}c:\\windows"
-      Puppet::Util.withenv( {"PATH" => path }, :windows ) do
+      Puppet::Util.withenv("PATH" => path) do
         Puppet.settings[:path] = "none" # this causes it to ignore the setting
         expect(ENV["PATH"]).to eq(path)
       end
@@ -145,7 +145,7 @@ describe "Puppet defaults" do
 
     it "path should support UTF8 characters" do
       path = "c:\\windows\\system32#{File::PATH_SEPARATOR}c:\\windows#{File::PATH_SEPARATOR}C:\\" + rune_utf8
-      Puppet::Util.withenv( {"PATH" => path }, :windows) do
+      Puppet::Util.withenv("PATH" => path) do
         Puppet.settings[:path] = "none" # this causes it to ignore the setting
 
         expect(ENV['Path']).to eq(path)

--- a/spec/integration/util_spec.rb
+++ b/spec/integration/util_spec.rb
@@ -96,7 +96,7 @@ describe Puppet::Util do
       Puppet::FileSystem.touch(filepath)
 
       path = [utf8, "c:\\windows\\system32", "c:\\windows"].join(File::PATH_SEPARATOR)
-      Puppet::Util.withenv( { "PATH" => path } , :windows) do
+      Puppet::Util.withenv("PATH" => path) do
         expect(Puppet::Util.which(filename)).to eq(filepath)
       end
     end

--- a/spec/unit/provider/package/gem_spec.rb
+++ b/spec/unit/provider/package/gem_spec.rb
@@ -51,8 +51,8 @@ context Puppet::Type.type(:package).provider(:gem) do
 
         before do
           allow(Puppet::Util::Platform).to receive(:windows?).and_return(true)
-          allow(Puppet::Util).to receive(:get_env)
-          allow(Puppet::Util).to receive(:get_env).with('PATH').and_return(path)
+          allow(ENV).to receive(:[]).and_call_original
+          allow(ENV).to receive(:[]).with('PATH').and_return(path)
           allow(described_class).to receive(:validate_command).with(provider_gem_cmd)
           stub_const('::File::PATH_SEPARATOR', ';')
         end

--- a/spec/unit/provider/package/puppet_gem_spec.rb
+++ b/spec/unit/provider/package/puppet_gem_spec.rb
@@ -35,8 +35,8 @@ describe Puppet::Type.type(:package).provider(:puppet_gem) do
   describe '.windows_gemcmd' do
     context 'when PUPPET_DIR is not set' do
       before do
-        allow(Puppet::Util).to receive(:get_env).and_call_original
-        allow(Puppet::Util).to receive(:get_env).with('PUPPET_DIR').and_return(nil)
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with('PUPPET_DIR').and_return(nil)
         allow(Gem).to receive(:default_bindir).and_return('default_gem_bin')
       end
 
@@ -48,8 +48,8 @@ describe Puppet::Type.type(:package).provider(:puppet_gem) do
 
     context 'when PUPPET_DIR is set' do
       before do
-        allow(Puppet::Util).to receive(:get_env).and_call_original
-        allow(Puppet::Util).to receive(:get_env).with('PUPPET_DIR').and_return('puppet_dir')
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with('PUPPET_DIR').and_return('puppet_dir')
       end
 
       it 'uses Gem.default_bindir' do

--- a/spec/unit/test/test_helper_spec.rb
+++ b/spec/unit/test/test_helper_spec.rb
@@ -4,14 +4,14 @@ describe "TestHelper" do
   context "#after_each_test" do
     it "restores the original environment" do
       varname = 'test_helper_spec-test_variable'
-      Puppet::Util.set_env(varname, "\u16A0")
+      ENV[varname] = "\u16A0"
 
-      expect(Puppet::Util.get_env(varname)).to eq("\u16A0")
+      expect(ENV[varname]).to eq("\u16A0")
 
       # Prematurely trigger the after_each_test method
       Puppet::Test::TestHelper.after_each_test
 
-      expect(Puppet::Util::get_env(varname)).to be_nil
+      expect(ENV[varname]).to be_nil
     end
   end
 end

--- a/spec/unit/util/run_mode_spec.rb
+++ b/spec/unit/util/run_mode_spec.rb
@@ -171,30 +171,6 @@ describe Puppet::Util::RunMode do
         end
       end
     end
-
-    describe "#without_env internal helper with UTF8 characters" do
-      let(:varname) { "\u16A0\u16C7\u16BB\u16EB\u16D2\u16E6\u16A6\u16EB\u16A0\u16B1\u16A9\u16A0\u16A2\u16B1\u16EB\u16A0\u16C1\u16B1\u16AA\u16EB\u16B7\u16D6\u16BB\u16B9\u16E6\u16DA\u16B3\u16A2\u16D7" }
-      let(:rune_utf8) { "\u16A0\u16C7\u16BB\u16EB\u16D2\u16E6\u16A6\u16EB\u16A0\u16B1\u16A9\u16A0\u16A2\u16B1\u16EB\u16A0\u16C1\u16B1\u16AA\u16EB\u16B7\u16D6\u16BB\u16B9\u16E6\u16DA\u16B3\u16A2\u16D7" }
-
-      before do
-        Puppet::Util::Windows::Process.set_environment_variable(varname, rune_utf8)
-      end
-
-      it "removes environment variables within the block with UTF8 name" do
-        without_env(varname) do
-          expect(ENV[varname]).to be(nil)
-        end
-      end
-
-      it "restores UTF8 characters in environment variable values" do
-        without_env(varname) do
-          Puppet::Util::Windows::Process.set_environment_variable(varname, 'bad value')
-        end
-
-        envhash = Puppet::Util::Windows::Process.get_environment_strings
-        expect(envhash[varname]).to eq(rune_utf8)
-      end
-    end
   end
 
   def as_root
@@ -205,13 +181,5 @@ describe Puppet::Util::RunMode do
   def as_non_root
     allow(Puppet.features).to receive(:root?).and_return(false)
     yield
-  end
-
-  def without_env(name, &block)
-    saved = Puppet::Util.get_env(name)
-    Puppet::Util.set_env(name, nil)
-    yield
-  ensure
-    Puppet::Util.set_env(name, saved)
   end
 end

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -129,7 +129,7 @@ describe Puppet::Util do
         ENV[env_key] = original_value
         new_value = 'goodbye'
 
-        Puppet::Util.withenv({env_key.upcase => new_value}, :posix) do
+        Puppet::Util.withenv(env_key.upcase => new_value) do
           expect(ENV[env_key]).to eq(original_value)
           expect(ENV[env_key.upcase]).to eq(new_value)
         end
@@ -154,7 +154,7 @@ describe Puppet::Util do
         ENV[env_key] = original_value
         new_value = 'goodbye'
 
-        Puppet::Util.withenv({env_key.upcase => new_value}, :windows) do
+        Puppet::Util.withenv(env_key.upcase => new_value) do
           expect(ENV[env_key]).to eq(new_value)
           expect(ENV[env_key.upcase]).to eq(new_value)
         end
@@ -174,7 +174,7 @@ describe Puppet::Util do
       utf_8_value = utf_8_key + 'value'
       codepage_key = utf_8_key.dup.force_encoding(Encoding.default_external)
 
-      Puppet::Util.withenv({utf_8_key => utf_8_value}, :windows) do
+      Puppet::Util.withenv(utf_8_key => utf_8_value) do
         # the true Windows environment APIs see the variables correctly
         expect(process.get_environment_strings[utf_8_key]).to eq(utf_8_value)
 
@@ -201,7 +201,7 @@ describe Puppet::Util do
         process.set_environment_variable(env_var_name, utf_8_str)
 
         original_keys = process.get_environment_strings.keys.to_a
-        Puppet::Util.withenv({}, :windows) { }
+        Puppet::Util.withenv({}) { }
 
         env = process.get_environment_strings
 

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -676,8 +676,8 @@ describe Puppet::Util do
       end
 
       it "should walk the search PATH returning the first executable" do
-        allow(Puppet::Util).to receive(:get_env).with('PATH').and_return(File.expand_path('/bin'))
-        allow(Puppet::Util).to receive(:get_env).with('PATHEXT').and_return(nil)
+        allow(ENV).to receive(:[]).with('PATH').and_return(File.expand_path('/bin'))
+        allow(ENV).to receive(:[]).with('PATHEXT').and_return(nil)
 
         expect(Puppet::Util.which('foo')).to eq(path)
       end
@@ -693,8 +693,8 @@ describe Puppet::Util do
 
       describe "when a file extension is specified" do
         it "should walk each directory in PATH ignoring PATHEXT" do
-          allow(Puppet::Util).to receive(:get_env).with('PATH').and_return(%w[/bar /bin].map{|dir| File.expand_path(dir)}.join(File::PATH_SEPARATOR))
-          allow(Puppet::Util).to receive(:get_env).with('PATHEXT').and_return('.FOOBAR')
+          allow(ENV).to receive(:[]).with('PATH').and_return(%w[/bar /bin].map{|dir| File.expand_path(dir)}.join(File::PATH_SEPARATOR))
+          allow(ENV).to receive(:[]).with('PATHEXT').and_return('.FOOBAR')
 
           expect(FileTest).to receive(:file?).with(File.join(File.expand_path('/bar'), 'foo.CMD')).and_return(false)
 
@@ -705,8 +705,8 @@ describe Puppet::Util do
       describe "when a file extension is not specified" do
         it "should walk each extension in PATHEXT until an executable is found" do
           bar = File.expand_path('/bar')
-          allow(Puppet::Util).to receive(:get_env).with('PATH').and_return("#{bar}#{File::PATH_SEPARATOR}#{base}")
-          allow(Puppet::Util).to receive(:get_env).with('PATHEXT').and_return(".EXE#{File::PATH_SEPARATOR}.CMD")
+          allow(ENV).to receive(:[]).with('PATH').and_return("#{bar}#{File::PATH_SEPARATOR}#{base}")
+          allow(ENV).to receive(:[]).with('PATHEXT').and_return(".EXE#{File::PATH_SEPARATOR}.CMD")
 
           expect(FileTest).to receive(:file?).ordered().with(File.join(bar, 'foo.EXE')).and_return(false)
           expect(FileTest).to receive(:file?).ordered().with(File.join(bar, 'foo.CMD')).and_return(false)
@@ -717,8 +717,8 @@ describe Puppet::Util do
         end
 
         it "should walk the default extension path if the environment variable is not defined" do
-          allow(Puppet::Util).to receive(:get_env).with('PATH').and_return(base)
-          allow(Puppet::Util).to receive(:get_env).with('PATHEXT').and_return(nil)
+          allow(ENV).to receive(:[]).with('PATH').and_return(base)
+          allow(ENV).to receive(:[]).with('PATHEXT').and_return(nil)
 
           %w[.COM .EXE .BAT].each do |ext|
             expect(FileTest).to receive(:file?).ordered().with(File.join(base, "foo#{ext}")).and_return(false)
@@ -729,8 +729,8 @@ describe Puppet::Util do
         end
 
         it "should fall back if no extension matches" do
-          allow(Puppet::Util).to receive(:get_env).with('PATH').and_return(base)
-          allow(Puppet::Util).to receive(:get_env).with('PATHEXT').and_return(".EXE")
+          allow(ENV).to receive(:[]).with('PATH').and_return(base)
+          allow(ENV).to receive(:[]).with('PATHEXT').and_return(".EXE")
 
           allow(FileTest).to receive(:file?).with(File.join(base, 'foo.EXE')).and_return(false)
           allow(FileTest).to receive(:file?).with(File.join(base, 'foo')).and_return(true)

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -65,6 +65,28 @@ describe Puppet::Util do
       end
       expect(ENV["FOO"]).to eq(nil)
     end
+    it "accepts a unicode key" do
+      key = "\u16A0\u16C7\u16BB\u16EB\u16D2\u16E6\u16A6\u16EB\u16A0\u16B1\u16A9\u16A0\u16A2\u16B1\u16EB\u16A0\u16C1\u16B1\u16AA\u16EB\u16B7\u16D6\u16BB\u16B9\u16E6\u16DA\u16B3\u16A2\u16D7"
+
+      Puppet::Util.withenv(key => "bar") do
+        expect(ENV[key]).to eq("bar")
+      end
+    end
+
+    it "accepts a unicode value" do
+      value = "\u16A0\u16C7\u16BB\u16EB\u16D2\u16E6\u16A6\u16EB\u16A0\u16B1\u16A9\u16A0\u16A2\u16B1\u16EB\u16A0\u16C1\u16B1\u16AA\u16EB\u16B7\u16D6\u16BB\u16B9\u16E6\u16DA\u16B3\u16A2\u16D7"
+
+      Puppet::Util.withenv("runes" => value) do
+        expect(ENV["runes"]).to eq(value)
+      end
+    end
+
+    it "accepts a nil value" do
+      Puppet::Util.withenv("foo" => nil) do
+        expect(ENV["foo"]).to eq(nil)
+      end
+    end
+
   end
 
   describe "#withenv on POSIX", :unless => Puppet::Util::Platform.windows? do


### PR DESCRIPTION
Ruby 3 no longer uses the current code page when getting and setting environment variables. Instead it always calls wide functions like [`GetEnvironmentVariableW`](https://learn.microsoft.com/en-us/windows/win32/api/processenv/nf-processenv-getenvironmentvariablew) and transcodes the value from `UTF-16LE` to `UTF-8`. And it does the reverse when setting environment variables. As a result, we don't need our Windows specific code for accessing environment variables.

* Deprecates `Puppet::Util.{get_env,get_environment,clear_environment,set_env,merge_environment}`
* Call `ENV` related methods directly
* Add more boundary cases for valid env keys and values

Tested Windows (x86, x64 and Japanese) in https://jenkins-platform.delivery.puppetlabs.net/view/puppet-agent/view/ad-hoc/job/platform_puppet-agent-extra_puppet-agent-integration-suite_adhoc-ad_hoc/1103/