### PR TITLE
(PUP-11785) Don't fallback to PSON if catalog rendering fails

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1718,7 +1718,7 @@ EOT
       }
     },
     :allow_pson_serialization => {
-      :default    => true,
+      :default    => false,
       :type       => :boolean,
       :desc       => "Whether when unable to serialize to JSON or other formats,
         Puppet falls back to PSON. This option affects both puppetserver's

--- a/spec/unit/network/http/api/indirected_routes_spec.rb
+++ b/spec/unit/network/http/api/indirected_routes_spec.rb
@@ -178,6 +178,7 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
     end
 
     it "falls back to the next supported format", if: Puppet.features.pson? do
+      Puppet[:allow_pson_serialization] = true
       data = Puppet::IndirectorTesting.new("my data")
       indirection.save(data, "my data")
       request = a_request_that_finds(data, :accept_header => "application/json, text/pson")
@@ -211,8 +212,7 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
       }.to raise_error(not_found_error)
     end
 
-    it "should raise FormatError if tries to fallback and pson serialization is not allowed" do
-      Puppet[:allow_pson_serialization] = false
+    it "should raise FormatError if tries to fallback" do
       data = Puppet::IndirectorTesting.new("my data")
       indirection.save(data, "my data")
       request = a_request_that_finds(data, :accept_header => "unknown, text/pson")
@@ -239,6 +239,7 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
     end
 
     it "falls back to the next supported format", if: Puppet.features.pson? do
+      Puppet[:allow_pson_serialization] = true
       data = Puppet::IndirectorTesting.new("my data")
       indirection.save(data, "my data")
       request = a_request_that_searches(Puppet::IndirectorTesting.new("my"), :accept_header => "application/json, text/pson")
@@ -254,17 +255,15 @@ describe Puppet::Network::HTTP::API::IndirectedRoutes do
     it "raises 406 not acceptable if no formats are accceptable" do
       data = Puppet::IndirectorTesting.new("my data")
       indirection.save(data, "my data")
-      request = a_request_that_searches(Puppet::IndirectorTesting.new("my"), :accept_header => "application/json")
-      allow(data).to receive(:to_json).and_raise(Puppet::Network::FormatHandler::FormatError, 'Could not render to Puppet::Network::Format[json]: source sequence is illegal/malformed utf-8')
+      request = a_request_that_searches(Puppet::IndirectorTesting.new("my"), :accept_header => "unknown")
 
       expect {
         handler.call(request, response)
       }.to raise_error(Puppet::Network::HTTP::Error::HTTPNotAcceptableError,
-                       %r{No supported formats are acceptable \(Accept: application/json\)})
+                       %r{No supported formats are acceptable \(Accept: unknown\)})
     end
 
-    it "raises FormatError if tries to fallback and pson serialization is not allowed" do
-      Puppet[:allow_pson_serialization] = false
+    it "raises FormatError if tries to fallback" do
       data = Puppet::IndirectorTesting.new("my data")
       indirection.save(data, "my data")
       request = a_request_that_searches(Puppet::IndirectorTesting.new("my"), :accept_header => "unknown, text/pson")


### PR DESCRIPTION
Rich data is enabled by default and when attempting to serialize rich data to PSON, there will be data loss since rich data cannot be serialized via PSON. Due to this, this commit sets the default value for :allow_pson_serialization to false for Puppet 8. This means an error will be raised when falling back to PSON.