### PR TITLE
(maint) Removes AIX 5.3-specific setting

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -3,11 +3,7 @@ require_relative '../puppet/util/platform'
 module Puppet
 
   def self.default_diffargs
-    if (Puppet.runtime[:facter].value(:kernel) == "AIX" && Puppet.runtime[:facter].value(:kernelmajversion) == "5300")
-      ""
-    else
-      "-u"
-    end
+    '-u'
   end
 
   def self.default_digest_algorithm

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -3,46 +3,8 @@ require 'puppet/settings'
 
 describe "Defaults" do
   describe ".default_diffargs" do
-    describe "on AIX" do
-      before(:each) do
-        allow(Facter).to receive(:value).with(:kernel).and_return("AIX")
-      end
-
-      describe "on 5.3" do
-        before(:each) do
-          allow(Facter).to receive(:value).with(:kernelmajversion).and_return("5300")
-        end
-
-        it "should be empty" do
-          expect(Puppet.default_diffargs).to eq("")
-        end
-      end
-
-      [ "",
-        nil,
-        "6300",
-        "7300",
-      ].each do |kernel_version|
-        describe "on kernel version #{kernel_version.inspect}" do
-          before(:each) do
-            allow(Facter).to receive(:value).with(:kernelmajversion).and_return(kernel_version)
-          end
-
-          it "should be '-u'" do
-            expect(Puppet.default_diffargs).to eq("-u")
-          end
-        end
-      end
-    end
-
-    describe "on everything else" do
-      before(:each) do
-        allow(Facter).to receive(:value).with(:kernel).and_return("NOT_AIX")
-      end
-
-      it "should be '-u'" do
-        expect(Puppet.default_diffargs).to eq("-u")
-      end
+    it "should be '-u'" do
+      expect(Puppet.default_diffargs).to eq("-u")
     end
   end
 


### PR DESCRIPTION
bb86ff6 added a conditional to Puppet's default settings to account for unique behavior for diff on AIX 5.3, which has long been end-of-life and is no longer supported by Puppet or Puppet Enterprise.

This commit updates Puppet's default settings for diff and associated spec tests to remove that AIX 5.3-specific conditional.