### PR TITLE
(PUP-11897) Handle EOF in order to avoid busy-loop

### DIFF
--- a/lib/puppet/util/execution.rb
+++ b/lib/puppet/util/execution.rb
@@ -223,8 +223,12 @@ module Puppet::Util::Execution
             # Use non-blocking read to check for data. After each attempt,
             # check whether the child is done. This is done in case the child
             # forks and inherits stdout, as happens in `foo &`.
-            
-            until results = Process.waitpid2(child_pid, Process::WNOHANG) #rubocop:disable Lint/AssignmentInCondition
+            # If we encounter EOF, though, then switch to a blocking wait for
+            # the child; after EOF, IO.select will never block and the loop
+            # below will use maximum CPU available.
+
+            wait_flags = Process::WNOHANG
+            until results = Process.waitpid2(child_pid, wait_flags) #rubocop:disable Lint/AssignmentInCondition
 
               # If not done, wait for data to read with a timeout
               # This timeout is selected to keep activity low while waiting on
@@ -235,6 +239,7 @@ module Puppet::Util::Execution
                 output << reader.read_nonblock(4096) if ready
               rescue Errno::EAGAIN
               rescue EOFError
+                wait_flags &= ~Process::WNOHANG
               end
             end
 


### PR DESCRIPTION
When EOF is reached, calls to IO.select() will return immediately, resulting in puppet executing the loop without any internal blocking. This causes up to 100% usage of a CPU core until the child finishes.

If the child does its own stdout/stderr redirection before a long operation, for example, this can result in much wasted CPU usage.

There is no need to execute the body of the loop after EOF is reached, so switch the Process.waitpid2 flags to block.