### PR TITLE
(PUP-11723) Remove concurrent-ruby private class

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency(%q<fast_gettext>, ">= 1.1", "< 3")
   s.add_runtime_dependency(%q<locale>, "~> 2.1")
   s.add_runtime_dependency(%q<multi_json>, "~> 1.13")
-  s.add_runtime_dependency(%q<concurrent-ruby>, ["~> 1.0", "< 1.2.0"])
+  s.add_runtime_dependency(%q<concurrent-ruby>, "~> 1.0")
   s.add_runtime_dependency(%q<deep_merge>, "~> 1.0")
   s.add_runtime_dependency(%q<scanf>, "~> 1.0")
 

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -25,7 +25,7 @@ gem_runtime_dependencies:
   locale: '~> 2.1'
   multi_json: '~> 1.10'
   puppet-resource_api: '~>1.5'
-  concurrent-ruby: ["~> 1.0", "< 1.2.0"]
+  concurrent-ruby: "~> 1.0"
   deep_merge: '~> 1.0'
   scanf: '~> 1.0'
 gem_rdoc_options:

--- a/lib/puppet/thread_local.rb
+++ b/lib/puppet/thread_local.rb
@@ -1,7 +1,4 @@
 require 'concurrent'
 
-# We want to use the pure Ruby implementation even on JRuby. If we use the Java
-# implementation of ThreadLocal, we end up leaking references to JRuby instances
-# and preventing them from being garbage collected.
-class Puppet::ThreadLocal < Concurrent::RubyThreadLocalVar
+class Puppet::ThreadLocal < Concurrent::ThreadLocalVar
 end


### PR DESCRIPTION
Prior to this commit, Puppet relied on the
Concurrent::RubyThreadLocalVar private class in concurrent-ruby.

This private class was removed in concurrent-ruby v1.2.0: https://github.com/ruby-concurrency/concurrent-ruby/commit/30465396

This commit updates Puppet::ThreadLocal to use
Concurrent::ThreadLocalVar instead of Concurrent::RubyThreadLocalVar and updates Puppet's dependency on concurrent-ruby to remove the pin to < v1.2.0.