### PR TITLE
(PUP-10928) Fix indirected_routes_spec.rb

### DIFF
--- a/spec/unit/network/http/api/indirected_routes_spec.rb
+++ b/spec/unit/network/http/api/indirected_routes_spec.rb
@@ -216,6 +216,7 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
       data = Puppet::IndirectorTesting.new("my data")
       indirection.save(data, "my data")
       request = a_request_that_finds(data, :accept_header => "unknown, text/pson")
+      allow(Puppet.features).to receive(:pson?).and_return(true)
       allow(data).to receive(:to_pson).and_raise(Puppet::Network::FormatHandler::FormatError, 'Could not render to Puppet::Network::Format[pson]: source sequence is illegal/malformed utf-8')
 
       expect {
@@ -267,6 +268,7 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
       data = Puppet::IndirectorTesting.new("my data")
       indirection.save(data, "my data")
       request = a_request_that_searches(Puppet::IndirectorTesting.new("my"), :accept_header => "unknown, text/pson")
+      allow(Puppet.features).to receive(:pson?).and_return(true)
       allow(data).to receive(:to_pson).and_raise(Puppet::Network::FormatHandler::FormatError, 'Could not render to Puppet::Network::Format[pson]: source sequence is illegal/malformed utf-8')
 
       expect {


### PR DESCRIPTION
Unlike puppet#7.x (where the `:allow_pson_serialization` setting was first
added), by default in puppet#main, pson is not a supported format so the rspec
tests for `:allow_pson_serialization` were not able to test the desired behavior.
This commit stubs out `Puppet.features.pson?` in those tests to stimulate that 
the `puppet-pson` library is present so pson is a supported format returned by
`accepted_response_formatters`.