### PR TITLE
(PUP-10639) Periodically refresh our CA bundle

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1212,6 +1212,24 @@ EOT
       :desc       => "The default TTL for new certificates.
       #{AS_DURATION}",
     },
+    :ca_refresh_interval => {
+      :default    => "1d",
+      :type       => :duration,
+      :desc       => "How often the Puppet agent refreshes its local CA certs. By
+         default the CA certs are refreshed once every 24 hours. If a different
+         duration is specified, then the agent will refresh its CA certs whenever
+         it next runs and the elapsed time since the certs were last refreshed
+         exceeds the duration.
+
+         In general, the duration should be greater than the `runinterval`.
+         Setting it to 0 or an equal or lesser value than `runinterval`,
+         will cause the CA certs to be refreshed on every run.
+
+         If the agent downloads new CA certs, the agent will use it for subsequent
+         network requests. If the refresh request fails or if the CA certs are
+         unchanged on the server, then the agent run will continue using the
+         local CA certs it already has. #{AS_DURATION}",
+    },
     :crl_refresh_interval => {
       :default    => "1d",
       :type       => :duration,
@@ -1222,8 +1240,8 @@ EOT
          exceeds the duration.
 
          In general, the duration should be greater than the `runinterval`.
-         Setting it to an equal or lesser value will cause the CRL to be
-         refreshed on every run.
+         Setting it to 0 or an equal or lesser value than `runinterval`,
+         will cause the CRL to be refreshed on every run.
 
          If the agent downloads a new CRL, the agent will use it for subsequent
          network requests. If the refresh request fails or if the CRL is

--- a/lib/puppet/http/service/ca.rb
+++ b/lib/puppet/http/service/ca.rb
@@ -28,16 +28,21 @@ class Puppet::HTTP::Service::Ca < Puppet::HTTP::Service
   # Submit a GET request to retrieve the named certificate from the server.
   #
   # @param [String] name name of the certificate to request
+  # @param [Time] if_modified_since If not nil, only download the cert if it has
+  #   been modified since the specified time.
   # @param [Puppet::SSL::SSLContext] ssl_context
   #
   # @return [Array<Puppet::HTTP::Response, String>] An array containing the
   #   request response and the stringified body of the request response
   #
   # @api public
-  def get_certificate(name, ssl_context: nil)
+  def get_certificate(name, if_modified_since: nil, ssl_context: nil)
+    headers = add_puppet_headers(HEADERS)
+    headers['If-Modified-Since'] = if_modified_since.httpdate if if_modified_since
+
     response = @client.get(
       with_base_url("/certificate/#{name}"),
-      headers: add_puppet_headers(HEADERS),
+      headers: headers,
       options: {ssl_context: ssl_context}
     )
 

--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -71,7 +71,7 @@ class Puppet::SSL::StateMachine
         route = @machine.session.route_to(:ca, ssl_context: @ssl_context)
         _, pem = route.get_certificate(Puppet::SSL::CA_NAME, ssl_context: @ssl_context)
         if @machine.ca_fingerprint
-          actual_digest = Puppet::SSL::Digest.new(@machine.digest, pem).to_hex
+          actual_digest = @machine.digest_as_hex(pem)
           expected_digest = @machine.ca_fingerprint.scan(/../).join(':').upcase
           if actual_digest == expected_digest
             Puppet.info(_("Verified CA bundle with digest (%{digest_type}) %{actual_digest}") %
@@ -139,8 +139,7 @@ class Puppet::SSL::StateMachine
       next_ctx = @ssl_provider.create_root_context(cacerts: cacerts, revocation: false)
       @cert_provider.save_cacerts(cacerts)
 
-      digest = Puppet::SSL::Digest.new(@machine.digest, pem).to_hex
-      Puppet.info("Refreshed CA certificate: #{digest}")
+      Puppet.info("Refreshed CA certificate: #{@machine.digest_as_hex(pem)}")
 
       next_ctx
     end
@@ -235,8 +234,7 @@ class Puppet::SSL::StateMachine
       next_ctx = @ssl_provider.create_root_context(cacerts: ssl_ctx[:cacerts], crls: crls)
       @cert_provider.save_crls(crls)
 
-      digest = Puppet::SSL::Digest.new(@machine.digest, pem).to_hex
-      Puppet.info("Refreshed CRL: #{digest}")
+      Puppet.info("Refreshed CRL: #{@machine.digest_as_hex(pem)}")
 
       next_ctx
     end
@@ -515,6 +513,10 @@ class Puppet::SSL::StateMachine
 
   def unlock
     @lockfile.unlock
+  end
+
+  def digest_as_hex(str)
+    Puppet::SSL::Digest.new(digest, str).to_hex
   end
 
   private

--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -139,6 +139,9 @@ class Puppet::SSL::StateMachine
       next_ctx = @ssl_provider.create_root_context(cacerts: cacerts, revocation: false)
       @cert_provider.save_cacerts(cacerts)
 
+      digest = Puppet::SSL::Digest.new(@machine.digest, pem).to_hex
+      Puppet.info("Refreshed CA certificate: #{digest}")
+
       next_ctx
     end
   end
@@ -231,6 +234,9 @@ class Puppet::SSL::StateMachine
       # verify crls before saving
       next_ctx = @ssl_provider.create_root_context(cacerts: ssl_ctx[:cacerts], crls: crls)
       @cert_provider.save_crls(crls)
+
+      digest = Puppet::SSL::Digest.new(@machine.digest, pem).to_hex
+      Puppet.info("Refreshed CRL: #{digest}")
 
       next_ctx
     end

--- a/lib/puppet/x509/cert_provider.rb
+++ b/lib/puppet/x509/cert_provider.rb
@@ -147,6 +147,28 @@ class Puppet::X509::CertProvider
     Puppet::FileSystem.touch(@crlpath, mtime: time)
   end
 
+  # Return the time when the CA bundle was last updated.
+  #
+  # @return [Time, nil] Time when the CA bundle was last updated, or nil if we don't
+  #   have a CA bundle
+  #
+  # @api private
+  def ca_last_update
+    stat = Puppet::FileSystem.stat(@capath)
+    Time.at(stat.mtime)
+  rescue Errno::ENOENT
+    nil
+  end
+
+  # Set the CA bundle last updated time.
+  #
+  # @param time [Time] The last updated time
+  #
+  # @api private
+  def ca_last_update=(time)
+    Puppet::FileSystem.touch(@capath, mtime: time)
+  end
+
   # Save named private key in the configured `privatekeydir`. For
   # historical reasons, names are case insensitive.
   #

--- a/spec/integration/application/agent_spec.rb
+++ b/spec/integration/application/agent_spec.rb
@@ -1043,6 +1043,7 @@ describe "puppet agent", unless: Puppet::Util::Platform.jruby? do
         expect {
           agent.run
         }.to exit_with(1)
+          .and output(/Info: Loading facts/).to_stdout
           .and output(
             match(/Error: Evaluation Error: Unknown variable: 'osfamily'/)
               .and match(/Error: Could not retrieve catalog from remote server: Error 500 on SERVER:/)

--- a/spec/integration/application/agent_spec.rb
+++ b/spec/integration/application/agent_spec.rb
@@ -896,6 +896,55 @@ describe "puppet agent", unless: Puppet::Util::Platform.jruby? do
          .and output(%r{Certificate 'CN=revoked' is revoked}).to_stderr
       end
     end
+
+    it "refreshes the CA and CRL" do
+      Puppet[:localcacert] = ca = tmpfile('ca')
+      Puppet[:hostcrl] = crl = tmpfile('crl')
+      copy_fixtures(%w[ca.pem intermediate.pem], ca)
+      copy_fixtures(%w[crl.pem intermediate-crl.pem], crl)
+
+      now = Time.now
+      yesterday = now - (60 * 60 * 24)
+      Puppet::FileSystem.touch(ca, mtime: yesterday)
+      Puppet::FileSystem.touch(crl, mtime: yesterday)
+
+      server.start_server do |port|
+        Puppet[:serverport] = port
+        Puppet[:ca_refresh_interval] = 1
+
+        expect {
+          agent.command_line.args << '--test'
+          agent.run
+        }.to exit_with(0)
+         .and output(/Info: Refreshed CA certificate: /).to_stdout
+      end
+
+      # If the CA is updated, then the CRL must be updated too
+      expect(Puppet::FileSystem.stat(ca).mtime).to be >= now
+      expect(Puppet::FileSystem.stat(crl).mtime).to be >= now
+    end
+
+    it "refreshes only the CRL" do
+      Puppet[:hostcrl] = crl = tmpfile('crl')
+      copy_fixtures(%w[crl.pem intermediate-crl.pem], crl)
+
+      now = Time.now
+      yesterday = now - (60 * 60 * 24)
+      Puppet::FileSystem.touch(crl, mtime: yesterday)
+
+      server.start_server do |port|
+        Puppet[:serverport] = port
+        Puppet[:crl_refresh_interval] = 1
+
+        expect {
+          agent.command_line.args << '--test'
+          agent.run
+        }.to exit_with(0)
+         .and output(/Info: Refreshed CRL: /).to_stdout
+      end
+
+      expect(Puppet::FileSystem.stat(crl).mtime).to be >= now
+    end
   end
 
   context "legacy facts" do

--- a/spec/unit/application/lookup_spec.rb
+++ b/spec/unit/application/lookup_spec.rb
@@ -668,6 +668,7 @@ Searching for "a"
           expect {
             lookup.run_command
           }.to exit_with(0)
+           .and output(/This is in facts hash/).to_stdout
         end
       end
     end

--- a/spec/unit/http/service/ca_spec.rb
+++ b/spec/unit/http/service/ca_spec.rb
@@ -95,6 +95,18 @@ describe Puppet::HTTP::Service::Ca do
         expect(err.response.code).to eq(404)
       end
     end
+
+    it 'raises a 304 response error if it is unmodified' do
+      stub_request(:get, url).to_return(status: [304, 'Not Modified'])
+
+      expect {
+        subject.get_certificate('ca', if_modified_since: Time.now)
+      }.to raise_error do |err|
+        expect(err).to be_an_instance_of(Puppet::HTTP::ResponseError)
+        expect(err.message).to eq("Not Modified")
+        expect(err.response.code).to eq(304)
+      end
+    end
   end
 
   context 'when getting CRLs' do

--- a/spec/unit/x509/cert_provider_spec.rb
+++ b/spec/unit/x509/cert_provider_spec.rb
@@ -586,6 +586,32 @@ describe Puppet::X509::CertProvider do
     end
   end
 
+  context 'CA last update time' do
+    let(:ca_path) { tmpfile('pem_ca') }
+
+    it 'returns nil if the CA does not exist' do
+      provider = create_provider(capath: '/does/not/exist')
+
+      expect(provider.ca_last_update).to be_nil
+    end
+
+    it 'returns the last update time' do
+      time = Time.now - 30
+      Puppet::FileSystem.touch(ca_path, mtime: time)
+      provider = create_provider(capath: ca_path)
+
+      expect(provider.ca_last_update).to be_within(1).of(time)
+    end
+
+    it 'sets the last update time' do
+      time = Time.now - 30
+      provider = create_provider(capath: ca_path)
+      provider.ca_last_update = time
+
+      expect(Puppet::FileSystem.stat(ca_path).mtime).to be_within(1).of(time)
+    end
+  end
+
   context 'CRL last update time' do
     let(:crl_path) { tmpfile('pem_crls') }
 


### PR DESCRIPTION
By default, puppet agents will now attempt to **refresh** their CA bundle once per day. If new certs are successfully downloaded, then those will be used for subsequent TLS connections. The agent will also automatically attempt to refresh its CRL bundle, since if a new CA was retrieved, then we will need its corresponding CRL to verify the full cert chain.

If there are no changes to the CA bundle or if the agent is unable to retrieve them, then it will continue using its existing CA certs and try again later (after another day).

- [x] Needs integration tests

```
$ bundle exec puppet agent -t --ca_refresh_interval=1s --crl_refresh_interval=1s
Info: Refreshing CA certificate
Info: Refreshed CA certificate: 44:B4:4F:8B:B4:D4:C5:9F:66:7F:46:BB:CF:CF:1C:EB:F6:C5:81:15:7B:E6:74:0F:04:31:FA:EC:F4:F4:E5:1A
Info: Refreshing CRL
Info: Refreshed CRL: 15:3F:67:7B:AD:94:87:CE:6B:6A:59:0B:B5:C6:8C:DF:F8:E8:CE:5A:49:A5:7E:F2:1D:57:C6:05:DB:8F:AC:28
Info: Using environment 'production'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Caching catalog for localhost
Info: Applying configuration version '1684976474'
Notice: Applied catalog in 0.03 seconds
```

Where puppetserver contains:

```
# openssl dgst -c /etc/puppetlabs/puppetserver/ca/ca_crt.pem
SHA256(/etc/puppetlabs/puppetserver/ca/ca_crt.pem)= 44:b4:4f:8b:b4:d4:c5:9f:66:7f:46:bb:cf:cf:1c:eb:f6:c5:81:15:7b:e6:74:0f:04:31:fa:ec:f4:f4:e5:1a
# openssl dgst -c /etc/puppetlabs/puppetserver/ca/ca_crl.pem 
SHA256(/etc/puppetlabs/puppetserver/ca/ca_crl.pem)= 15:3f:67:7b:ad:94:87:ce:6b:6a:59:0b:b5:c6:8c:df:f8:e8:ce:5a:49:a5:7e:f2:1d:57:c6:05:db:8f:ac:28
```