### PR TITLE
(PUP-11846) Handle unprocessed, deferred sensitive

### DIFF
--- a/lib/puppet/pops/evaluator/deferred_resolver.rb
+++ b/lib/puppet/pops/evaluator/deferred_resolver.rb
@@ -93,14 +93,12 @@ class DeferredResolver
         #
         if resolved.is_a?(Puppet::Pops::Types::PSensitiveType::Sensitive)
           resolved = resolved.unwrap
-          unless r.sensitive_parameters.include?(k.to_sym)
-            r.sensitive_parameters = (r.sensitive_parameters + [k.to_sym]).freeze
-          end
+          mark_sensitive_parameters(r, k)
         # If the value is a DeferredValue and it has an argument of type PSensitiveType, mark it as sensitive
         # The DeferredValue.resolve method will unwrap it during catalog application
         elsif resolved.is_a?(Puppet::Pops::Evaluator::DeferredValue)
-          if v.arguments.any? {|arg| arg.is_a?(Puppet::Pops::Types::PSensitiveType)} and not r.sensitive_parameters.include?(k.to_sym)
-            r.sensitive_parameters = (r.sensitive_parameters + [k.to_sym]).freeze
+          if v.arguments.any? {|arg| arg.is_a?(Puppet::Pops::Types::PSensitiveType)}
+            mark_sensitive_parameters(r, k)
           end
         end
         overrides[ k ] = resolved
@@ -108,6 +106,13 @@ class DeferredResolver
       r.parameters.merge!(overrides) unless overrides.empty?
     end
   end
+
+  def mark_sensitive_parameters(r, k)
+    unless r.sensitive_parameters.include?(k.to_sym)
+      r.sensitive_parameters = (r.sensitive_parameters + [k.to_sym]).freeze
+    end
+  end
+  private :mark_sensitive_parameters
 
   def resolve(x)
     if x.class == @deferred_class

--- a/spec/integration/application/apply_spec.rb
+++ b/spec/integration/application/apply_spec.rb
@@ -755,5 +755,19 @@ class amod::bad_type {
         .and output(/Notify\[runs before file\]/).to_stdout
         .and output(/Validation of File.* failed: You cannot specify more than one of content, source, target/).to_stderr
     end
+
+    it "applies deferred sensitive file content" do
+      manifest = <<~END
+      file { '#{deferred_file}':
+        ensure => file,
+        content => Deferred('new', [Sensitive, "hello\n"])
+      }
+      END
+      apply.command_line.args = ['-e', manifest]
+      expect {
+        apply.run
+      }.to exit_with(0)
+        .and output(/ensure: changed \[redacted\] to \[redacted\]/).to_stdout
+    end
   end
 end


### PR DESCRIPTION
Prior to this commit, evaluating a deferred resource that includes a Sensitive value would fail during munging.  This commit marks these resources as sensitive and unwraps them during catalog application.