### PR TITLE
(maint) Update CODEOWNERS with modules team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,11 +1,11 @@
 # defaults
-* @puppetlabs/phoenix @puppetlabs/puppetserver-maintainers
+* @puppetlabs/phoenix
 
 # PAL
 /lib/puppet/pal @puppetlabs/bolt
 
 # puppet module
-/lib/puppet/application/module.rb @puppetlabs/pdk
-/lib/puppet/face/module @puppetlabs/pdk
-/lib/puppet/forge @puppetlabs/pdk
-/lib/puppet/module_tool @puppetlabs/pdk
+/lib/puppet/application/module.rb @puppetlabs/modules
+/lib/puppet/face/module @puppetlabs/modules
+/lib/puppet/forge @puppetlabs/modules
+/lib/puppet/module_tool @puppetlabs/modules


### PR DESCRIPTION
This commit transfers ownership of certain parts of the codebase from the PDK GitHub team to the larger, more current Modules GitHub team.