### PR TITLE
(docs) `--` and `---` are not rendered as `–` and `—`

### DIFF
--- a/api/docs/http_file_metadata.md
+++ b/api/docs/http_file_metadata.md
@@ -13,11 +13,11 @@ the following three types:
 
 The endpoint path includes a `:mount` which can be one of the following types:
 
-* Custom file serving mounts as specified in fileserver.conf --- see [the docs on configuring mount points](https://puppet.com/docs/puppet/latest/file_serving.html).
-* `modules/<MODULE>` --- a semi-magical mount point which allows access to the `files` subdirectory of `<MODULE>` --- see [the docs on file serving](https://puppet.com/docs/puppet/latest/file_serving.html).
-* `plugins` --- a highly magical mount point which merges the `lib`  directory of every module together. Used for syncing plugins; not intended for general consumption. Per-module sub-paths can not be specified.
-* `pluginfacts` --- a highly magical mount point which merges the `facts.d` directory of every module together. Used for syncing external facts; not intended for general consumption. Per-module sub-paths can not be specified.
-* `tasks/<MODULE>` --- a semi-magical mount point which allows access to files in the `tasks` subdirectory of `<MODULE>` --- see the [the docs on file serving](https://puppet.com/docs/puppet/latest/file_serving.html).
+* Custom file serving mounts as specified in fileserver.conf – see [the docs on configuring mount points](https://puppet.com/docs/puppet/latest/file_serving.html).
+* `modules/<MODULE>` – a semi-magical mount point which allows access to the `files` subdirectory of `<MODULE>` – see [the docs on file serving](https://puppet.com/docs/puppet/latest/file_serving.html).
+* `plugins` – a highly magical mount point which merges the `lib`  directory of every module together. Used for syncing plugins; not intended for general consumption. Per-module sub-paths can not be specified.
+* `pluginfacts` – a highly magical mount point which merges the `facts.d` directory of every module together. Used for syncing external facts; not intended for general consumption. Per-module sub-paths can not be specified.
+* `tasks/<MODULE>` – a semi-magical mount point which allows access to files in the `tasks` subdirectory of `<MODULE>` – see the [the docs on file serving](https://puppet.com/docs/puppet/latest/file_serving.html).
 
 Note: JSON responses in the examples below are pretty-printed for readability.
 
@@ -40,9 +40,9 @@ GET
 
 Optional parameters to GET:
 
-* `links` -- either `manage` (default) or `follow`. See examples in Search below.
-* `checksum_type` -- the checksum type to calculate the checksum value for the result metadata; one of `md5` (default), `md5lite`, `sha256`, `sha256lite`, `mtime`, `ctime`, and `none`.
-* `source_permissions` -- whether (and how) Puppet should copy owner, group, and mode permissions; one of
+* `links` – either `manage` (default) or `follow`. See examples in Search below.
+* `checksum_type` – the checksum type to calculate the checksum value for the result metadata; one of `md5` (default), `md5lite`, `sha256`, `sha256lite`, `mtime`, `ctime`, and `none`.
+* `source_permissions` – whether (and how) Puppet should copy owner, group, and mode permissions; one of
   * `ignore` (the default) will never apply the owner, group, or mode from the source when managing a file. When creating new files without explicit permissions, the permissions they receive will depend on platform-specific behavior. On POSIX, Puppet will use the umask of the user it is running as. On Windows, Puppet will use the default DACL associated with the user it is running as.
   * `use` will cause Puppet to apply the owner, group, and mode from the source to any files it is managing.
   * `use_when_creating` will only apply the owner, group, and mode from the source when creating a file; existing files will not have their permissions overwritten.
@@ -140,11 +140,11 @@ GET
 
 ### Parameters
 
-* `recurse` -- should always be set to `yes`; unfortunately the default is `no`, which causes a search to behave like a find operation.
-* `ignore` -- file or directory regex to ignore; can be repeated.
-* `links` -- either `manage` (default) or `follow`. See examples below.
-* `checksum_type` -- the checksum type to calculate the checksum value for the result metadata; one of `md5` (default), `md5lite`, `sha256`, `sha256lite`, `mtime`, `ctime`, and `none`.
-* `source_permissions` -- whether (and how) Puppet should copy owner, group, and mode permissions; one of
+* `recurse` – should always be set to `yes`; unfortunately the default is `no`, which causes a search to behave like a find operation.
+* `ignore` – file or directory regex to ignore; can be repeated.
+* `links` – either `manage` (default) or `follow`. See examples below.
+* `checksum_type` – the checksum type to calculate the checksum value for the result metadata; one of `md5` (default), `md5lite`, `sha256`, `sha256lite`, `mtime`, `ctime`, and `none`.
+* `source_permissions` – whether (and how) Puppet should copy owner, group, and mode permissions; one of
   * `ignore` (the default) will never apply the owner, group, or mode from the source when managing a file. When creating new files without explicit permissions, the permissions they receive will depend on platform-specific behavior. On POSIX, Puppet will use the umask of the user it is running as. On Windows, Puppet will use the default DACL associated with the user it is running as.
   * `use` will cause Puppet to apply the owner, group, and mode from the source to any files it is managing.
   * `use_when_creating` will only apply the owner, group, and mode from the source when creating a file; existing files will not have their permissions overwritten.

--- a/lib/puppet/type/exec.rb
+++ b/lib/puppet/type/exec.rb
@@ -7,7 +7,7 @@ module Puppet
     @doc = "Executes external commands.
 
       Any command in an `exec` resource **must** be able to run multiple times
-      without causing harm --- that is, it must be *idempotent*. There are three
+      without causing harm – that is, it must be *idempotent*. There are three
       main ways for an exec to be idempotent:
 
       * The command itself is already idempotent. (For example, `apt-get update`.)
@@ -256,7 +256,7 @@ module Puppet
 
     newparam(:group) do
       desc "The group to run the command as.  This seems to work quite
-        haphazardly on different platforms -- it is a platform issue
+        haphazardly on different platforms – it is a platform issue
         not a Ruby or Puppet one, since the same variety exists when
         running commands as different users in the shell."
       # Validation is handled by the SUIDManager class.

--- a/lib/puppet/type/file.rb
+++ b/lib/puppet/type/file.rb
@@ -147,9 +147,9 @@ Puppet::Type.newtype(:file) do
     desc "Whether to recursively manage the _contents_ of a directory. This attribute
       is only used when `ensure => directory` is set. The allowed values are:
 
-      * `false` --- The default behavior. The contents of the directory will not be
+      * `false` – The default behavior. The contents of the directory will not be
         automatically managed.
-      * `remote` --- If the `source` attribute is set, Puppet will automatically
+      * `remote` – If the `source` attribute is set, Puppet will automatically
         manage the contents of the source directory (or directories), ensuring
         that equivalent files and directories exist on the target system and
         that their contents match.
@@ -158,7 +158,7 @@ Puppet::Type.newtype(:file) do
         catalog application than `recurse => true`.
 
         The `source` attribute is mandatory when `recurse => remote`.
-      * `true` --- If the `source` attribute is set, this behaves similarly to
+      * `true` – If the `source` attribute is set, this behaves similarly to
         `recurse => remote`, automatically managing files from the source directory.
 
         This also enables the `purge` attribute, which can delete unmanaged
@@ -193,7 +193,7 @@ Puppet::Type.newtype(:file) do
       The recursion limit affects which files will be copied from the `source`
       directory, as well as which files can be purged when `purge => true`.
 
-      Setting `recurselimit => 0` is the same as setting `recurse => false` ---
+      Setting `recurselimit => 0` is the same as setting `recurse => false` –
       Puppet will manage the directory, but all of its contents will be treated
       as unmanaged.
 

--- a/lib/puppet/type/service.rb
+++ b/lib/puppet/type/service.rb
@@ -10,7 +10,7 @@ module Puppet
 
   Type.newtype(:service) do
     @doc = "Manage running services.  Service support unfortunately varies
-      widely by platform --- some platforms have very little if any concept of a
+      widely by platform – some platforms have very little if any concept of a
       running service, and some have a very codified and powerful concept.
       Puppet's service support is usually capable of doing the right thing, but
       the more information you can provide, the better behaviour you will get.

--- a/lib/puppet/type/tidy.rb
+++ b/lib/puppet/type/tidy.rb
@@ -86,7 +86,7 @@ Puppet::Type.newtype(:tidy) do
       are not in a subdirectory and match one of the shell globs given.
 
       Note that the patterns are matched against the basename of each
-      file -- that is, your glob patterns should not have any '/'
+      file – that is, your glob patterns should not have any '/'
       characters in them, since you are only specifying against the last
       bit of the file.
 

--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -445,7 +445,7 @@ module Puppet
     newproperty(:expiry, :required_features => :manages_expiry) do
       desc "The expiry date for this user. Provide as either the special
            value `absent` to ensure that the account never expires, or as
-           a zero-padded YYYY-MM-DD format -- for example, 2010-02-19."
+           a zero-padded YYYY-MM-DD format – for example, 2010-02-19."
 
       newvalues :absent
       newvalues(/^\d{4}-\d{2}-\d{2}$/)
@@ -715,11 +715,11 @@ module Puppet
         
         Allowed values are:
 
-        * `false` (default) --- don't purge SSH keys for this user.
-        * `true` --- look for keys in the `.ssh/authorized_keys` file in the user's
+        * `false` (default) – don't purge SSH keys for this user.
+        * `true` – look for keys in the `.ssh/authorized_keys` file in the user's
           home directory. Purge any keys that aren't managed as `ssh_authorized_key`
           resources.
-        * An array of file paths --- look for keys in all of the files listed. Purge
+        * An array of file paths – look for keys in all of the files listed. Purge
           any keys that aren't managed as `ssh_authorized_key` resources. If any of
           these paths starts with `~` or `%h`, that token will be replaced with
           the user's home directory."


### PR DESCRIPTION
* This is not LaTeX: `--` and `---` do not get expanded to `–`   (U+2013 EN DASH) and `—` (U+2014 EM DASH) respectively.
* Typographical tradition has it that it is either `foo – bar` (en “short” dash with surrounding spaces) or `foo—bar` (em “long” dash _without_ surrounding spaces). Stick to one style and use endash throughout documentation.
* There should be a non-breaking space (U+00A0 NO-BREAK SPACE) in front of the endash `foo – bar`, because an endash at the beginning of a line is considered ugly, but since some users do not like such invisible special characters, I did not perform that change.