### PR TITLE
(PUP-11849) Always print the CRL authorityKeyIdentifier

### DIFF
--- a/lib/puppet/ssl/ssl_provider.rb
+++ b/lib/puppet/ssl/ssl_provider.rb
@@ -225,7 +225,7 @@ class Puppet::SSL::SSLProvider
       ssl_context.crls.each do |crl|
         oid_values = Hash[crl.extensions.map { |ext| [ext.oid, ext.value] }]
         crlNumber = oid_values['crlNumber'] || 'unknown'
-        authKeyId = (oid_values['authorityKeyIdentifier'] || 'unknown').chomp!
+        authKeyId = (oid_values['authorityKeyIdentifier'] || 'unknown').chomp
         Puppet.debug("Using CRL '#{crl.issuer.to_utf8}' authorityKeyIdentifier '#{authKeyId}' crlNumber '#{crlNumber }'")
       end
     end

--- a/spec/unit/ssl/ssl_provider_spec.rb
+++ b/spec/unit/ssl/ssl_provider_spec.rb
@@ -634,4 +634,24 @@ describe Puppet::SSL::SSLProvider do
                        "The CSR for host 'CN=signed' does not match the public key")
     end
   end
+
+  context 'printing' do
+    let(:client_cert) { cert_fixture('signed.pem') }
+    let(:private_key) { key_fixture('signed-key.pem') }
+    let(:config) { { cacerts: global_cacerts, crls: global_crls, client_cert: client_cert, private_key: private_key } }
+
+    it 'prints in debug' do
+      Puppet[:log_level] = 'debug'
+
+      ctx = subject.create_context(**config)
+      subject.print(ctx)
+      expect(@logs.map(&:message)).to include(
+        /Verified CA certificate 'CN=Test CA' fingerprint/,
+        /Verified CA certificate 'CN=Test CA Subauthority' fingerprint/,
+        /Verified client certificate 'CN=signed' fingerprint/,
+        /Using CRL 'CN=Test CA' authorityKeyIdentifier '(keyid:)?[A-Z0-9:]{59}' crlNumber '0'/,
+        /Using CRL 'CN=Test CA Subauthority' authorityKeyIdentifier '(keyid:)?[A-Z0-9:]{59}' crlNumber '0'/
+      )
+    end
+  end
 end


### PR DESCRIPTION
String#chomp! returns nil if the string is not modified, but String#chomp doesn't. So just use that.