### PR TITLE
(PUP-11788) Account for JRuby behavior in Dir.glob

### DIFF
--- a/spec/unit/file_system/path_pattern_spec.rb
+++ b/spec/unit/file_system/path_pattern_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 require 'puppet_spec/files'
 require 'puppet/file_system'
+require 'puppet/util'
 
 describe Puppet::FileSystem::PathPattern do
   include PuppetSpec::Files
@@ -130,6 +131,20 @@ describe Puppet::FileSystem::PathPattern do
 
     expect(pattern.glob).to match_array([File.join(dir, "found_one"),
                                          File.join(dir, "found_two")])
+  end
+
+  it 'globs wildcard patterns properly' do
+    # See PUP-11788 and https://github.com/jruby/jruby/issues/7836.
+    pending 'JRuby does not properly handle Dir.glob' if Puppet::Util::Platform.jruby?
+
+    dir = tmpdir('globtest')
+    create_file_in(dir, 'foo.pp')
+    create_file_in(dir, 'foo.pp.pp')
+
+    pattern = Puppet::FileSystem::PathPattern.absolute(File.join(dir, '**/*.pp'))
+
+    expect(pattern.glob).to match_array([File.join(dir, 'foo.pp'),
+                                         File.join(dir, 'foo.pp.pp')])
   end
 
   def create_file_in(dir, name)


### PR DESCRIPTION
JRuby does not properly match both directory and file wildcards when using Dir.glob (e.g. Dir.glob('**/*.pp'), which can lead to incorrect matches. Because of this, if a manifest name contains ".pp" in its filename (e.g. foo.pp.pp), Puppet does not recognize it as a manifest file when importing and parsing manifests.

This commit updates the perform_initial_import method to no longer rely on that wildcard Dir.glob behavior to recursively traverse a directory and instead uses only the directory wildcard and uses Array.select to identify files ending in ".pp" from there.