### PR TITLE
(PE-35920) Respect `:avoid_hiera_interpolation_errors` if it is set

### DIFF
--- a/lib/puppet/pops/lookup/hiera_config.rb
+++ b/lib/puppet/pops/lookup/hiera_config.rb
@@ -253,7 +253,9 @@ class HieraConfig
       scope = lookup_invocation.scope
       lookup_invocation.without_explain do
         @scope_interpolations.all? do |key, root_key, segments, old_value|
-          value = Puppet.override(avoid_hiera_interpolation_errors: true) { scope[root_key] }
+          value = Puppet.override(avoid_hiera_interpolation_errors: Puppet.lookup(:avoid_hiera_interpolation_errors) {true}) do
+            scope[root_key]
+          end
           unless value.nil? || segments.empty?
             found = nil;
             catch(:no_such_key) { found = sub_lookup(key, lookup_invocation, segments, value) }
@@ -635,7 +637,7 @@ class HieraConfigV5 < HieraConfig
       entry_datadir = Pathname(interpolate(entry_datadir.to_s, lookup_invocation, false))
       location_key = LOCATION_KEYS.find { |key| he.include?(key) }
       locations = []
-      Puppet.override(avoid_hiera_interpolation_errors: true) do
+      Puppet.override(avoid_hiera_interpolation_errors: Puppet.lookup(:avoid_hiera_interpolation_errors) {true}) do
         locations = case location_key
                     when KEY_PATHS
                       resolve_paths(entry_datadir, he[location_key], lookup_invocation, @config_path.nil?)


### PR DESCRIPTION
Previously `:avoid_hiera_interpolation_errors` was set to True unconditionally. In order to forbid interpolations in plan scope for bolt we rely on raising when an interpolation fails. This commit changes the hiera config class to respect the `:avoid_hiera_interpolation_errors` if it is set.