### PR TITLE
(PUP-11856) State machine renews host cert

### DIFF
--- a/lib/puppet/http/service/ca.rb
+++ b/lib/puppet/http/service/ca.rb
@@ -109,7 +109,7 @@ class Puppet::HTTP::Service::Ca < Puppet::HTTP::Service
   #
   # @param [Puppet::SSL::SSLContext] ssl_context
   #
-  # @return [Puppet::HTTP::Response] The request response
+  # @return [Array<Puppet::HTTP::Response, String>] The request response
   #
   # @api public
   def post_certificate_renewal(ssl_context)

--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -546,7 +546,7 @@ class Puppet::SSL::StateMachine
     final_state.ssl_context
   end
 
-  # Run the state machine for CA certs and CRLs.
+  # Run the state machine for client certs.
   #
   # @return [Puppet::SSL::SSLContext] initialized SSLContext
   # @raise [Puppet::Error] If we fail to generate an SSLContext

--- a/spec/fixtures/ssl/127.0.0.1-key.pem
+++ b/spec/fixtures/ssl/127.0.0.1-key.pem
@@ -1,117 +1,117 @@
-RSA Private-Key: (2048 bit, 2 primes)
+Private-Key: (2048 bit, 2 primes)
 modulus:
-    00:df:40:52:59:4f:eb:dd:d8:06:f5:c0:e8:eb:11:
-    52:31:80:a1:45:8e:3e:07:81:5c:cd:90:ea:2a:d0:
-    84:d3:6d:54:8a:78:0c:6b:34:eb:fc:dd:90:e9:9a:
-    5a:23:24:3b:31:99:17:d9:06:70:a8:51:95:68:50:
-    9d:59:aa:76:2f:28:18:99:81:be:ca:1d:79:75:8b:
-    85:3c:a4:05:39:06:f6:d8:25:13:54:e8:bb:d2:b4:
-    30:35:9e:10:64:2d:25:44:2a:f8:75:1f:60:ec:8a:
-    57:fc:fe:4d:57:f2:9c:e2:0d:6b:c5:f7:2d:ce:f5:
-    9e:93:f8:83:1a:b6:94:e3:c0:e2:b2:56:92:7e:e5:
-    d2:bd:f8:3c:9d:07:b4:85:93:77:5f:62:bd:ba:0e:
-    30:cc:77:46:07:2a:6a:aa:18:bf:0c:f0:23:ef:7d:
-    d9:84:86:35:3e:b5:76:1a:02:f3:9a:11:70:3f:f0:
-    6d:58:d1:2a:19:f8:e1:ed:77:ab:0a:e7:98:12:33:
-    5e:f9:b0:a8:f8:a5:98:c9:4e:3f:6c:01:8a:94:30:
-    c9:19:a1:29:46:18:5e:83:9f:9d:2a:cb:70:db:8a:
-    de:ca:2d:c1:47:82:ba:0b:20:b9:20:09:3c:1d:1c:
-    62:77:a7:85:83:5a:08:28:34:6b:75:e1:cd:7b:b7:
-    e7:e5
+    00:d0:13:11:3b:81:35:76:84:fb:b6:4e:c6:e2:7d:
+    1a:16:a5:88:08:dd:50:fd:08:04:a6:ea:a0:6d:09:
+    8c:f2:bf:68:4b:a0:7b:68:84:b3:e4:51:e1:62:3c:
+    68:06:c8:38:3b:0a:a5:8b:da:87:25:cd:2a:76:0b:
+    82:71:89:5b:11:57:cb:dd:b5:ec:75:56:06:a1:26:
+    57:08:54:2d:83:c9:2f:83:f6:d0:e0:c3:ee:78:14:
+    47:f4:5b:ed:54:6a:93:fe:f0:68:a4:fa:93:8c:72:
+    f0:4b:84:f9:94:a2:ed:d8:83:79:9a:0c:c7:d4:33:
+    8e:e6:76:fd:cc:93:e3:3a:b7:56:97:85:f9:87:7e:
+    a9:60:e2:fd:35:9e:31:6b:2e:cb:86:47:e2:67:08:
+    fe:13:52:aa:64:d4:7c:76:09:b5:99:17:19:ed:6b:
+    76:6c:e8:09:b5:98:06:59:c0:4a:1a:0a:a5:f9:0a:
+    73:7c:56:46:32:17:80:3f:09:fa:a7:00:bb:a6:8b:
+    d0:20:83:fe:ab:3c:a6:bf:ed:e6:e4:71:5e:8a:12:
+    da:65:2a:9a:c9:9a:bd:a7:d4:56:c5:42:b9:bc:0f:
+    0d:19:35:d1:72:37:30:e0:28:0f:36:91:a2:7b:e3:
+    62:37:0e:5c:ba:0d:26:dc:0a:66:b3:18:ed:6e:d1:
+    63:b7
 publicExponent: 65537 (0x10001)
 privateExponent:
-    00:bc:48:9b:2b:07:e4:7d:2c:fc:71:b7:48:b9:37:
-    da:82:35:61:ce:2f:b0:d0:d3:a1:59:1d:a6:e0:85:
-    0c:00:e4:6c:30:7c:1e:bd:2b:dc:fb:5e:42:21:42:
-    34:52:fe:f3:8d:58:f8:6b:e8:aa:8a:ca:83:9f:7e:
-    9d:b6:49:b5:72:ff:f5:ff:41:15:8f:90:5c:27:6e:
-    8b:e8:20:cc:e6:d3:a0:cb:9a:39:3b:9b:2d:0c:ff:
-    3a:c9:7d:8d:85:6f:2d:c6:d8:16:c3:70:bb:65:c3:
-    27:82:0f:57:5b:9d:1a:02:ec:1e:c0:cf:3e:ab:15:
-    2b:b0:d0:1e:82:21:0a:61:29:70:2a:34:5b:15:18:
-    67:30:5e:88:ad:d9:e4:59:61:7f:cc:4b:b2:9a:cf:
-    ac:49:fe:49:63:0a:14:db:89:49:22:6f:64:8b:bc:
-    62:4d:61:44:05:be:cc:5c:0c:2f:0e:fa:5f:6a:2e:
-    10:64:a4:db:86:1a:a9:da:1a:0d:ce:57:ec:c1:03:
-    7a:00:bd:49:31:b4:8b:bd:56:99:a2:14:dd:78:82:
-    ea:09:9f:74:12:bd:45:56:b5:6e:ee:d6:69:47:68:
-    e6:6d:75:ea:87:e1:6a:88:8b:b1:c2:7a:ae:35:89:
-    a3:3c:86:97:d1:de:ba:14:2b:d0:d1:3e:d7:af:92:
-    86:01
+    1a:08:60:ae:10:b6:e7:2a:b1:31:78:7e:b2:a4:93:
+    48:85:12:55:85:97:15:e9:54:67:ab:d0:41:84:21:
+    e1:d7:27:cd:da:78:c6:35:60:2a:6f:42:23:1f:ca:
+    a6:1a:93:ca:73:45:0e:0f:db:bb:d3:84:fd:fa:e7:
+    a9:9b:d5:4c:80:af:0d:80:ae:e2:69:4e:70:08:13:
+    78:83:cb:a4:02:de:52:84:e5:52:51:c1:3a:bd:d2:
+    d8:d4:4d:87:b3:c3:eb:70:19:af:96:78:32:68:c8:
+    fe:b1:d6:e6:0d:52:73:b5:d3:57:7e:44:dc:1c:4d:
+    43:31:5d:04:a4:f6:17:88:d1:c2:3c:05:a0:e9:06:
+    a4:00:0a:db:5d:1b:1d:77:64:fd:b5:23:57:27:9c:
+    91:2f:da:7a:81:a4:3e:fe:e0:f2:5e:00:b7:55:02:
+    84:b0:07:17:f9:64:4a:a2:61:4e:9b:48:85:d7:5b:
+    34:c3:e6:d2:01:9d:20:3f:76:db:7d:f0:96:f8:80:
+    2c:f0:f2:88:8a:99:be:49:20:05:8b:64:aa:54:4b:
+    5b:d5:75:d7:30:0d:29:4a:07:c2:06:77:f5:b6:bc:
+    68:8d:eb:98:30:6e:42:f6:1d:da:8d:0a:bd:ad:11:
+    eb:44:01:17:e8:a1:55:06:76:37:84:9c:af:ce:fd:
+    81
 prime1:
-    00:fc:aa:e9:66:8b:09:55:59:35:21:19:ff:72:8a:
-    47:cc:ed:36:24:3a:6c:ee:81:75:cd:aa:6d:af:1f:
-    4d:83:a5:e5:77:c8:a2:de:72:11:a0:72:af:79:0a:
-    b5:b0:e5:e4:28:75:11:b5:56:eb:86:32:f0:32:1f:
-    1d:a8:26:9f:40:d7:6c:ae:7c:7d:90:27:39:95:0f:
-    6b:0a:91:3e:03:c1:e8:04:01:2e:16:a0:dc:6e:70:
-    9f:1a:17:c1:7e:65:ea:4c:2d:33:00:23:83:d9:3b:
-    f7:a5:0b:5f:f5:a9:65:7d:bd:1e:79:e9:24:62:a3:
-    49:d7:d2:6f:5f:9e:2e:03:75
+    00:f8:0b:a4:03:60:bf:e6:54:b2:c3:8f:63:a4:71:
+    50:84:81:9b:80:fb:19:ce:f1:68:39:8b:0e:65:a6:
+    3a:f3:78:00:7b:83:bf:4a:dc:49:bc:9e:42:fd:7e:
+    69:e9:13:56:cb:f9:78:e1:8e:f5:13:fc:dd:a5:5a:
+    0d:24:2c:06:57:1d:fe:b4:23:88:6d:a1:91:53:72:
+    9c:95:4f:93:31:26:54:a2:49:c2:a7:ca:c7:a5:94:
+    0d:15:2e:8e:a3:54:3a:ee:6f:fd:2d:52:55:ed:22:
+    84:53:29:51:de:2d:98:3e:22:82:60:e8:96:34:a7:
+    d0:31:9a:19:f7:d2:db:27:37
 prime2:
-    00:e2:32:17:38:94:ba:d3:63:eb:a3:83:77:09:4f:
-    ef:52:ef:ce:1e:86:b2:4e:bc:30:eb:67:f2:c1:aa:
-    be:04:fd:c5:76:43:15:e7:7f:f7:c7:a3:6f:e9:e3:
-    df:7e:ad:9c:a1:eb:ee:dc:ad:6d:bc:4e:88:1c:d4:
-    d1:5c:1d:21:f0:7a:19:4d:cc:0d:4b:37:08:34:8d:
-    ac:1c:fd:3a:e9:f3:5e:f3:f2:5a:1c:15:76:38:d3:
-    ff:b5:2f:fd:59:37:c6:86:6e:29:4b:10:01:75:f0:
-    5e:46:aa:ab:32:e3:0f:4c:72:e7:36:d7:5a:9b:76:
-    e2:08:09:32:49:30:ac:f4:b1
+    00:d6:bf:47:ab:68:ce:0b:0f:1a:13:fb:ce:ca:66:
+    e4:a5:dd:a0:7f:d2:77:89:66:5f:08:33:6c:1d:e1:
+    0d:b7:d5:88:bb:00:4b:0f:85:9c:83:42:9f:01:64:
+    e0:c5:0f:5d:19:4b:bc:af:71:7d:5e:eb:7b:aa:69:
+    75:11:75:81:4c:42:f4:b2:8a:29:7e:7a:1b:e6:a3:
+    b2:20:6f:07:b9:f9:03:8e:5a:2a:af:f5:5a:2d:a0:
+    00:db:b6:22:e8:8d:1d:d0:69:3d:01:e9:05:eb:8b:
+    2c:89:77:c3:a3:10:57:2c:7f:e3:70:72:d3:56:9f:
+    72:b9:ea:07:56:02:00:e7:81
 exponent1:
-    44:c4:8b:a3:d2:21:a7:2e:11:6c:c1:f3:a9:8c:03:
-    40:be:2b:27:2f:13:a8:d2:69:6a:a1:81:1a:d1:ad:
-    3a:30:73:c4:e7:41:94:c3:7d:12:ab:44:20:f0:8e:
-    44:e8:3c:f1:d9:f3:08:e4:f0:53:65:17:c4:bc:7d:
-    48:df:c2:26:56:bb:88:bd:ef:3a:c5:c2:41:54:a1:
-    f0:8d:59:50:92:7d:00:62:05:d6:38:cf:e5:eb:17:
-    12:75:f6:be:dd:24:28:b9:80:91:00:19:89:8d:6d:
-    b8:68:e1:24:2e:87:a5:f2:4c:12:28:27:34:05:77:
-    3a:9b:56:9e:b2:a1:99:65
+    00:d0:80:70:78:ca:6d:e4:be:53:9a:21:40:ff:ec:
+    a4:63:0d:d3:5a:43:38:79:84:e1:38:65:94:4f:8b:
+    c0:c8:01:9a:5e:38:eb:a6:90:af:86:d6:7d:b7:39:
+    f8:eb:0b:ef:8c:fc:02:49:8f:f2:a0:bf:90:cc:ba:
+    7a:8b:6a:5a:56:06:87:a0:82:b1:de:7d:ce:7c:17:
+    be:59:a0:0f:39:64:60:06:1e:fc:7a:30:f1:4b:54:
+    bc:fe:8e:29:26:4f:da:4d:ad:63:63:22:6f:ca:2a:
+    96:92:95:0c:15:37:bc:5e:96:81:83:d6:5e:d4:9a:
+    2f:5e:52:8b:fb:8e:89:db:57
 exponent2:
-    00:d3:3b:d7:f7:9c:dd:43:9f:e2:64:56:d7:09:39:
-    3e:d4:02:e2:48:1b:9d:d4:6d:66:79:d0:1f:21:c0:
-    e3:a7:21:9e:0f:ac:e2:7d:c8:41:8a:8c:14:6d:25:
-    c2:87:38:76:37:b8:6e:de:62:8f:41:f5:4c:a3:30:
-    13:3b:a4:71:17:73:ce:c1:9a:37:27:f0:82:97:21:
-    5e:83:cb:f0:02:9e:a6:23:c6:45:64:48:9e:98:bf:
-    51:e2:d0:a8:15:73:42:d0:33:7c:18:7f:1f:fe:15:
-    b4:d4:e5:78:ef:12:a0:2c:d2:79:1d:fb:ca:bf:b8:
-    2b:a9:39:7d:5e:60:38:84:61
+    5b:99:de:05:64:c0:37:01:6b:1b:49:16:ed:49:34:
+    90:f7:d7:85:8e:8e:44:c2:b1:18:bb:6e:8b:d4:3a:
+    d8:c6:b1:fb:2a:65:da:2a:21:17:f0:6c:08:d9:31:
+    f3:7c:d9:36:78:12:f5:37:50:c6:13:66:7d:cb:5c:
+    0f:65:73:10:c7:a2:bf:21:a6:0f:78:20:bc:a1:e8:
+    d2:62:ea:05:cf:0d:50:44:6f:de:fc:a6:49:bd:ed:
+    7f:ca:d2:5b:26:0e:a8:9e:ab:52:4c:46:a5:31:89:
+    7e:dd:e2:4a:85:26:da:29:77:27:b9:23:22:d9:02:
+    c4:00:ea:be:2a:3e:9e:81
 coefficient:
-    0b:f3:f3:f2:06:4d:f4:8d:dc:88:d0:da:24:f1:03:
-    4a:5f:91:40:29:ff:85:be:a1:6c:e2:00:ac:05:46:
-    79:db:9d:b6:5f:7e:92:a7:cb:f1:77:e6:4e:c6:b9:
-    ee:76:0e:fe:c3:ba:91:69:00:75:dc:d6:76:2e:f1:
-    dd:1b:75:5d:3b:f4:6b:d6:a2:3d:bf:8e:49:45:0f:
-    b1:4e:c6:e5:fb:c3:91:05:92:51:b1:c1:59:97:e0:
-    1a:a5:c9:ee:3f:af:32:dc:0c:4a:00:37:04:94:64:
-    fa:97:ab:47:17:fe:ce:bb:d4:6c:02:26:5d:41:1f:
-    42:8b:06:d9:e0:a0:ae:68
+    08:16:69:41:c7:f5:15:7a:f9:0d:3d:b8:d2:4d:8f:
+    82:22:2f:89:76:11:5d:e9:7f:fc:d3:e4:76:ba:46:
+    44:eb:91:be:45:e1:1c:5c:75:1e:ff:c3:b2:5c:ae:
+    0f:a7:fb:16:2a:e2:9d:26:4f:ab:40:f2:d4:33:a3:
+    fd:c7:76:e0:f3:b9:f6:ff:05:92:8b:60:15:fc:76:
+    d1:f7:b2:45:8a:4e:4d:16:23:5a:d0:27:81:fb:61:
+    94:b1:aa:38:ea:1d:81:52:0b:e3:8f:59:40:e1:35:
+    d7:ee:cb:80:2d:28:15:b8:61:07:d0:50:da:89:83:
+    5b:88:5b:2e:fb:20:9b:fd
 -----BEGIN RSA PRIVATE KEY-----
-MIIEpAIBAAKCAQEA30BSWU/r3dgG9cDo6xFSMYChRY4+B4FczZDqKtCE021UingM
-azTr/N2Q6ZpaIyQ7MZkX2QZwqFGVaFCdWap2LygYmYG+yh15dYuFPKQFOQb22CUT
-VOi70rQwNZ4QZC0lRCr4dR9g7IpX/P5NV/Kc4g1rxfctzvWek/iDGraU48DislaS
-fuXSvfg8nQe0hZN3X2K9ug4wzHdGBypqqhi/DPAj733ZhIY1PrV2GgLzmhFwP/Bt
-WNEqGfjh7XerCueYEjNe+bCo+KWYyU4/bAGKlDDJGaEpRhheg5+dKstw24reyi3B
-R4K6CyC5IAk8HRxid6eFg1oIKDRrdeHNe7fn5QIDAQABAoIBAQC8SJsrB+R9LPxx
-t0i5N9qCNWHOL7DQ06FZHabghQwA5GwwfB69K9z7XkIhQjRS/vONWPhr6KqKyoOf
-fp22SbVy//X/QRWPkFwnbovoIMzm06DLmjk7my0M/zrJfY2Fby3G2BbDcLtlwyeC
-D1dbnRoC7B7Azz6rFSuw0B6CIQphKXAqNFsVGGcwXoit2eRZYX/MS7Kaz6xJ/klj
-ChTbiUkib2SLvGJNYUQFvsxcDC8O+l9qLhBkpNuGGqnaGg3OV+zBA3oAvUkxtIu9
-VpmiFN14guoJn3QSvUVWtW7u1mlHaOZtdeqH4WqIi7HCeq41iaM8hpfR3roUK9DR
-PtevkoYBAoGBAPyq6WaLCVVZNSEZ/3KKR8ztNiQ6bO6Bdc2qba8fTYOl5XfIot5y
-EaByr3kKtbDl5Ch1EbVW64Yy8DIfHagmn0DXbK58fZAnOZUPawqRPgPB6AQBLhag
-3G5wnxoXwX5l6kwtMwAjg9k796ULX/WpZX29HnnpJGKjSdfSb1+eLgN1AoGBAOIy
-FziUutNj66ODdwlP71Lvzh6Gsk68MOtn8sGqvgT9xXZDFed/98ejb+nj336tnKHr
-7tytbbxOiBzU0VwdIfB6GU3MDUs3CDSNrBz9OunzXvPyWhwVdjjT/7Uv/Vk3xoZu
-KUsQAXXwXkaqqzLjD0xy5zbXWpt24ggJMkkwrPSxAoGARMSLo9Ihpy4RbMHzqYwD
-QL4rJy8TqNJpaqGBGtGtOjBzxOdBlMN9EqtEIPCOROg88dnzCOTwU2UXxLx9SN/C
-Jla7iL3vOsXCQVSh8I1ZUJJ9AGIF1jjP5esXEnX2vt0kKLmAkQAZiY1tuGjhJC6H
-pfJMEignNAV3OptWnrKhmWUCgYEA0zvX95zdQ5/iZFbXCTk+1ALiSBud1G1medAf
-IcDjpyGeD6zifchBiowUbSXChzh2N7hu3mKPQfVMozATO6RxF3POwZo3J/CClyFe
-g8vwAp6mI8ZFZEiemL9R4tCoFXNC0DN8GH8f/hW01OV47xKgLNJ5HfvKv7grqTl9
-XmA4hGECgYAL8/PyBk30jdyI0Nok8QNKX5FAKf+FvqFs4gCsBUZ52522X36Sp8vx
-d+ZOxrnudg7+w7qRaQB13NZ2LvHdG3VdO/Rr1qI9v45JRQ+xTsbl+8ORBZJRscFZ
-l+AapcnuP68y3AxKADcElGT6l6tHF/7Ou9RsAiZdQR9CiwbZ4KCuaA==
+MIIEowIBAAKCAQEA0BMRO4E1doT7tk7G4n0aFqWICN1Q/QgEpuqgbQmM8r9oS6B7
+aISz5FHhYjxoBsg4Owqli9qHJc0qdguCcYlbEVfL3bXsdVYGoSZXCFQtg8kvg/bQ
+4MPueBRH9FvtVGqT/vBopPqTjHLwS4T5lKLt2IN5mgzH1DOO5nb9zJPjOrdWl4X5
+h36pYOL9NZ4xay7LhkfiZwj+E1KqZNR8dgm1mRcZ7Wt2bOgJtZgGWcBKGgql+Qpz
+fFZGMheAPwn6pwC7povQIIP+qzymv+3m5HFeihLaZSqayZq9p9RWxUK5vA8NGTXR
+cjcw4CgPNpGie+NiNw5cug0m3ApmsxjtbtFjtwIDAQABAoIBABoIYK4QtucqsTF4
+frKkk0iFElWFlxXpVGer0EGEIeHXJ83aeMY1YCpvQiMfyqYak8pzRQ4P27vThP36
+56mb1UyArw2AruJpTnAIE3iDy6QC3lKE5VJRwTq90tjUTYezw+twGa+WeDJoyP6x
+1uYNUnO101d+RNwcTUMxXQSk9heI0cI8BaDpBqQACttdGx13ZP21I1cnnJEv2nqB
+pD7+4PJeALdVAoSwBxf5ZEqiYU6bSIXXWzTD5tIBnSA/dtt98Jb4gCzw8oiKmb5J
+IAWLZKpUS1vVddcwDSlKB8IGd/W2vGiN65gwbkL2HdqNCr2tEetEARfooVUGdjeE
+nK/O/YECgYEA+AukA2C/5lSyw49jpHFQhIGbgPsZzvFoOYsOZaY683gAe4O/StxJ
+vJ5C/X5p6RNWy/l44Y71E/zdpVoNJCwGVx3+tCOIbaGRU3KclU+TMSZUoknCp8rH
+pZQNFS6Oo1Q67m/9LVJV7SKEUylR3i2YPiKCYOiWNKfQMZoZ99LbJzcCgYEA1r9H
+q2jOCw8aE/vOymbkpd2gf9J3iWZfCDNsHeENt9WIuwBLD4Wcg0KfAWTgxQ9dGUu8
+r3F9Xut7qml1EXWBTEL0soopfnob5qOyIG8HufkDjloqr/VaLaAA27Yi6I0d0Gk9
+AekF64ssiXfDoxBXLH/jcHLTVp9yueoHVgIA54ECgYEA0IBweMpt5L5TmiFA/+yk
+Yw3TWkM4eYThOGWUT4vAyAGaXjjrppCvhtZ9tzn46wvvjPwCSY/yoL+QzLp6i2pa
+VgaHoIKx3n3OfBe+WaAPOWRgBh78ejDxS1S8/o4pJk/aTa1jYyJvyiqWkpUMFTe8
+XpaBg9Ze1JovXlKL+46J21cCgYBbmd4FZMA3AWsbSRbtSTSQ99eFjo5EwrEYu26L
+1DrYxrH7KmXaKiEX8GwI2THzfNk2eBL1N1DGE2Z9y1wPZXMQx6K/IaYPeCC8oejS
+YuoFzw1QRG/e/KZJve1/ytJbJg6onqtSTEalMYl+3eJKhSbaKXcnuSMi2QLEAOq+
+Kj6egQKBgAgWaUHH9RV6+Q09uNJNj4IiL4l2EV3pf/zT5Ha6RkTrkb5F4RxcdR7/
+w7Jcrg+n+xYq4p0mT6tA8tQzo/3HduDzufb/BZKLYBX8dtH3skWKTk0WI1rQJ4H7
+YZSxqjjqHYFSC+OPWUDhNdfuy4AtKBW4YQfQUNqJg1uIWy77IJv9
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/127.0.0.1.pem
+++ b/spec/fixtures/ssl/127.0.0.1.pem
@@ -1,69 +1,70 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 5 (0x5)
+        Serial Number: 6 (0x6)
         Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Jun 15 01:19:37 2031 GMT
+            Not After : Jun 24 21:18:00 2033 GMT
         Subject: CN=127.0.0.1
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                RSA Public-Key: (2048 bit)
+                Public-Key: (2048 bit)
                 Modulus:
-                    00:df:40:52:59:4f:eb:dd:d8:06:f5:c0:e8:eb:11:
-                    52:31:80:a1:45:8e:3e:07:81:5c:cd:90:ea:2a:d0:
-                    84:d3:6d:54:8a:78:0c:6b:34:eb:fc:dd:90:e9:9a:
-                    5a:23:24:3b:31:99:17:d9:06:70:a8:51:95:68:50:
-                    9d:59:aa:76:2f:28:18:99:81:be:ca:1d:79:75:8b:
-                    85:3c:a4:05:39:06:f6:d8:25:13:54:e8:bb:d2:b4:
-                    30:35:9e:10:64:2d:25:44:2a:f8:75:1f:60:ec:8a:
-                    57:fc:fe:4d:57:f2:9c:e2:0d:6b:c5:f7:2d:ce:f5:
-                    9e:93:f8:83:1a:b6:94:e3:c0:e2:b2:56:92:7e:e5:
-                    d2:bd:f8:3c:9d:07:b4:85:93:77:5f:62:bd:ba:0e:
-                    30:cc:77:46:07:2a:6a:aa:18:bf:0c:f0:23:ef:7d:
-                    d9:84:86:35:3e:b5:76:1a:02:f3:9a:11:70:3f:f0:
-                    6d:58:d1:2a:19:f8:e1:ed:77:ab:0a:e7:98:12:33:
-                    5e:f9:b0:a8:f8:a5:98:c9:4e:3f:6c:01:8a:94:30:
-                    c9:19:a1:29:46:18:5e:83:9f:9d:2a:cb:70:db:8a:
-                    de:ca:2d:c1:47:82:ba:0b:20:b9:20:09:3c:1d:1c:
-                    62:77:a7:85:83:5a:08:28:34:6b:75:e1:cd:7b:b7:
-                    e7:e5
+                    00:d0:13:11:3b:81:35:76:84:fb:b6:4e:c6:e2:7d:
+                    1a:16:a5:88:08:dd:50:fd:08:04:a6:ea:a0:6d:09:
+                    8c:f2:bf:68:4b:a0:7b:68:84:b3:e4:51:e1:62:3c:
+                    68:06:c8:38:3b:0a:a5:8b:da:87:25:cd:2a:76:0b:
+                    82:71:89:5b:11:57:cb:dd:b5:ec:75:56:06:a1:26:
+                    57:08:54:2d:83:c9:2f:83:f6:d0:e0:c3:ee:78:14:
+                    47:f4:5b:ed:54:6a:93:fe:f0:68:a4:fa:93:8c:72:
+                    f0:4b:84:f9:94:a2:ed:d8:83:79:9a:0c:c7:d4:33:
+                    8e:e6:76:fd:cc:93:e3:3a:b7:56:97:85:f9:87:7e:
+                    a9:60:e2:fd:35:9e:31:6b:2e:cb:86:47:e2:67:08:
+                    fe:13:52:aa:64:d4:7c:76:09:b5:99:17:19:ed:6b:
+                    76:6c:e8:09:b5:98:06:59:c0:4a:1a:0a:a5:f9:0a:
+                    73:7c:56:46:32:17:80:3f:09:fa:a7:00:bb:a6:8b:
+                    d0:20:83:fe:ab:3c:a6:bf:ed:e6:e4:71:5e:8a:12:
+                    da:65:2a:9a:c9:9a:bd:a7:d4:56:c5:42:b9:bc:0f:
+                    0d:19:35:d1:72:37:30:e0:28:0f:36:91:a2:7b:e3:
+                    62:37:0e:5c:ba:0d:26:dc:0a:66:b3:18:ed:6e:d1:
+                    63:b7
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Subject Alternative Name: 
                 DNS:127.0.0.1, DNS:127.0.0.2
     Signature Algorithm: sha256WithRSAEncryption
-         6f:ef:ac:da:0b:a5:4f:d0:30:57:0c:8c:5a:90:be:18:11:ec:
-         e0:25:c2:0e:ef:05:cb:b5:50:43:ba:b7:25:1c:26:60:e8:ad:
-         b6:a5:1a:6a:2b:e2:66:e1:3a:b6:00:80:39:e1:19:ef:c2:e8:
-         fd:f2:04:0e:ed:fa:1e:e5:f8:f1:32:dc:4e:47:7e:43:a4:09:
-         3a:24:b4:fe:ab:7e:d6:b2:d4:4e:e0:9f:e5:c9:79:9b:87:f4:
-         7b:3d:40:a4:cf:0e:03:5c:dc:14:82:bf:1b:32:9a:18:0c:5b:
-         94:2d:1f:41:b6:a5:e7:89:d7:3b:dc:c8:17:f6:0e:ea:2d:7b:
-         a6:04:02:08:9a:b6:3d:66:03:67:16:94:2d:36:13:ee:61:18:
-         f9:17:04:6e:16:f3:65:9b:5c:34:ed:49:d8:6e:26:58:ca:68:
-         3f:2c:bb:0e:42:64:93:a7:8c:d4:d9:15:ae:fb:0f:f7:f7:ce:
-         be:99:6f:40:90:bf:e4:44:c5:44:4a:09:9a:8f:da:f6:b5:a6:
-         63:af:6b:37:ee:7c:b7:69:b6:67:76:98:f1:69:18:8e:2c:45:
-         bb:04:82:d9:03:31:85:c6:61:d3:38:60:39:45:43:a9:7b:d7:
-         f5:fd:18:f2:ec:43:42:0b:69:b8:c5:84:05:ae:a2:02:d3:19:
-         80:bd:88:a5
+    Signature Value:
+        4f:f7:58:a4:e1:bb:12:ea:e0:6b:e0:f0:ca:18:bd:f6:b8:5e:
+        f2:c4:0d:9d:1d:b1:d6:a1:96:7f:94:96:1a:c2:91:22:f4:2b:
+        e1:96:71:ce:83:0c:84:ff:72:f6:18:72:76:ee:26:9f:0a:92:
+        f4:d9:86:f7:62:90:77:6a:b9:a0:b9:61:53:64:f2:12:e9:23:
+        31:5a:ee:f7:f7:70:bb:f3:b6:89:b3:bc:64:f1:01:2f:c7:c8:
+        0c:70:a9:c6:1f:ca:95:d0:ec:25:43:e4:93:88:8b:c4:4b:50:
+        a0:77:79:f0:2f:81:4d:d3:71:93:2a:58:d1:d7:89:64:c0:30:
+        50:45:ae:36:e4:37:69:d8:d1:50:83:8d:a4:2f:55:ad:a1:c9:
+        ae:68:ac:4d:5f:1b:c9:bc:dc:ff:30:7b:10:da:16:fb:60:f9:
+        ba:73:26:44:7d:de:1e:2b:12:69:40:d4:c2:17:b2:76:d4:40:
+        fa:2c:b0:c5:54:4a:af:1a:94:b9:62:0c:81:42:9a:c3:bc:d6:
+        3a:f7:69:8e:82:91:24:48:46:be:10:bd:ed:c4:71:56:f2:e8:
+        73:64:18:d0:8b:7d:b0:66:2f:a6:e3:4d:23:68:11:b0:48:16:
+        db:8a:dd:bf:e5:de:5e:35:fa:7a:76:0e:ec:9d:e3:ee:d1:28:
+        58:bc:23:bf
 -----BEGIN CERTIFICATE-----
-MIICxDCCAaygAwIBAgIBBTANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
-IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMxMDYxNTAxMTkzN1owFDESMBAGA1UEAwwJ
-MTI3LjAuMC4xMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA30BSWU/r
-3dgG9cDo6xFSMYChRY4+B4FczZDqKtCE021UingMazTr/N2Q6ZpaIyQ7MZkX2QZw
-qFGVaFCdWap2LygYmYG+yh15dYuFPKQFOQb22CUTVOi70rQwNZ4QZC0lRCr4dR9g
-7IpX/P5NV/Kc4g1rxfctzvWek/iDGraU48DislaSfuXSvfg8nQe0hZN3X2K9ug4w
-zHdGBypqqhi/DPAj733ZhIY1PrV2GgLzmhFwP/BtWNEqGfjh7XerCueYEjNe+bCo
-+KWYyU4/bAGKlDDJGaEpRhheg5+dKstw24reyi3BR4K6CyC5IAk8HRxid6eFg1oI
-KDRrdeHNe7fn5QIDAQABoyMwITAfBgNVHREEGDAWggkxMjcuMC4wLjGCCTEyNy4w
-LjAuMjANBgkqhkiG9w0BAQsFAAOCAQEAb++s2gulT9AwVwyMWpC+GBHs4CXCDu8F
-y7VQQ7q3JRwmYOittqUaaiviZuE6tgCAOeEZ78Lo/fIEDu36HuX48TLcTkd+Q6QJ
-OiS0/qt+1rLUTuCf5cl5m4f0ez1ApM8OA1zcFIK/GzKaGAxblC0fQbal54nXO9zI
-F/YO6i17pgQCCJq2PWYDZxaULTYT7mEY+RcEbhbzZZtcNO1J2G4mWMpoPyy7DkJk
-k6eM1NkVrvsP9/fOvplvQJC/5ETFREoJmo/a9rWmY69rN+58t2m2Z3aY8WkYjixF
-uwSC2QMxhcZh0zhgOUVDqXvX9f0Y8uxDQgtpuMWEBa6iAtMZgL2IpQ==
+MIICxDCCAaygAwIBAgIBBjANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMzMDYyNDIxMTgwMFowFDESMBAGA1UEAwwJ
+MTI3LjAuMC4xMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0BMRO4E1
+doT7tk7G4n0aFqWICN1Q/QgEpuqgbQmM8r9oS6B7aISz5FHhYjxoBsg4Owqli9qH
+Jc0qdguCcYlbEVfL3bXsdVYGoSZXCFQtg8kvg/bQ4MPueBRH9FvtVGqT/vBopPqT
+jHLwS4T5lKLt2IN5mgzH1DOO5nb9zJPjOrdWl4X5h36pYOL9NZ4xay7LhkfiZwj+
+E1KqZNR8dgm1mRcZ7Wt2bOgJtZgGWcBKGgql+QpzfFZGMheAPwn6pwC7povQIIP+
+qzymv+3m5HFeihLaZSqayZq9p9RWxUK5vA8NGTXRcjcw4CgPNpGie+NiNw5cug0m
+3ApmsxjtbtFjtwIDAQABoyMwITAfBgNVHREEGDAWggkxMjcuMC4wLjGCCTEyNy4w
+LjAuMjANBgkqhkiG9w0BAQsFAAOCAQEAT/dYpOG7Eurga+Dwyhi99rhe8sQNnR2x
+1qGWf5SWGsKRIvQr4ZZxzoMMhP9y9hhydu4mnwqS9NmG92KQd2q5oLlhU2TyEukj
+MVru9/dwu/O2ibO8ZPEBL8fIDHCpxh/KldDsJUPkk4iLxEtQoHd58C+BTdNxkypY
+0deJZMAwUEWuNuQ3adjRUIONpC9VraHJrmisTV8bybzc/zB7ENoW+2D5unMmRH3e
+HisSaUDUwheydtRA+iywxVRKrxqUuWIMgUKaw7zWOvdpjoKRJEhGvhC97cRxVvLo
+c2QY0It9sGYvpuNNI2gRsEgW24rdv+XeXjX6enYO7J3j7tEoWLwjvw==
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/bad-basic-constraints.pem
+++ b/spec/fixtures/ssl/bad-basic-constraints.pem
@@ -1,35 +1,35 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 11 (0xb)
+        Serial Number: 12 (0xc)
         Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Jun 15 01:19:37 2031 GMT
+            Not After : Jun 24 21:18:00 2033 GMT
         Subject: CN=Test CA
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                RSA Public-Key: (2048 bit)
+                Public-Key: (2048 bit)
                 Modulus:
-                    00:b0:eb:f6:b5:c4:28:a8:18:53:85:91:20:76:5d:
-                    aa:be:78:ae:10:60:d3:b5:66:f7:41:c8:bf:42:00:
-                    c8:99:63:ed:d0:92:12:5a:71:c0:da:d2:fd:b3:65:
-                    3b:a5:fa:be:0d:e5:2a:20:2f:df:a1:c5:41:c3:c3:
-                    9c:04:eb:07:6c:8d:48:9c:14:be:24:81:7d:03:4d:
-                    56:62:80:6b:34:e0:ad:68:f0:17:3d:fa:3b:b4:f7:
-                    a9:a3:fb:7d:30:0d:dd:c5:0b:b6:32:b6:c2:d9:b1:
-                    e8:97:ce:19:66:89:1b:5d:d6:4a:d9:0e:a6:b2:ad:
-                    cc:57:e9:0a:12:83:98:a3:18:90:a3:ae:ec:8e:a1:
-                    96:ee:a4:36:7b:13:c4:95:45:02:69:89:f4:d3:49:
-                    17:e6:e4:d5:91:23:24:7e:94:52:b5:4f:f3:0b:11:
-                    d8:b2:69:7e:72:25:88:03:15:7b:2f:64:ca:8c:a9:
-                    ce:b0:ed:eb:00:aa:68:af:cd:e4:1c:13:af:a7:ff:
-                    54:b6:7d:be:b5:6c:bd:6a:20:be:47:2f:a8:dd:7a:
-                    1d:2a:44:a4:0b:15:eb:68:85:05:32:17:01:cf:a7:
-                    27:03:cb:85:12:c1:ec:4f:c1:4b:2a:11:34:55:7c:
-                    b3:6c:fa:79:6d:4f:be:31:92:b8:f3:01:90:8e:42:
-                    6b:71
+                    00:f4:9a:3e:d9:2b:e1:1e:ea:3c:85:7d:27:87:f5:
+                    f7:50:c6:60:f0:79:3b:86:23:ce:c9:ba:42:22:1b:
+                    61:1a:bc:33:c7:cf:e2:56:8f:6c:84:3e:4e:d0:48:
+                    b5:27:7e:7b:49:de:2b:5d:b2:9c:e6:49:53:52:c8:
+                    89:92:cb:e1:6c:30:67:c6:74:25:e3:3f:7a:37:ef:
+                    54:b4:bd:80:07:a6:db:77:5c:8f:56:ed:1b:14:af:
+                    2a:12:f5:44:88:15:a3:63:f2:f9:44:fb:51:ed:9a:
+                    6d:9c:cf:48:69:f6:d0:c9:6c:57:ee:1b:be:04:91:
+                    b3:ad:16:ed:c8:d0:bf:b4:55:6b:e9:3c:2b:8c:57:
+                    19:bc:f1:76:6f:90:8d:e4:60:79:c7:03:e3:9d:83:
+                    42:ec:0e:79:78:3c:30:c4:d5:87:63:4d:2c:17:ad:
+                    c6:ea:3b:ff:e4:73:1a:12:bb:ed:d3:f6:9d:9d:d9:
+                    e7:05:7f:21:6c:27:0a:27:c5:6e:c8:53:6c:a3:bb:
+                    0e:11:fa:c4:ab:97:8f:a1:fd:bd:f3:5e:fb:80:1d:
+                    15:87:c7:b4:20:94:fc:cb:ac:06:a8:ae:b1:80:a0:
+                    5d:50:68:8d:49:63:1b:b2:77:a2:6b:81:21:b6:58:
+                    3a:f2:3d:21:ac:a5:91:bc:7d:36:46:f4:87:ea:ce:
+                    a3:0f
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Basic Constraints: critical
@@ -37,45 +37,45 @@ Certificate:
             X509v3 Key Usage: critical
                 Certificate Sign, CRL Sign
             X509v3 Subject Key Identifier: 
-                B2:EE:24:88:34:99:18:60:81:9E:2A:D3:F4:5A:66:FA:91:F6:E1:C6
+                83:68:26:16:4A:C3:88:0A:A6:48:43:98:E7:2D:4F:5F:70:8C:62:B2
             Netscape Comment: 
                 Puppet Server Internal Certificate
             X509v3 Authority Key Identifier: 
-                keyid:B2:EE:24:88:34:99:18:60:81:9E:2A:D3:F4:5A:66:FA:91:F6:E1:C6
-
+                83:68:26:16:4A:C3:88:0A:A6:48:43:98:E7:2D:4F:5F:70:8C:62:B2
     Signature Algorithm: sha256WithRSAEncryption
-         82:de:f4:cb:97:76:b0:a7:52:71:6c:94:4c:e6:8d:d6:e5:32:
-         1d:ca:99:44:9c:a2:b5:e4:a5:ba:06:08:6b:e7:b5:55:76:02:
-         7e:ee:69:6a:0d:27:69:7b:e3:80:97:10:9c:40:98:13:e4:d1:
-         40:b6:e6:59:1d:c2:1c:6e:64:ba:b5:af:7b:aa:70:d7:34:1b:
-         d3:cb:9f:2b:c0:72:36:70:ad:04:a0:07:9c:dd:e5:fa:02:b3:
-         c9:f1:f0:6a:99:89:95:20:e2:31:7f:21:2e:8b:b8:76:5e:31:
-         82:ec:4b:31:43:e7:20:d9:97:0f:52:8e:26:1d:0b:31:2d:f6:
-         74:40:6b:09:cf:39:e8:d9:c8:27:ed:9d:76:a5:b2:2a:83:db:
-         16:8e:5f:ee:e7:90:44:68:34:92:33:bd:39:7c:96:8f:e3:61:
-         78:b5:4e:59:d8:12:0a:0d:90:17:22:7c:0e:34:bb:ad:94:66:
-         07:d5:4f:d9:79:34:6f:12:c1:77:69:a1:20:ae:cc:b0:2e:e9:
-         9c:bb:94:89:70:ee:d0:14:1c:05:89:40:76:bb:47:64:83:24:
-         73:95:cc:f1:65:ee:f8:bf:55:f0:c3:e6:34:6b:07:09:67:3e:
-         03:01:8d:ba:cb:5d:5b:89:d6:e3:cb:ce:55:dc:ad:8d:7f:de:
-         c6:5a:7c:9f
+    Signature Value:
+        f2:d5:76:aa:ff:05:b2:63:2d:81:23:3d:d5:dc:8f:a8:eb:bc:
+        17:35:7f:64:1a:37:50:02:ac:54:4b:c9:74:fb:07:f8:ec:f7:
+        c2:6a:80:bd:f7:d1:43:1b:4d:d1:2c:c2:71:d9:28:46:01:0f:
+        14:ab:8e:20:14:93:e7:dc:a7:b1:6d:4a:7d:a9:f7:a2:5d:ea:
+        4d:89:5f:fb:45:4b:98:c8:93:12:d9:74:5e:a4:3e:25:13:2c:
+        92:96:3e:15:c6:d3:46:c7:03:5c:4b:70:65:9e:1f:89:ef:7e:
+        70:63:3c:78:d8:a2:92:53:2d:39:a3:f5:0d:36:aa:2a:7b:a8:
+        a9:63:66:39:e3:49:55:0f:45:d6:14:9e:f4:77:18:16:90:13:
+        41:6a:27:8f:84:c9:c5:0d:ad:cc:d9:bf:62:90:02:56:63:76:
+        76:bc:3f:36:5d:41:ad:07:5e:f9:e2:66:e9:63:e3:ba:79:b9:
+        07:b6:e8:b5:27:0f:18:4e:a4:6d:82:d7:e9:a9:40:ce:eb:d9:
+        6a:b8:d6:04:c4:b2:62:1f:c5:cb:fe:14:f3:c5:cd:0e:11:32:
+        b5:cf:ea:fc:98:3c:59:23:eb:69:c5:0b:f6:83:5b:dc:25:9c:
+        6d:93:29:c2:30:58:c1:10:80:49:86:67:09:fd:22:67:01:e5:
+        32:9a:a3:83
 -----BEGIN CERTIFICATE-----
-MIIDNDCCAhygAwIBAgIBCzANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
-IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMxMDYxNTAxMTkzN1owEjEQMA4GA1UEAwwH
-VGVzdCBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALDr9rXEKKgY
-U4WRIHZdqr54rhBg07Vm90HIv0IAyJlj7dCSElpxwNrS/bNlO6X6vg3lKiAv36HF
-QcPDnATrB2yNSJwUviSBfQNNVmKAazTgrWjwFz36O7T3qaP7fTAN3cULtjK2wtmx
-6JfOGWaJG13WStkOprKtzFfpChKDmKMYkKOu7I6hlu6kNnsTxJVFAmmJ9NNJF+bk
-1ZEjJH6UUrVP8wsR2LJpfnIliAMVey9kyoypzrDt6wCqaK/N5BwTr6f/VLZ9vrVs
-vWogvkcvqN16HSpEpAsV62iFBTIXAc+nJwPLhRLB7E/BSyoRNFV8s2z6eW1PvjGS
-uPMBkI5Ca3ECAwEAAaOBlDCBkTAMBgNVHRMBAf8EAjAAMA4GA1UdDwEB/wQEAwIB
-BjAdBgNVHQ4EFgQUsu4kiDSZGGCBnirT9Fpm+pH24cYwMQYJYIZIAYb4QgENBCQW
+MIIDNDCCAhygAwIBAgIBDDANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMzMDYyNDIxMTgwMFowEjEQMA4GA1UEAwwH
+VGVzdCBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAPSaPtkr4R7q
+PIV9J4f191DGYPB5O4Yjzsm6QiIbYRq8M8fP4laPbIQ+TtBItSd+e0neK12ynOZJ
+U1LIiZLL4WwwZ8Z0JeM/ejfvVLS9gAem23dcj1btGxSvKhL1RIgVo2Py+UT7Ue2a
+bZzPSGn20MlsV+4bvgSRs60W7cjQv7RVa+k8K4xXGbzxdm+QjeRgeccD452DQuwO
+eXg8MMTVh2NNLBetxuo7/+RzGhK77dP2nZ3Z5wV/IWwnCifFbshTbKO7DhH6xKuX
+j6H9vfNe+4AdFYfHtCCU/MusBqiusYCgXVBojUljG7J3omuBIbZYOvI9Iaylkbx9
+Nkb0h+rOow8CAwEAAaOBlDCBkTAMBgNVHRMBAf8EAjAAMA4GA1UdDwEB/wQEAwIB
+BjAdBgNVHQ4EFgQUg2gmFkrDiAqmSEOY5y1PX3CMYrIwMQYJYIZIAYb4QgENBCQW
 IlB1cHBldCBTZXJ2ZXIgSW50ZXJuYWwgQ2VydGlmaWNhdGUwHwYDVR0jBBgwFoAU
-su4kiDSZGGCBnirT9Fpm+pH24cYwDQYJKoZIhvcNAQELBQADggEBAILe9MuXdrCn
-UnFslEzmjdblMh3KmUScorXkpboGCGvntVV2An7uaWoNJ2l744CXEJxAmBPk0UC2
-5lkdwhxuZLq1r3uqcNc0G9PLnyvAcjZwrQSgB5zd5foCs8nx8GqZiZUg4jF/IS6L
-uHZeMYLsSzFD5yDZlw9SjiYdCzEt9nRAawnPOejZyCftnXalsiqD2xaOX+7nkERo
-NJIzvTl8lo/jYXi1TlnYEgoNkBcifA40u62UZgfVT9l5NG8SwXdpoSCuzLAu6Zy7
-lIlw7tAUHAWJQHa7R2SDJHOVzPFl7vi/VfDD5jRrBwlnPgMBjbrLXVuJ1uPLzlXc
-rY1/3sZafJ8=
+g2gmFkrDiAqmSEOY5y1PX3CMYrIwDQYJKoZIhvcNAQELBQADggEBAPLVdqr/BbJj
+LYEjPdXcj6jrvBc1f2QaN1ACrFRLyXT7B/js98JqgL330UMbTdEswnHZKEYBDxSr
+jiAUk+fcp7FtSn2p96Jd6k2JX/tFS5jIkxLZdF6kPiUTLJKWPhXG00bHA1xLcGWe
+H4nvfnBjPHjYopJTLTmj9Q02qip7qKljZjnjSVUPRdYUnvR3GBaQE0FqJ4+EycUN
+rczZv2KQAlZjdna8PzZdQa0HXvniZulj47p5uQe26LUnDxhOpG2C1+mpQM7r2Wq4
+1gTEsmIfxcv+FPPFzQ4RMrXP6vyYPFkj62nFC/aDW9wlnG2TKcIwWMEQgEmGZwn9
+ImcB5TKao4M=
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/bad-int-basic-constraints.pem
+++ b/spec/fixtures/ssl/bad-int-basic-constraints.pem
@@ -6,30 +6,30 @@ Certificate:
         Issuer: CN=Test CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Jun 15 01:19:37 2031 GMT
+            Not After : Jun 24 21:18:00 2033 GMT
         Subject: CN=Test CA Subauthority
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                RSA Public-Key: (2048 bit)
+                Public-Key: (2048 bit)
                 Modulus:
-                    00:af:36:20:41:45:0b:d1:13:0c:82:fd:b8:e5:ea:
-                    f8:32:6b:5e:f7:a5:1c:7d:21:24:cb:85:bf:cd:f5:
-                    ca:48:85:39:c1:42:a4:65:93:d2:a2:04:f9:c9:19:
-                    10:da:64:0d:be:e3:d0:a5:d3:85:17:79:aa:18:32:
-                    f7:0a:b9:8e:08:de:d8:97:06:28:99:ac:ed:d1:a6:
-                    d4:0a:34:de:3d:33:e3:08:17:c2:22:6c:1d:fc:51:
-                    df:98:e6:de:6e:c6:4b:26:f4:87:44:1e:86:b6:44:
-                    b2:f3:82:9c:9c:2f:5b:66:bf:27:71:49:53:bf:c9:
-                    d2:f5:06:7e:fe:fd:1c:59:ba:aa:a9:05:c8:cb:44:
-                    f5:f5:51:7b:80:1c:59:0e:a5:bf:bb:af:f5:96:68:
-                    26:ca:52:b6:a8:e3:f6:3f:b9:a0:60:09:67:4a:86:
-                    5b:b4:ae:13:d9:39:ca:e0:84:dc:2e:83:51:ce:09:
-                    34:36:30:9c:ff:54:32:a6:b6:5b:a6:41:bd:b3:2b:
-                    5d:1d:eb:79:45:f4:fb:de:47:56:3c:8d:b1:96:34:
-                    2d:ec:9a:66:4c:50:ab:c6:c4:05:3e:8c:27:7c:be:
-                    54:53:5e:ae:20:70:15:12:0f:85:ab:be:18:dd:da:
-                    f5:33:a5:55:6a:c7:d8:36:89:bb:1c:5d:ce:46:45:
-                    ba:7d
+                    00:c0:91:fc:98:ec:30:6b:f0:5c:d6:0b:ed:79:ab:
+                    69:80:c1:ca:5b:d5:4a:a3:e3:1b:3e:25:f1:47:0b:
+                    7b:9f:dc:1b:0a:8b:d6:0a:c1:e8:8b:ca:38:68:be:
+                    91:58:d7:ff:41:a1:00:48:59:a0:62:2e:1d:e7:2d:
+                    7a:c5:64:4d:be:48:30:eb:4f:e3:9e:3f:06:a4:ef:
+                    e4:95:5c:86:ff:54:24:49:75:16:84:41:78:c5:8d:
+                    ac:ff:af:95:91:ae:e1:f3:92:f0:a1:dd:18:e9:7c:
+                    8e:d0:86:e9:84:84:f3:cb:4c:9c:12:f6:a7:54:f0:
+                    9c:87:3b:f1:50:67:cf:12:04:11:c0:1b:e0:46:e4:
+                    03:73:9c:3c:ea:ed:3e:31:2f:bc:cf:bd:38:fb:1d:
+                    fa:f5:8d:66:e7:f2:0b:5f:df:0f:99:ec:45:c9:aa:
+                    e4:10:ad:5b:64:a5:da:af:27:e1:47:ac:4f:aa:aa:
+                    74:a5:0e:9c:14:c4:89:ef:ce:fb:50:38:b9:f9:09:
+                    d6:f9:ba:5b:49:1c:8c:70:9c:0d:4e:3c:94:6d:9e:
+                    63:24:c3:e8:49:74:7a:79:02:0d:b4:6f:f3:b9:e0:
+                    c0:4c:74:24:21:56:b5:57:e6:c9:29:08:1b:63:6d:
+                    2d:9c:e2:68:33:c1:cf:60:07:54:88:d4:da:6c:15:
+                    48:1b
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Basic Constraints: critical
@@ -37,45 +37,45 @@ Certificate:
             X509v3 Key Usage: critical
                 Certificate Sign, CRL Sign
             X509v3 Subject Key Identifier: 
-                59:79:27:C1:94:D7:09:B0:B2:1C:23:44:22:E2:25:25:1B:83:5F:34
+                38:7E:66:C4:7A:8B:16:EC:8A:0C:76:FC:C4:A6:7F:79:E5:DD:9A:FB
             Netscape Comment: 
                 Puppet Server Internal Certificate
             X509v3 Authority Key Identifier: 
-                keyid:B2:EE:24:88:34:99:18:60:81:9E:2A:D3:F4:5A:66:FA:91:F6:E1:C6
-
+                83:68:26:16:4A:C3:88:0A:A6:48:43:98:E7:2D:4F:5F:70:8C:62:B2
     Signature Algorithm: sha256WithRSAEncryption
-         8e:52:e6:46:dc:23:4a:6f:09:4a:e5:72:96:90:9c:8c:c0:ff:
-         4c:cd:eb:16:a7:8d:fe:56:4a:c4:be:97:50:43:c9:a7:4b:97:
-         c1:fe:5f:e0:0c:17:ea:3b:cd:a8:27:03:21:9b:ee:33:eb:23:
-         46:e6:fc:e3:80:d4:4a:a2:29:5c:a3:d5:f3:0b:c9:74:41:49:
-         45:65:59:48:7f:93:49:5f:d0:20:e7:b1:93:dc:a9:78:ad:b7:
-         ef:97:cc:13:ef:29:04:56:c6:bc:10:97:3a:09:5b:fb:34:80:
-         a4:64:88:0d:b9:cb:bf:4e:e6:fe:98:bf:dc:e5:00:47:ad:7d:
-         74:c6:13:19:a9:d8:9c:1e:1c:60:55:f2:71:02:c9:7d:10:48:
-         b8:4e:8d:22:e8:b4:ee:e0:ce:a3:24:f9:33:d0:aa:d6:aa:cb:
-         dd:38:8a:bd:05:3f:b2:52:17:80:8c:a4:1a:97:44:19:1b:e5:
-         92:d3:b4:9b:58:44:91:dc:67:1d:e1:43:1a:85:1d:da:c3:52:
-         45:50:01:6c:f9:e2:64:a1:e9:2f:d6:88:20:fd:d0:8b:e4:c8:
-         76:50:f2:79:bf:6f:ad:8f:11:e5:81:3b:53:da:39:9e:d4:d7:
-         6c:f8:7c:36:ed:76:8c:b0:ca:86:a8:1d:01:d9:25:92:54:ae:
-         a9:dc:b2:73
+    Signature Value:
+        8c:4b:be:0e:b0:af:d0:14:7f:04:4d:99:65:3e:ec:43:6e:62:
+        5c:89:4e:60:74:c3:72:ae:2d:f1:9c:e6:5f:c6:2c:d3:d7:9b:
+        af:f2:8d:51:d3:7c:bc:34:4d:35:49:f5:78:6d:41:8c:c3:0d:
+        bf:4a:6f:dc:f0:d7:92:9d:2b:71:16:c8:20:40:b8:21:f8:2a:
+        6b:a0:f5:54:40:13:25:b9:fe:bf:29:0a:d3:b5:71:13:9d:92:
+        f9:db:c1:e6:fa:04:24:b6:1c:61:46:2d:6c:8e:18:c5:f2:30:
+        00:6e:f5:d3:4b:c0:2e:68:3e:6e:b6:5c:ee:e4:98:04:71:df:
+        b5:58:0b:3b:04:72:e2:1e:ea:cf:94:a2:d4:1e:60:a4:87:00:
+        5a:80:28:85:85:5e:98:d6:bc:7a:be:ce:68:cd:3f:d4:2d:b2:
+        e3:84:61:d5:4d:d1:86:74:3a:e1:47:ec:7d:0f:3f:88:e2:1b:
+        86:5a:01:03:6a:cb:1d:10:5b:0d:c7:c5:66:e4:e4:7e:02:ae:
+        d3:a9:3f:0a:66:70:48:65:f0:fa:53:bb:65:1c:dd:03:6c:ff:
+        3a:6d:47:7d:b1:a0:68:df:ff:59:05:84:e3:fb:de:59:a4:00:
+        7b:6b:8a:de:a2:d5:69:62:57:af:11:5e:12:40:6a:58:a1:8a:
+        f5:55:34:30
 -----BEGIN CERTIFICATE-----
 MIIDQTCCAimgAwIBAgIBAzANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
-IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMxMDYxNTAxMTkzN1owHzEdMBsGA1UEAwwU
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMzMDYyNDIxMTgwMFowHzEdMBsGA1UEAwwU
 VGVzdCBDQSBTdWJhdXRob3JpdHkwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
-AoIBAQCvNiBBRQvREwyC/bjl6vgya173pRx9ISTLhb/N9cpIhTnBQqRlk9KiBPnJ
-GRDaZA2+49Cl04UXeaoYMvcKuY4I3tiXBiiZrO3RptQKNN49M+MIF8IibB38Ud+Y
-5t5uxksm9IdEHoa2RLLzgpycL1tmvydxSVO/ydL1Bn7+/RxZuqqpBcjLRPX1UXuA
-HFkOpb+7r/WWaCbKUrao4/Y/uaBgCWdKhlu0rhPZOcrghNwug1HOCTQ2MJz/VDKm
-tlumQb2zK10d63lF9PveR1Y8jbGWNC3smmZMUKvGxAU+jCd8vlRTXq4gcBUSD4Wr
-vhjd2vUzpVVqx9g2ibscXc5GRbp9AgMBAAGjgZQwgZEwDAYDVR0TAQH/BAIwADAO
-BgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFFl5J8GU1wmwshwjRCLiJSUbg180MDEG
+AoIBAQDAkfyY7DBr8FzWC+15q2mAwcpb1Uqj4xs+JfFHC3uf3BsKi9YKweiLyjho
+vpFY1/9BoQBIWaBiLh3nLXrFZE2+SDDrT+OePwak7+SVXIb/VCRJdRaEQXjFjaz/
+r5WRruHzkvCh3RjpfI7QhumEhPPLTJwS9qdU8JyHO/FQZ88SBBHAG+BG5ANznDzq
+7T4xL7zPvTj7Hfr1jWbn8gtf3w+Z7EXJquQQrVtkpdqvJ+FHrE+qqnSlDpwUxInv
+zvtQOLn5Cdb5ultJHIxwnA1OPJRtnmMkw+hJdHp5Ag20b/O54MBMdCQhVrVX5skp
+CBtjbS2c4mgzwc9gB1SI1NpsFUgbAgMBAAGjgZQwgZEwDAYDVR0TAQH/BAIwADAO
+BgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFDh+ZsR6ixbsigx2/MSmf3nl3Zr7MDEG
 CWCGSAGG+EIBDQQkFiJQdXBwZXQgU2VydmVyIEludGVybmFsIENlcnRpZmljYXRl
-MB8GA1UdIwQYMBaAFLLuJIg0mRhggZ4q0/RaZvqR9uHGMA0GCSqGSIb3DQEBCwUA
-A4IBAQCOUuZG3CNKbwlK5XKWkJyMwP9MzesWp43+VkrEvpdQQ8mnS5fB/l/gDBfq
-O82oJwMhm+4z6yNG5vzjgNRKoilco9XzC8l0QUlFZVlIf5NJX9Ag57GT3Kl4rbfv
-l8wT7ykEVsa8EJc6CVv7NICkZIgNucu/Tub+mL/c5QBHrX10xhMZqdicHhxgVfJx
-Asl9EEi4To0i6LTu4M6jJPkz0KrWqsvdOIq9BT+yUheAjKQal0QZG+WS07SbWESR
-3Gcd4UMahR3aw1JFUAFs+eJkoekv1ogg/dCL5Mh2UPJ5v2+tjxHlgTtT2jme1Nds
-+Hw27XaMsMqGqB0B2SWSVK6p3LJz
+MB8GA1UdIwQYMBaAFINoJhZKw4gKpkhDmOctT19wjGKyMA0GCSqGSIb3DQEBCwUA
+A4IBAQCMS74OsK/QFH8ETZllPuxDbmJciU5gdMNyri3xnOZfxizT15uv8o1R03y8
+NE01SfV4bUGMww2/Sm/c8NeSnStxFsggQLgh+CproPVUQBMluf6/KQrTtXETnZL5
+28Hm+gQkthxhRi1sjhjF8jAAbvXTS8AuaD5utlzu5JgEcd+1WAs7BHLiHurPlKLU
+HmCkhwBagCiFhV6Y1rx6vs5ozT/ULbLjhGHVTdGGdDrhR+x9Dz+I4huGWgEDassd
+EFsNx8Vm5OR+Aq7TqT8KZnBIZfD6U7tlHN0DbP86bUd9saBo3/9ZBYTj+95ZpAB7
+a4reotVpYlevEV4SQGpYoYr1VTQw
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/ca.pem
+++ b/spec/fixtures/ssl/ca.pem
@@ -6,30 +6,30 @@ Certificate:
         Issuer: CN=Test CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Jun 15 01:19:37 2031 GMT
+            Not After : Jun 24 21:18:00 2033 GMT
         Subject: CN=Test CA
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                RSA Public-Key: (2048 bit)
+                Public-Key: (2048 bit)
                 Modulus:
-                    00:b0:eb:f6:b5:c4:28:a8:18:53:85:91:20:76:5d:
-                    aa:be:78:ae:10:60:d3:b5:66:f7:41:c8:bf:42:00:
-                    c8:99:63:ed:d0:92:12:5a:71:c0:da:d2:fd:b3:65:
-                    3b:a5:fa:be:0d:e5:2a:20:2f:df:a1:c5:41:c3:c3:
-                    9c:04:eb:07:6c:8d:48:9c:14:be:24:81:7d:03:4d:
-                    56:62:80:6b:34:e0:ad:68:f0:17:3d:fa:3b:b4:f7:
-                    a9:a3:fb:7d:30:0d:dd:c5:0b:b6:32:b6:c2:d9:b1:
-                    e8:97:ce:19:66:89:1b:5d:d6:4a:d9:0e:a6:b2:ad:
-                    cc:57:e9:0a:12:83:98:a3:18:90:a3:ae:ec:8e:a1:
-                    96:ee:a4:36:7b:13:c4:95:45:02:69:89:f4:d3:49:
-                    17:e6:e4:d5:91:23:24:7e:94:52:b5:4f:f3:0b:11:
-                    d8:b2:69:7e:72:25:88:03:15:7b:2f:64:ca:8c:a9:
-                    ce:b0:ed:eb:00:aa:68:af:cd:e4:1c:13:af:a7:ff:
-                    54:b6:7d:be:b5:6c:bd:6a:20:be:47:2f:a8:dd:7a:
-                    1d:2a:44:a4:0b:15:eb:68:85:05:32:17:01:cf:a7:
-                    27:03:cb:85:12:c1:ec:4f:c1:4b:2a:11:34:55:7c:
-                    b3:6c:fa:79:6d:4f:be:31:92:b8:f3:01:90:8e:42:
-                    6b:71
+                    00:f4:9a:3e:d9:2b:e1:1e:ea:3c:85:7d:27:87:f5:
+                    f7:50:c6:60:f0:79:3b:86:23:ce:c9:ba:42:22:1b:
+                    61:1a:bc:33:c7:cf:e2:56:8f:6c:84:3e:4e:d0:48:
+                    b5:27:7e:7b:49:de:2b:5d:b2:9c:e6:49:53:52:c8:
+                    89:92:cb:e1:6c:30:67:c6:74:25:e3:3f:7a:37:ef:
+                    54:b4:bd:80:07:a6:db:77:5c:8f:56:ed:1b:14:af:
+                    2a:12:f5:44:88:15:a3:63:f2:f9:44:fb:51:ed:9a:
+                    6d:9c:cf:48:69:f6:d0:c9:6c:57:ee:1b:be:04:91:
+                    b3:ad:16:ed:c8:d0:bf:b4:55:6b:e9:3c:2b:8c:57:
+                    19:bc:f1:76:6f:90:8d:e4:60:79:c7:03:e3:9d:83:
+                    42:ec:0e:79:78:3c:30:c4:d5:87:63:4d:2c:17:ad:
+                    c6:ea:3b:ff:e4:73:1a:12:bb:ed:d3:f6:9d:9d:d9:
+                    e7:05:7f:21:6c:27:0a:27:c5:6e:c8:53:6c:a3:bb:
+                    0e:11:fa:c4:ab:97:8f:a1:fd:bd:f3:5e:fb:80:1d:
+                    15:87:c7:b4:20:94:fc:cb:ac:06:a8:ae:b1:80:a0:
+                    5d:50:68:8d:49:63:1b:b2:77:a2:6b:81:21:b6:58:
+                    3a:f2:3d:21:ac:a5:91:bc:7d:36:46:f4:87:ea:ce:
+                    a3:0f
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Basic Constraints: critical
@@ -37,45 +37,45 @@ Certificate:
             X509v3 Key Usage: critical
                 Certificate Sign, CRL Sign
             X509v3 Subject Key Identifier: 
-                B2:EE:24:88:34:99:18:60:81:9E:2A:D3:F4:5A:66:FA:91:F6:E1:C6
+                83:68:26:16:4A:C3:88:0A:A6:48:43:98:E7:2D:4F:5F:70:8C:62:B2
             Netscape Comment: 
                 Puppet Server Internal Certificate
             X509v3 Authority Key Identifier: 
-                keyid:B2:EE:24:88:34:99:18:60:81:9E:2A:D3:F4:5A:66:FA:91:F6:E1:C6
-
+                83:68:26:16:4A:C3:88:0A:A6:48:43:98:E7:2D:4F:5F:70:8C:62:B2
     Signature Algorithm: sha256WithRSAEncryption
-         7a:7f:46:71:8a:41:c5:43:91:be:aa:2c:ca:96:12:6f:0a:1b:
-         7c:57:a7:cc:b3:8d:c5:ff:8c:77:f0:4e:ea:ae:b0:c3:af:01:
-         c5:17:32:4d:b5:c6:72:77:20:a7:05:02:a0:26:a3:0d:a6:da:
-         b4:cf:c8:96:36:76:c9:2f:db:90:db:e1:8e:83:5e:24:e5:47:
-         22:1f:e5:17:0b:16:19:db:a2:ae:55:db:3b:6a:2a:f2:a8:95:
-         25:d1:4f:13:bd:d8:07:b2:a1:63:18:0d:7d:4b:d8:74:be:bb:
-         c5:b2:26:3a:6c:7d:b1:84:20:6c:53:ab:fc:27:5a:06:84:a5:
-         f4:4d:63:ba:a2:43:40:76:c7:97:2a:ae:8f:5a:ca:0e:ab:4b:
-         59:c3:6c:b5:3e:f5:d2:bd:55:ce:88:19:de:e5:4e:ca:fe:c1:
-         83:02:9c:11:a2:97:88:64:8a:df:20:17:f3:47:9e:61:cf:c4:
-         bc:13:bb:e8:ba:97:37:90:8f:1a:5c:f5:b1:00:8d:70:fe:a2:
-         4c:8e:0a:bc:62:ed:8e:4e:e7:2a:15:13:59:7e:3b:a2:b8:41:
-         f0:13:41:39:29:99:1a:ca:c6:6a:b6:99:c5:ca:57:1d:53:c4:
-         c6:f5:7f:96:3b:11:05:96:10:a3:3c:96:d8:c3:07:2b:e2:66:
-         a5:93:13:98
+    Signature Value:
+        53:4c:5e:b5:86:73:e9:d0:ab:f1:87:8e:3c:3e:8c:5c:ce:c9:
+        aa:86:a5:ea:96:96:77:e5:31:98:04:e5:46:f8:75:7b:00:b7:
+        2a:b4:f6:a4:6c:e8:e8:7e:95:b0:c2:bb:a3:ae:87:49:9f:a2:
+        ea:49:5a:d8:ac:79:b4:f7:aa:0c:6c:57:fb:27:8c:c0:31:97:
+        b0:8f:b0:4e:53:96:99:3a:0e:4c:47:51:d1:93:88:48:a4:c4:
+        e7:7b:c2:d7:34:4c:22:88:1b:85:f2:3f:ff:88:39:c1:61:da:
+        52:ba:42:69:1a:9a:5b:1f:b5:f6:88:76:4e:21:f9:48:0a:4d:
+        6e:4c:f2:b4:8c:4d:3b:c1:95:6d:f1:09:26:68:63:83:f5:d2:
+        3e:d2:6d:c0:09:8e:93:36:c3:58:5e:c7:8b:79:1a:72:b6:af:
+        eb:2e:3b:1d:2b:19:55:49:09:df:55:49:2b:d4:93:bf:95:df:
+        ab:6d:aa:bc:57:e2:67:33:ec:6a:7a:33:e9:31:c8:01:01:53:
+        03:f5:43:fb:8f:18:7c:0b:69:0d:81:d9:af:4b:f2:b9:b0:cd:
+        5f:3d:24:a0:ad:ca:c5:b5:60:3c:fb:52:8f:48:1c:2d:ec:45:
+        01:03:79:40:4e:f9:1c:e4:e5:67:27:21:2c:f7:48:95:ff:22:
+        da:2b:2e:48
 -----BEGIN CERTIFICATE-----
 MIIDNzCCAh+gAwIBAgIBAjANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
-IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMxMDYxNTAxMTkzN1owEjEQMA4GA1UEAwwH
-VGVzdCBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALDr9rXEKKgY
-U4WRIHZdqr54rhBg07Vm90HIv0IAyJlj7dCSElpxwNrS/bNlO6X6vg3lKiAv36HF
-QcPDnATrB2yNSJwUviSBfQNNVmKAazTgrWjwFz36O7T3qaP7fTAN3cULtjK2wtmx
-6JfOGWaJG13WStkOprKtzFfpChKDmKMYkKOu7I6hlu6kNnsTxJVFAmmJ9NNJF+bk
-1ZEjJH6UUrVP8wsR2LJpfnIliAMVey9kyoypzrDt6wCqaK/N5BwTr6f/VLZ9vrVs
-vWogvkcvqN16HSpEpAsV62iFBTIXAc+nJwPLhRLB7E/BSyoRNFV8s2z6eW1PvjGS
-uPMBkI5Ca3ECAwEAAaOBlzCBlDAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQE
-AwIBBjAdBgNVHQ4EFgQUsu4kiDSZGGCBnirT9Fpm+pH24cYwMQYJYIZIAYb4QgEN
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMzMDYyNDIxMTgwMFowEjEQMA4GA1UEAwwH
+VGVzdCBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAPSaPtkr4R7q
+PIV9J4f191DGYPB5O4Yjzsm6QiIbYRq8M8fP4laPbIQ+TtBItSd+e0neK12ynOZJ
+U1LIiZLL4WwwZ8Z0JeM/ejfvVLS9gAem23dcj1btGxSvKhL1RIgVo2Py+UT7Ue2a
+bZzPSGn20MlsV+4bvgSRs60W7cjQv7RVa+k8K4xXGbzxdm+QjeRgeccD452DQuwO
+eXg8MMTVh2NNLBetxuo7/+RzGhK77dP2nZ3Z5wV/IWwnCifFbshTbKO7DhH6xKuX
+j6H9vfNe+4AdFYfHtCCU/MusBqiusYCgXVBojUljG7J3omuBIbZYOvI9Iaylkbx9
+Nkb0h+rOow8CAwEAAaOBlzCBlDAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQE
+AwIBBjAdBgNVHQ4EFgQUg2gmFkrDiAqmSEOY5y1PX3CMYrIwMQYJYIZIAYb4QgEN
 BCQWIlB1cHBldCBTZXJ2ZXIgSW50ZXJuYWwgQ2VydGlmaWNhdGUwHwYDVR0jBBgw
-FoAUsu4kiDSZGGCBnirT9Fpm+pH24cYwDQYJKoZIhvcNAQELBQADggEBAHp/RnGK
-QcVDkb6qLMqWEm8KG3xXp8yzjcX/jHfwTuqusMOvAcUXMk21xnJ3IKcFAqAmow2m
-2rTPyJY2dskv25Db4Y6DXiTlRyIf5RcLFhnboq5V2ztqKvKolSXRTxO92AeyoWMY
-DX1L2HS+u8WyJjpsfbGEIGxTq/wnWgaEpfRNY7qiQ0B2x5cqro9ayg6rS1nDbLU+
-9dK9Vc6IGd7lTsr+wYMCnBGil4hkit8gF/NHnmHPxLwTu+i6lzeQjxpc9bEAjXD+
-okyOCrxi7Y5O5yoVE1l+O6K4QfATQTkpmRrKxmq2mcXKVx1TxMb1f5Y7EQWWEKM8
-ltjDByviZqWTE5g=
+FoAUg2gmFkrDiAqmSEOY5y1PX3CMYrIwDQYJKoZIhvcNAQELBQADggEBAFNMXrWG
+c+nQq/GHjjw+jFzOyaqGpeqWlnflMZgE5Ub4dXsAtyq09qRs6Oh+lbDCu6Ouh0mf
+oupJWtisebT3qgxsV/snjMAxl7CPsE5Tlpk6DkxHUdGTiEikxOd7wtc0TCKIG4Xy
+P/+IOcFh2lK6QmkamlsftfaIdk4h+UgKTW5M8rSMTTvBlW3xCSZoY4P10j7SbcAJ
+jpM2w1hex4t5GnK2r+suOx0rGVVJCd9VSSvUk7+V36ttqrxX4mcz7Gp6M+kxyAEB
+UwP1Q/uPGHwLaQ2B2a9L8rmwzV89JKCtysW1YDz7Uo9IHC3sRQEDeUBO+Rzk5Wcn
+ISz3SJX/ItorLkg=
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/crl.pem
+++ b/spec/fixtures/ssl/crl.pem
@@ -3,38 +3,38 @@ Certificate Revocation List (CRL):
         Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA
         Last Update: Jan  1 00:00:00 1970 GMT
-        Next Update: Jun 15 01:19:37 2031 GMT
+        Next Update: Jun 24 21:18:00 2033 GMT
         CRL extensions:
             X509v3 Authority Key Identifier: 
-                keyid:B2:EE:24:88:34:99:18:60:81:9E:2A:D3:F4:5A:66:FA:91:F6:E1:C6
-
+                83:68:26:16:4A:C3:88:0A:A6:48:43:98:E7:2D:4F:5F:70:8C:62:B2
             X509v3 CRL Number: 
                 0
 No Revoked Certificates.
     Signature Algorithm: sha256WithRSAEncryption
-         94:c0:29:e4:a6:0d:fb:0f:8d:96:5a:74:40:0b:1f:c7:58:0d:
-         b8:a4:3d:44:b8:2e:93:82:c1:b0:56:4b:ee:c1:a3:a3:9d:cd:
-         dd:48:89:92:18:d0:d5:bf:87:06:6c:00:65:9e:73:30:9a:57:
-         8a:21:26:73:60:2b:a6:46:59:1a:9a:ca:64:3e:fa:ea:0b:f1:
-         07:4f:70:0a:27:eb:89:d7:51:5a:62:73:ec:ef:23:5e:c5:04:
-         07:b0:17:b9:7a:4a:b7:9f:77:8d:5e:7c:fe:30:d5:37:3a:f2:
-         22:d9:14:a6:cb:b3:10:36:27:49:87:28:42:2f:0e:9d:04:36:
-         6e:0a:8f:01:a8:35:b8:46:05:8b:02:25:69:5d:0c:55:a4:5b:
-         d1:7f:48:5a:e3:06:4f:13:f8:b6:fc:34:93:b7:20:27:7d:79:
-         44:a2:ce:1f:24:42:7e:c8:9b:3d:d4:62:db:0a:3a:1b:d4:30:
-         94:5e:ff:9b:b3:eb:c2:19:36:a9:71:a6:9a:d6:a5:04:f1:05:
-         7a:6b:3d:82:7f:8b:96:8c:27:41:13:8d:2e:82:94:68:a0:0b:
-         10:75:cb:e6:05:07:86:d7:44:7c:09:1d:e9:65:a9:29:13:dc:
-         ef:a6:c7:93:8e:e7:09:c2:14:7d:d4:31:e4:db:f9:1f:dd:15:
-         93:e5:23:2f
+    Signature Value:
+        8a:b8:7b:ae:cf:3e:a0:77:0b:35:2f:98:d9:35:29:97:56:2f:
+        7b:e4:74:1e:29:2c:46:1f:bb:da:1d:60:fb:83:8b:fe:dd:42:
+        f6:94:ab:c3:f1:a2:b9:1c:11:e8:85:be:5c:fd:ac:21:d9:e8:
+        d7:af:be:bd:5c:e9:df:c4:13:6f:a6:5b:2e:9e:c5:dd:49:16:
+        b5:ef:c8:21:c7:85:42:f0:b6:b5:d9:56:8d:d4:e8:0b:78:ba:
+        96:44:a7:14:60:47:af:a6:6d:ac:11:1c:7d:52:59:57:ec:03:
+        ea:de:ce:58:5d:0e:5a:71:c9:e5:0c:80:01:37:91:dc:14:b2:
+        0e:3e:20:7e:e2:2e:18:56:6b:9a:3d:2c:d8:76:68:12:83:1a:
+        b2:54:c8:82:30:12:52:b0:64:c8:b8:37:39:48:2a:5b:6b:0d:
+        f8:01:5f:e6:c9:bd:73:64:82:af:66:62:d5:22:b6:eb:05:14:
+        6b:cc:95:32:e6:bc:87:07:32:33:c1:2a:92:ef:16:48:be:40:
+        4a:0d:78:de:bd:46:9c:d6:22:b2:44:8b:47:3f:79:28:7e:f9:
+        16:23:74:d7:bc:19:64:b6:78:82:f1:4c:13:9f:12:c3:b8:57:
+        c5:ce:2d:56:81:36:88:9d:99:6b:61:f5:60:21:e5:26:39:77:
+        ce:60:08:2c
 -----BEGIN X509 CRL-----
 MIIBizB1AgEBMA0GCSqGSIb3DQEBCwUAMBIxEDAOBgNVBAMMB1Rlc3QgQ0EXDTcw
-MDEwMTAwMDAwMFoXDTMxMDYxNTAxMTkzN1qgLzAtMB8GA1UdIwQYMBaAFLLuJIg0
-mRhggZ4q0/RaZvqR9uHGMAoGA1UdFAQDAgEAMA0GCSqGSIb3DQEBCwUAA4IBAQCU
-wCnkpg37D42WWnRACx/HWA24pD1EuC6TgsGwVkvuwaOjnc3dSImSGNDVv4cGbABl
-nnMwmleKISZzYCumRlkamspkPvrqC/EHT3AKJ+uJ11FaYnPs7yNexQQHsBe5ekq3
-n3eNXnz+MNU3OvIi2RSmy7MQNidJhyhCLw6dBDZuCo8BqDW4RgWLAiVpXQxVpFvR
-f0ha4wZPE/i2/DSTtyAnfXlEos4fJEJ+yJs91GLbCjob1DCUXv+bs+vCGTapcaaa
-1qUE8QV6az2Cf4uWjCdBE40ugpRooAsQdcvmBQeG10R8CR3pZakpE9zvpseTjucJ
-whR91DHk2/kf3RWT5SMv
+MDEwMTAwMDAwMFoXDTMzMDYyNDIxMTgwMFqgLzAtMB8GA1UdIwQYMBaAFINoJhZK
+w4gKpkhDmOctT19wjGKyMAoGA1UdFAQDAgEAMA0GCSqGSIb3DQEBCwUAA4IBAQCK
+uHuuzz6gdws1L5jZNSmXVi975HQeKSxGH7vaHWD7g4v+3UL2lKvD8aK5HBHohb5c
+/awh2ejXr769XOnfxBNvplsunsXdSRa178ghx4VC8La12VaN1OgLeLqWRKcUYEev
+pm2sERx9UllX7APq3s5YXQ5accnlDIABN5HcFLIOPiB+4i4YVmuaPSzYdmgSgxqy
+VMiCMBJSsGTIuDc5SCpbaw34AV/myb1zZIKvZmLVIrbrBRRrzJUy5ryHBzIzwSqS
+7xZIvkBKDXjevUac1iKyRItHP3kofvkWI3TXvBlktniC8UwTnxLDuFfFzi1WgTaI
+nZlrYfVgIeUmOXfOYAgs
 -----END X509 CRL-----

--- a/spec/fixtures/ssl/ec-key.pem
+++ b/spec/fixtures/ssl/ec-key.pem
@@ -1,18 +1,18 @@
 Private-Key: (256 bit)
 priv:
-    27:12:6c:11:ab:f5:ea:31:bb:92:9d:6f:e5:8d:2c:
-    37:77:53:04:94:21:e7:ac:cd:b5:e1:95:fe:9b:3e:
-    2b:35
+    da:dd:0f:94:97:b5:3a:8d:cb:0c:1b:b1:55:85:e4:
+    71:e4:6c:f3:45:0c:55:07:3d:9c:1d:d0:86:06:1a:
+    f7:12
 pub:
-    04:82:0e:06:bf:c4:ae:37:d8:b1:7f:49:07:20:0f:
-    0c:46:52:a5:f7:28:89:66:ed:70:0f:8d:f9:95:55:
-    74:27:78:9a:f7:8d:7b:9e:1f:3c:0c:1a:59:2b:64:
-    d4:66:d3:76:55:b7:a3:e6:11:c7:c1:5c:94:37:89:
-    01:21:58:07:3c
+    04:d0:40:f7:c9:01:ec:97:dc:32:1c:19:85:59:29:
+    19:a9:40:21:ba:9e:f9:87:f6:49:d6:97:e4:1a:d3:
+    d6:ac:12:de:63:34:2b:62:16:19:0b:af:3c:fd:87:
+    a1:66:3e:36:39:65:83:fd:2f:36:bc:fd:58:14:ff:
+    a5:2b:fb:35:32
 ASN1 OID: prime256v1
 NIST CURVE: P-256
 -----BEGIN EC PRIVATE KEY-----
-MHcCAQEEICcSbBGr9eoxu5Kdb+WNLDd3UwSUIeeszbXhlf6bPis1oAoGCCqGSM49
-AwEHoUQDQgAEgg4Gv8SuN9ixf0kHIA8MRlKl9yiJZu1wD435lVV0J3ia9417nh88
-DBpZK2TUZtN2Vbej5hHHwVyUN4kBIVgHPA==
+MHcCAQEEINrdD5SXtTqNywwbsVWF5HHkbPNFDFUHPZwd0IYGGvcSoAoGCCqGSM49
+AwEHoUQDQgAE0ED3yQHsl9wyHBmFWSkZqUAhup75h/ZJ1pfkGtPWrBLeYzQrYhYZ
+C688/YehZj42OWWD/S82vP1YFP+lK/s1Mg==
 -----END EC PRIVATE KEY-----

--- a/spec/fixtures/ssl/ec.pem
+++ b/spec/fixtures/ssl/ec.pem
@@ -1,49 +1,50 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 8 (0x8)
+        Serial Number: 9 (0x9)
         Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA Subauthority
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Jun 15 01:19:37 2031 GMT
+            Not After : Jun 24 21:18:00 2033 GMT
         Subject: CN=ec
         Subject Public Key Info:
             Public Key Algorithm: id-ecPublicKey
                 Public-Key: (256 bit)
                 pub:
-                    04:82:0e:06:bf:c4:ae:37:d8:b1:7f:49:07:20:0f:
-                    0c:46:52:a5:f7:28:89:66:ed:70:0f:8d:f9:95:55:
-                    74:27:78:9a:f7:8d:7b:9e:1f:3c:0c:1a:59:2b:64:
-                    d4:66:d3:76:55:b7:a3:e6:11:c7:c1:5c:94:37:89:
-                    01:21:58:07:3c
+                    04:d0:40:f7:c9:01:ec:97:dc:32:1c:19:85:59:29:
+                    19:a9:40:21:ba:9e:f9:87:f6:49:d6:97:e4:1a:d3:
+                    d6:ac:12:de:63:34:2b:62:16:19:0b:af:3c:fd:87:
+                    a1:66:3e:36:39:65:83:fd:2f:36:bc:fd:58:14:ff:
+                    a5:2b:fb:35:32
                 ASN1 OID: prime256v1
                 NIST CURVE: P-256
     Signature Algorithm: sha256WithRSAEncryption
-         73:45:fa:9b:af:0b:0b:74:21:80:8b:4c:c7:25:ad:ed:aa:6e:
-         0a:5e:86:f3:77:93:fe:b5:7d:4d:9d:cf:16:e6:27:81:c7:2e:
-         a0:fd:6b:09:24:78:3e:d3:4f:48:c6:c0:55:a5:0e:ee:8a:b7:
-         c5:70:c3:ac:d1:67:fd:fb:92:81:85:ea:8f:0e:49:29:49:a0:
-         4f:92:5c:2c:39:db:7e:01:5b:4f:c6:36:4d:aa:84:36:b5:73:
-         70:a4:e2:b8:bc:0c:1c:a4:b7:84:f5:81:9d:31:31:57:46:e7:
-         0b:1c:53:20:0a:ee:0e:b0:93:a3:88:4a:66:33:c1:11:dc:b8:
-         f9:1d:ee:72:97:e0:3a:53:9d:e5:25:16:4c:8a:12:4d:d1:39:
-         21:68:21:cf:2f:f6:52:25:38:49:06:f5:41:d5:68:28:9c:73:
-         40:16:3f:57:fc:4a:85:e4:c7:a6:bf:8b:66:e8:d5:0c:ce:8b:
-         95:a8:53:e2:e9:a1:ef:53:5f:c4:87:a6:57:03:67:28:f1:eb:
-         19:db:2a:81:55:e7:d4:a1:e9:be:97:39:28:e8:fe:01:48:c0:
-         95:a6:3a:d5:f0:69:63:6c:ca:e8:74:f9:24:76:39:26:71:21:
-         ad:c7:f3:dc:4a:24:a8:16:22:15:35:2a:43:3b:30:9d:67:99:
-         a6:18:ec:77
+    Signature Value:
+        97:13:55:70:9a:23:39:f8:08:f9:a6:9e:18:a0:08:23:a9:39:
+        1b:2f:88:b9:db:37:da:28:4c:49:a0:eb:e5:5d:ee:c5:60:f7:
+        6d:13:b1:cb:92:73:70:40:7e:d2:b8:7a:19:08:63:78:a3:0d:
+        ab:c5:f3:93:90:93:fa:25:e5:f6:18:f7:bf:57:68:97:51:9f:
+        04:69:f9:10:7d:63:2a:2c:d4:41:0d:65:19:6e:3a:cd:dd:fd:
+        17:64:9e:14:1c:ef:d7:64:09:3f:16:b6:23:c1:f5:97:a8:5a:
+        79:97:61:10:9e:f4:88:dc:78:ef:5e:2f:6d:05:a3:b1:8a:d7:
+        92:2f:0e:66:3e:b4:fd:00:5c:f9:7c:0a:7d:78:75:33:3c:8f:
+        59:0a:ca:0a:da:14:a7:36:00:5c:ec:df:26:e0:cb:90:0d:4a:
+        12:8b:f1:c2:a8:9f:a8:de:f2:a0:2c:33:28:38:c0:00:a6:09:
+        e8:80:7f:2a:aa:e5:9c:55:c7:ed:62:21:2b:33:0c:6e:a7:04:
+        b0:e1:63:19:75:26:76:80:2c:af:23:9d:d6:39:c8:b2:e3:78:
+        8d:fe:2c:a6:06:55:11:10:9d:23:12:e9:74:5b:75:73:19:32:
+        a1:83:d7:24:ba:61:b3:8b:81:2b:45:80:bf:f2:fa:6a:0b:7c:
+        8d:46:81:0f
 -----BEGIN CERTIFICATE-----
-MIIB2TCBwqADAgECAgEIMA0GCSqGSIb3DQEBCwUAMB8xHTAbBgNVBAMMFFRlc3Qg
-Q0EgU3ViYXV0aG9yaXR5MB4XDTcwMDEwMTAwMDAwMFoXDTMxMDYxNTAxMTkzN1ow
-DTELMAkGA1UEAwwCZWMwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASCDga/xK43
-2LF/SQcgDwxGUqX3KIlm7XAPjfmVVXQneJr3jXueHzwMGlkrZNRm03ZVt6PmEcfB
-XJQ3iQEhWAc8MA0GCSqGSIb3DQEBCwUAA4IBAQBzRfqbrwsLdCGAi0zHJa3tqm4K
-Xobzd5P+tX1Nnc8W5ieBxy6g/WsJJHg+009IxsBVpQ7uirfFcMOs0Wf9+5KBheqP
-DkkpSaBPklwsOdt+AVtPxjZNqoQ2tXNwpOK4vAwcpLeE9YGdMTFXRucLHFMgCu4O
-sJOjiEpmM8ER3Lj5He5yl+A6U53lJRZMihJN0TkhaCHPL/ZSJThJBvVB1WgonHNA
-Fj9X/EqF5Memv4tm6NUMzouVqFPi6aHvU1/Eh6ZXA2co8esZ2yqBVefUoem+lzko
-6P4BSMCVpjrV8GljbMrodPkkdjkmcSGtx/PcSiSoFiIVNSpDOzCdZ5mmGOx3
+MIIB2TCBwqADAgECAgEJMA0GCSqGSIb3DQEBCwUAMB8xHTAbBgNVBAMMFFRlc3Qg
+Q0EgU3ViYXV0aG9yaXR5MB4XDTcwMDEwMTAwMDAwMFoXDTMzMDYyNDIxMTgwMFow
+DTELMAkGA1UEAwwCZWMwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATQQPfJAeyX
+3DIcGYVZKRmpQCG6nvmH9knWl+Qa09asEt5jNCtiFhkLrzz9h6FmPjY5ZYP9Lza8
+/VgU/6Ur+zUyMA0GCSqGSIb3DQEBCwUAA4IBAQCXE1VwmiM5+Aj5pp4YoAgjqTkb
+L4i52zfaKExJoOvlXe7FYPdtE7HLknNwQH7SuHoZCGN4ow2rxfOTkJP6JeX2GPe/
+V2iXUZ8EafkQfWMqLNRBDWUZbjrN3f0XZJ4UHO/XZAk/FrYjwfWXqFp5l2EQnvSI
+3HjvXi9tBaOxiteSLw5mPrT9AFz5fAp9eHUzPI9ZCsoK2hSnNgBc7N8m4MuQDUoS
+i/HCqJ+o3vKgLDMoOMAApgnogH8qquWcVcftYiErMwxupwSw4WMZdSZ2gCyvI53W
+Ociy43iN/iymBlUREJ0jEul0W3VzGTKhg9ckumGzi4ErRYC/8vpqC3yNRoEP
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/encrypted-ec-key.pem
+++ b/spec/fixtures/ssl/encrypted-ec-key.pem
@@ -1,21 +1,21 @@
 Private-Key: (256 bit)
 priv:
-    27:12:6c:11:ab:f5:ea:31:bb:92:9d:6f:e5:8d:2c:
-    37:77:53:04:94:21:e7:ac:cd:b5:e1:95:fe:9b:3e:
-    2b:35
+    da:dd:0f:94:97:b5:3a:8d:cb:0c:1b:b1:55:85:e4:
+    71:e4:6c:f3:45:0c:55:07:3d:9c:1d:d0:86:06:1a:
+    f7:12
 pub:
-    04:82:0e:06:bf:c4:ae:37:d8:b1:7f:49:07:20:0f:
-    0c:46:52:a5:f7:28:89:66:ed:70:0f:8d:f9:95:55:
-    74:27:78:9a:f7:8d:7b:9e:1f:3c:0c:1a:59:2b:64:
-    d4:66:d3:76:55:b7:a3:e6:11:c7:c1:5c:94:37:89:
-    01:21:58:07:3c
+    04:d0:40:f7:c9:01:ec:97:dc:32:1c:19:85:59:29:
+    19:a9:40:21:ba:9e:f9:87:f6:49:d6:97:e4:1a:d3:
+    d6:ac:12:de:63:34:2b:62:16:19:0b:af:3c:fd:87:
+    a1:66:3e:36:39:65:83:fd:2f:36:bc:fd:58:14:ff:
+    a5:2b:fb:35:32
 ASN1 OID: prime256v1
 NIST CURVE: P-256
 -----BEGIN EC PRIVATE KEY-----
 Proc-Type: 4,ENCRYPTED
-DEK-Info: AES-128-CBC,3000460EBCF5BF07FA28AC674DAC7481
+DEK-Info: AES-128-CBC,F24798971C256A4FC58DE36E2AF14278
 
-DZ8eBxSQ3PNLVsXV62TdK+L7lvMvZl3kre28PVE4YfR8WFGDKK39OUpup8pOmy9p
-a0VcDRaQ0MGse43mWl7/JbQGPP9U4cswow4jqLUifprZTCoTlXy4mFleD0rLiT0F
-la0gg7fR+18maGiknmYam/euhmNx9dh4+E0HXQ8357Q=
+AhRyG1cSvDiQGOj3S5BxWwB3udT0rEan5kKlXeXSqWFay3u2SM3jMqWvzc0cZtyo
+/OHDtRkyHohDtTJNqcJJSqrwAyjQ6w/XQVKd9dqfX3ATssUA9yvZKYIoS67uUrbW
+fQXzaBFNJoh7wtL3qK2f6of6LpQsyK6WQNDQvDbo2dc=
 -----END EC PRIVATE KEY-----

--- a/spec/fixtures/ssl/encrypted-key.pem
+++ b/spec/fixtures/ssl/encrypted-key.pem
@@ -1,120 +1,120 @@
-RSA Private-Key: (2048 bit, 2 primes)
+Private-Key: (2048 bit, 2 primes)
 modulus:
-    00:94:3b:fc:18:7e:09:d6:93:10:9a:d7:df:84:49:
-    74:7d:9a:0e:91:ff:31:ca:9f:c0:c0:cf:4a:6b:1e:
-    be:77:b0:82:9f:a6:17:fc:f3:99:f1:e5:ed:c4:d3:
-    e1:f4:e8:ee:d2:70:3b:98:b1:21:55:9a:9e:6d:89:
-    f1:82:ba:82:43:00:af:e6:05:7e:0f:a1:50:ff:ec:
-    77:88:28:92:a2:f0:f9:29:1d:cb:86:ca:63:a9:c7:
-    9e:01:99:6e:56:c8:39:f1:c6:33:b9:b4:96:b2:05:
-    5e:e1:f7:1c:55:58:23:ec:bd:bb:4d:a0:54:3c:09:
-    d0:c9:83:27:9b:3c:f5:50:8c:1e:54:22:b3:0a:0f:
-    97:c1:68:d5:07:b7:0d:b9:16:d6:f8:d0:2c:87:25:
-    5e:53:65:31:d5:d6:94:ab:8b:77:29:a2:78:4e:c7:
-    cf:66:f2:79:f2:66:ca:ce:c9:9a:04:a2:0d:47:6f:
-    a0:1c:cc:39:7d:f2:01:73:3d:9c:56:0f:15:f6:06:
-    92:98:19:9b:52:ed:43:f8:84:6c:1f:96:0b:dd:8e:
-    c7:0f:dc:13:08:7b:1a:07:c1:ac:de:ba:dc:ce:1b:
-    a8:c5:c5:d5:c8:6c:32:6a:e2:2c:aa:e2:56:ba:55:
-    b4:3c:2b:7f:87:99:3e:d0:0c:47:ba:6e:60:86:2b:
-    3d:51
+    00:c4:7f:b6:dd:ab:a8:58:7f:49:48:9d:bd:6f:91:
+    9a:ea:bc:8c:3c:20:5f:ec:3b:30:4e:c2:c5:98:8e:
+    52:27:74:d9:d1:28:7e:6a:09:b1:fc:ea:d2:28:a7:
+    48:30:b8:bc:93:11:e8:56:93:bf:02:86:1c:78:16:
+    0b:b8:c3:ce:aa:b1:27:de:c6:96:20:f8:d4:8e:63:
+    58:b3:05:c6:df:a7:eb:eb:85:14:98:04:0e:d7:99:
+    17:81:0c:15:0b:c7:f0:bf:14:a5:8e:e9:5b:88:65:
+    e9:b4:3e:9f:77:f4:77:60:dd:aa:75:e9:f2:75:07:
+    a8:47:17:a3:79:f1:e5:ea:01:80:25:5a:5a:1b:fb:
+    8d:6e:17:c7:b8:7d:bb:1d:ec:67:bf:c9:83:8f:28:
+    02:99:83:16:f4:2c:f0:94:25:1b:7f:f0:99:fb:ec:
+    75:63:88:97:2f:1d:f8:bf:14:92:3b:df:ed:a0:56:
+    0c:94:c6:92:b4:91:e2:85:88:de:99:93:00:17:b0:
+    f1:ed:45:03:8f:07:2e:5a:e5:82:6a:99:6f:45:00:
+    54:2a:37:93:77:23:06:c3:99:fa:c1:1f:4c:59:63:
+    e1:35:b9:f7:f6:ab:81:a5:11:ef:9c:a1:e6:64:ab:
+    2f:fc:f9:cd:b3:d0:b7:33:81:4c:36:13:03:3a:5e:
+    e6:e5
 publicExponent: 65537 (0x10001)
 privateExponent:
-    0b:61:af:b1:91:bb:df:a5:db:18:88:8a:b8:f5:8a:
-    e4:39:f7:f4:6d:cb:bc:eb:17:39:b6:b0:d8:18:bc:
-    37:24:6e:63:23:b5:a3:ce:70:7b:8a:53:ff:50:e5:
-    80:90:82:05:d6:68:3d:09:1c:ae:1d:f9:1c:20:03:
-    53:2e:4e:e2:26:23:5b:5e:00:97:e2:a2:fd:83:82:
-    8a:09:d3:78:7f:58:22:38:0f:70:82:09:b4:f7:86:
-    c2:48:ad:98:2c:37:86:c0:d9:27:e1:1d:d0:fd:68:
-    93:a1:0d:a3:df:e8:a2:3c:cf:2c:de:aa:99:11:87:
-    de:71:1b:91:67:d4:ce:22:56:27:a3:7d:4d:58:5c:
-    d3:76:80:54:b6:28:ed:60:e7:ba:ef:da:4a:f5:86:
-    b9:f7:7e:c5:94:5f:87:55:d0:5c:6b:8c:ea:4e:82:
-    ca:3d:bc:23:b5:1c:77:4c:bd:57:98:db:1f:ec:af:
-    0d:70:e0:a0:fa:86:d6:ac:cf:2f:a2:55:24:2e:98:
-    60:b0:f5:cf:60:db:bf:97:b8:e2:c0:1f:03:b5:5c:
-    af:ce:fd:5b:2b:97:cd:d5:eb:95:ef:17:bc:19:69:
-    5a:12:1f:28:24:d2:8e:cd:91:8f:90:7c:54:bf:31:
-    75:bd:66:31:eb:61:20:b1:7f:5f:3b:3a:af:48:8d:
-    81
+    02:ae:22:f2:7d:43:2a:53:da:ce:20:02:ae:63:d1:
+    75:b6:b5:2b:4e:73:68:7f:8f:d8:df:2c:be:a2:e0:
+    54:29:47:f2:f8:fc:57:c4:c2:95:ff:d0:f6:87:7e:
+    43:55:dd:bd:46:cf:01:11:4f:ac:c0:8e:0b:b0:47:
+    4a:d1:a1:94:6f:f3:ff:d9:fc:6b:13:8c:78:ab:0f:
+    bc:6a:0d:81:f8:4d:23:95:03:88:7a:f3:b0:8a:a6:
+    1e:01:ea:19:3d:f4:ac:1d:38:bb:37:e1:22:52:e6:
+    35:69:c3:97:3e:b1:25:d3:d8:32:f6:b4:dd:2b:9f:
+    26:bb:17:e5:29:00:c3:bd:e9:36:1a:19:b2:df:0c:
+    42:d0:9d:e0:c4:9a:6e:73:00:fc:57:c5:32:62:da:
+    0e:67:0e:bc:10:de:80:17:cd:bc:39:80:d2:d8:d9:
+    c1:11:c0:ac:6d:32:11:3a:e1:7d:64:c7:d9:5e:f0:
+    c8:e0:3f:ae:c2:8b:07:0a:da:a8:15:58:e0:2e:c1:
+    f5:f5:1a:4e:c5:bc:e8:c7:63:bf:28:84:0d:1d:e4:
+    8d:8c:9b:74:7b:9f:2b:f8:ba:9d:ee:d6:c4:9f:d6:
+    3d:90:d6:18:34:84:82:d2:12:4c:be:55:13:54:6b:
+    d1:9e:39:e9:62:6f:30:de:9d:c2:06:49:4d:78:04:
+    11
 prime1:
-    00:c2:f2:79:65:6e:d5:61:bd:e0:6a:fb:67:89:ba:
-    23:fa:db:e4:fc:0f:58:9e:63:37:c4:ad:d8:80:c6:
-    a6:3f:9b:20:a5:70:48:20:f4:37:f3:36:01:8f:47:
-    ff:00:fe:b6:50:6a:56:f4:08:37:0a:0f:7f:28:42:
-    60:f8:01:a9:53:37:29:9c:24:83:14:1c:c3:56:b9:
-    18:33:5a:44:99:fe:b8:ab:45:26:71:b7:c5:1e:56:
-    a1:49:3c:71:5b:b5:c1:7c:bb:64:68:fe:af:24:3d:
-    60:6a:eb:de:d7:58:1d:bd:ff:56:92:5f:05:e6:8f:
-    57:88:5e:71:08:ce:12:e5:ad
+    00:db:85:36:5e:39:8e:46:b4:d2:ab:09:db:b1:c4:
+    d9:56:3c:c2:44:92:b7:60:74:e7:6d:07:75:ea:78:
+    bf:32:86:05:71:ab:e3:ad:22:b5:70:45:e7:26:49:
+    07:2a:92:1c:a0:31:c3:42:7e:7a:34:72:a0:c5:32:
+    92:65:17:bf:59:0a:59:41:d5:63:e8:ea:df:ae:1b:
+    e2:d8:b6:eb:bb:76:41:45:26:21:ac:de:4d:70:e1:
+    d4:bb:ce:30:c9:3b:a3:a9:96:95:7a:21:a3:6b:a1:
+    ea:e2:12:07:d9:0e:00:26:24:ee:91:2a:a5:69:ed:
+    d4:1c:03:c5:9d:80:35:5f:95
 prime2:
-    00:c2:a8:65:15:66:07:a2:14:75:17:ab:ed:f4:f5:
-    e6:cc:0b:70:6a:ee:a6:d0:3e:69:37:94:e8:3f:41:
-    02:f1:70:98:f4:5a:0d:0e:75:f5:37:4c:68:7a:cb:
-    1a:f2:57:69:5c:5d:b7:73:ce:95:48:92:1a:8a:2c:
-    33:08:a1:a6:3a:e2:7d:16:3b:c2:f7:86:68:da:18:
-    94:e5:9e:32:04:31:a4:07:2d:d4:4c:8c:e5:db:77:
-    72:ef:d9:e8:c2:0d:4e:17:83:7d:09:c5:df:83:35:
-    3b:bc:31:ae:a4:f7:d0:44:f1:98:7d:ad:2d:08:ae:
-    76:11:20:d7:cd:36:81:82:b5
+    00:e5:27:20:94:a0:f1:36:3f:97:ea:86:ed:4c:21:
+    8f:23:2b:09:49:7d:58:48:9f:c4:44:3f:8b:67:4b:
+    d4:1e:c2:87:fc:09:c6:06:d3:8b:82:e2:17:95:a6:
+    89:7c:df:43:2c:5b:fe:bb:ea:85:32:a7:59:eb:41:
+    31:81:e6:d2:8a:e8:1f:65:9e:dd:91:55:75:52:09:
+    e5:90:6a:44:22:99:47:e6:57:bb:f9:e6:df:f2:42:
+    b0:dd:1a:8f:6c:93:04:70:35:a9:3b:05:a9:04:78:
+    5a:97:39:53:d2:4c:3d:74:9a:d1:36:4c:98:9b:1a:
+    ba:1c:46:d0:46:5d:f9:d6:11
 exponent1:
-    68:16:6f:1a:e9:82:a5:1d:6c:a5:b2:76:25:e3:6d:
-    32:94:16:3f:3f:32:61:df:37:f7:9b:9a:ed:a7:23:
-    3c:f2:e7:0b:6e:58:14:c0:50:df:5b:06:9a:2a:26:
-    cd:b1:32:46:dd:80:6f:eb:b2:f7:7c:2e:b8:a0:38:
-    86:32:dc:e5:c1:9e:45:f0:78:cc:54:4f:38:0e:bc:
-    0d:2f:35:51:c3:df:76:13:05:e3:d1:eb:3d:b7:a3:
-    86:26:ef:9f:b7:fc:07:4d:46:df:88:9c:9b:0c:ea:
-    5e:2c:72:5f:28:7d:38:e5:0c:a4:3a:78:3c:12:6c:
-    fa:32:f2:c7:70:c0:46:41
+    27:ad:ce:83:fd:97:50:04:83:47:d3:42:58:c1:a2:
+    1f:4a:60:3b:10:e2:00:97:60:f5:7e:31:bc:2e:13:
+    31:48:b4:57:35:a0:b3:bc:e0:5a:e8:e7:bd:2d:da:
+    13:c1:d1:56:cb:67:e5:ef:02:9b:d4:54:67:10:9b:
+    11:96:d7:49:7a:eb:63:50:f4:fc:36:e8:33:8a:6a:
+    d8:8d:47:d2:dc:af:33:96:8e:e3:b6:52:fd:22:74:
+    d7:75:8f:af:f0:0d:c7:2b:a6:dd:2a:93:65:73:21:
+    07:b8:06:9f:1f:3e:bb:a6:55:50:fc:0a:66:39:4c:
+    eb:bb:6a:ce:eb:4b:ba:79
 exponent2:
-    4c:f2:27:d3:07:9b:e8:d3:d1:5d:64:17:12:07:ca:
-    0d:ca:4f:cb:d5:3e:97:7e:b4:34:c6:65:ef:eb:10:
-    f0:c3:a3:92:a3:ae:19:93:43:35:72:bc:b2:1d:6b:
-    2f:74:a2:2f:62:d4:4b:b0:d3:8d:f6:43:0b:6f:61:
-    54:fe:21:29:91:b2:04:81:e7:15:d5:49:c9:3c:82:
-    4f:29:f3:77:78:ef:ef:ee:8b:c7:1e:c3:15:b7:e7:
-    f5:2b:dc:38:28:ee:3f:99:38:6a:0e:8f:c5:db:db:
-    1b:0f:40:8b:f1:71:a0:6f:27:ea:35:f4:61:44:25:
-    63:ab:e9:e2:32:b3:8b:29
+    5f:ff:5f:3f:c4:98:a8:70:45:b5:23:67:3f:d0:83:
+    45:69:5f:0f:a1:6a:1d:aa:88:af:4a:ab:9c:cf:80:
+    82:8e:5e:27:70:f4:bb:a1:5d:bd:ab:f7:d3:62:9c:
+    10:6a:fb:9a:16:c4:05:77:3e:eb:b4:7e:0f:f7:14:
+    c5:65:ac:68:32:cc:0c:67:5c:4c:e9:2f:27:fa:2b:
+    68:af:8b:f1:ae:a3:17:55:43:d3:72:2b:f9:32:85:
+    23:6b:60:10:4d:1a:bb:e3:4f:0d:01:d7:07:9f:5f:
+    dc:20:51:04:35:9a:3d:42:2a:49:04:17:9e:4a:b9:
+    12:e5:7b:95:2f:03:5d:f1
 coefficient:
-    0d:ae:36:95:c9:a2:b3:6a:3d:d4:38:01:ce:e4:10:
-    da:e9:0e:c5:58:dd:0f:cf:9e:ac:cd:fc:68:9b:24:
-    6c:58:76:2b:78:57:ef:03:e5:d9:d6:e8:9a:15:9e:
-    15:c8:21:8c:34:19:9a:7c:e3:bf:dd:a1:c0:dd:ad:
-    50:69:2a:d8:36:60:b2:c0:b3:ab:14:19:f9:4e:8b:
-    b1:f9:2c:5c:28:9c:ce:64:74:07:80:20:15:e1:a1:
-    b6:dc:8f:2a:be:bd:20:f0:62:22:4e:03:a2:aa:a0:
-    fd:46:bf:e1:89:30:ac:1a:09:0a:fe:5b:20:d5:59:
-    72:a1:ce:75:32:a8:70:b4
+    56:b9:68:ee:96:8e:20:df:9c:e5:3c:29:41:a0:e9:
+    32:8f:a1:e9:de:1a:c5:e2:cd:c6:0c:b7:63:e6:9c:
+    f6:b4:0e:f4:fb:6a:7f:a7:7b:3f:fe:6c:0b:d6:da:
+    c4:9d:ef:59:72:da:0e:14:4f:e2:37:78:b0:34:00:
+    58:05:48:cb:0d:e8:c6:67:6f:2b:76:20:5f:93:36:
+    bc:6e:1b:b0:6d:67:fd:67:71:4c:18:08:73:52:95:
+    59:11:39:f3:4c:73:93:37:57:53:5d:30:32:75:99:
+    46:a1:b9:d8:84:86:32:5c:0d:93:95:46:f4:17:3f:
+    38:15:ac:eb:eb:51:79:68
 -----BEGIN RSA PRIVATE KEY-----
 Proc-Type: 4,ENCRYPTED
-DEK-Info: AES-128-CBC,126A8E3A0DF846B4718A612CDDA959E9
+DEK-Info: AES-128-CBC,A4FAB87C746D77094021EC8C6EA63235
 
-Su2RyNUrjAnJY2IHpM3y+DcxpOYK80taVjAnDetAAstL5pM74QyQAySPsK7QSepf
-ppVyKtxcMVD0ChmicPxf2YJjJkcPLM0EGQna+r2w85u+rj7+l6m5ULXLaFz5RJap
-pKrGH8lgMKZyBw3sZ36P95jaVnfr6fos+TRWHhWwnrnwbjVcMKRYgrqbHxudydyp
-nWpZmjSyQjTRxG2shI3t5TXjN3XphIuQ/9cKIc8Obte2QHTBh/oU8kyYqsMlP8ZT
-h9tIX6i71PKQxi0U/+JcmupxerM/zdR0A//VWq8lhmudcXMvmlSIj8JIDhcSC9ah
-JyvZyuYsSj5gqFav/NdHCf9OLQMbk9j876RderSMFOKkhNUb1S3xRyepbF0hHisV
-vD8R5kufN0dOPjeghepFf3V6vJvexC3WxwE/txdrhi2KXEs3QRwtryJsN1oiMyrG
-P/QwNw/njA6uPoDXFBhGz/owemW6SwsvrSD/1nruq8nCCDA90HleOq+I6WlySLFs
-gA2Pi9lQ8GgSRw/LkIElOuv7/Xc1IgtzPGBRMajIAeKjOMhl+hwEY6+Z2ncwi8VG
-fydaEeAmX2pOWbxEfi0m+ed6DSfNnGxMmAuEMrCg9nwhkUpwWXgpAs7yBZJksh73
-wb0BDm+nKhAMwWB9Dt7nyDnDsih6EGatOPVS03PSeLt5MB83TlYie0HsUMcHd06o
-8idkXtkYOntBkAu4tcCwQr7Fr5q2rvW5VgGX261BzWZwqTITZs5XVizYj85ppRp7
-n2qrQjViTgK9ZZ52e+1lNQ0J2HVczNirUjCPPt1Pg+ghzmFw1UH8z+ezGH0oYkyw
-tyWJyqdmxl0QM45g6VQuw6yhYkXOVMenxMtFm/LBaxZxJZKhaxpnj5ClVSRZlst1
-WisJfJtH4k35f1JcaSWt3LrSJOLPFJHqgpLusASMEcA6FLT1PErWktPnuLQEFTjh
-6l2nxYR9/X2rxNIVc/IZtGtda8qOGzi13FscPHoTNoC1JUaIiYySXIq26bqli8pr
-bu7xwo+xw31eIhfn0dRMqKltkS7N0FeBTylXKtViLTbuPBaa8a9627xJIuDQm5AD
-JJGyN0sXhkHpGXMNarb3QfpKPUuUWkLJXbDOUXc/9v5trKQF4biF+s0seYiJtec4
-m6QHtUZfonaSS18TK8SXxv3fwuscpJWu7vzRah/Jj5in8cjV9nvdazSuIfrKa1fj
-uvGQ1jsU4Ap9GVPDQI90UzH8Wu7o3c64KLnQIbPxOWvgTWxFJst6w/o/Qf/0bMxZ
-skn/wc1WuiWFk+Yu6Drpp7rNGebJhUKXu6j5rrWnlaw3lHUexPbU9TcV1sfD1K+G
-KIAPt3xayTOXlJMfyquxEPOnCs9eP9wyELFvNIwPtix8QGoDDrm+ojhX0YivF9aX
-AJv3UFPX3yHe6zIUVZoThk9YJIAqp9aem25Xx2CBwFhdihpR0BSf1cgv7Bko23WK
-triO9Zrjk3ySdJ290Xo36imufA6o/P5ledDH/a1zSj1g39DUAv6w5gtHNx4dSUve
-Z2WEvxHIQUGx/KNZeIenrLLBohKBbxNc3ISzDDpOEb7y5Cn7Nfhr6V11QaTkcKRt
+R7Ge2FyBxV2ElhGdTAbNR2J8M88roYKyiuXhhGuggLDHf66C7IigzFMvsxds37a+
+932ksUA011XvYjCRbCgTaDbfv02tmmClTNABnMUv/NQS6+OhY/KjCR99ZCzOWfwz
+0msj7k5UaEZyUPfX1JAgW0SV06j+WjoM+wEzKdRc4c+RXYJKlBF9UecdknE8Tkch
+MoVcMIlATkiJ0FCTXxlTyIicP9K0YdGAAzpa4wvKCflZuRiKbrGaelmI1nsMhEY6
+xMXMuhxxD39KyAHaWySrR4TVmgw2fRvdwuBUsGtSVgbnCop51znALtMzspmy2Nz3
+dvTYSa0GdJ6YwXaoWUEipWVCvT9hNADUe8MKtFQqO8/Hhazaceb//7Mn/kPIwnsD
+5vF/6xd5dALMSJ9zXSnJ8XpBMFszzgyN/FxzKu1p3GMU7QJNe24f4LfucQvGgiy3
+Ql/JrQdFDAHpMlLVgJj84H8L+xmMOZ80M1eQCk9/KiAGi69NARPScPrnnyOJtKbW
+uQXnKwKHHT7BQkdIJAb3Gyu1K29VMEZU15+xRJyvWIUPf8hWUohsn8eA0XdxQKBv
+OeAED0ptNHtaUL7uExQH3mn3qgYSw07/Ynlq0wg9Eugvdq3sU2xdbBDP/txuXUdF
+2evaA1YioV1NdYcAYsT5m2Sreeq2RW1o2MLX0IWGxV89TKX8SHoS/nIi4QhB9oLB
+q9Viv+8PW2G5OCKhxyJStSieER3dbAXOHoVzhFB7pS2HkpkL2dwh9eOHpKwFdcdu
+galMWHmb6+wGkFhVgFRTZ9F6mTCHcsEUoXt7a/ddydMB36tHQYUdxQuGlyGeF7C5
+cretPwuhUmIxlmPfoqYqNyDyTpVZaFI7823enscxu3fyqlF8AwO+REPVZt1yzqmf
+YZfnfYHWk3f7TvKBF9ZNjv7gWC4L+QyEOfQUcx0Vi4j0I4pgxo5Gk+7Eb0tw116w
+qALQ8qzwm1BUCPiP6WnwvM4oL4kZgMNgBAbxgxyeUeypm+tGQr2zya7h7RZJe4bw
+0XrBgerkj/Va78Wy//cJC2gwFzKJPtfcaQlzanNslMPAJ+Te6k8Tip+7HYD6F0f6
+FK+VDeuqBGAwNN9cPD8HBnjKltX4RggAaWasRukWWbCfjO0xuFFeLCZscf9vnvbz
+hq16xvoAHCA0O3WXUtdbTJNiRIjYpr9qymQynUN/eMSLEk1sduwBnGXRWuUvBCDS
+APFI9G5F7NM3GC+HqYyEsPe/mT8mqH0KU6881mudaZVu4QZzcIl1maRKMNBrUtep
+kmtFKWzC3YbMax05L4nA0HtWDZh28eCZyTOKqGzh0K/BDHM1FkyQmIt85UHT+MtJ
+SiXzL1514oY0+4uE0bSDv2seybS5KiKsEjvWeerPyYzgElmK8hQcWADDmrafDB9N
+2iybONLuPzKrDFmVmb20He3JKWGYcGyBqUVD203bdErlIbPLuoCnUmGhIxACqPdv
+dXs9U8eUAKpGwctHnnuYVb9aFt2QK+leNlYh4KNR7hVjqDpURBm84Va6gE/kvkIp
+wt23YK4OK4G1mDFXObmuk0a5zTrN1MC5J3tFvXh7R4N9e4+LnQ0Edgk5aE7Zfm06
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/intermediate-agent-crl.pem
+++ b/spec/fixtures/ssl/intermediate-agent-crl.pem
@@ -3,38 +3,38 @@ Certificate Revocation List (CRL):
         Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA Agent Subauthority
         Last Update: Jan  1 00:00:00 1970 GMT
-        Next Update: Jun 15 01:19:37 2031 GMT
+        Next Update: Jun 24 21:18:00 2033 GMT
         CRL extensions:
             X509v3 Authority Key Identifier: 
-                keyid:97:84:A5:C2:28:B4:15:97:89:C4:52:2C:69:8F:7B:75:DD:5F:2A:DC
-
+                92:84:BC:BD:F2:05:CC:1C:E3:00:5A:75:B1:A4:67:A9:31:08:9A:F2
             X509v3 CRL Number: 
                 0
 No Revoked Certificates.
     Signature Algorithm: sha256WithRSAEncryption
-         14:7b:e6:cd:e2:be:2a:78:b9:05:94:16:e7:82:79:c9:03:b1:
-         51:8a:0a:0f:8e:44:bf:da:9d:47:72:a9:08:4e:b5:d5:ef:17:
-         54:5d:ba:db:bb:61:e9:5f:b4:8c:49:f7:2b:90:3a:50:00:57:
-         89:00:3d:3c:dd:c2:2d:b2:6c:0d:29:21:4f:4d:68:57:44:bb:
-         36:ba:fe:7f:97:e3:f0:87:7e:73:ba:c5:48:73:13:2c:30:2f:
-         77:86:98:e2:24:93:1a:0c:dc:11:fb:38:48:b6:66:77:a6:d6:
-         d8:c8:dd:23:16:b6:d9:1a:27:14:0f:28:68:8f:38:27:d2:a2:
-         4f:c0:d6:61:f1:61:20:ef:59:4d:5a:20:c3:e7:01:98:36:d5:
-         94:33:b1:8f:15:19:17:1b:d8:60:74:bc:5c:3f:6f:8b:95:f9:
-         fc:77:2c:d6:42:17:0c:0e:4b:db:ed:66:0a:06:25:08:3d:03:
-         6b:56:8b:7b:76:47:6a:c5:3c:97:c0:41:20:43:c8:b2:4b:bf:
-         a0:07:94:58:ad:63:46:89:b2:b7:2a:76:fe:8e:69:d2:7d:51:
-         df:07:bd:c0:14:ce:0d:46:24:ee:de:8b:7b:e4:04:87:be:90:
-         f3:6e:dd:ae:4d:d7:93:d1:dc:3e:f5:4c:e8:1e:24:ca:26:59:
-         ee:ce:48:f3
+    Signature Value:
+        78:e1:8b:90:01:c2:44:ae:09:0b:a0:d3:09:c7:3b:cc:10:bc:
+        87:4a:e2:85:76:45:8e:31:2c:96:3c:97:7b:ec:5a:4b:0d:ae:
+        30:e6:5f:53:18:ce:88:88:21:f9:4d:ff:00:07:14:37:d3:c1:
+        04:f7:03:55:29:59:60:95:ec:b7:d8:ad:0b:7f:b0:6a:7f:ec:
+        93:ac:52:ee:18:e3:85:d3:d1:82:c2:19:87:ae:2c:84:d1:e7:
+        59:dd:92:7b:84:bb:b9:ab:54:01:4f:84:71:80:53:36:b9:15:
+        43:a1:da:e3:ea:3b:d0:65:54:8d:4e:52:5f:6d:9b:28:47:20:
+        ce:be:bd:dd:e7:77:8c:43:f4:cd:83:d0:81:83:63:47:38:9f:
+        29:fd:fd:c5:ea:e2:28:1f:22:be:57:c5:82:6c:45:62:00:ea:
+        fc:4b:69:b9:d0:b2:02:7f:20:4e:d2:c4:ae:e1:96:7a:2e:bd:
+        85:d7:f7:47:e2:00:da:4c:0a:ca:c2:4f:05:be:49:92:7c:4b:
+        6d:39:48:1f:ab:83:de:a2:12:04:85:85:57:b0:78:7e:69:07:
+        ff:3b:bc:d8:53:74:94:e5:21:34:5b:30:09:08:9b:3e:f9:cd:
+        84:14:e0:51:46:5f:23:34:6c:47:d0:57:71:f9:b9:9c:94:c7:
+        df:4c:f5:2c
 -----BEGIN X509 CRL-----
 MIIBnzCBiAIBATANBgkqhkiG9w0BAQsFADAlMSMwIQYDVQQDDBpUZXN0IENBIEFn
-ZW50IFN1YmF1dGhvcml0eRcNNzAwMTAxMDAwMDAwWhcNMzEwNjE1MDExOTM3WqAv
-MC0wHwYDVR0jBBgwFoAUl4Slwii0FZeJxFIsaY97dd1fKtwwCgYDVR0UBAMCAQAw
-DQYJKoZIhvcNAQELBQADggEBABR75s3ivip4uQWUFueCeckDsVGKCg+ORL/anUdy
-qQhOtdXvF1Rdutu7YelftIxJ9yuQOlAAV4kAPTzdwi2ybA0pIU9NaFdEuza6/n+X
-4/CHfnO6xUhzEywwL3eGmOIkkxoM3BH7OEi2Znem1tjI3SMWttkaJxQPKGiPOCfS
-ok/A1mHxYSDvWU1aIMPnAZg21ZQzsY8VGRcb2GB0vFw/b4uV+fx3LNZCFwwOS9vt
-ZgoGJQg9A2tWi3t2R2rFPJfAQSBDyLJLv6AHlFitY0aJsrcqdv6OadJ9Ud8HvcAU
-zg1GJO7ei3vkBIe+kPNu3a5N15PR3D71TOgeJMomWe7OSPM=
+ZW50IFN1YmF1dGhvcml0eRcNNzAwMTAxMDAwMDAwWhcNMzMwNjI0MjExODAwWqAv
+MC0wHwYDVR0jBBgwFoAUkoS8vfIFzBzjAFp1saRnqTEImvIwCgYDVR0UBAMCAQAw
+DQYJKoZIhvcNAQELBQADggEBAHjhi5ABwkSuCQug0wnHO8wQvIdK4oV2RY4xLJY8
+l3vsWksNrjDmX1MYzoiIIflN/wAHFDfTwQT3A1UpWWCV7LfYrQt/sGp/7JOsUu4Y
+44XT0YLCGYeuLITR51ndknuEu7mrVAFPhHGAUza5FUOh2uPqO9BlVI1OUl9tmyhH
+IM6+vd3nd4xD9M2D0IGDY0c4nyn9/cXq4igfIr5XxYJsRWIA6vxLabnQsgJ/IE7S
+xK7hlnouvYXX90fiANpMCsrCTwW+SZJ8S205SB+rg96iEgSFhVeweH5pB/87vNhT
+dJTlITRbMAkImz75zYQU4FFGXyM0bEfQV3H5uZyUx99M9Sw=
 -----END X509 CRL-----

--- a/spec/fixtures/ssl/intermediate-agent.pem
+++ b/spec/fixtures/ssl/intermediate-agent.pem
@@ -1,35 +1,35 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 9 (0x9)
+        Serial Number: 10 (0xa)
         Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Jun 15 01:19:37 2031 GMT
+            Not After : Jun 24 21:18:00 2033 GMT
         Subject: CN=Test CA Agent Subauthority
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                RSA Public-Key: (2048 bit)
+                Public-Key: (2048 bit)
                 Modulus:
-                    00:ae:c8:f1:11:5e:bd:b9:e8:60:81:9d:7d:00:b3:
-                    e6:5b:d4:03:e3:46:a0:e2:8b:e9:1f:ed:06:36:c7:
-                    e9:e1:9d:1a:8f:2b:d0:aa:63:00:12:35:44:d4:4d:
-                    d2:d8:69:3f:71:14:f0:0b:21:86:ab:93:37:ee:94:
-                    af:3a:56:35:95:b5:18:88:3b:25:96:dc:7e:b3:ab:
-                    98:58:3b:03:54:90:bf:cf:e5:fc:2a:54:9e:a7:6e:
-                    78:dc:36:cb:0f:20:49:c5:b2:61:76:f5:d2:19:d3:
-                    7a:c2:82:6e:b4:8b:ff:9f:f1:bb:aa:60:b7:8e:6f:
-                    b7:24:f7:39:9f:9b:aa:86:65:8e:67:56:96:79:d3:
-                    10:d8:0e:17:39:35:cb:ef:2d:db:c5:a7:7b:30:68:
-                    68:65:04:a8:8b:ba:23:49:8a:ce:1e:65:9d:9d:02:
-                    3f:5c:4e:1a:3d:ec:af:e4:53:46:c7:9f:17:bd:a2:
-                    0c:81:72:78:89:a0:54:2c:7c:53:99:21:03:5c:b7:
-                    0b:22:56:19:f2:bb:13:5a:35:22:e1:5b:ec:5a:52:
-                    84:f7:e4:69:d9:4f:57:55:c4:e7:40:8c:96:01:e4:
-                    19:03:37:bb:1b:1a:ed:a8:f8:0d:35:83:77:31:9f:
-                    a8:86:de:f8:97:ee:df:14:5e:ba:94:cd:23:38:0b:
-                    6a:f9
+                    00:ab:b8:fb:97:80:ff:7b:4a:ff:d9:6f:f6:8e:10:
+                    4c:d9:ea:0b:66:ed:3d:45:6f:06:cb:d8:ce:56:6c:
+                    3e:5a:c2:1b:fd:7a:ff:48:1c:0c:3e:a2:3a:f4:57:
+                    20:92:a5:35:98:4a:19:1b:8c:71:ce:0c:29:61:ca:
+                    58:9c:52:03:ef:73:3f:e4:66:8c:ac:00:d8:1e:4e:
+                    06:45:db:72:ac:59:63:05:30:6a:17:bd:f1:81:6c:
+                    e3:74:4d:90:a5:04:50:24:2a:c4:8e:9d:3f:45:c9:
+                    2e:47:03:f8:69:ad:49:b7:06:78:4a:dd:0d:e2:9b:
+                    f1:48:1b:81:4a:ef:5d:3e:28:44:49:4c:d8:53:25:
+                    f6:ca:1f:f6:76:86:97:b3:44:91:69:f2:c5:94:48:
+                    5d:3c:4a:21:e3:7e:a7:76:b6:14:bc:00:ac:58:92:
+                    b2:c6:83:cb:66:fd:8e:f8:89:23:c0:f2:5b:f9:74:
+                    6a:8d:0c:32:7e:dd:6e:75:38:c3:06:6c:ad:56:5d:
+                    3c:1f:40:80:c4:0b:2c:09:fc:c1:e2:d6:60:44:9f:
+                    8b:86:29:42:27:c0:67:d8:1e:2d:d8:8f:a8:55:94:
+                    7f:90:75:0c:27:52:ff:66:34:bd:74:49:54:f4:dd:
+                    32:b4:ce:b7:67:61:bb:45:8f:54:c0:27:ce:33:54:
+                    40:8f
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Basic Constraints: critical
@@ -37,45 +37,45 @@ Certificate:
             X509v3 Key Usage: critical
                 Certificate Sign, CRL Sign
             X509v3 Subject Key Identifier: 
-                97:84:A5:C2:28:B4:15:97:89:C4:52:2C:69:8F:7B:75:DD:5F:2A:DC
+                92:84:BC:BD:F2:05:CC:1C:E3:00:5A:75:B1:A4:67:A9:31:08:9A:F2
             Netscape Comment: 
                 Puppet Server Internal Certificate
             X509v3 Authority Key Identifier: 
-                keyid:B2:EE:24:88:34:99:18:60:81:9E:2A:D3:F4:5A:66:FA:91:F6:E1:C6
-
+                83:68:26:16:4A:C3:88:0A:A6:48:43:98:E7:2D:4F:5F:70:8C:62:B2
     Signature Algorithm: sha256WithRSAEncryption
-         73:fd:64:e0:87:64:11:b7:31:9e:e2:03:9d:9d:14:71:f1:f6:
-         81:96:78:10:6a:ed:0d:e6:12:57:aa:f8:31:2c:d9:00:83:07:
-         58:14:8c:97:2a:23:09:b0:57:56:68:95:d1:e7:0b:76:0b:82:
-         95:3a:90:15:3d:ae:cb:18:c0:38:2a:11:3d:04:a1:1f:bb:e9:
-         3e:a0:f1:b0:30:78:fb:58:0b:f9:cb:0a:99:2d:2a:a2:50:57:
-         6c:ef:b4:e2:c9:38:88:71:31:61:59:7e:10:c9:c9:51:32:d9:
-         6e:0b:c0:64:c3:40:eb:51:81:26:c3:1a:51:0b:90:ff:44:0e:
-         4f:fe:a7:45:41:00:ea:2a:1e:87:7c:e3:90:8a:2e:19:6c:a4:
-         ec:db:e5:19:b0:79:b2:35:75:08:5a:63:30:29:bb:f3:6a:36:
-         c7:28:9c:1e:88:a6:97:50:82:71:0d:1b:a0:9b:6f:99:33:60:
-         cf:eb:65:60:49:73:6b:81:b6:ee:9c:c7:30:c4:0a:30:43:c1:
-         2c:ef:81:3c:d0:e4:9a:1e:72:eb:ed:37:76:f3:fb:8b:00:09:
-         f6:53:a6:2f:1a:ba:68:32:f2:48:bb:5d:36:bb:31:05:b7:1c:
-         83:d8:ac:c9:af:2c:6f:d5:66:92:e9:f0:3f:1d:c6:fb:fd:37:
-         70:90:65:f5
+    Signature Value:
+        89:7e:9c:5b:0f:48:35:ef:96:2c:4c:f9:c0:11:49:4c:5e:7a:
+        da:d3:e0:0a:11:f0:a3:55:1e:46:c1:d9:79:43:0c:00:2d:1f:
+        20:21:2a:0c:3b:a6:17:7b:6c:f2:74:8e:90:93:64:f9:0c:33:
+        0b:23:7d:a2:0c:0e:fd:82:ed:22:9b:d0:5f:bc:10:49:9d:ab:
+        2b:50:65:11:81:ee:3f:dc:48:49:2c:cf:41:e6:af:4f:34:8b:
+        da:47:b8:65:55:4f:85:bc:25:0e:e7:f5:ec:07:46:1c:19:03:
+        e2:6a:8a:95:7d:99:26:f1:66:46:35:7d:96:93:4d:e3:8f:1a:
+        c2:71:fe:3c:a9:45:c0:18:d8:43:d3:6c:68:56:b9:e4:04:15:
+        52:ea:4e:b3:d3:78:e9:87:51:18:f8:bd:b1:87:3a:59:ac:e4:
+        e1:ed:55:eb:de:27:85:a8:38:bc:ba:96:57:c3:9c:ec:64:65:
+        23:19:ec:f6:a6:c1:ce:83:08:13:a4:c5:fe:d0:e5:67:e3:70:
+        8b:96:84:b6:d4:4e:c4:43:60:d8:70:54:93:cd:24:44:ea:d5:
+        e9:f6:35:ee:a4:66:b4:2a:e0:5a:c1:7e:ad:e8:63:44:19:3e:
+        9d:49:61:50:91:d9:15:31:61:9c:59:68:d6:d3:5d:82:58:8c:
+        60:03:82:4e
 -----BEGIN CERTIFICATE-----
-MIIDSjCCAjKgAwIBAgIBCTANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
-IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMxMDYxNTAxMTkzN1owJTEjMCEGA1UEAwwa
+MIIDSjCCAjKgAwIBAgIBCjANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMzMDYyNDIxMTgwMFowJTEjMCEGA1UEAwwa
 VGVzdCBDQSBBZ2VudCBTdWJhdXRob3JpdHkwggEiMA0GCSqGSIb3DQEBAQUAA4IB
-DwAwggEKAoIBAQCuyPERXr256GCBnX0As+Zb1APjRqDii+kf7QY2x+nhnRqPK9Cq
-YwASNUTUTdLYaT9xFPALIYarkzfulK86VjWVtRiIOyWW3H6zq5hYOwNUkL/P5fwq
-VJ6nbnjcNssPIEnFsmF29dIZ03rCgm60i/+f8buqYLeOb7ck9zmfm6qGZY5nVpZ5
-0xDYDhc5NcvvLdvFp3swaGhlBKiLuiNJis4eZZ2dAj9cTho97K/kU0bHnxe9ogyB
-cniJoFQsfFOZIQNctwsiVhnyuxNaNSLhW+xaUoT35GnZT1dVxOdAjJYB5BkDN7sb
-Gu2o+A01g3cxn6iG3viX7t8UXrqUzSM4C2r5AgMBAAGjgZcwgZQwDwYDVR0TAQH/
-BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFJeEpcIotBWXicRSLGmP
-e3XdXyrcMDEGCWCGSAGG+EIBDQQkFiJQdXBwZXQgU2VydmVyIEludGVybmFsIENl
-cnRpZmljYXRlMB8GA1UdIwQYMBaAFLLuJIg0mRhggZ4q0/RaZvqR9uHGMA0GCSqG
-SIb3DQEBCwUAA4IBAQBz/WTgh2QRtzGe4gOdnRRx8faBlngQau0N5hJXqvgxLNkA
-gwdYFIyXKiMJsFdWaJXR5wt2C4KVOpAVPa7LGMA4KhE9BKEfu+k+oPGwMHj7WAv5
-ywqZLSqiUFds77TiyTiIcTFhWX4QyclRMtluC8Bkw0DrUYEmwxpRC5D/RA5P/qdF
-QQDqKh6HfOOQii4ZbKTs2+UZsHmyNXUIWmMwKbvzajbHKJweiKaXUIJxDRugm2+Z
-M2DP62VgSXNrgbbunMcwxAowQ8Es74E80OSaHnLr7Td28/uLAAn2U6YvGrpoMvJI
-u102uzEFtxyD2KzJryxv1WaS6fA/Hcb7/TdwkGX1
+DwAwggEKAoIBAQCruPuXgP97Sv/Zb/aOEEzZ6gtm7T1FbwbL2M5WbD5awhv9ev9I
+HAw+ojr0VyCSpTWYShkbjHHODClhylicUgPvcz/kZoysANgeTgZF23KsWWMFMGoX
+vfGBbON0TZClBFAkKsSOnT9FyS5HA/hprUm3BnhK3Q3im/FIG4FK710+KERJTNhT
+JfbKH/Z2hpezRJFp8sWUSF08SiHjfqd2thS8AKxYkrLGg8tm/Y74iSPA8lv5dGqN
+DDJ+3W51OMMGbK1WXTwfQIDECywJ/MHi1mBEn4uGKUInwGfYHi3Yj6hVlH+QdQwn
+Uv9mNL10SVT03TK0zrdnYbtFj1TAJ84zVECPAgMBAAGjgZcwgZQwDwYDVR0TAQH/
+BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFJKEvL3yBcwc4wBadbGk
+Z6kxCJryMDEGCWCGSAGG+EIBDQQkFiJQdXBwZXQgU2VydmVyIEludGVybmFsIENl
+cnRpZmljYXRlMB8GA1UdIwQYMBaAFINoJhZKw4gKpkhDmOctT19wjGKyMA0GCSqG
+SIb3DQEBCwUAA4IBAQCJfpxbD0g175YsTPnAEUlMXnra0+AKEfCjVR5Gwdl5QwwA
+LR8gISoMO6YXe2zydI6Qk2T5DDMLI32iDA79gu0im9BfvBBJnasrUGURge4/3EhJ
+LM9B5q9PNIvaR7hlVU+FvCUO5/XsB0YcGQPiaoqVfZkm8WZGNX2Wk03jjxrCcf48
+qUXAGNhD02xoVrnkBBVS6k6z03jph1EY+L2xhzpZrOTh7VXr3ieFqDi8upZXw5zs
+ZGUjGez2psHOgwgTpMX+0OVn43CLloS21E7EQ2DYcFSTzSRE6tXp9jXupGa0KuBa
+wX6t6GNEGT6dSWFQkdkVMWGcWWjW012CWIxgA4JO
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/intermediate-crl.pem
+++ b/spec/fixtures/ssl/intermediate-crl.pem
@@ -3,44 +3,44 @@ Certificate Revocation List (CRL):
         Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA Subauthority
         Last Update: Jan  1 00:00:00 1970 GMT
-        Next Update: Jun 15 01:19:37 2031 GMT
+        Next Update: Jun 24 21:18:00 2033 GMT
         CRL extensions:
             X509v3 Authority Key Identifier: 
-                keyid:59:79:27:C1:94:D7:09:B0:B2:1C:23:44:22:E2:25:25:1B:83:5F:34
-
+                38:7E:66:C4:7A:8B:16:EC:8A:0C:76:FC:C4:A6:7F:79:E5:DD:9A:FB
             X509v3 CRL Number: 
                 0
 Revoked Certificates:
-    Serial Number: 07
-        Revocation Date: Jun 17 01:19:38 2021 GMT
+    Serial Number: 08
+        Revocation Date: Jun 27 21:18:00 2023 GMT
         CRL entry extensions:
             X509v3 CRL Reason Code: 
                 Key Compromise
     Signature Algorithm: sha256WithRSAEncryption
-         82:21:ef:06:be:b2:af:42:d5:6a:bf:e3:47:f2:b8:77:fe:76:
-         14:a4:08:51:ae:27:92:4a:fd:20:cb:57:58:1c:ae:f0:15:3b:
-         33:ff:05:5e:77:20:a0:0a:34:2f:c0:d6:15:02:b3:72:7e:58:
-         08:ec:ad:db:b6:4b:a2:89:97:bf:9a:8e:08:c2:0b:ed:82:4d:
-         cf:ee:1a:62:02:df:46:3e:03:55:39:56:64:33:ab:dd:be:54:
-         fa:d9:cd:c8:65:a6:26:09:ef:12:f2:92:d3:aa:7f:88:c4:4c:
-         7e:35:9e:64:11:8c:a2:46:c9:cc:f8:29:56:22:88:0e:94:96:
-         e4:5c:4b:e7:ae:4d:1c:96:80:73:60:e3:69:a3:3a:61:ca:d4:
-         b6:2e:1c:e9:c6:93:e7:8c:5a:ae:b0:c9:92:51:0f:2c:b0:54:
-         43:e7:cf:14:4f:b5:e2:0c:ae:11:19:f2:a4:55:6f:3b:1d:3a:
-         47:d2:ee:0a:71:9b:a5:2d:41:6e:97:8f:02:ff:9f:13:20:c7:
-         6c:67:a5:47:c8:c2:27:a6:8b:66:56:3e:dd:d3:27:f9:8d:21:
-         73:20:c9:f1:e3:70:8f:72:e5:f8:6c:60:7d:c5:71:03:4c:ce:
-         72:8e:78:2d:30:f8:44:1a:4b:41:d3:f5:f4:31:c6:c3:89:cb:
-         88:da:b3:a0
+    Signature Value:
+        ab:a0:b0:99:81:11:c8:ed:1e:3d:af:3f:9e:96:c3:b8:e0:13:
+        15:0a:e4:23:15:e7:12:16:b9:4b:3e:37:e4:ba:80:c7:c5:b1:
+        e8:7d:1a:18:1c:5d:ef:10:00:5a:6a:e9:4e:99:6b:3a:fc:9c:
+        fc:55:70:eb:0d:64:60:38:ea:a7:81:9e:9a:46:2a:14:21:f7:
+        24:8a:db:49:77:47:9e:4e:ee:95:fc:3e:a1:04:cd:6e:db:80:
+        e2:cf:a2:bd:c1:6c:94:e2:43:3d:14:42:bf:a7:f3:b0:d9:9d:
+        a6:1d:d4:aa:b0:6c:87:d2:46:5e:b0:d5:26:ba:39:68:c3:34:
+        04:1f:c1:63:ac:1d:53:b4:47:ec:e5:e5:24:8f:ef:2d:75:c6:
+        a0:94:ef:5c:9c:d8:7e:52:7b:9e:5c:43:2d:7b:dc:94:40:6b:
+        99:65:ea:29:15:7c:25:7b:bd:6e:cd:b7:e2:3f:c7:fc:67:d0:
+        6e:b7:33:3b:57:64:29:f3:e1:88:b7:72:4e:4e:68:dd:7f:4a:
+        2b:3b:ae:30:45:a4:1f:a2:e5:43:af:b5:56:1f:63:da:42:20:
+        aa:20:82:0e:c3:68:06:c4:5f:33:bb:4b:a2:9c:a4:ea:44:b6:
+        3e:d5:df:c2:08:b4:6b:cf:6e:fb:a8:cf:80:0f:34:f2:d8:75:
+        1e:9e:28:1a
 -----BEGIN X509 CRL-----
 MIIBvTCBpgIBATANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0IENBIFN1
-YmF1dGhvcml0eRcNNzAwMTAxMDAwMDAwWhcNMzEwNjE1MDExOTM3WjAiMCACAQcX
-DTIxMDYxNzAxMTkzOFowDDAKBgNVHRUEAwoBAaAvMC0wHwYDVR0jBBgwFoAUWXkn
-wZTXCbCyHCNEIuIlJRuDXzQwCgYDVR0UBAMCAQAwDQYJKoZIhvcNAQELBQADggEB
-AIIh7wa+sq9C1Wq/40fyuHf+dhSkCFGuJ5JK/SDLV1gcrvAVOzP/BV53IKAKNC/A
-1hUCs3J+WAjsrdu2S6KJl7+ajgjCC+2CTc/uGmIC30Y+A1U5VmQzq92+VPrZzchl
-piYJ7xLyktOqf4jETH41nmQRjKJGycz4KVYiiA6UluRcS+euTRyWgHNg42mjOmHK
-1LYuHOnGk+eMWq6wyZJRDyywVEPnzxRPteIMrhEZ8qRVbzsdOkfS7gpxm6UtQW6X
-jwL/nxMgx2xnpUfIwiemi2ZWPt3TJ/mNIXMgyfHjcI9y5fhsYH3FcQNMznKOeC0w
-+EQaS0HT9fQxxsOJy4jas6A=
+YmF1dGhvcml0eRcNNzAwMTAxMDAwMDAwWhcNMzMwNjI0MjExODAwWjAiMCACAQgX
+DTIzMDYyNzIxMTgwMFowDDAKBgNVHRUEAwoBAaAvMC0wHwYDVR0jBBgwFoAUOH5m
+xHqLFuyKDHb8xKZ/eeXdmvswCgYDVR0UBAMCAQAwDQYJKoZIhvcNAQELBQADggEB
+AKugsJmBEcjtHj2vP56Ww7jgExUK5CMV5xIWuUs+N+S6gMfFseh9GhgcXe8QAFpq
+6U6Zazr8nPxVcOsNZGA46qeBnppGKhQh9ySK20l3R55O7pX8PqEEzW7bgOLPor3B
+bJTiQz0UQr+n87DZnaYd1KqwbIfSRl6w1Sa6OWjDNAQfwWOsHVO0R+zl5SSP7y11
+xqCU71yc2H5Se55cQy173JRAa5ll6ikVfCV7vW7Nt+I/x/xn0G63MztXZCnz4Yi3
+ck5OaN1/Sis7rjBFpB+i5UOvtVYfY9pCIKoggg7DaAbEXzO7S6KcpOpEtj7V38II
+tGvPbvuoz4APNPLYdR6eKBo=
 -----END X509 CRL-----

--- a/spec/fixtures/ssl/intermediate.pem
+++ b/spec/fixtures/ssl/intermediate.pem
@@ -6,30 +6,30 @@ Certificate:
         Issuer: CN=Test CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Jun 15 01:19:37 2031 GMT
+            Not After : Jun 24 21:18:00 2033 GMT
         Subject: CN=Test CA Subauthority
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                RSA Public-Key: (2048 bit)
+                Public-Key: (2048 bit)
                 Modulus:
-                    00:af:36:20:41:45:0b:d1:13:0c:82:fd:b8:e5:ea:
-                    f8:32:6b:5e:f7:a5:1c:7d:21:24:cb:85:bf:cd:f5:
-                    ca:48:85:39:c1:42:a4:65:93:d2:a2:04:f9:c9:19:
-                    10:da:64:0d:be:e3:d0:a5:d3:85:17:79:aa:18:32:
-                    f7:0a:b9:8e:08:de:d8:97:06:28:99:ac:ed:d1:a6:
-                    d4:0a:34:de:3d:33:e3:08:17:c2:22:6c:1d:fc:51:
-                    df:98:e6:de:6e:c6:4b:26:f4:87:44:1e:86:b6:44:
-                    b2:f3:82:9c:9c:2f:5b:66:bf:27:71:49:53:bf:c9:
-                    d2:f5:06:7e:fe:fd:1c:59:ba:aa:a9:05:c8:cb:44:
-                    f5:f5:51:7b:80:1c:59:0e:a5:bf:bb:af:f5:96:68:
-                    26:ca:52:b6:a8:e3:f6:3f:b9:a0:60:09:67:4a:86:
-                    5b:b4:ae:13:d9:39:ca:e0:84:dc:2e:83:51:ce:09:
-                    34:36:30:9c:ff:54:32:a6:b6:5b:a6:41:bd:b3:2b:
-                    5d:1d:eb:79:45:f4:fb:de:47:56:3c:8d:b1:96:34:
-                    2d:ec:9a:66:4c:50:ab:c6:c4:05:3e:8c:27:7c:be:
-                    54:53:5e:ae:20:70:15:12:0f:85:ab:be:18:dd:da:
-                    f5:33:a5:55:6a:c7:d8:36:89:bb:1c:5d:ce:46:45:
-                    ba:7d
+                    00:c0:91:fc:98:ec:30:6b:f0:5c:d6:0b:ed:79:ab:
+                    69:80:c1:ca:5b:d5:4a:a3:e3:1b:3e:25:f1:47:0b:
+                    7b:9f:dc:1b:0a:8b:d6:0a:c1:e8:8b:ca:38:68:be:
+                    91:58:d7:ff:41:a1:00:48:59:a0:62:2e:1d:e7:2d:
+                    7a:c5:64:4d:be:48:30:eb:4f:e3:9e:3f:06:a4:ef:
+                    e4:95:5c:86:ff:54:24:49:75:16:84:41:78:c5:8d:
+                    ac:ff:af:95:91:ae:e1:f3:92:f0:a1:dd:18:e9:7c:
+                    8e:d0:86:e9:84:84:f3:cb:4c:9c:12:f6:a7:54:f0:
+                    9c:87:3b:f1:50:67:cf:12:04:11:c0:1b:e0:46:e4:
+                    03:73:9c:3c:ea:ed:3e:31:2f:bc:cf:bd:38:fb:1d:
+                    fa:f5:8d:66:e7:f2:0b:5f:df:0f:99:ec:45:c9:aa:
+                    e4:10:ad:5b:64:a5:da:af:27:e1:47:ac:4f:aa:aa:
+                    74:a5:0e:9c:14:c4:89:ef:ce:fb:50:38:b9:f9:09:
+                    d6:f9:ba:5b:49:1c:8c:70:9c:0d:4e:3c:94:6d:9e:
+                    63:24:c3:e8:49:74:7a:79:02:0d:b4:6f:f3:b9:e0:
+                    c0:4c:74:24:21:56:b5:57:e6:c9:29:08:1b:63:6d:
+                    2d:9c:e2:68:33:c1:cf:60:07:54:88:d4:da:6c:15:
+                    48:1b
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Basic Constraints: critical
@@ -37,45 +37,45 @@ Certificate:
             X509v3 Key Usage: critical
                 Certificate Sign, CRL Sign
             X509v3 Subject Key Identifier: 
-                59:79:27:C1:94:D7:09:B0:B2:1C:23:44:22:E2:25:25:1B:83:5F:34
+                38:7E:66:C4:7A:8B:16:EC:8A:0C:76:FC:C4:A6:7F:79:E5:DD:9A:FB
             Netscape Comment: 
                 Puppet Server Internal Certificate
             X509v3 Authority Key Identifier: 
-                keyid:B2:EE:24:88:34:99:18:60:81:9E:2A:D3:F4:5A:66:FA:91:F6:E1:C6
-
+                83:68:26:16:4A:C3:88:0A:A6:48:43:98:E7:2D:4F:5F:70:8C:62:B2
     Signature Algorithm: sha256WithRSAEncryption
-         95:3d:3f:6f:47:83:12:b6:c1:06:dc:86:dc:7b:d3:1b:53:28:
-         cd:d6:38:10:ca:9c:af:bd:da:a2:64:df:6d:36:eb:5c:2b:c9:
-         34:49:6b:d3:0e:22:94:3b:5e:ab:8b:f9:ee:ca:83:1e:94:1b:
-         fe:38:de:a1:f1:7b:54:4b:0a:9a:95:43:03:9c:0c:45:b8:ac:
-         4e:6f:38:76:8a:ac:87:10:e3:0c:f2:58:7b:3c:7c:75:4b:17:
-         52:0f:88:8f:c5:3f:31:b1:09:3c:06:20:00:4a:30:cb:83:1a:
-         fa:eb:32:be:5e:06:57:60:b3:59:40:a9:81:ee:b3:a5:68:f2:
-         30:8a:2f:1f:22:e8:6f:58:e1:32:ae:28:59:39:97:84:bc:a8:
-         10:b8:af:a6:9b:64:e1:a9:78:58:db:ad:0d:b1:00:dd:96:92:
-         45:88:a0:22:f3:2a:e8:e1:27:4d:d0:67:af:a3:01:76:ef:5a:
-         dc:22:c5:3c:78:1b:b1:a5:d3:8f:de:7c:21:29:9a:88:3b:7e:
-         17:f4:5c:c2:b3:cc:b4:fc:f2:49:bb:cd:22:6c:71:ea:6b:1e:
-         b0:6e:bd:5f:2a:0e:31:18:f7:9f:78:98:d7:51:98:0a:cd:da:
-         89:28:f5:22:68:a1:36:1b:80:e7:dc:1c:d8:72:b1:7b:55:5e:
-         90:d8:3b:9b
+    Signature Value:
+        df:f7:e8:04:78:9d:61:be:69:3d:07:19:7f:d0:dd:53:b9:8a:
+        84:64:af:d2:17:07:77:83:9b:a4:cf:de:c1:a0:b6:88:1d:d7:
+        94:01:b7:7b:15:36:56:03:5d:70:97:cf:50:87:60:83:40:73:
+        a6:16:47:71:cd:74:32:3c:1f:36:be:cd:11:a7:2c:34:a4:3f:
+        1e:d8:e2:79:9f:7a:2e:20:41:ef:cf:7f:45:6a:3b:5c:fa:ff:
+        cb:f6:c2:0e:7d:ad:55:51:b8:23:bf:c1:77:74:7a:58:e3:a6:
+        db:2f:3b:09:16:26:98:0f:02:04:dd:aa:cd:b1:bc:16:ab:02:
+        50:97:68:4c:93:4c:1a:11:9e:b1:7e:88:b3:ce:cf:31:10:a7:
+        ba:3a:13:c0:5f:cf:74:4e:9f:a6:fc:90:26:3a:b1:cb:cb:45:
+        28:63:e6:2d:e1:cb:e3:93:1b:07:76:f2:6b:f6:00:87:94:1d:
+        91:5c:2e:84:e4:03:9c:32:23:fc:14:30:57:e5:e5:9c:b5:e8:
+        c3:0b:d2:82:a2:9b:1b:e7:66:68:78:92:3f:cd:0a:0c:ae:90:
+        66:50:d8:67:64:9a:48:3d:8f:a2:03:b1:7f:31:f2:b6:e5:46:
+        ac:16:53:c5:9f:2f:bd:44:85:e0:93:b7:3b:dc:b4:c6:b6:af:
+        a2:c3:ea:95
 -----BEGIN CERTIFICATE-----
 MIIDRDCCAiygAwIBAgIBAzANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
-IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMxMDYxNTAxMTkzN1owHzEdMBsGA1UEAwwU
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMzMDYyNDIxMTgwMFowHzEdMBsGA1UEAwwU
 VGVzdCBDQSBTdWJhdXRob3JpdHkwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
-AoIBAQCvNiBBRQvREwyC/bjl6vgya173pRx9ISTLhb/N9cpIhTnBQqRlk9KiBPnJ
-GRDaZA2+49Cl04UXeaoYMvcKuY4I3tiXBiiZrO3RptQKNN49M+MIF8IibB38Ud+Y
-5t5uxksm9IdEHoa2RLLzgpycL1tmvydxSVO/ydL1Bn7+/RxZuqqpBcjLRPX1UXuA
-HFkOpb+7r/WWaCbKUrao4/Y/uaBgCWdKhlu0rhPZOcrghNwug1HOCTQ2MJz/VDKm
-tlumQb2zK10d63lF9PveR1Y8jbGWNC3smmZMUKvGxAU+jCd8vlRTXq4gcBUSD4Wr
-vhjd2vUzpVVqx9g2ibscXc5GRbp9AgMBAAGjgZcwgZQwDwYDVR0TAQH/BAUwAwEB
-/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFFl5J8GU1wmwshwjRCLiJSUbg180
+AoIBAQDAkfyY7DBr8FzWC+15q2mAwcpb1Uqj4xs+JfFHC3uf3BsKi9YKweiLyjho
+vpFY1/9BoQBIWaBiLh3nLXrFZE2+SDDrT+OePwak7+SVXIb/VCRJdRaEQXjFjaz/
+r5WRruHzkvCh3RjpfI7QhumEhPPLTJwS9qdU8JyHO/FQZ88SBBHAG+BG5ANznDzq
+7T4xL7zPvTj7Hfr1jWbn8gtf3w+Z7EXJquQQrVtkpdqvJ+FHrE+qqnSlDpwUxInv
+zvtQOLn5Cdb5ultJHIxwnA1OPJRtnmMkw+hJdHp5Ag20b/O54MBMdCQhVrVX5skp
+CBtjbS2c4mgzwc9gB1SI1NpsFUgbAgMBAAGjgZcwgZQwDwYDVR0TAQH/BAUwAwEB
+/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFDh+ZsR6ixbsigx2/MSmf3nl3Zr7
 MDEGCWCGSAGG+EIBDQQkFiJQdXBwZXQgU2VydmVyIEludGVybmFsIENlcnRpZmlj
-YXRlMB8GA1UdIwQYMBaAFLLuJIg0mRhggZ4q0/RaZvqR9uHGMA0GCSqGSIb3DQEB
-CwUAA4IBAQCVPT9vR4MStsEG3Ibce9MbUyjN1jgQypyvvdqiZN9tNutcK8k0SWvT
-DiKUO16ri/nuyoMelBv+ON6h8XtUSwqalUMDnAxFuKxObzh2iqyHEOMM8lh7PHx1
-SxdSD4iPxT8xsQk8BiAASjDLgxr66zK+XgZXYLNZQKmB7rOlaPIwii8fIuhvWOEy
-rihZOZeEvKgQuK+mm2ThqXhY260NsQDdlpJFiKAi8yro4SdN0GevowF271rcIsU8
-eBuxpdOP3nwhKZqIO34X9FzCs8y0/PJJu80ibHHqax6wbr1fKg4xGPefeJjXUZgK
-zdqJKPUiaKE2G4Dn3BzYcrF7VV6Q2Dub
+YXRlMB8GA1UdIwQYMBaAFINoJhZKw4gKpkhDmOctT19wjGKyMA0GCSqGSIb3DQEB
+CwUAA4IBAQDf9+gEeJ1hvmk9Bxl/0N1TuYqEZK/SFwd3g5ukz97BoLaIHdeUAbd7
+FTZWA11wl89Qh2CDQHOmFkdxzXQyPB82vs0Rpyw0pD8e2OJ5n3ouIEHvz39Fajtc
++v/L9sIOfa1VUbgjv8F3dHpY46bbLzsJFiaYDwIE3arNsbwWqwJQl2hMk0waEZ6x
+foizzs8xEKe6OhPAX890Tp+m/JAmOrHLy0UoY+Yt4cvjkxsHdvJr9gCHlB2RXC6E
+5AOcMiP8FDBX5eWctejDC9KCopsb52ZoeJI/zQoMrpBmUNhnZJpIPY+iA7F/MfK2
+5UasFlPFny+9RIXgk7c73LTGtq+iw+qV
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/oid-key.pem
+++ b/spec/fixtures/ssl/oid-key.pem
@@ -1,117 +1,117 @@
-RSA Private-Key: (2048 bit, 2 primes)
+Private-Key: (2048 bit, 2 primes)
 modulus:
-    00:bf:24:ca:22:a8:10:63:f7:0f:23:43:b3:19:fd:
-    42:02:d0:07:12:7f:3b:06:ff:04:3a:b4:d3:8c:bf:
-    c2:21:3a:de:ac:f0:13:ef:00:11:e4:84:f1:f2:08:
-    53:84:aa:74:de:98:ef:05:87:f6:4c:62:cf:8a:c2:
-    0e:c9:02:27:23:35:b9:62:15:1b:51:b0:26:00:e7:
-    7d:be:33:92:a9:a0:48:b6:d9:00:c8:7e:ab:97:28:
-    94:2e:c8:e2:01:57:da:3c:6c:86:02:58:87:69:47:
-    8d:61:2f:7f:0d:e7:a6:83:12:34:f1:17:0d:ca:82:
-    e0:82:91:a2:2d:51:28:1d:d9:f2:01:27:05:ad:30:
-    8c:47:2b:ac:c9:ee:14:a6:0a:4f:a6:e0:3a:c2:93:
-    12:92:84:1f:76:5f:5b:3a:75:7a:08:99:16:77:fd:
-    ba:71:e7:d4:0e:37:5c:ca:3f:80:27:c9:64:87:9a:
-    d3:9e:5d:31:9f:20:c4:0f:65:47:f4:ea:5e:28:70:
-    ed:b9:cf:09:67:ae:fb:c7:99:5f:11:16:e7:99:30:
-    94:01:35:9d:4d:94:a4:55:c5:1b:88:30:25:1b:21:
-    9d:20:0c:91:49:93:92:a7:97:bb:90:4e:8f:27:bf:
-    55:fa:78:2b:6b:40:76:16:ed:44:4d:79:71:75:87:
-    b6:4b
+    00:e9:88:51:72:dc:84:5c:91:8c:bb:47:f5:d5:d5:
+    a0:d2:56:53:d7:5d:48:f1:bc:3a:fb:7f:68:37:31:
+    b5:2d:a7:3a:10:5b:fa:57:a4:b6:be:0b:73:ea:37:
+    95:66:6d:20:15:4e:cd:da:b7:d7:fe:55:b9:09:ed:
+    3e:c0:99:ad:85:1e:5c:b0:cd:91:76:2f:bb:a7:d0:
+    10:3e:58:81:29:80:c0:93:c9:e9:33:7c:05:08:f4:
+    b4:5f:fa:5b:e9:4b:4e:ff:61:25:00:00:c6:99:04:
+    45:81:c8:69:55:02:28:ff:07:c2:cc:1b:cb:c1:57:
+    17:31:15:2f:32:1f:0b:ac:76:7a:a5:0f:8e:c0:22:
+    ef:bb:b6:0b:3b:50:7b:b2:62:7b:86:83:19:43:74:
+    33:14:36:a1:95:38:85:80:72:4d:b8:65:b1:2c:29:
+    65:73:0f:9b:8f:f1:97:84:33:7d:ae:82:cd:0d:85:
+    b1:fe:09:8e:35:65:ae:02:83:2a:26:f3:63:68:73:
+    37:dd:b7:a1:3b:8e:18:ce:6a:2e:e4:fa:67:0c:2c:
+    b1:18:ae:bc:62:81:f2:0d:97:dc:c3:f1:eb:58:bf:
+    56:e8:7b:20:2d:91:1d:57:64:19:5b:93:4f:97:65:
+    bd:a4:6c:bd:eb:70:b6:1f:10:18:83:ee:61:d4:d5:
+    ba:59
 publicExponent: 65537 (0x10001)
 privateExponent:
-    00:9e:b0:e2:88:c7:53:64:4b:17:6c:45:a6:8a:6b:
-    32:c4:b7:05:48:1c:0d:5b:8f:99:69:4b:fb:5e:9d:
-    4d:84:dd:25:46:1a:c3:d1:e7:12:f3:d0:54:36:87:
-    27:1f:bb:8c:ef:c9:b4:97:b8:fb:89:0b:78:17:51:
-    69:89:04:9a:8d:a6:ea:d4:3d:85:c2:da:25:93:16:
-    9d:d4:ad:68:94:1f:98:7f:05:c6:9a:ae:5f:b3:4d:
-    63:49:3c:4a:36:a7:43:6e:6b:03:0f:2b:84:b0:a9:
-    50:fd:60:bb:71:45:e3:7e:6a:3d:3d:f3:cf:e5:53:
-    a7:25:7f:d7:4f:1c:53:dc:03:44:ec:40:4d:0f:53:
-    cd:3e:a2:93:14:79:e9:4f:b4:bb:f1:a6:a0:29:dd:
-    39:7d:e6:5d:30:35:6f:d1:2f:df:00:d5:19:22:b3:
-    47:cf:ec:ce:35:97:a4:cd:8b:aa:5f:e0:f2:80:58:
-    2b:37:59:58:cd:e4:3d:d9:dd:02:d6:ce:88:91:73:
-    16:05:f2:9b:24:ad:23:d1:be:84:8d:a4:b2:db:14:
-    16:e1:b8:84:2e:b8:59:be:5a:20:83:6d:be:b9:bf:
-    88:d4:2b:79:6a:53:66:d7:56:75:26:2f:dc:f3:97:
-    ec:2e:fb:6e:6c:b3:1a:11:a7:f5:be:ad:1b:5a:cd:
-    86:d1
+    01:53:0a:eb:34:d6:f1:fe:1d:51:de:94:45:54:83:
+    27:4e:38:06:d6:4f:98:97:5c:5a:45:71:b3:86:6e:
+    4e:f0:f8:d7:a8:e8:8a:e0:b3:41:f1:52:04:a2:5b:
+    65:8b:a4:37:f0:0c:ce:25:bc:18:2e:d2:45:7d:23:
+    f2:f7:01:7b:3f:73:2a:74:2f:fe:a9:ec:a2:d9:ff:
+    8d:95:a0:e8:8f:03:5d:e8:87:90:5e:d9:59:cb:51:
+    79:38:89:41:91:c7:6e:94:00:20:0c:e1:13:73:13:
+    c0:80:56:20:96:4a:37:3a:b5:b4:6f:4a:96:31:1b:
+    ea:3a:58:31:d7:92:90:60:24:dc:49:45:18:3f:bf:
+    89:d0:ea:89:a1:3b:06:c5:85:e3:b1:eb:ca:31:7a:
+    18:30:8e:ad:6a:5f:a0:d4:e3:41:65:51:4a:ac:86:
+    9d:f9:62:d4:76:31:0b:c0:9f:7e:b9:9e:26:e6:85:
+    10:81:3c:ad:72:af:7f:c4:58:90:65:d6:bb:a5:8f:
+    a4:fc:a0:ad:ab:51:5f:2b:0d:51:c5:cd:7a:22:2e:
+    2e:d9:66:9e:6c:47:d7:24:79:df:13:ae:c1:5d:3d:
+    b8:3a:52:88:32:2c:e8:71:4f:af:f8:d0:2c:5c:7b:
+    5a:2f:64:dc:b7:06:db:6d:c2:9c:2e:78:c2:c2:d0:
+    91
 prime1:
-    00:fe:af:eb:ab:d3:5d:64:16:81:f5:69:6f:61:24:
-    aa:f5:7b:26:0c:b2:f5:8f:93:33:b7:e4:41:a0:bf:
-    ed:32:80:4e:90:3e:ec:34:07:89:6d:b6:98:39:4b:
-    78:e8:b3:85:4d:f6:4a:29:5c:f9:17:5f:3e:d7:4d:
-    7e:a8:e0:af:af:89:bf:34:c8:98:f1:4d:c9:74:43:
-    44:e2:98:47:6a:e7:c3:39:9b:9c:ab:8c:22:d2:2a:
-    99:c9:78:a8:a6:bc:77:04:8a:8e:56:20:b0:62:19:
-    e2:2e:19:a5:18:76:0f:e4:93:0a:17:f5:57:92:22:
-    8b:43:1e:24:b9:6f:49:fd:17
+    00:fc:12:1d:13:e9:88:b0:51:1e:ae:c6:41:cf:27:
+    12:ce:27:f6:13:4b:5b:f9:79:28:24:d2:de:bd:f6:
+    b6:e1:90:a4:f1:ce:33:81:0a:bf:66:d7:d4:37:d5:
+    cf:24:60:f7:94:5f:4f:62:ac:ca:36:b1:4c:10:cf:
+    3d:8f:2a:a6:78:a5:57:11:dd:1b:c6:58:06:7f:2a:
+    4d:e5:94:64:da:4e:f9:38:d4:70:3b:32:e2:24:9d:
+    71:bc:fb:5e:52:84:0b:f1:8b:c9:9f:1e:46:9d:fe:
+    76:ba:2c:f6:c9:41:a6:05:96:af:cf:00:d8:8e:f7:
+    b9:0b:7b:c0:11:1c:b2:b5:75
 prime2:
-    00:c0:21:04:ba:9d:b3:37:75:e4:b7:f4:95:dc:3b:
-    d9:d5:bb:6f:44:7b:99:2a:d4:54:68:7b:18:a3:31:
-    fd:e9:d2:ee:58:00:74:aa:b1:e6:a3:3b:94:96:90:
-    9f:d7:6a:93:aa:c2:9c:72:36:27:1d:89:87:aa:3c:
-    c5:e6:3f:7b:0f:21:19:a1:69:8b:3b:23:5a:33:b9:
-    ce:40:2b:f1:85:55:21:0c:1d:9d:0e:97:71:f3:55:
-    f0:3d:82:e0:52:d9:cb:a4:30:1b:a2:7b:9b:73:93:
-    e7:7f:af:27:b1:a4:1f:10:dc:ba:56:75:9c:5f:b3:
-    d2:08:ae:83:51:33:8b:d8:ed
+    00:ed:2c:3a:4f:8b:dc:bf:5f:41:ef:f0:f8:2e:43:
+    c2:05:27:94:09:55:96:13:43:5c:69:7d:e5:58:0a:
+    de:7d:a3:91:e5:41:9d:c1:9f:a4:d5:15:16:22:e0:
+    71:43:f0:b5:8d:46:33:94:2d:e9:58:e1:86:7a:ad:
+    c0:e6:78:3c:10:ff:fa:e2:cf:f9:fd:95:3d:69:8c:
+    db:e4:a4:88:4a:6d:ff:22:25:c3:ce:ae:6e:42:02:
+    df:66:1e:4b:28:fc:31:9d:bf:d9:9e:8c:da:27:37:
+    41:50:85:be:2c:e6:dc:9d:a6:5d:63:79:f0:62:13:
+    66:2d:71:f7:f0:d1:39:c0:d5
 exponent1:
-    00:97:d0:13:41:cb:ee:fa:4f:34:4e:2d:f7:f7:46:
-    dd:25:10:b0:20:97:b8:2a:4a:0b:65:0d:09:55:a1:
-    b1:e9:0d:74:47:25:4a:b4:c4:dd:55:69:a7:19:57:
-    f4:8d:79:1c:f7:d8:dc:62:05:8a:71:35:14:07:50:
-    a9:34:4f:22:4a:17:68:c3:34:e3:7d:ca:e9:4f:85:
-    1d:95:98:41:d1:e6:ae:87:33:4b:d3:31:e8:3b:b0:
-    ab:14:dd:f8:61:d3:2b:7a:a8:80:a9:b4:38:8f:71:
-    70:52:1c:75:3d:bc:7a:42:bc:a7:22:9a:db:05:3f:
-    d4:15:40:ed:91:1f:56:52:27
+    7e:47:94:c9:a4:f5:15:5f:8e:3f:80:92:f7:74:5b:
+    b7:6b:cd:9b:5c:e5:76:d5:7b:86:f7:1d:1f:8d:b9:
+    90:c7:25:da:fd:b2:4f:b3:52:af:f2:f0:1e:08:be:
+    fd:3a:96:cd:7d:f2:07:3d:09:10:dd:41:7e:2a:54:
+    6c:a4:b1:41:3f:93:9f:1f:66:0a:b7:8e:89:a6:67:
+    df:db:b7:aa:a6:65:b4:52:b8:e6:ef:56:db:81:04:
+    b9:e8:34:18:a2:8e:59:33:ee:8e:08:5c:d8:49:e2:
+    b0:e2:55:bf:fd:63:6e:e9:4e:aa:25:82:58:1d:42:
+    56:be:68:3a:2a:66:5d:01
 exponent2:
-    5c:f3:1c:70:94:3e:d2:04:0d:45:19:e5:2e:89:1e:
-    18:12:f7:ff:af:b4:28:4e:55:0f:bf:0d:ea:56:13:
-    3b:7e:3a:a5:04:83:6c:d9:68:75:6c:2b:b4:b3:ff:
-    40:9e:65:16:65:d4:7e:44:c8:a3:b7:97:94:ba:96:
-    1b:90:76:9e:99:2a:e7:36:42:8f:b7:c8:b9:e1:98:
-    70:df:51:97:69:d9:f5:1c:96:91:2a:9f:8c:53:f5:
-    48:2c:fb:0d:da:24:75:28:79:16:20:aa:d2:3d:a9:
-    ef:d1:f3:68:33:b8:7b:d5:ed:a8:4a:79:fe:aa:e6:
-    60:20:dd:92:f9:57:1c:f9
+    28:70:fd:34:69:2d:e7:f7:ef:3f:61:c0:7f:eb:0f:
+    df:5f:23:50:00:27:09:fb:d7:7b:29:7b:7c:ea:c5:
+    8b:78:e3:bc:ca:d6:82:98:9d:3b:b4:4f:c4:fc:ae:
+    73:9e:4c:e6:dd:0c:98:7c:c7:a8:5f:34:56:20:e0:
+    9e:ab:eb:da:1e:3c:02:86:e2:22:ca:5a:e1:6f:a2:
+    63:37:67:02:02:05:9a:26:04:60:6e:bf:e0:43:ab:
+    22:37:92:2b:57:ed:81:ef:9f:c4:f8:51:8e:94:4e:
+    6f:d3:8e:5d:0b:b4:9c:b1:2c:85:74:da:77:6e:c5:
+    62:84:67:79:c9:c3:66:4d
 coefficient:
-    00:c9:d7:2a:ea:1c:8f:85:34:e5:5d:26:23:65:41:
-    71:25:1a:8e:1c:01:52:b3:04:54:fd:71:a3:1b:91:
-    a6:5d:3a:be:16:6f:d7:87:8a:49:aa:5b:92:a1:7e:
-    1d:a1:6a:b0:24:22:0f:f9:39:9f:5a:f9:81:19:ce:
-    7a:d6:b7:8f:e0:3b:59:d2:49:a4:f1:4f:28:9e:0d:
-    bf:15:6d:95:4d:56:8e:1b:7d:84:a2:41:6a:e4:88:
-    98:d9:92:ec:b4:7d:92:7c:f5:39:85:30:e9:52:7e:
-    a4:5f:e7:8e:1c:45:6c:f4:e2:78:0d:26:19:52:9b:
-    87:c3:0e:9c:22:92:4a:9b:e2
+    00:b0:4e:a7:6e:f5:ba:26:52:c6:ec:07:82:e2:91:
+    ea:ac:08:05:dc:cd:c7:8b:00:01:7e:2a:c5:05:0b:
+    88:d1:74:1b:71:3b:9e:03:6d:df:cf:6e:cd:cd:47:
+    2d:73:3d:56:1a:ab:10:20:d5:67:1a:7e:87:ef:dc:
+    ac:71:5c:72:68:1c:15:20:87:82:a7:b9:0d:df:55:
+    92:f5:de:76:c6:e8:d2:06:78:b8:90:bc:43:1d:53:
+    49:99:b6:54:66:e5:ee:ca:5f:8e:ef:73:1a:55:71:
+    4e:1e:ec:95:4a:1d:f6:6c:51:09:2d:77:f4:17:49:
+    76:4c:3b:08:75:37:80:c3:f9
 -----BEGIN RSA PRIVATE KEY-----
-MIIEpQIBAAKCAQEAvyTKIqgQY/cPI0OzGf1CAtAHEn87Bv8EOrTTjL/CITrerPAT
-7wAR5ITx8ghThKp03pjvBYf2TGLPisIOyQInIzW5YhUbUbAmAOd9vjOSqaBIttkA
-yH6rlyiULsjiAVfaPGyGAliHaUeNYS9/DeemgxI08RcNyoLggpGiLVEoHdnyAScF
-rTCMRyusye4UpgpPpuA6wpMSkoQfdl9bOnV6CJkWd/26cefUDjdcyj+AJ8lkh5rT
-nl0xnyDED2VH9OpeKHDtuc8JZ677x5lfERbnmTCUATWdTZSkVcUbiDAlGyGdIAyR
-SZOSp5e7kE6PJ79V+ngra0B2Fu1ETXlxdYe2SwIDAQABAoIBAQCesOKIx1NkSxds
-RaaKazLEtwVIHA1bj5lpS/tenU2E3SVGGsPR5xLz0FQ2hycfu4zvybSXuPuJC3gX
-UWmJBJqNpurUPYXC2iWTFp3UrWiUH5h/Bcaarl+zTWNJPEo2p0NuawMPK4SwqVD9
-YLtxReN+aj0988/lU6clf9dPHFPcA0TsQE0PU80+opMUeelPtLvxpqAp3Tl95l0w
-NW/RL98A1Rkis0fP7M41l6TNi6pf4PKAWCs3WVjN5D3Z3QLWzoiRcxYF8pskrSPR
-voSNpLLbFBbhuIQuuFm+WiCDbb65v4jUK3lqU2bXVnUmL9zzl+wu+25ssxoRp/W+
-rRtazYbRAoGBAP6v66vTXWQWgfVpb2EkqvV7Jgyy9Y+TM7fkQaC/7TKATpA+7DQH
-iW22mDlLeOizhU32Silc+RdfPtdNfqjgr6+JvzTImPFNyXRDROKYR2rnwzmbnKuM
-ItIqmcl4qKa8dwSKjlYgsGIZ4i4ZpRh2D+STChf1V5Iii0MeJLlvSf0XAoGBAMAh
-BLqdszd15Lf0ldw72dW7b0R7mSrUVGh7GKMx/enS7lgAdKqx5qM7lJaQn9dqk6rC
-nHI2Jx2Jh6o8xeY/ew8hGaFpizsjWjO5zkAr8YVVIQwdnQ6XcfNV8D2C4FLZy6Qw
-G6J7m3OT53+vJ7GkHxDculZ1nF+z0giug1Ezi9jtAoGBAJfQE0HL7vpPNE4t9/dG
-3SUQsCCXuCpKC2UNCVWhsekNdEclSrTE3VVppxlX9I15HPfY3GIFinE1FAdQqTRP
-IkoXaMM0433K6U+FHZWYQdHmroczS9Mx6DuwqxTd+GHTK3qogKm0OI9xcFIcdT28
-ekK8pyKa2wU/1BVA7ZEfVlInAoGAXPMccJQ+0gQNRRnlLokeGBL3/6+0KE5VD78N
-6lYTO346pQSDbNlodWwrtLP/QJ5lFmXUfkTIo7eXlLqWG5B2npkq5zZCj7fIueGY
-cN9Rl2nZ9RyWkSqfjFP1SCz7DdokdSh5FiCq0j2p79HzaDO4e9XtqEp5/qrmYCDd
-kvlXHPkCgYEAydcq6hyPhTTlXSYjZUFxJRqOHAFSswRU/XGjG5GmXTq+Fm/Xh4pJ
-qluSoX4doWqwJCIP+TmfWvmBGc561reP4DtZ0kmk8U8ong2/FW2VTVaOG32EokFq
-5IiY2ZLstH2SfPU5hTDpUn6kX+eOHEVs9OJ4DSYZUpuHww6cIpJKm+I=
+MIIEowIBAAKCAQEA6YhRctyEXJGMu0f11dWg0lZT111I8bw6+39oNzG1Lac6EFv6
+V6S2vgtz6jeVZm0gFU7N2rfX/lW5Ce0+wJmthR5csM2Rdi+7p9AQPliBKYDAk8np
+M3wFCPS0X/pb6UtO/2ElAADGmQRFgchpVQIo/wfCzBvLwVcXMRUvMh8LrHZ6pQ+O
+wCLvu7YLO1B7smJ7hoMZQ3QzFDahlTiFgHJNuGWxLCllcw+bj/GXhDN9roLNDYWx
+/gmONWWuAoMqJvNjaHM33behO44Yzmou5PpnDCyxGK68YoHyDZfcw/HrWL9W6Hsg
+LZEdV2QZW5NPl2W9pGy963C2HxAYg+5h1NW6WQIDAQABAoIBAAFTCus01vH+HVHe
+lEVUgydOOAbWT5iXXFpFcbOGbk7w+Neo6Irgs0HxUgSiW2WLpDfwDM4lvBgu0kV9
+I/L3AXs/cyp0L/6p7KLZ/42VoOiPA13oh5Be2VnLUXk4iUGRx26UACAM4RNzE8CA
+ViCWSjc6tbRvSpYxG+o6WDHXkpBgJNxJRRg/v4nQ6omhOwbFheOx68oxehgwjq1q
+X6DU40FlUUqshp35YtR2MQvAn365nibmhRCBPK1yr3/EWJBl1rulj6T8oK2rUV8r
+DVHFzXoiLi7ZZp5sR9cked8TrsFdPbg6UogyLOhxT6/40Cxce1ovZNy3Btttwpwu
+eMLC0JECgYEA/BIdE+mIsFEersZBzycSzif2E0tb+XkoJNLevfa24ZCk8c4zgQq/
+ZtfUN9XPJGD3lF9PYqzKNrFMEM89jyqmeKVXEd0bxlgGfypN5ZRk2k75ONRwOzLi
+JJ1xvPteUoQL8YvJnx5Gnf52uiz2yUGmBZavzwDYjve5C3vAERyytXUCgYEA7Sw6
+T4vcv19B7/D4LkPCBSeUCVWWE0NcaX3lWArefaOR5UGdwZ+k1RUWIuBxQ/C1jUYz
+lC3pWOGGeq3A5ng8EP/64s/5/ZU9aYzb5KSISm3/IiXDzq5uQgLfZh5LKPwxnb/Z
+nozaJzdBUIW+LObcnaZdY3nwYhNmLXH38NE5wNUCgYB+R5TJpPUVX44/gJL3dFu3
+a82bXOV21XuG9x0fjbmQxyXa/bJPs1Kv8vAeCL79OpbNffIHPQkQ3UF+KlRspLFB
+P5OfH2YKt46Jpmff27eqpmW0Urjm71bbgQS56DQYoo5ZM+6OCFzYSeKw4lW//WNu
+6U6qJYJYHUJWvmg6KmZdAQKBgChw/TRpLef37z9hwH/rD99fI1AAJwn713spe3zq
+xYt447zK1oKYnTu0T8T8rnOeTObdDJh8x6hfNFYg4J6r69oePAKG4iLKWuFvomM3
+ZwICBZomBGBuv+BDqyI3kitX7YHvn8T4UY6UTm/Tjl0LtJyxLIV02nduxWKEZ3nJ
+w2ZNAoGBALBOp271uiZSxuwHguKR6qwIBdzNx4sAAX4qxQULiNF0G3E7ngNt389u
+zc1HLXM9VhqrECDVZxp+h+/crHFccmgcFSCHgqe5Dd9VkvXedsbo0gZ4uJC8Qx1T
+SZm2VGbl7spfju9zGlVxTh7slUod9mxRCS139BdJdkw7CHU3gMP5
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/oid.pem
+++ b/spec/fixtures/ssl/oid.pem
@@ -1,69 +1,70 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 6 (0x6)
+        Serial Number: 7 (0x7)
         Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA Subauthority
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Jun 15 01:19:37 2031 GMT
+            Not After : Jun 24 21:18:00 2033 GMT
         Subject: CN=oid
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                RSA Public-Key: (2048 bit)
+                Public-Key: (2048 bit)
                 Modulus:
-                    00:bf:24:ca:22:a8:10:63:f7:0f:23:43:b3:19:fd:
-                    42:02:d0:07:12:7f:3b:06:ff:04:3a:b4:d3:8c:bf:
-                    c2:21:3a:de:ac:f0:13:ef:00:11:e4:84:f1:f2:08:
-                    53:84:aa:74:de:98:ef:05:87:f6:4c:62:cf:8a:c2:
-                    0e:c9:02:27:23:35:b9:62:15:1b:51:b0:26:00:e7:
-                    7d:be:33:92:a9:a0:48:b6:d9:00:c8:7e:ab:97:28:
-                    94:2e:c8:e2:01:57:da:3c:6c:86:02:58:87:69:47:
-                    8d:61:2f:7f:0d:e7:a6:83:12:34:f1:17:0d:ca:82:
-                    e0:82:91:a2:2d:51:28:1d:d9:f2:01:27:05:ad:30:
-                    8c:47:2b:ac:c9:ee:14:a6:0a:4f:a6:e0:3a:c2:93:
-                    12:92:84:1f:76:5f:5b:3a:75:7a:08:99:16:77:fd:
-                    ba:71:e7:d4:0e:37:5c:ca:3f:80:27:c9:64:87:9a:
-                    d3:9e:5d:31:9f:20:c4:0f:65:47:f4:ea:5e:28:70:
-                    ed:b9:cf:09:67:ae:fb:c7:99:5f:11:16:e7:99:30:
-                    94:01:35:9d:4d:94:a4:55:c5:1b:88:30:25:1b:21:
-                    9d:20:0c:91:49:93:92:a7:97:bb:90:4e:8f:27:bf:
-                    55:fa:78:2b:6b:40:76:16:ed:44:4d:79:71:75:87:
-                    b6:4b
+                    00:e9:88:51:72:dc:84:5c:91:8c:bb:47:f5:d5:d5:
+                    a0:d2:56:53:d7:5d:48:f1:bc:3a:fb:7f:68:37:31:
+                    b5:2d:a7:3a:10:5b:fa:57:a4:b6:be:0b:73:ea:37:
+                    95:66:6d:20:15:4e:cd:da:b7:d7:fe:55:b9:09:ed:
+                    3e:c0:99:ad:85:1e:5c:b0:cd:91:76:2f:bb:a7:d0:
+                    10:3e:58:81:29:80:c0:93:c9:e9:33:7c:05:08:f4:
+                    b4:5f:fa:5b:e9:4b:4e:ff:61:25:00:00:c6:99:04:
+                    45:81:c8:69:55:02:28:ff:07:c2:cc:1b:cb:c1:57:
+                    17:31:15:2f:32:1f:0b:ac:76:7a:a5:0f:8e:c0:22:
+                    ef:bb:b6:0b:3b:50:7b:b2:62:7b:86:83:19:43:74:
+                    33:14:36:a1:95:38:85:80:72:4d:b8:65:b1:2c:29:
+                    65:73:0f:9b:8f:f1:97:84:33:7d:ae:82:cd:0d:85:
+                    b1:fe:09:8e:35:65:ae:02:83:2a:26:f3:63:68:73:
+                    37:dd:b7:a1:3b:8e:18:ce:6a:2e:e4:fa:67:0c:2c:
+                    b1:18:ae:bc:62:81:f2:0d:97:dc:c3:f1:eb:58:bf:
+                    56:e8:7b:20:2d:91:1d:57:64:19:5b:93:4f:97:65:
+                    bd:a4:6c:bd:eb:70:b6:1f:10:18:83:ee:61:d4:d5:
+                    ba:59
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             1.3.6.1.4.1.34380.1.2.1.1: 
                 ..somevalue
     Signature Algorithm: sha256WithRSAEncryption
-         6f:40:86:4d:b1:68:6e:1a:a5:52:b1:cb:a0:24:90:2f:20:72:
-         2b:da:cb:25:af:ab:01:8e:fb:94:95:ef:eb:a6:8c:12:a2:3e:
-         dc:9a:fe:c3:70:95:6b:38:04:d5:1b:81:8a:37:5c:c3:eb:85:
-         c7:04:28:ba:f3:33:20:b1:dc:7d:d0:05:6a:eb:25:7a:4f:d4:
-         ae:c5:8b:1f:41:4f:fe:10:a5:b3:55:15:c9:a0:b9:98:33:f2:
-         a3:21:7d:29:34:90:e0:c8:45:d7:ac:27:a7:54:9b:53:9d:5c:
-         cb:52:2e:d5:db:cf:a6:84:c7:4d:50:05:41:6c:59:44:77:bf:
-         de:5f:36:60:7f:50:9e:ed:00:71:63:9e:35:a4:5f:f1:b5:46:
-         8c:c6:3a:e5:ec:05:66:23:d3:a2:05:46:17:0d:24:c1:eb:c5:
-         ff:43:ce:1a:86:2b:e7:d5:a6:73:a5:3a:64:1a:e0:20:97:f9:
-         45:82:12:cc:eb:da:b4:48:a6:8f:67:3d:15:c6:a7:27:12:c6:
-         9a:aa:88:35:6d:21:5d:d5:f9:86:e9:ff:c4:f3:7d:29:ac:2e:
-         ec:d9:8e:c6:ab:40:23:77:7d:ed:7a:76:e3:a9:74:c7:9e:24:
-         87:00:76:7b:fc:e4:98:1e:90:d8:51:dd:8e:b9:ca:90:b7:79:
-         e2:0c:9b:f3
+    Signature Value:
+        58:a5:3a:35:f2:ca:bc:9e:6f:a3:84:e4:2e:3a:1e:00:3d:34:
+        b2:23:f6:88:0b:e0:50:18:83:0f:16:6f:13:02:54:e7:30:16:
+        43:a0:aa:cf:f0:56:67:ac:c2:a5:38:e3:3b:f1:6a:59:e2:c2:
+        d6:56:49:52:9e:18:35:a2:58:5c:0a:ac:5f:dc:0d:65:60:23:
+        8d:a4:83:9e:05:c3:c5:a8:9e:6d:d0:97:26:f0:60:ca:b3:a4:
+        19:cc:ab:d1:82:3f:b5:00:85:96:aa:bf:2f:b7:12:83:8c:f0:
+        5e:95:f7:10:4d:5a:22:e7:f7:94:cc:48:44:47:5d:6f:68:23:
+        3a:f3:37:24:52:90:c9:70:e9:c2:15:2f:d1:fb:ad:88:ea:b9:
+        3e:58:57:1e:3d:96:af:32:5d:f8:1a:ec:f8:e2:1a:82:16:2f:
+        91:89:7e:7b:27:30:5e:df:4c:f9:b9:bd:87:0f:c2:6f:67:55:
+        06:a9:d1:9a:fa:3f:bf:4f:c8:66:d5:8d:c2:2f:2f:fb:72:1d:
+        b6:94:db:7c:94:1a:4d:09:0b:0b:7b:d0:db:f1:5b:0a:f0:1a:
+        71:a7:31:91:a0:43:0a:53:77:bf:ff:bd:9f:f7:3f:32:ba:4b:
+        d9:f3:af:9c:cb:00:aa:05:78:02:9d:6f:56:f9:f7:12:64:06:
+        f4:80:86:9f
 -----BEGIN CERTIFICATE-----
-MIICxzCCAa+gAwIBAgIBBjANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0
-IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zMTA2MTUwMTE5Mzda
+MIICxzCCAa+gAwIBAgIBBzANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0
+IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zMzA2MjQyMTE4MDBa
 MA4xDDAKBgNVBAMMA29pZDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
-AL8kyiKoEGP3DyNDsxn9QgLQBxJ/Owb/BDq004y/wiE63qzwE+8AEeSE8fIIU4Sq
-dN6Y7wWH9kxiz4rCDskCJyM1uWIVG1GwJgDnfb4zkqmgSLbZAMh+q5colC7I4gFX
-2jxshgJYh2lHjWEvfw3npoMSNPEXDcqC4IKRoi1RKB3Z8gEnBa0wjEcrrMnuFKYK
-T6bgOsKTEpKEH3ZfWzp1egiZFnf9unHn1A43XMo/gCfJZIea055dMZ8gxA9lR/Tq
-Xihw7bnPCWeu+8eZXxEW55kwlAE1nU2UpFXFG4gwJRshnSAMkUmTkqeXu5BOjye/
-Vfp4K2tAdhbtRE15cXWHtksCAwEAAaMfMB0wGwYMKwYBBAGCjEwBAgEBBAsMCXNv
-bWV2YWx1ZTANBgkqhkiG9w0BAQsFAAOCAQEAb0CGTbFobhqlUrHLoCSQLyByK9rL
-Ja+rAY77lJXv66aMEqI+3Jr+w3CVazgE1RuBijdcw+uFxwQouvMzILHcfdAFausl
-ek/UrsWLH0FP/hCls1UVyaC5mDPyoyF9KTSQ4MhF16wnp1SbU51cy1Iu1dvPpoTH
-TVAFQWxZRHe/3l82YH9Qnu0AcWOeNaRf8bVGjMY65ewFZiPTogVGFw0kwevF/0PO
-GoYr59Wmc6U6ZBrgIJf5RYISzOvatEimj2c9FcanJxLGmqqINW0hXdX5hun/xPN9
-Kawu7NmOxqtAI3d97Xp246l0x54khwB2e/zkmB6Q2FHdjrnKkLd54gyb8w==
+AOmIUXLchFyRjLtH9dXVoNJWU9ddSPG8Ovt/aDcxtS2nOhBb+lektr4Lc+o3lWZt
+IBVOzdq31/5VuQntPsCZrYUeXLDNkXYvu6fQED5YgSmAwJPJ6TN8BQj0tF/6W+lL
+Tv9hJQAAxpkERYHIaVUCKP8Hwswby8FXFzEVLzIfC6x2eqUPjsAi77u2CztQe7Ji
+e4aDGUN0MxQ2oZU4hYByTbhlsSwpZXMPm4/xl4Qzfa6CzQ2Fsf4JjjVlrgKDKibz
+Y2hzN923oTuOGM5qLuT6ZwwssRiuvGKB8g2X3MPx61i/Vuh7IC2RHVdkGVuTT5dl
+vaRsvetwth8QGIPuYdTVulkCAwEAAaMfMB0wGwYMKwYBBAGCjEwBAgEBBAsMCXNv
+bWV2YWx1ZTANBgkqhkiG9w0BAQsFAAOCAQEAWKU6NfLKvJ5vo4TkLjoeAD00siP2
+iAvgUBiDDxZvEwJU5zAWQ6Cqz/BWZ6zCpTjjO/FqWeLC1lZJUp4YNaJYXAqsX9wN
+ZWAjjaSDngXDxaiebdCXJvBgyrOkGcyr0YI/tQCFlqq/L7cSg4zwXpX3EE1aIuf3
+lMxIREddb2gjOvM3JFKQyXDpwhUv0futiOq5PlhXHj2WrzJd+Brs+OIaghYvkYl+
+eycwXt9M+bm9hw/Cb2dVBqnRmvo/v0/IZtWNwi8v+3IdtpTbfJQaTQkLC3vQ2/Fb
+CvAacacxkaBDClN3v/+9n/c/MrpL2fOvnMsAqgV4Ap1vVvn3EmQG9ICGnw==
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/pluto-key.pem
+++ b/spec/fixtures/ssl/pluto-key.pem
@@ -1,117 +1,117 @@
-RSA Private-Key: (2048 bit, 2 primes)
+Private-Key: (2048 bit, 2 primes)
 modulus:
-    00:a7:b5:af:10:3a:4a:46:00:f7:51:66:8b:1d:35:
-    11:65:e6:1a:50:0a:37:56:ff:93:16:20:cd:35:58:
-    28:c4:6f:06:31:d8:86:77:ed:20:85:55:ad:8a:46:
-    b8:3d:70:51:aa:31:f9:58:ad:a5:d5:4f:ca:d0:3e:
-    10:8f:4f:b9:c6:cc:e8:6e:f2:24:15:26:c3:3a:24:
-    85:d2:e8:f7:63:3a:97:b4:e9:ff:5e:c0:ee:e7:ed:
-    9b:2e:59:87:36:08:8f:e4:df:5a:03:25:a3:35:40:
-    69:a1:e4:a4:f0:c0:28:32:64:ef:ab:2a:f9:cd:ed:
-    d4:0e:bd:46:dd:fc:9d:a3:1f:d6:14:c2:58:1f:0d:
-    9e:85:f4:ce:c9:b1:91:1b:6e:d1:71:4e:ae:8a:c6:
-    65:67:af:27:93:8b:be:80:46:57:9e:a6:8a:5c:0b:
-    18:86:c0:77:b6:57:87:2d:2a:31:fd:34:75:33:58:
-    c3:8b:9c:c1:5b:61:4c:28:94:a9:2a:e1:24:7e:c2:
-    6f:ce:be:fc:98:1b:49:4a:91:b1:2b:73:30:c7:44:
-    ef:d9:f3:af:43:1b:ab:c2:c9:eb:97:a9:9f:6c:6e:
-    b1:12:d3:cb:d0:3e:1d:2d:cc:ee:3e:ea:24:0d:1e:
-    24:f8:3e:bc:8a:4d:85:78:be:c4:e3:97:86:31:6e:
-    d9:07
+    00:a1:e2:44:51:1d:f3:95:9a:29:9d:d1:a5:3f:b5:
+    57:e4:2d:cb:45:94:b8:d8:80:9b:f1:e0:de:81:b9:
+    50:0a:37:24:34:91:b3:43:c7:ad:fb:eb:91:de:62:
+    15:39:70:6c:be:48:4d:98:2b:82:fb:74:6a:5e:26:
+    38:49:0a:5c:81:c0:1a:90:b8:15:70:60:a9:80:2f:
+    3b:b8:3e:f3:57:c8:75:bb:34:da:17:68:3f:00:04:
+    2d:fe:97:24:cc:2c:3c:d7:ca:81:53:46:f6:7c:ec:
+    9a:55:b2:b7:97:dd:3a:76:e3:c8:89:0c:19:40:dd:
+    17:63:36:66:5c:ad:17:e8:2b:02:98:54:e7:bf:0d:
+    5d:b0:5c:97:4b:23:99:ce:97:f9:59:e5:1e:ba:33:
+    6e:35:39:ef:7b:a0:62:4b:ac:91:05:8f:79:5b:7c:
+    82:88:41:e7:dc:51:1c:7d:80:3e:1c:aa:92:f0:7f:
+    67:5f:18:09:8a:35:02:82:4b:38:c0:03:8d:20:51:
+    d8:b2:18:63:96:9a:68:6e:e5:ae:5a:08:09:c2:01:
+    2f:2b:be:54:6b:c9:77:75:2e:71:30:b6:26:d9:5a:
+    12:0c:75:47:2e:c6:c2:b0:82:2f:64:5b:f0:b3:68:
+    af:83:8c:97:06:fc:99:5f:95:dc:ac:4e:99:95:b3:
+    47:cb
 publicExponent: 65537 (0x10001)
 privateExponent:
-    00:a0:5e:d6:f9:d0:93:a7:9f:52:e0:4f:0b:66:31:
-    91:e2:7c:07:db:53:f9:99:42:a9:97:36:64:a4:c7:
-    19:ac:c5:72:0a:06:40:87:bb:84:26:9c:48:67:7a:
-    ba:c1:5d:7f:6a:1d:81:8f:af:f5:6d:26:71:0d:72:
-    dc:08:fe:b6:ea:88:95:17:4a:8b:00:82:e1:9a:de:
-    c3:ed:6c:02:ec:ab:61:d8:89:0e:3e:c0:85:73:d8:
-    bd:54:b4:1d:dc:a8:91:58:cd:cf:d8:44:8c:6d:e6:
-    9b:5c:49:35:04:56:eb:d9:4c:b5:f6:5b:11:27:3f:
-    6e:51:6d:e3:af:70:da:18:da:53:63:47:68:4a:e1:
-    86:7f:89:dc:f2:7e:fd:b5:a7:84:98:30:c3:6b:d5:
-    c6:a1:89:51:af:e9:f6:ca:3e:8c:00:b5:cc:99:90:
-    22:c5:d7:a7:8d:21:bc:58:85:64:ea:5e:00:47:b3:
-    33:f3:df:a9:e3:d8:66:bc:19:83:ad:fa:4f:a5:25:
-    a3:de:bd:8c:65:52:a1:19:92:07:0f:67:27:ab:dc:
-    60:58:8e:88:98:96:3d:ea:30:30:1c:88:2c:6e:d3:
-    e0:db:f2:2e:f4:13:eb:a1:7d:15:de:95:2e:1f:7c:
-    33:fa:ad:79:70:71:05:f4:2c:19:28:5b:f7:e6:54:
-    d4:49
+    0a:41:9e:7d:70:83:30:72:6f:7a:39:c0:43:fc:8b:
+    cb:2a:4c:40:d0:ce:dd:f2:01:59:fe:45:6a:a7:a0:
+    81:67:d9:49:e1:59:f5:0c:8f:77:db:5c:1c:60:4f:
+    78:44:fe:06:c2:3d:9e:f5:fc:1a:f8:01:b8:8c:53:
+    05:96:fb:f7:16:82:38:5d:5e:b2:5b:80:1c:5d:cc:
+    65:51:cb:b3:69:eb:c2:46:c8:c8:87:33:72:9f:51:
+    2b:5a:4d:1b:b3:1e:79:b7:86:a1:0d:93:c1:4f:70:
+    e9:c6:b9:be:0b:e7:4f:da:ac:fd:0d:d6:03:17:89:
+    8b:4b:74:df:20:9d:02:a4:59:25:41:c3:3e:b9:93:
+    86:af:f0:bd:a0:f6:9b:2e:5d:b2:4b:19:ac:2c:98:
+    ab:db:b4:38:49:3f:68:3d:c9:97:f9:00:00:8b:66:
+    a8:bc:16:68:69:a9:5a:51:9e:fc:dd:e2:3d:8e:68:
+    cf:d4:2c:4c:63:14:9b:02:0c:52:2c:63:ca:9b:ac:
+    12:f7:4a:44:e7:45:2e:a3:9c:9a:5f:1c:2a:52:6f:
+    f7:6b:c4:0a:55:30:ff:99:19:d9:62:83:15:85:4b:
+    ae:17:c0:17:85:5c:f4:c1:d5:dc:99:1c:09:20:26:
+    60:47:24:3d:e7:98:bf:b7:b8:76:c5:7e:df:3c:cc:
+    d1
 prime1:
-    00:d1:45:25:20:50:11:d5:b3:c8:67:01:4d:ca:8b:
-    0d:8d:70:78:4d:90:40:16:d0:6b:ac:4e:25:c2:4a:
-    c6:3f:9b:ab:1a:7e:c2:2c:a1:0c:91:de:e0:20:40:
-    a7:fa:bb:07:d3:71:9b:a7:ce:c8:83:d1:7c:8c:b0:
-    24:c7:ff:45:f0:6c:e0:02:47:5c:9a:92:2a:7c:68:
-    08:d8:f7:20:1f:79:e0:90:e1:9a:9b:18:fe:7d:29:
-    19:57:75:4f:e0:89:0b:9d:d9:12:b4:31:78:25:8d:
-    f2:da:2a:f9:1f:f9:53:ec:fa:74:33:fb:28:7c:ed:
-    eb:00:c9:88:0b:55:b0:e1:1b
+    00:c4:a4:4a:f9:ac:32:ef:e0:08:84:bb:c8:58:df:
+    7e:e7:85:5d:2d:46:12:2d:f1:fc:4e:5b:c7:a0:34:
+    9a:6c:fd:2c:95:70:54:df:68:76:b2:8d:23:73:ae:
+    de:96:9b:48:26:28:f8:f8:30:52:ca:f4:e9:ff:ff:
+    d9:e0:fa:b9:b3:a9:14:bc:66:fc:7a:23:69:88:4d:
+    80:98:3b:14:32:a4:55:7d:de:f4:3c:71:c9:25:a9:
+    36:b7:85:32:b3:86:e3:29:66:f6:f5:4b:4b:96:49:
+    fc:fe:c5:ac:64:09:3f:0c:1a:6b:14:17:7f:b8:29:
+    6c:29:d3:a4:82:a8:f7:d6:bb
 prime2:
-    00:cd:28:c0:b4:ac:11:f6:d6:76:10:35:43:1f:ae:
-    cb:ab:65:08:1e:6a:79:e0:ef:ea:5c:fe:11:7e:42:
-    c5:60:b0:aa:c5:26:09:f9:9c:4d:72:10:0b:c2:f4:
-    f3:00:f5:4a:b0:bd:db:24:71:3d:11:c7:4e:39:21:
-    6f:45:95:ad:1d:06:56:d8:4a:a9:f1:4c:a6:ad:57:
-    0e:ae:71:30:7e:02:d4:47:07:49:81:9c:b8:dd:a2:
-    82:3d:e5:d9:ea:52:d3:cf:11:a0:a9:87:95:62:d8:
-    39:b3:a0:14:67:b3:d9:6e:eb:0c:2a:79:8e:d0:d3:
-    a9:67:58:d2:39:97:82:12:85
+    00:d2:c0:04:ad:cf:4f:b8:b7:d5:43:87:ad:9c:12:
+    30:fd:27:e3:e7:2e:76:d6:4a:a2:fe:b4:d3:a1:00:
+    ba:c9:52:a7:59:56:41:38:b8:79:f2:f2:cb:85:11:
+    bb:d9:50:11:99:76:4b:d9:9d:56:ae:02:82:e1:2b:
+    65:c8:6b:a1:37:55:c0:93:df:c9:7f:00:70:67:be:
+    c7:e4:b9:f2:fe:d3:5c:3e:40:42:5d:10:90:13:d8:
+    ce:66:40:92:69:f5:79:ed:80:e5:3d:a3:8e:f4:a8:
+    47:06:47:0e:4b:43:fa:b5:75:98:24:d6:67:84:69:
+    90:6a:08:65:d6:e1:d1:aa:31
 exponent1:
-    7d:39:12:ee:32:fb:79:15:0b:66:17:b1:a4:f1:70:
-    3a:a2:82:5a:67:66:f2:3f:e5:2e:45:d4:f2:5e:2c:
-    23:03:d3:6f:17:4a:b9:c9:e4:eb:a4:a2:18:aa:97:
-    d9:c0:f0:fd:e5:8d:6e:ec:9d:af:c3:3a:f4:34:b2:
-    cd:ba:42:ef:8b:36:c0:26:53:93:6a:c3:61:8e:1f:
-    3d:35:23:53:b2:6a:5e:47:a1:6c:0d:98:ba:ec:4c:
-    ed:b8:95:03:96:fe:0c:86:48:5a:ea:ff:29:f9:b6:
-    c8:35:ce:bd:03:44:e5:19:39:4f:a1:8a:a8:b6:f5:
-    58:93:3f:85:08:d1:be:e1
+    00:c1:01:54:c9:ac:57:ae:93:a1:28:ce:bb:3d:67:
+    d8:42:5b:e6:f1:99:f6:1b:fc:88:9d:4c:7e:2a:63:
+    97:32:e4:68:0f:21:5b:5c:90:46:f8:c7:89:05:71:
+    9c:ee:0b:e9:8b:f2:e9:33:89:12:aa:3c:2b:34:e6:
+    a5:ae:a9:c8:fd:6b:36:7c:19:45:34:88:6f:7b:a6:
+    3e:52:ac:a2:0d:76:b8:a6:bb:df:d3:38:07:ab:1c:
+    64:25:4a:ea:51:c5:52:4f:7f:cd:63:43:8d:24:2c:
+    e8:d2:13:a9:39:e2:cd:6c:0e:be:0c:d1:67:bd:95:
+    82:a1:a7:26:b0:4c:32:3e:23
 exponent2:
-    00:82:e4:8e:56:77:36:1a:eb:67:76:1d:d5:4e:a0:
-    82:17:3f:25:77:ea:6d:0a:43:67:9e:9f:06:e0:2c:
-    8f:ab:89:eb:da:4e:d3:ac:6a:b9:ca:9d:4c:33:bd:
-    7e:50:cd:2f:33:26:5e:6b:98:c7:e2:d0:eb:2a:6e:
-    17:85:28:e2:c3:12:e9:53:a4:07:5b:09:91:8a:24:
-    72:1c:7f:e0:f5:74:ae:a5:06:94:32:5a:a0:63:df:
-    ac:02:fb:e4:15:a9:74:b3:b7:46:6f:03:2f:1f:5a:
-    5f:2e:28:62:fc:6a:f5:bd:db:be:ee:56:91:f4:d0:
-    26:53:e6:8a:71:ee:25:31:d5
+    00:b2:f8:09:81:28:7a:04:dd:68:27:ce:c2:69:b5:
+    31:10:ea:9d:29:27:56:17:a8:8e:3e:4a:85:25:46:
+    9f:58:73:ee:55:79:60:2d:b0:cb:2e:bb:6c:85:76:
+    87:d5:85:9f:4c:79:1e:f4:90:1e:99:ea:dc:06:27:
+    7a:69:f6:ac:93:77:28:f0:ea:ac:0c:43:ed:30:cc:
+    dc:a7:aa:19:66:b9:4a:ae:3a:97:a0:bc:7d:fd:bc:
+    b1:9a:37:df:9e:47:ad:e1:39:02:73:93:bf:c4:98:
+    5a:a8:44:13:29:6b:73:2e:41:cc:90:0b:db:20:a1:
+    1c:d8:4e:85:5d:33:ab:7f:21
 coefficient:
-    72:cc:12:f1:eb:3b:5b:d1:93:65:c7:39:51:e5:0e:
-    5f:bb:80:f0:44:1f:b5:b8:76:0b:ad:1c:8c:50:b8:
-    83:67:a1:2f:e1:fe:3c:b1:c6:22:48:39:18:ff:39:
-    59:c4:12:7c:03:20:50:f2:1f:64:b7:4d:50:19:45:
-    cc:65:f5:ae:ee:45:1a:74:bb:f3:85:53:4e:cb:5d:
-    a7:59:ad:ca:24:d0:35:a5:7c:b1:2f:b8:33:bf:0d:
-    ae:66:62:67:69:99:f0:a7:b3:f8:8f:6e:50:2b:ba:
-    49:95:88:80:c9:7f:31:f5:20:c9:1d:45:29:5b:c0:
-    b4:cd:6e:94:ab:3b:89:6e
+    2a:20:ea:12:bc:82:60:de:30:0d:2d:74:f1:94:0f:
+    66:4d:8a:34:92:ec:2f:da:ba:f4:b8:3e:b5:90:62:
+    35:89:2e:7c:5b:d0:8d:fc:7e:23:e5:02:cb:b7:69:
+    08:a1:7e:3c:93:8c:06:1d:9b:fd:69:a0:9d:13:95:
+    00:cc:bb:50:90:2d:6a:5e:fc:ab:4e:b1:9c:a4:f4:
+    fe:f4:8d:3e:73:21:67:48:53:3d:70:eb:c1:1d:ab:
+    ce:9a:9c:35:61:88:ba:96:9a:25:2b:f8:af:8d:f4:
+    a9:8a:8f:2a:21:73:8d:b9:3e:12:47:b6:ff:03:c7:
+    27:c6:59:5a:ac:3a:fc:1c
 -----BEGIN RSA PRIVATE KEY-----
-MIIEpAIBAAKCAQEAp7WvEDpKRgD3UWaLHTURZeYaUAo3Vv+TFiDNNVgoxG8GMdiG
-d+0ghVWtika4PXBRqjH5WK2l1U/K0D4Qj0+5xszobvIkFSbDOiSF0uj3YzqXtOn/
-XsDu5+2bLlmHNgiP5N9aAyWjNUBpoeSk8MAoMmTvqyr5ze3UDr1G3fydox/WFMJY
-Hw2ehfTOybGRG27RcU6uisZlZ68nk4u+gEZXnqaKXAsYhsB3tleHLSox/TR1M1jD
-i5zBW2FMKJSpKuEkfsJvzr78mBtJSpGxK3Mwx0Tv2fOvQxurwsnrl6mfbG6xEtPL
-0D4dLczuPuokDR4k+D68ik2FeL7E45eGMW7ZBwIDAQABAoIBAQCgXtb50JOnn1Lg
-TwtmMZHifAfbU/mZQqmXNmSkxxmsxXIKBkCHu4QmnEhnerrBXX9qHYGPr/VtJnEN
-ctwI/rbqiJUXSosAguGa3sPtbALsq2HYiQ4+wIVz2L1UtB3cqJFYzc/YRIxt5ptc
-STUEVuvZTLX2WxEnP25RbeOvcNoY2lNjR2hK4YZ/idzyfv21p4SYMMNr1cahiVGv
-6fbKPowAtcyZkCLF16eNIbxYhWTqXgBHszPz36nj2Ga8GYOt+k+lJaPevYxlUqEZ
-kgcPZyer3GBYjoiYlj3qMDAciCxu0+Db8i70E+uhfRXelS4ffDP6rXlwcQX0LBko
-W/fmVNRJAoGBANFFJSBQEdWzyGcBTcqLDY1weE2QQBbQa6xOJcJKxj+bqxp+wiyh
-DJHe4CBAp/q7B9Nxm6fOyIPRfIywJMf/RfBs4AJHXJqSKnxoCNj3IB954JDhmpsY
-/n0pGVd1T+CJC53ZErQxeCWN8toq+R/5U+z6dDP7KHzt6wDJiAtVsOEbAoGBAM0o
-wLSsEfbWdhA1Qx+uy6tlCB5qeeDv6lz+EX5CxWCwqsUmCfmcTXIQC8L08wD1SrC9
-2yRxPRHHTjkhb0WVrR0GVthKqfFMpq1XDq5xMH4C1EcHSYGcuN2igj3l2epS088R
-oKmHlWLYObOgFGez2W7rDCp5jtDTqWdY0jmXghKFAoGAfTkS7jL7eRULZhexpPFw
-OqKCWmdm8j/lLkXU8l4sIwPTbxdKucnk66SiGKqX2cDw/eWNbuydr8M69DSyzbpC
-74s2wCZTk2rDYY4fPTUjU7JqXkehbA2YuuxM7biVA5b+DIZIWur/Kfm2yDXOvQNE
-5Rk5T6GKqLb1WJM/hQjRvuECgYEAguSOVnc2Gutndh3VTqCCFz8ld+ptCkNnnp8G
-4CyPq4nr2k7TrGq5yp1MM71+UM0vMyZea5jH4tDrKm4XhSjiwxLpU6QHWwmRiiRy
-HH/g9XSupQaUMlqgY9+sAvvkFal0s7dGbwMvH1pfLihi/Gr1vdu+7laR9NAmU+aK
-ce4lMdUCgYByzBLx6ztb0ZNlxzlR5Q5fu4DwRB+1uHYLrRyMULiDZ6Ev4f48scYi
-SDkY/zlZxBJ8AyBQ8h9kt01QGUXMZfWu7kUadLvzhVNOy12nWa3KJNA1pXyxL7gz
-vw2uZmJnaZnwp7P4j25QK7pJlYiAyX8x9SDJHUUpW8C0zW6UqzuJbg==
+MIIEpAIBAAKCAQEAoeJEUR3zlZopndGlP7VX5C3LRZS42ICb8eDegblQCjckNJGz
+Q8et++uR3mIVOXBsvkhNmCuC+3RqXiY4SQpcgcAakLgVcGCpgC87uD7zV8h1uzTa
+F2g/AAQt/pckzCw818qBU0b2fOyaVbK3l906duPIiQwZQN0XYzZmXK0X6CsCmFTn
+vw1dsFyXSyOZzpf5WeUeujNuNTnve6BiS6yRBY95W3yCiEHn3FEcfYA+HKqS8H9n
+XxgJijUCgks4wAONIFHYshhjlppobuWuWggJwgEvK75Ua8l3dS5xMLYm2VoSDHVH
+LsbCsIIvZFvws2ivg4yXBvyZX5XcrE6ZlbNHywIDAQABAoIBAApBnn1wgzByb3o5
+wEP8i8sqTEDQzt3yAVn+RWqnoIFn2UnhWfUMj3fbXBxgT3hE/gbCPZ71/Br4AbiM
+UwWW+/cWgjhdXrJbgBxdzGVRy7Np68JGyMiHM3KfUStaTRuzHnm3hqENk8FPcOnG
+ub4L50/arP0N1gMXiYtLdN8gnQKkWSVBwz65k4av8L2g9psuXbJLGawsmKvbtDhJ
+P2g9yZf5AACLZqi8FmhpqVpRnvzd4j2OaM/ULExjFJsCDFIsY8qbrBL3SkTnRS6j
+nJpfHCpSb/drxApVMP+ZGdligxWFS64XwBeFXPTB1dyZHAkgJmBHJD3nmL+3uHbF
+ft88zNECgYEAxKRK+awy7+AIhLvIWN9+54VdLUYSLfH8TlvHoDSabP0slXBU32h2
+so0jc67elptIJij4+DBSyvTp///Z4Pq5s6kUvGb8eiNpiE2AmDsUMqRVfd70PHHJ
+Jak2t4Uys4bjKWb29UtLlkn8/sWsZAk/DBprFBd/uClsKdOkgqj31rsCgYEA0sAE
+rc9PuLfVQ4etnBIw/Sfj5y521kqi/rTToQC6yVKnWVZBOLh58vLLhRG72VARmXZL
+2Z1WrgKC4StlyGuhN1XAk9/JfwBwZ77H5Lny/tNcPkBCXRCQE9jOZkCSafV57YDl
+PaOO9KhHBkcOS0P6tXWYJNZnhGmQaghl1uHRqjECgYEAwQFUyaxXrpOhKM67PWfY
+Qlvm8Zn2G/yInUx+KmOXMuRoDyFbXJBG+MeJBXGc7gvpi/LpM4kSqjwrNOalrqnI
+/Ws2fBlFNIhve6Y+UqyiDXa4prvf0zgHqxxkJUrqUcVST3/NY0ONJCzo0hOpOeLN
+bA6+DNFnvZWCoacmsEwyPiMCgYEAsvgJgSh6BN1oJ87CabUxEOqdKSdWF6iOPkqF
+JUafWHPuVXlgLbDLLrtshXaH1YWfTHke9JAemercBid6afask3co8OqsDEPtMMzc
+p6oZZrlKrjqXoLx9/byxmjffnket4TkCc5O/xJhaqEQTKWtzLkHMkAvbIKEc2E6F
+XTOrfyECgYAqIOoSvIJg3jANLXTxlA9mTYo0kuwv2rr0uD61kGI1iS58W9CN/H4j
+5QLLt2kIoX48k4wGHZv9aaCdE5UAzLtQkC1qXvyrTrGcpPT+9I0+cyFnSFM9cOvB
+HavOmpw1YYi6lpolK/ivjfSpio8qIXONuT4SR7b/A8cnxllarDr8HA==
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/pluto.pem
+++ b/spec/fixtures/ssl/pluto.pem
@@ -1,66 +1,67 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 10 (0xa)
+        Serial Number: 11 (0xb)
         Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA Agent Subauthority
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Jun 15 01:19:37 2031 GMT
+            Not After : Jun 24 21:18:00 2033 GMT
         Subject: CN=pluto
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                RSA Public-Key: (2048 bit)
+                Public-Key: (2048 bit)
                 Modulus:
-                    00:a7:b5:af:10:3a:4a:46:00:f7:51:66:8b:1d:35:
-                    11:65:e6:1a:50:0a:37:56:ff:93:16:20:cd:35:58:
-                    28:c4:6f:06:31:d8:86:77:ed:20:85:55:ad:8a:46:
-                    b8:3d:70:51:aa:31:f9:58:ad:a5:d5:4f:ca:d0:3e:
-                    10:8f:4f:b9:c6:cc:e8:6e:f2:24:15:26:c3:3a:24:
-                    85:d2:e8:f7:63:3a:97:b4:e9:ff:5e:c0:ee:e7:ed:
-                    9b:2e:59:87:36:08:8f:e4:df:5a:03:25:a3:35:40:
-                    69:a1:e4:a4:f0:c0:28:32:64:ef:ab:2a:f9:cd:ed:
-                    d4:0e:bd:46:dd:fc:9d:a3:1f:d6:14:c2:58:1f:0d:
-                    9e:85:f4:ce:c9:b1:91:1b:6e:d1:71:4e:ae:8a:c6:
-                    65:67:af:27:93:8b:be:80:46:57:9e:a6:8a:5c:0b:
-                    18:86:c0:77:b6:57:87:2d:2a:31:fd:34:75:33:58:
-                    c3:8b:9c:c1:5b:61:4c:28:94:a9:2a:e1:24:7e:c2:
-                    6f:ce:be:fc:98:1b:49:4a:91:b1:2b:73:30:c7:44:
-                    ef:d9:f3:af:43:1b:ab:c2:c9:eb:97:a9:9f:6c:6e:
-                    b1:12:d3:cb:d0:3e:1d:2d:cc:ee:3e:ea:24:0d:1e:
-                    24:f8:3e:bc:8a:4d:85:78:be:c4:e3:97:86:31:6e:
-                    d9:07
+                    00:a1:e2:44:51:1d:f3:95:9a:29:9d:d1:a5:3f:b5:
+                    57:e4:2d:cb:45:94:b8:d8:80:9b:f1:e0:de:81:b9:
+                    50:0a:37:24:34:91:b3:43:c7:ad:fb:eb:91:de:62:
+                    15:39:70:6c:be:48:4d:98:2b:82:fb:74:6a:5e:26:
+                    38:49:0a:5c:81:c0:1a:90:b8:15:70:60:a9:80:2f:
+                    3b:b8:3e:f3:57:c8:75:bb:34:da:17:68:3f:00:04:
+                    2d:fe:97:24:cc:2c:3c:d7:ca:81:53:46:f6:7c:ec:
+                    9a:55:b2:b7:97:dd:3a:76:e3:c8:89:0c:19:40:dd:
+                    17:63:36:66:5c:ad:17:e8:2b:02:98:54:e7:bf:0d:
+                    5d:b0:5c:97:4b:23:99:ce:97:f9:59:e5:1e:ba:33:
+                    6e:35:39:ef:7b:a0:62:4b:ac:91:05:8f:79:5b:7c:
+                    82:88:41:e7:dc:51:1c:7d:80:3e:1c:aa:92:f0:7f:
+                    67:5f:18:09:8a:35:02:82:4b:38:c0:03:8d:20:51:
+                    d8:b2:18:63:96:9a:68:6e:e5:ae:5a:08:09:c2:01:
+                    2f:2b:be:54:6b:c9:77:75:2e:71:30:b6:26:d9:5a:
+                    12:0c:75:47:2e:c6:c2:b0:82:2f:64:5b:f0:b3:68:
+                    af:83:8c:97:06:fc:99:5f:95:dc:ac:4e:99:95:b3:
+                    47:cb
                 Exponent: 65537 (0x10001)
     Signature Algorithm: sha256WithRSAEncryption
-         21:81:c6:f9:ce:10:12:5a:52:73:52:90:7f:7d:f0:1c:7a:48:
-         91:6e:f7:5d:f2:6b:10:b1:6d:d1:19:62:40:7e:bb:3f:23:0d:
-         7f:6c:5a:51:b4:07:80:17:f2:6d:2e:44:a4:f2:07:3c:1e:ce:
-         85:4e:bc:3c:69:ce:94:b5:4e:03:66:8e:21:68:15:c8:8d:06:
-         79:ab:ff:ac:0d:03:8a:02:06:1f:8c:09:87:64:ee:75:37:eb:
-         db:54:79:0f:03:7b:dd:c2:c3:c3:4b:fc:76:72:8c:b5:ae:f3:
-         ea:6e:c5:b1:ff:96:0e:05:fc:0f:16:88:bd:2e:e5:04:3b:a4:
-         fd:ed:1f:fb:b2:14:ab:30:d8:f9:44:5c:bb:8b:bc:86:c7:d7:
-         59:e8:f4:b0:9e:28:24:f4:93:14:97:27:73:a5:8e:8a:3b:09:
-         cb:76:fc:02:9e:72:3f:f5:12:ce:84:82:d4:7e:d5:b9:32:ff:
-         af:cf:0e:7a:97:29:4e:c3:e7:1c:e5:c1:61:bb:85:5a:47:c1:
-         6d:ac:e4:a8:a1:68:d7:bc:aa:e6:16:08:5a:4e:dc:8b:7d:0d:
-         53:6f:c1:8b:bd:a0:57:70:b5:1c:a8:27:8a:1a:93:18:3d:72:
-         0d:97:49:63:88:f9:af:51:9e:87:2d:8f:98:b2:cb:42:b6:ee:
-         44:18:8d:93
+    Signature Value:
+        5c:74:cb:17:df:f2:1e:a8:de:4b:cd:c9:45:ee:d8:46:94:be:
+        19:e8:2f:66:28:01:29:18:4e:0e:b3:59:66:9d:d4:44:e2:44:
+        f0:34:e2:2c:08:d9:d3:ae:e0:70:77:79:32:4a:56:8c:11:84:
+        c2:8d:be:bc:c9:80:6f:f2:fb:fd:bc:96:7e:76:59:c7:46:12:
+        14:69:51:65:26:83:60:bf:f6:e9:f3:76:25:65:c2:12:4c:7f:
+        8b:3e:53:ba:8b:48:6e:e8:c2:a9:03:26:dc:af:58:3e:77:20:
+        a9:d6:0f:15:ea:7d:28:df:1d:88:7b:72:59:56:58:7a:46:b3:
+        2d:ca:3b:e8:fc:21:9b:fd:c2:c7:3d:24:78:7f:ad:23:b6:4b:
+        83:f0:d1:8a:40:8f:66:44:79:fb:ae:23:e5:5f:3e:3c:93:33:
+        34:cd:15:00:d7:d7:96:bb:61:42:8b:a2:07:0b:03:88:5f:b2:
+        47:a1:c3:66:eb:3a:b3:70:b1:44:61:10:c5:da:a6:34:9a:f6:
+        d3:c1:70:94:7c:6c:1f:ec:12:dc:c5:76:b6:58:92:a2:e7:3a:
+        7a:ea:8b:bf:96:57:f8:dc:ed:28:97:3f:b7:d9:96:ff:e9:42:
+        49:0a:02:9c:5e:44:84:9c:1f:c5:12:a0:3f:d5:14:0c:7f:e6:
+        3e:db:c0:3d
 -----BEGIN CERTIFICATE-----
-MIICrjCCAZagAwIBAgIBCjANBgkqhkiG9w0BAQsFADAlMSMwIQYDVQQDDBpUZXN0
-IENBIEFnZW50IFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zMTA2MTUw
-MTE5MzdaMBAxDjAMBgNVBAMMBXBsdXRvMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
-MIIBCgKCAQEAp7WvEDpKRgD3UWaLHTURZeYaUAo3Vv+TFiDNNVgoxG8GMdiGd+0g
-hVWtika4PXBRqjH5WK2l1U/K0D4Qj0+5xszobvIkFSbDOiSF0uj3YzqXtOn/XsDu
-5+2bLlmHNgiP5N9aAyWjNUBpoeSk8MAoMmTvqyr5ze3UDr1G3fydox/WFMJYHw2e
-hfTOybGRG27RcU6uisZlZ68nk4u+gEZXnqaKXAsYhsB3tleHLSox/TR1M1jDi5zB
-W2FMKJSpKuEkfsJvzr78mBtJSpGxK3Mwx0Tv2fOvQxurwsnrl6mfbG6xEtPL0D4d
-LczuPuokDR4k+D68ik2FeL7E45eGMW7ZBwIDAQABMA0GCSqGSIb3DQEBCwUAA4IB
-AQAhgcb5zhASWlJzUpB/ffAcekiRbvdd8msQsW3RGWJAfrs/Iw1/bFpRtAeAF/Jt
-LkSk8gc8Hs6FTrw8ac6UtU4DZo4haBXIjQZ5q/+sDQOKAgYfjAmHZO51N+vbVHkP
-A3vdwsPDS/x2coy1rvPqbsWx/5YOBfwPFoi9LuUEO6T97R/7shSrMNj5RFy7i7yG
-x9dZ6PSwnigk9JMUlydzpY6KOwnLdvwCnnI/9RLOhILUftW5Mv+vzw56lylOw+cc
-5cFhu4VaR8FtrOSooWjXvKrmFghaTtyLfQ1Tb8GLvaBXcLUcqCeKGpMYPXINl0lj
-iPmvUZ6HLY+YsstCtu5EGI2T
+MIICrjCCAZagAwIBAgIBCzANBgkqhkiG9w0BAQsFADAlMSMwIQYDVQQDDBpUZXN0
+IENBIEFnZW50IFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zMzA2MjQy
+MTE4MDBaMBAxDjAMBgNVBAMMBXBsdXRvMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+MIIBCgKCAQEAoeJEUR3zlZopndGlP7VX5C3LRZS42ICb8eDegblQCjckNJGzQ8et
+++uR3mIVOXBsvkhNmCuC+3RqXiY4SQpcgcAakLgVcGCpgC87uD7zV8h1uzTaF2g/
+AAQt/pckzCw818qBU0b2fOyaVbK3l906duPIiQwZQN0XYzZmXK0X6CsCmFTnvw1d
+sFyXSyOZzpf5WeUeujNuNTnve6BiS6yRBY95W3yCiEHn3FEcfYA+HKqS8H9nXxgJ
+ijUCgks4wAONIFHYshhjlppobuWuWggJwgEvK75Ua8l3dS5xMLYm2VoSDHVHLsbC
+sIIvZFvws2ivg4yXBvyZX5XcrE6ZlbNHywIDAQABMA0GCSqGSIb3DQEBCwUAA4IB
+AQBcdMsX3/IeqN5LzclF7thGlL4Z6C9mKAEpGE4Os1lmndRE4kTwNOIsCNnTruBw
+d3kySlaMEYTCjb68yYBv8vv9vJZ+dlnHRhIUaVFlJoNgv/bp83YlZcISTH+LPlO6
+i0hu6MKpAybcr1g+dyCp1g8V6n0o3x2Ie3JZVlh6RrMtyjvo/CGb/cLHPSR4f60j
+tkuD8NGKQI9mRHn7riPlXz48kzM0zRUA19eWu2FCi6IHCwOIX7JHocNm6zqzcLFE
+YRDF2qY0mvbTwXCUfGwf7BLcxXa2WJKi5zp66ou/llf43O0olz+32Zb/6UJJCgKc
+XkSEnB/FEqA/1RQMf+Y+28A9
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/renewed.pem
+++ b/spec/fixtures/ssl/renewed.pem
@@ -1,0 +1,67 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 5 (0x5)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=Test CA Subauthority
+        Validity
+            Not Before: Jan  1 00:00:00 1970 GMT
+            Not After : Jun 24 21:18:00 2033 GMT
+        Subject: CN=renewed
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:c4:7f:b6:dd:ab:a8:58:7f:49:48:9d:bd:6f:91:
+                    9a:ea:bc:8c:3c:20:5f:ec:3b:30:4e:c2:c5:98:8e:
+                    52:27:74:d9:d1:28:7e:6a:09:b1:fc:ea:d2:28:a7:
+                    48:30:b8:bc:93:11:e8:56:93:bf:02:86:1c:78:16:
+                    0b:b8:c3:ce:aa:b1:27:de:c6:96:20:f8:d4:8e:63:
+                    58:b3:05:c6:df:a7:eb:eb:85:14:98:04:0e:d7:99:
+                    17:81:0c:15:0b:c7:f0:bf:14:a5:8e:e9:5b:88:65:
+                    e9:b4:3e:9f:77:f4:77:60:dd:aa:75:e9:f2:75:07:
+                    a8:47:17:a3:79:f1:e5:ea:01:80:25:5a:5a:1b:fb:
+                    8d:6e:17:c7:b8:7d:bb:1d:ec:67:bf:c9:83:8f:28:
+                    02:99:83:16:f4:2c:f0:94:25:1b:7f:f0:99:fb:ec:
+                    75:63:88:97:2f:1d:f8:bf:14:92:3b:df:ed:a0:56:
+                    0c:94:c6:92:b4:91:e2:85:88:de:99:93:00:17:b0:
+                    f1:ed:45:03:8f:07:2e:5a:e5:82:6a:99:6f:45:00:
+                    54:2a:37:93:77:23:06:c3:99:fa:c1:1f:4c:59:63:
+                    e1:35:b9:f7:f6:ab:81:a5:11:ef:9c:a1:e6:64:ab:
+                    2f:fc:f9:cd:b3:d0:b7:33:81:4c:36:13:03:3a:5e:
+                    e6:e5
+                Exponent: 65537 (0x10001)
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        be:f3:06:34:39:36:1e:41:38:64:bd:c8:01:05:b4:6d:f5:df:
+        44:2f:17:e5:86:b9:15:96:5e:94:38:2d:63:4a:54:90:21:cf:
+        d5:3e:e3:6e:0f:bf:0d:b9:9b:e9:a8:53:cb:38:c3:9b:88:af:
+        0c:c9:fa:2a:9b:0f:cc:be:d6:15:e8:fe:1d:6b:cb:30:3e:28:
+        c2:a5:87:69:be:8d:51:17:ed:c3:7f:e0:05:c2:3c:5c:d7:89:
+        d6:69:f2:44:25:1a:55:31:76:0f:83:4e:d7:30:d2:d5:82:eb:
+        e8:a3:75:15:01:b7:96:ca:4b:05:ca:81:6f:80:26:38:c5:5e:
+        a2:1c:24:0d:4a:bb:4a:41:51:9a:d1:ed:7e:bc:ad:1c:6a:cd:
+        fc:c4:53:11:14:a5:ff:a1:60:0b:3a:04:35:c4:03:a2:56:24:
+        92:a4:b6:e9:c0:c5:f5:2d:16:60:97:89:92:08:03:48:c2:ef:
+        9f:d1:7e:a7:56:ec:12:26:7f:36:0c:3b:7c:65:82:77:ba:0d:
+        28:fb:d2:e0:5c:19:5e:56:11:38:12:54:b6:b9:eb:55:3a:08:
+        81:e3:db:bc:6d:1a:c9:90:e2:1f:47:fa:55:23:c7:d0:e4:ba:
+        44:23:a8:39:52:fe:52:fc:6c:c8:4a:97:7d:4c:47:ab:21:79:
+        9f:25:bf:35
+-----BEGIN CERTIFICATE-----
+MIICqjCCAZKgAwIBAgIBBTANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0
+IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zMzA2MjQyMTE4MDBa
+MBIxEDAOBgNVBAMMB3JlbmV3ZWQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
+AoIBAQDEf7bdq6hYf0lInb1vkZrqvIw8IF/sOzBOwsWYjlIndNnRKH5qCbH86tIo
+p0gwuLyTEehWk78Chhx4Fgu4w86qsSfexpYg+NSOY1izBcbfp+vrhRSYBA7XmReB
+DBULx/C/FKWO6VuIZem0Pp939Hdg3ap16fJ1B6hHF6N58eXqAYAlWlob+41uF8e4
+fbsd7Ge/yYOPKAKZgxb0LPCUJRt/8Jn77HVjiJcvHfi/FJI73+2gVgyUxpK0keKF
+iN6ZkwAXsPHtRQOPBy5a5YJqmW9FAFQqN5N3IwbDmfrBH0xZY+E1uff2q4GlEe+c
+oeZkqy/8+c2z0LczgUw2EwM6XublAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAL7z
+BjQ5Nh5BOGS9yAEFtG3130QvF+WGuRWWXpQ4LWNKVJAhz9U+424Pvw25m+moU8s4
+w5uIrwzJ+iqbD8y+1hXo/h1ryzA+KMKlh2m+jVEX7cN/4AXCPFzXidZp8kQlGlUx
+dg+DTtcw0tWC6+ijdRUBt5bKSwXKgW+AJjjFXqIcJA1Ku0pBUZrR7X68rRxqzfzE
+UxEUpf+hYAs6BDXEA6JWJJKktunAxfUtFmCXiZIIA0jC75/RfqdW7BImfzYMO3xl
+gne6DSj70uBcGV5WETgSVLa561U6CIHj27xtGsmQ4h9H+lUjx9DkukQjqDlS/lL8
+bMhKl31MR6sheZ8lvzU=
+-----END CERTIFICATE-----

--- a/spec/fixtures/ssl/request-key.pem
+++ b/spec/fixtures/ssl/request-key.pem
@@ -1,117 +1,117 @@
-RSA Private-Key: (2048 bit, 2 primes)
+Private-Key: (2048 bit, 2 primes)
 modulus:
-    00:a8:02:d7:77:d2:93:b5:c3:7f:1b:4f:6f:cf:ba:
-    3b:ab:2c:07:de:7f:ce:ea:8e:21:54:29:39:7a:b7:
-    53:19:e1:1a:98:52:86:e9:22:ef:b4:30:b7:0a:d1:
-    52:40:cd:de:50:31:6e:93:f3:b2:03:8b:aa:23:d7:
-    86:23:fa:f3:8e:bc:af:a7:4a:86:3d:4f:58:d3:6c:
-    d6:6c:81:78:70:9c:6a:88:c0:e9:86:c6:76:1c:73:
-    53:ab:9f:47:01:4a:68:44:99:1e:15:ef:56:b6:1a:
-    2b:3d:28:a9:3e:b5:64:cf:8f:90:d7:e8:1a:70:52:
-    72:2c:d9:2e:a4:78:d9:4d:45:12:98:d1:a2:03:16:
-    d4:5a:eb:22:39:f5:4b:39:41:df:02:77:dd:62:0d:
-    1b:71:c1:8d:0a:b7:d9:a2:57:b6:0a:56:75:7f:6a:
-    cd:cc:3a:b5:06:db:80:55:36:03:89:65:a4:d3:82:
-    cf:b0:d3:d1:fd:07:ee:ab:27:07:95:c5:8b:e4:a8:
-    36:50:ac:83:17:ff:ff:05:6c:6e:fa:cb:46:4b:31:
-    14:db:c3:6b:aa:97:32:f5:a3:65:83:39:da:df:d9:
-    43:7f:01:62:d0:dc:09:4a:0a:aa:44:ff:42:6c:24:
-    e5:09:9a:c3:59:18:aa:30:60:38:bc:0a:93:4a:3c:
-    7d:55
+    00:c2:92:fa:28:25:5c:fe:d2:29:cb:70:b2:91:56:
+    cc:94:18:3d:f3:d6:e0:c9:fe:3e:92:c9:11:35:ac:
+    40:20:37:7e:1d:73:dc:45:67:50:29:8d:c4:40:be:
+    ae:53:4b:0e:58:22:b1:cc:fe:6c:da:3c:a7:ed:e4:
+    1c:ab:33:94:e6:40:85:44:c3:78:28:cb:c3:3d:c3:
+    fd:cc:91:d7:36:2c:f2:1f:01:f6:93:2c:00:cf:70:
+    d0:42:55:62:af:b3:93:5e:57:b7:03:0c:d9:22:b0:
+    d6:68:26:c6:d2:d7:32:7a:57:e6:96:bb:b0:69:71:
+    ad:77:48:64:ab:3b:4e:e5:ea:03:f4:d9:0f:5c:04:
+    4e:60:d3:b7:d7:89:c6:a2:50:b5:f4:da:f6:69:d5:
+    11:a8:50:67:a2:fd:ec:15:4f:13:22:8f:c7:74:ac:
+    84:31:c6:7f:1a:d1:9e:12:bf:dd:69:b6:79:46:ac:
+    e5:d2:d9:ae:59:51:77:e5:2a:6e:13:c4:a8:99:68:
+    d2:18:cd:3b:07:92:b7:7a:ad:a2:09:f6:ac:2d:2c:
+    47:4a:ce:2c:cc:fc:79:db:cf:71:41:1b:f0:0c:c5:
+    74:a8:2f:a4:18:7f:1f:45:35:b2:4d:d0:43:a2:62:
+    56:98:0f:6f:62:74:ad:8b:62:a8:8b:9b:5d:a8:23:
+    24:0d
 publicExponent: 65537 (0x10001)
 privateExponent:
-    00:93:e1:b4:70:26:6c:97:5f:95:40:9f:a2:06:10:
-    a1:36:a0:51:e8:d9:4c:72:8e:59:ed:af:3f:85:b1:
-    59:36:fd:39:20:7b:fb:7d:b7:9f:8f:56:15:b7:32:
-    d9:98:6a:dc:54:6f:be:2a:02:25:5d:13:90:d5:6d:
-    7e:07:ab:7a:b7:d7:83:30:d7:da:e2:9a:35:d0:1b:
-    0b:7d:84:54:53:a2:89:ef:07:06:45:f7:e7:bc:51:
-    12:83:8c:75:be:40:15:18:d4:41:74:03:2f:aa:a7:
-    cc:09:50:01:f0:4d:4f:87:96:91:62:49:4d:04:32:
-    bd:86:96:3f:84:cb:4e:51:c0:9d:d0:0d:5f:a1:5c:
-    44:bf:cb:31:1f:ee:ed:6c:4b:32:7b:c7:f3:42:80:
-    7a:08:71:09:2b:39:ac:a3:54:5e:15:fc:f1:de:2c:
-    25:79:75:f0:23:51:52:0f:1d:1b:09:79:ca:04:3b:
-    20:4e:e4:36:00:66:9b:a2:42:7b:ac:9d:e2:7a:a6:
-    13:84:21:6f:36:e5:28:b4:14:8c:eb:b9:7e:b1:b5:
-    b2:3b:55:04:8c:da:a7:47:85:be:3f:67:b3:bc:93:
-    be:31:c6:33:ac:12:5c:7e:ca:fb:7b:77:7d:22:2d:
-    87:53:ee:85:7f:99:43:17:b1:4d:b1:f9:3e:ed:7e:
-    5f:bd
+    2c:db:4f:06:15:d5:0a:5f:1f:a9:09:d6:74:f8:be:
+    89:ae:cc:0b:8c:c0:7e:78:d9:6a:a4:25:8e:4a:e3:
+    6e:b9:f4:5e:6c:61:3d:f3:db:30:75:41:27:0e:fe:
+    a7:ef:b0:03:24:1e:7a:ec:b5:e2:1b:25:38:cc:03:
+    ca:f9:45:8c:ce:97:9a:ba:78:97:69:20:5d:fb:32:
+    e5:e8:42:65:f8:37:2a:6c:5c:b0:e1:ae:5f:24:7a:
+    32:ac:b6:27:5c:fe:2e:bc:08:92:50:b2:37:53:ee:
+    de:0c:80:7e:47:83:d8:de:2e:68:16:25:8d:ad:9a:
+    28:db:7c:ef:d7:e8:b0:ca:9a:fb:33:c8:f6:ab:cb:
+    44:25:4a:9a:a9:4d:06:83:0b:d3:c5:00:cb:dd:8a:
+    a8:b9:39:c7:af:f9:8e:8b:e5:7c:ea:a3:0c:9b:bf:
+    3d:2d:c2:79:2d:57:74:df:46:84:c1:d3:2c:54:0d:
+    c4:86:31:03:09:25:61:3e:30:b8:3e:8b:ff:c0:61:
+    38:31:f5:56:d5:c2:0b:4b:d1:50:30:bb:3a:00:59:
+    dd:63:16:1a:8d:83:b1:71:84:12:f2:7c:1b:6d:44:
+    e4:b9:38:36:07:0e:e7:a9:93:68:5e:83:7f:8d:30:
+    31:51:6e:15:68:04:62:7d:1c:1f:35:49:c6:1a:15:
+    21
 prime1:
-    00:db:dc:17:0e:0f:25:c6:46:0a:a3:6f:b6:d2:44:
-    e7:39:75:d0:77:8d:29:77:63:76:11:2b:7e:8c:63:
-    dc:4a:57:e6:12:7a:b2:4b:c6:cc:cf:b9:41:e1:af:
-    e2:63:a3:33:68:3a:d0:47:c3:13:71:74:ba:c4:6d:
-    f0:2b:ef:96:6a:48:0e:79:b7:dc:71:dd:c9:0c:b6:
-    ca:55:36:46:b6:36:e1:dd:af:4e:b4:c7:10:72:39:
-    85:12:d4:63:65:10:14:35:a3:db:72:f1:6b:e6:15:
-    ab:61:e6:07:ec:17:a3:50:94:35:ac:2a:5b:13:97:
-    82:26:eb:97:59:31:46:22:57
+    00:f1:a4:e8:bd:f8:07:5e:de:e4:e6:83:ba:83:78:
+    f4:a7:fb:c6:78:b3:ef:5e:09:67:88:7a:53:59:ec:
+    37:f6:07:ac:32:82:e7:c7:cc:93:8b:e4:e5:26:de:
+    7f:c3:c8:e2:6f:26:02:72:83:2c:7c:f7:36:10:04:
+    bb:a3:cc:68:60:dc:8b:98:6c:0d:2d:6e:9e:d0:d9:
+    be:cf:78:76:04:58:93:43:cf:2b:83:10:8a:fb:ea:
+    fd:d7:76:29:fa:dd:bd:c5:e8:f4:c7:c6:27:80:42:
+    8a:68:a7:ad:6b:cd:0f:af:06:f6:9d:62:2e:0b:fe:
+    67:93:08:b9:57:9c:32:5d:21
 prime2:
-    00:c3:a0:e9:48:a4:9b:16:8a:37:14:37:c4:41:75:
-    28:24:f8:6a:d9:f4:bc:9a:4d:3c:ba:c7:29:89:f7:
-    c0:3b:9c:60:ca:ec:20:37:f8:e3:f0:ea:7c:8c:c1:
-    35:8f:c7:37:4f:bc:ad:e0:ae:9e:bf:47:5e:2c:e0:
-    35:73:94:7f:21:ff:f8:af:4b:ae:af:14:f6:16:a4:
-    c2:21:02:52:92:8f:28:53:95:be:6e:cc:d7:e8:77:
-    6e:db:c5:f9:03:55:b8:96:ce:a5:16:f0:39:f8:71:
-    dc:8f:0f:69:9e:86:fa:d7:d9:b4:8e:db:d8:a0:13:
-    a1:96:96:03:1c:e2:4d:ca:33
+    00:ce:22:31:c2:b9:6d:58:a0:c8:49:95:2e:35:48:
+    93:ce:85:7f:13:37:72:c1:1b:96:a7:ee:93:05:fa:
+    ca:c5:d0:49:96:a4:a2:9c:02:29:92:c3:62:f6:d8:
+    c6:75:40:5c:7c:30:da:0f:9a:9e:a8:a2:5e:39:a4:
+    a3:07:51:ea:8b:7f:e0:7d:e0:6d:04:f2:69:05:dc:
+    03:9d:6f:c7:84:1c:f8:d0:f5:fd:e7:da:a2:9d:cc:
+    cf:40:f4:f8:14:ff:4a:fa:61:4e:f2:da:4d:ad:1e:
+    f2:db:72:80:4a:60:6d:b2:6e:91:4e:26:b8:40:5c:
+    5f:90:32:33:c1:b6:cc:dd:6d
 exponent1:
-    02:d5:b2:a2:66:c5:98:e9:dc:47:41:30:7d:43:90:
-    2b:a8:7e:38:9c:64:55:7a:bd:d1:f8:da:97:da:cd:
-    c3:53:a0:ce:ca:30:34:53:ea:de:1e:c8:5f:ad:91:
-    e0:b1:00:ff:ae:0a:73:72:6b:74:c2:09:8a:70:d4:
-    70:ec:94:e6:e7:e8:ef:de:d4:03:cf:d5:40:c9:b6:
-    90:24:b4:02:b3:70:74:18:47:8e:83:26:8e:22:79:
-    b9:c5:6d:46:a7:4f:6b:65:a2:75:b7:f1:29:35:4c:
-    51:65:d2:e2:53:67:b2:a9:46:8b:e2:bb:eb:e3:bf:
-    34:db:42:c7:4e:a0:55:df
+    10:38:40:83:17:d5:ee:d1:49:4e:0b:c3:86:35:a5:
+    3e:6d:50:fa:23:21:cb:0f:18:8a:f9:a3:04:a3:2d:
+    72:6f:3b:68:bc:8e:b0:43:94:17:cc:ca:70:dc:78:
+    78:fc:cf:ee:24:00:00:0d:bb:fb:bb:60:3e:9d:02:
+    b7:50:ee:24:aa:49:18:77:10:3f:5f:70:7b:96:52:
+    0f:7d:07:76:ed:37:1d:53:17:99:99:8f:aa:af:30:
+    50:b9:16:c2:47:06:08:f5:c5:10:6f:c5:90:ff:66:
+    68:f5:f0:57:0f:11:a1:6e:f7:38:c3:31:52:0e:c6:
+    87:01:0b:e7:cc:8d:38:e1
 exponent2:
-    36:33:a9:2f:15:5c:5a:fc:64:92:57:79:2a:e1:b9:
-    03:b5:48:75:a7:17:72:71:1f:f8:68:22:1c:35:e6:
-    af:1d:7e:bb:fa:7c:5a:c5:bc:f2:0d:26:01:21:af:
-    23:6d:00:e8:38:d0:bc:45:e5:79:fd:de:1b:f4:eb:
-    1a:60:f4:70:89:29:6f:f8:3a:28:0c:58:ba:a1:5f:
-    a0:21:b2:9b:24:ca:f9:8d:ad:bb:a9:49:d1:00:f6:
-    58:32:1b:f2:4e:97:dc:40:d9:00:e8:02:47:d1:d4:
-    58:56:de:de:ab:6b:68:ce:ca:f6:21:f7:7d:32:b3:
-    3c:b3:c7:9d:03:1e:a6:7d
+    5a:16:73:ac:e8:a1:33:54:c1:73:f7:30:c4:b4:bd:
+    74:4a:bf:a8:c4:58:f0:b0:7f:fd:50:b5:0c:ad:f8:
+    a4:cf:4c:f9:fb:65:dd:cc:cc:22:8a:25:dc:40:0d:
+    2b:fd:3e:ee:3f:e3:6d:62:63:e8:cb:5d:66:cf:df:
+    38:39:c2:c9:c8:cf:71:f3:fd:71:66:08:24:39:6d:
+    93:06:e1:29:8a:07:ec:3b:36:06:78:75:0d:86:0f:
+    26:12:69:c1:b3:79:2f:48:0b:da:f3:31:73:71:cd:
+    2d:bf:32:f6:4e:82:62:b3:13:ea:15:dd:fc:b2:e2:
+    49:00:c7:c1:e7:84:4d:59
 coefficient:
-    6f:16:3f:5d:96:b8:bd:b8:3f:7c:a8:a5:4d:66:13:
-    77:47:73:d9:11:be:67:d0:81:0c:4c:b3:e7:cb:33:
-    ba:49:42:dc:8e:44:2d:b6:ca:52:05:48:c1:27:36:
-    88:d1:dc:cb:ba:d2:b0:99:30:a2:19:f9:47:ae:38:
-    de:26:ae:44:76:0f:c4:f2:1c:b4:0d:d4:74:96:f5:
-    f4:e8:23:1d:c5:e9:d9:47:7f:ce:83:c4:58:1f:99:
-    42:c5:ac:65:26:99:df:ec:b0:e9:0a:78:e1:09:5f:
-    16:44:a0:4b:30:a1:d5:3a:c4:f7:9c:28:b0:e9:89:
-    3c:15:13:eb:85:ed:5d:66
+    4e:75:e2:4f:d8:2f:70:8e:e1:88:8c:6c:12:e4:22:
+    05:ff:d9:3d:e1:c2:c4:ec:a9:7e:16:85:23:a5:55:
+    29:87:08:cb:ab:99:4d:c7:64:88:42:90:e7:f3:41:
+    4b:f8:cb:27:66:7d:20:63:33:82:bc:e4:d3:6a:26:
+    91:51:a0:96:b7:b6:22:d4:dc:ae:02:43:f8:f6:78:
+    34:54:16:c1:c8:9d:29:97:0a:c8:54:53:db:a9:73:
+    74:95:49:f2:cb:50:de:3e:45:c0:5c:b9:c8:e4:a2:
+    0f:32:a3:bc:2f:db:10:9b:01:80:c1:63:b0:6d:53:
+    71:a1:43:1e:9d:94:d0:1d
 -----BEGIN RSA PRIVATE KEY-----
-MIIEowIBAAKCAQEAqALXd9KTtcN/G09vz7o7qywH3n/O6o4hVCk5erdTGeEamFKG
-6SLvtDC3CtFSQM3eUDFuk/OyA4uqI9eGI/rzjryvp0qGPU9Y02zWbIF4cJxqiMDp
-hsZ2HHNTq59HAUpoRJkeFe9WthorPSipPrVkz4+Q1+gacFJyLNkupHjZTUUSmNGi
-AxbUWusiOfVLOUHfAnfdYg0bccGNCrfZole2ClZ1f2rNzDq1BtuAVTYDiWWk04LP
-sNPR/QfuqycHlcWL5Kg2UKyDF///BWxu+stGSzEU28Nrqpcy9aNlgzna39lDfwFi
-0NwJSgqqRP9CbCTlCZrDWRiqMGA4vAqTSjx9VQIDAQABAoIBAQCT4bRwJmyXX5VA
-n6IGEKE2oFHo2Uxyjlntrz+FsVk2/Tkge/t9t5+PVhW3MtmYatxUb74qAiVdE5DV
-bX4Hq3q314Mw19rimjXQGwt9hFRToonvBwZF9+e8URKDjHW+QBUY1EF0Ay+qp8wJ
-UAHwTU+HlpFiSU0EMr2Glj+Ey05RwJ3QDV+hXES/yzEf7u1sSzJ7x/NCgHoIcQkr
-OayjVF4V/PHeLCV5dfAjUVIPHRsJecoEOyBO5DYAZpuiQnusneJ6phOEIW825Si0
-FIzruX6xtbI7VQSM2qdHhb4/Z7O8k74xxjOsElx+yvt7d30iLYdT7oV/mUMXsU2x
-+T7tfl+9AoGBANvcFw4PJcZGCqNvttJE5zl10HeNKXdjdhErfoxj3EpX5hJ6skvG
-zM+5QeGv4mOjM2g60EfDE3F0usRt8CvvlmpIDnm33HHdyQy2ylU2RrY24d2vTrTH
-EHI5hRLUY2UQFDWj23Lxa+YVq2HmB+wXo1CUNawqWxOXgibrl1kxRiJXAoGBAMOg
-6UikmxaKNxQ3xEF1KCT4atn0vJpNPLrHKYn3wDucYMrsIDf44/DqfIzBNY/HN0+8
-reCunr9HXizgNXOUfyH/+K9Lrq8U9hakwiECUpKPKFOVvm7M1+h3btvF+QNVuJbO
-pRbwOfhx3I8PaZ6G+tfZtI7b2KAToZaWAxziTcozAoGAAtWyombFmOncR0EwfUOQ
-K6h+OJxkVXq90fjal9rNw1OgzsowNFPq3h7IX62R4LEA/64Kc3JrdMIJinDUcOyU
-5ufo797UA8/VQMm2kCS0ArNwdBhHjoMmjiJ5ucVtRqdPa2WidbfxKTVMUWXS4lNn
-sqlGi+K76+O/NNtCx06gVd8CgYA2M6kvFVxa/GSSV3kq4bkDtUh1pxdycR/4aCIc
-NeavHX67+nxaxbzyDSYBIa8jbQDoONC8ReV5/d4b9OsaYPRwiSlv+DooDFi6oV+g
-IbKbJMr5ja27qUnRAPZYMhvyTpfcQNkA6AJH0dRYVt7eq2tozsr2Ifd9MrM8s8ed
-Ax6mfQKBgG8WP12WuL24P3yopU1mE3dHc9kRvmfQgQxMs+fLM7pJQtyORC22ylIF
-SMEnNojR3Mu60rCZMKIZ+UeuON4mrkR2D8TyHLQN1HSW9fToIx3F6dlHf86DxFgf
-mULFrGUmmd/ssOkKeOEJXxZEoEswodU6xPecKLDpiTwVE+uF7V1m
+MIIEogIBAAKCAQEAwpL6KCVc/tIpy3CykVbMlBg989bgyf4+kskRNaxAIDd+HXPc
+RWdQKY3EQL6uU0sOWCKxzP5s2jyn7eQcqzOU5kCFRMN4KMvDPcP9zJHXNizyHwH2
+kywAz3DQQlVir7OTXle3AwzZIrDWaCbG0tcyelfmlruwaXGtd0hkqztO5eoD9NkP
+XAROYNO314nGolC19Nr2adURqFBnov3sFU8TIo/HdKyEMcZ/GtGeEr/dabZ5Rqzl
+0tmuWVF35SpuE8SomWjSGM07B5K3eq2iCfasLSxHSs4szPx5289xQRvwDMV0qC+k
+GH8fRTWyTdBDomJWmA9vYnSti2Koi5tdqCMkDQIDAQABAoIBACzbTwYV1QpfH6kJ
+1nT4vomuzAuMwH542WqkJY5K42659F5sYT3z2zB1QScO/qfvsAMkHnrsteIbJTjM
+A8r5RYzOl5q6eJdpIF37MuXoQmX4NypsXLDhrl8kejKstidc/i68CJJQsjdT7t4M
+gH5Hg9jeLmgWJY2tmijbfO/X6LDKmvszyPary0QlSpqpTQaDC9PFAMvdiqi5Ocev
++Y6L5Xzqowybvz0twnktV3TfRoTB0yxUDcSGMQMJJWE+MLg+i//AYTgx9VbVwgtL
+0VAwuzoAWd1jFhqNg7FxhBLyfBttROS5ODYHDuepk2heg3+NMDFRbhVoBGJ9HB81
+ScYaFSECgYEA8aTovfgHXt7k5oO6g3j0p/vGeLPvXglniHpTWew39gesMoLnx8yT
+i+TlJt5/w8jibyYCcoMsfPc2EAS7o8xoYNyLmGwNLW6e0Nm+z3h2BFiTQ88rgxCK
+++r913Yp+t29xej0x8YngEKKaKeta80Prwb2nWIuC/5nkwi5V5wyXSECgYEAziIx
+wrltWKDISZUuNUiTzoV/EzdywRuWp+6TBfrKxdBJlqSinAIpksNi9tjGdUBcfDDa
+D5qeqKJeOaSjB1Hqi3/gfeBtBPJpBdwDnW/HhBz40PX959qinczPQPT4FP9K+mFO
+8tpNrR7y23KASmBtsm6RTia4QFxfkDIzwbbM3W0CgYAQOECDF9Xu0UlOC8OGNaU+
+bVD6IyHLDxiK+aMEoy1ybztovI6wQ5QXzMpw3Hh4/M/uJAAADbv7u2A+nQK3UO4k
+qkkYdxA/X3B7llIPfQd27TcdUxeZmY+qrzBQuRbCRwYI9cUQb8WQ/2Zo9fBXDxGh
+bvc4wzFSDsaHAQvnzI044QKBgFoWc6zooTNUwXP3MMS0vXRKv6jEWPCwf/1QtQyt
++KTPTPn7Zd3MzCKKJdxADSv9Pu4/421iY+jLXWbP3zg5wsnIz3Hz/XFmCCQ5bZMG
+4SmKB+w7NgZ4dQ2GDyYSacGzeS9IC9rzMXNxzS2/MvZOgmKzE+oV3fyy4kkAx8Hn
+hE1ZAoGATnXiT9gvcI7hiIxsEuQiBf/ZPeHCxOypfhaFI6VVKYcIy6uZTcdkiEKQ
+5/NBS/jLJ2Z9IGMzgrzk02omkVGglre2ItTcrgJD+PZ4NFQWwcidKZcKyFRT26lz
+dJVJ8stQ3j5FwFy5yOSiDzKjvC/bEJsBgMFjsG1TcaFDHp2U0B0=
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/request.pem
+++ b/spec/fixtures/ssl/request.pem
@@ -1,60 +1,62 @@
 Certificate Request:
     Data:
-        Version: 3 (0x2)
+        Version: Unknown (2)
         Subject: CN=pending
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                RSA Public-Key: (2048 bit)
+                Public-Key: (2048 bit)
                 Modulus:
-                    00:a8:02:d7:77:d2:93:b5:c3:7f:1b:4f:6f:cf:ba:
-                    3b:ab:2c:07:de:7f:ce:ea:8e:21:54:29:39:7a:b7:
-                    53:19:e1:1a:98:52:86:e9:22:ef:b4:30:b7:0a:d1:
-                    52:40:cd:de:50:31:6e:93:f3:b2:03:8b:aa:23:d7:
-                    86:23:fa:f3:8e:bc:af:a7:4a:86:3d:4f:58:d3:6c:
-                    d6:6c:81:78:70:9c:6a:88:c0:e9:86:c6:76:1c:73:
-                    53:ab:9f:47:01:4a:68:44:99:1e:15:ef:56:b6:1a:
-                    2b:3d:28:a9:3e:b5:64:cf:8f:90:d7:e8:1a:70:52:
-                    72:2c:d9:2e:a4:78:d9:4d:45:12:98:d1:a2:03:16:
-                    d4:5a:eb:22:39:f5:4b:39:41:df:02:77:dd:62:0d:
-                    1b:71:c1:8d:0a:b7:d9:a2:57:b6:0a:56:75:7f:6a:
-                    cd:cc:3a:b5:06:db:80:55:36:03:89:65:a4:d3:82:
-                    cf:b0:d3:d1:fd:07:ee:ab:27:07:95:c5:8b:e4:a8:
-                    36:50:ac:83:17:ff:ff:05:6c:6e:fa:cb:46:4b:31:
-                    14:db:c3:6b:aa:97:32:f5:a3:65:83:39:da:df:d9:
-                    43:7f:01:62:d0:dc:09:4a:0a:aa:44:ff:42:6c:24:
-                    e5:09:9a:c3:59:18:aa:30:60:38:bc:0a:93:4a:3c:
-                    7d:55
+                    00:c2:92:fa:28:25:5c:fe:d2:29:cb:70:b2:91:56:
+                    cc:94:18:3d:f3:d6:e0:c9:fe:3e:92:c9:11:35:ac:
+                    40:20:37:7e:1d:73:dc:45:67:50:29:8d:c4:40:be:
+                    ae:53:4b:0e:58:22:b1:cc:fe:6c:da:3c:a7:ed:e4:
+                    1c:ab:33:94:e6:40:85:44:c3:78:28:cb:c3:3d:c3:
+                    fd:cc:91:d7:36:2c:f2:1f:01:f6:93:2c:00:cf:70:
+                    d0:42:55:62:af:b3:93:5e:57:b7:03:0c:d9:22:b0:
+                    d6:68:26:c6:d2:d7:32:7a:57:e6:96:bb:b0:69:71:
+                    ad:77:48:64:ab:3b:4e:e5:ea:03:f4:d9:0f:5c:04:
+                    4e:60:d3:b7:d7:89:c6:a2:50:b5:f4:da:f6:69:d5:
+                    11:a8:50:67:a2:fd:ec:15:4f:13:22:8f:c7:74:ac:
+                    84:31:c6:7f:1a:d1:9e:12:bf:dd:69:b6:79:46:ac:
+                    e5:d2:d9:ae:59:51:77:e5:2a:6e:13:c4:a8:99:68:
+                    d2:18:cd:3b:07:92:b7:7a:ad:a2:09:f6:ac:2d:2c:
+                    47:4a:ce:2c:cc:fc:79:db:cf:71:41:1b:f0:0c:c5:
+                    74:a8:2f:a4:18:7f:1f:45:35:b2:4d:d0:43:a2:62:
+                    56:98:0f:6f:62:74:ad:8b:62:a8:8b:9b:5d:a8:23:
+                    24:0d
                 Exponent: 65537 (0x10001)
         Attributes:
-            a0:00
+            (none)
+            Requested Extensions:
     Signature Algorithm: sha256WithRSAEncryption
-         7f:17:53:8b:56:b0:49:60:90:10:48:a0:76:88:39:65:6a:33:
-         90:42:6b:1d:51:b1:8d:df:67:c0:02:ae:03:16:19:8b:dc:f5:
-         e4:ef:99:a6:a7:97:cc:3c:cc:e0:ce:dd:14:a1:b7:f7:a5:a0:
-         04:67:e0:63:b7:4a:8f:5b:c7:d9:ef:b8:4a:a0:77:ad:52:de:
-         cf:05:c4:f5:29:5c:e1:7e:3c:f1:a5:6f:da:56:66:50:45:2e:
-         49:d7:23:71:2a:4c:0a:9f:b3:6f:b8:ad:77:ad:08:e9:be:3c:
-         14:8d:5e:48:44:40:b4:0f:00:1d:7d:ed:60:2d:fa:f5:c7:e8:
-         5e:d0:8b:3d:da:0c:11:bc:bd:5f:37:93:7b:0a:20:03:0d:ce:
-         e3:2c:c7:de:67:ae:07:d8:48:67:69:ad:1a:6e:03:31:23:f2:
-         ca:05:d9:45:e9:8c:ce:e2:f7:e5:7d:da:50:0a:50:31:0b:3e:
-         85:e7:11:6a:c4:00:8f:ea:c2:74:06:2b:c3:58:61:5a:8c:54:
-         b4:7a:70:3d:a0:50:5a:35:79:35:32:0f:a6:90:4c:1a:74:ac:
-         a7:f1:44:2a:29:06:68:c9:47:90:73:d6:1d:bc:7a:d8:48:39:
-         25:8b:2e:a0:3a:32:ca:6f:b0:08:5c:2d:cb:54:2a:5c:39:94:
-         45:01:95:3a
+    Signature Value:
+        6c:33:bb:a7:17:97:ea:c8:e1:5c:d2:f6:43:bf:25:b7:5e:d6:
+        86:6b:d0:0b:2f:9e:1f:4b:24:98:e3:a7:6c:b3:3c:aa:a7:4d:
+        4c:9f:77:80:c8:2b:6a:d4:1e:90:bf:8b:31:2b:33:68:e9:55:
+        e5:41:82:10:f2:28:53:89:a8:97:00:05:d5:0f:48:22:38:0a:
+        69:ce:de:12:06:8c:f7:28:df:a9:d3:34:61:7e:31:a4:e9:13:
+        d3:de:e8:b9:81:bf:66:49:08:bd:3f:fd:63:6a:97:29:fa:42:
+        65:4a:b4:46:59:b9:63:12:f4:1e:f2:89:e6:17:6d:6f:28:fd:
+        10:d4:b8:9a:00:51:27:48:ef:65:41:76:c7:32:00:ac:d4:84:
+        2e:25:ee:b0:27:4d:f6:9f:75:b7:1a:92:ef:10:91:15:85:b9:
+        3c:8b:c9:c0:95:74:20:b6:46:d7:cb:5d:51:f8:b6:cf:52:0c:
+        70:9f:20:e0:63:21:d3:95:a9:e8:a5:7f:1d:71:32:22:a3:79:
+        bc:b8:e8:15:f9:a7:4e:26:b3:3e:3a:43:83:3c:23:05:98:18:
+        be:54:a7:ed:b3:cb:33:8d:22:0b:a0:1c:9b:fd:8b:d5:07:09:
+        bf:ad:31:06:02:a8:93:3a:ea:d6:75:a5:a1:72:1a:1b:f1:8c:
+        8c:47:0f:f7
 -----BEGIN CERTIFICATE REQUEST-----
 MIICVzCCAT8CAQIwEjEQMA4GA1UEAwwHcGVuZGluZzCCASIwDQYJKoZIhvcNAQEB
-BQADggEPADCCAQoCggEBAKgC13fSk7XDfxtPb8+6O6ssB95/zuqOIVQpOXq3Uxnh
-GphShuki77QwtwrRUkDN3lAxbpPzsgOLqiPXhiP68468r6dKhj1PWNNs1myBeHCc
-aojA6YbGdhxzU6ufRwFKaESZHhXvVrYaKz0oqT61ZM+PkNfoGnBScizZLqR42U1F
-EpjRogMW1FrrIjn1SzlB3wJ33WING3HBjQq32aJXtgpWdX9qzcw6tQbbgFU2A4ll
-pNOCz7DT0f0H7qsnB5XFi+SoNlCsgxf//wVsbvrLRksxFNvDa6qXMvWjZYM52t/Z
-Q38BYtDcCUoKqkT/Qmwk5Qmaw1kYqjBgOLwKk0o8fVUCAwEAAaAAMA0GCSqGSIb3
-DQEBCwUAA4IBAQB/F1OLVrBJYJAQSKB2iDllajOQQmsdUbGN32fAAq4DFhmL3PXk
-75mmp5fMPMzgzt0Uobf3paAEZ+Bjt0qPW8fZ77hKoHetUt7PBcT1KVzhfjzxpW/a
-VmZQRS5J1yNxKkwKn7NvuK13rQjpvjwUjV5IREC0DwAdfe1gLfr1x+he0Is92gwR
-vL1fN5N7CiADDc7jLMfeZ64H2Ehnaa0abgMxI/LKBdlF6YzO4vflfdpQClAxCz6F
-5xFqxACP6sJ0BivDWGFajFS0enA9oFBaNXk1Mg+mkEwadKyn8UQqKQZoyUeQc9Yd
-vHrYSDkliy6gOjLKb7AIXC3LVCpcOZRFAZU6
+BQADggEPADCCAQoCggEBAMKS+iglXP7SKctwspFWzJQYPfPW4Mn+PpLJETWsQCA3
+fh1z3EVnUCmNxEC+rlNLDlgiscz+bNo8p+3kHKszlOZAhUTDeCjLwz3D/cyR1zYs
+8h8B9pMsAM9w0EJVYq+zk15XtwMM2SKw1mgmxtLXMnpX5pa7sGlxrXdIZKs7TuXq
+A/TZD1wETmDTt9eJxqJQtfTa9mnVEahQZ6L97BVPEyKPx3SshDHGfxrRnhK/3Wm2
+eUas5dLZrllRd+UqbhPEqJlo0hjNOweSt3qtogn2rC0sR0rOLMz8edvPcUEb8AzF
+dKgvpBh/H0U1sk3QQ6JiVpgPb2J0rYtiqIubXagjJA0CAwEAAaAAMA0GCSqGSIb3
+DQEBCwUAA4IBAQBsM7unF5fqyOFc0vZDvyW3XtaGa9ALL54fSySY46dsszyqp01M
+n3eAyCtq1B6Qv4sxKzNo6VXlQYIQ8ihTiaiXAAXVD0giOAppzt4SBoz3KN+p0zRh
+fjGk6RPT3ui5gb9mSQi9P/1japcp+kJlSrRGWbljEvQe8onmF21vKP0Q1LiaAFEn
+SO9lQXbHMgCs1IQuJe6wJ032n3W3GpLvEJEVhbk8i8nAlXQgtkbXy11R+LbPUgxw
+nyDgYyHTlanopX8dcTIio3m8uOgV+adOJrM+OkODPCMFmBi+VKfts8szjSILoByb
+/YvVBwm/rTEGAqiTOurWdaWhchob8YyMRw/3
 -----END CERTIFICATE REQUEST-----

--- a/spec/fixtures/ssl/revoked-key.pem
+++ b/spec/fixtures/ssl/revoked-key.pem
@@ -1,117 +1,117 @@
-RSA Private-Key: (2048 bit, 2 primes)
+Private-Key: (2048 bit, 2 primes)
 modulus:
-    00:dd:c1:e0:87:23:e8:91:3c:90:ab:fe:9c:ac:69:
-    08:e1:7d:ba:10:ac:b7:7d:eb:47:ae:25:ff:6d:ab:
-    f4:d2:47:2f:bd:16:c9:21:09:e2:1e:e1:9a:aa:24:
-    0c:7a:8e:f9:bf:72:56:0d:b7:f8:0e:b6:5b:01:d1:
-    96:3d:e4:41:d9:71:57:d3:34:d9:85:c2:86:ef:29:
-    54:7d:f7:6a:3a:90:9c:00:f4:4e:77:2e:e1:32:2f:
-    c5:14:8e:ab:db:ec:36:ec:b1:aa:12:b6:27:76:e3:
-    df:88:08:40:e5:4e:6b:fa:20:dd:28:68:21:50:fd:
-    1c:a0:10:53:39:21:96:81:88:cd:4b:9a:e6:b1:d1:
-    3c:29:30:0e:ed:d8:e7:c6:29:c7:72:2c:f8:51:fe:
-    ce:1f:72:65:0d:03:a3:ab:5e:ba:90:3f:09:f7:df:
-    f5:37:e4:4d:d6:4d:2d:28:6a:d5:e2:c6:9d:7b:41:
-    f8:b7:5f:44:3e:27:61:ad:ac:9d:60:5b:02:b2:ff:
-    76:6b:83:75:e6:64:8d:ee:3e:68:17:0e:b9:18:c6:
-    47:e0:ca:77:9a:e2:6e:6e:71:64:7f:a2:fa:fb:33:
-    74:42:8f:8d:c1:43:69:4d:6e:a3:96:57:26:54:7d:
-    52:45:d8:6b:7e:5d:4a:20:f1:89:a5:70:a7:3c:2e:
-    98:25
+    00:98:44:c4:15:34:87:c3:40:f4:b0:e6:2b:71:98:
+    b1:cc:de:56:ef:8c:51:49:35:17:0b:15:09:e9:ad:
+    45:2c:f0:c3:0e:20:99:6e:46:92:53:7f:cd:ec:fe:
+    62:60:1e:6f:7e:3e:f7:cf:cf:e0:de:ed:67:d9:f9:
+    0b:59:d8:c8:b5:8c:55:68:e3:2a:d4:bc:6b:73:38:
+    42:23:41:45:05:fa:ca:94:e7:98:d6:47:67:75:16:
+    6b:51:46:e5:66:f1:b4:e1:fe:18:07:ad:e6:3d:e0:
+    f0:6b:c9:0e:87:2e:12:27:7c:c1:35:cd:99:fa:8d:
+    dc:80:05:85:0a:2e:9f:9d:c0:87:76:7e:c8:aa:94:
+    2a:c3:91:07:67:25:7f:b2:b1:dc:e1:92:9b:db:20:
+    3e:75:05:36:a6:d0:a5:8f:54:4c:45:f6:c9:5c:15:
+    16:e9:fb:a4:a4:a7:47:a3:1b:9b:18:08:11:80:fd:
+    62:c3:6f:43:f7:a8:6c:f8:1a:9c:4b:8f:fe:64:2d:
+    27:9c:c5:11:e4:de:ea:7d:39:aa:62:d5:09:4d:c2:
+    fd:7a:d8:18:85:e9:07:de:4b:ac:b7:03:ff:6d:ca:
+    d7:96:2c:33:4d:cd:a9:0a:c1:7b:4a:d1:5c:07:90:
+    b2:ff:d6:48:54:2e:97:00:13:22:93:c5:6b:77:ab:
+    89:d5
 publicExponent: 65537 (0x10001)
 privateExponent:
-    12:cb:05:6e:2e:7a:dd:24:16:d6:9c:a3:46:71:38:
-    51:73:c8:3a:f5:88:2f:61:ab:17:75:1c:ea:7c:72:
-    29:07:e3:61:d0:f6:86:98:41:d3:80:27:0d:58:34:
-    be:86:33:60:28:1e:66:d7:3a:6c:74:c3:cd:a9:a7:
-    63:e3:5e:39:41:43:c2:20:6e:76:c9:7f:89:f1:24:
-    b9:f0:27:ce:82:c6:d5:c5:de:88:77:2e:9a:84:35:
-    dd:82:21:ca:67:80:58:1a:ce:60:fb:92:e8:9e:73:
-    29:22:19:ed:d4:f1:8d:a7:0f:57:07:4c:1b:82:f7:
-    d4:10:ce:1c:bf:5d:f3:e8:2d:a5:72:95:c5:58:d1:
-    2c:70:2a:bc:84:4c:3c:29:19:6d:ac:5d:a4:10:99:
-    af:b2:ef:db:79:dd:76:80:ac:46:fb:48:57:ad:7e:
-    a3:ab:a7:81:03:3f:d3:ba:e4:17:78:ba:f3:dd:5c:
-    41:8f:4f:4d:9b:8d:eb:1d:5d:1a:61:a5:f5:31:62:
-    3e:f3:f3:f9:3b:2f:ee:1c:31:8b:f0:af:8b:1d:27:
-    b2:ed:71:3b:32:cc:09:b2:12:7f:a3:4c:ff:d8:8d:
-    47:54:47:af:fc:3d:4a:62:cf:fe:4c:2b:ff:1e:22:
-    5d:1c:50:a7:a8:b1:c3:58:1e:6e:90:5c:c8:e6:75:
-    81
+    22:5f:07:6a:07:f9:0b:5c:9a:bf:61:bd:75:bf:73:
+    87:1c:bb:40:08:8b:02:bc:ee:ae:2c:3a:18:1a:ea:
+    2e:0a:4c:e5:5f:fb:72:56:90:ca:33:63:be:f6:ef:
+    2a:e6:43:e1:9a:02:23:51:37:df:ea:74:12:52:72:
+    ba:fd:c1:d4:a5:50:54:44:4f:13:45:52:f5:e7:c1:
+    9a:26:ae:17:7a:f4:86:a7:3e:ab:43:e3:f9:1c:ad:
+    ed:e3:54:7e:27:da:5e:57:16:82:89:41:1b:3f:ae:
+    d5:8d:c5:6f:43:39:8a:db:50:db:bd:c4:df:b7:6d:
+    0a:22:f4:d4:87:10:b5:b1:7a:40:c8:44:80:30:81:
+    e9:b2:33:3f:c6:3e:1a:a2:b4:c9:8c:6e:3d:c4:fa:
+    3e:e7:85:d4:c2:00:58:a0:1e:d9:01:ba:7b:42:51:
+    9b:65:37:fa:96:1c:57:1e:15:8e:c2:8c:27:60:55:
+    cf:cd:85:97:60:e9:ca:e5:e9:fc:cb:82:75:d8:24:
+    1f:6f:bb:66:15:5e:3e:a4:0e:32:58:36:ec:1a:f3:
+    3d:5c:7c:d4:f1:ad:39:f5:6c:ff:96:b2:c0:2f:58:
+    f0:0d:19:35:bb:67:e4:bd:f2:a8:9a:db:14:28:98:
+    9b:e3:74:a6:a7:c4:b1:a0:6c:09:3f:3b:87:a7:03:
+    33
 prime1:
-    00:f6:70:7b:5d:e7:a9:74:f9:b5:e1:fc:2b:ab:81:
-    3e:24:25:9a:8f:92:8f:63:ae:bd:10:41:a2:40:4b:
-    f5:9f:b6:97:74:48:b0:d1:d7:68:4c:9f:d0:a0:97:
-    35:e4:76:38:03:28:0b:db:de:68:2b:fd:12:0b:4e:
-    b5:34:81:d6:18:73:4f:e5:b3:11:67:ec:b2:24:b7:
-    34:60:d0:d2:96:05:d3:f0:d2:dc:3b:49:d8:a5:83:
-    98:0f:cd:04:ad:68:c3:60:7a:69:b7:97:22:32:3e:
-    af:f9:25:c6:9d:8f:44:1e:e2:14:12:81:56:f0:10:
-    eb:9d:db:d8:93:71:c9:d3:f1
+    00:bb:5c:ab:7b:d1:66:04:73:ec:75:b1:59:79:33:
+    8b:be:82:c1:13:34:b0:88:48:53:60:1c:8f:b5:2e:
+    81:35:9a:60:c2:9d:b0:77:db:3e:3a:a7:0a:91:50:
+    54:ac:29:2a:34:c1:32:6d:e2:b5:fd:57:b8:f9:c0:
+    9e:c2:4e:04:a5:dd:9d:96:64:f1:29:b3:d9:e8:6d:
+    78:30:de:14:6e:18:8d:4e:30:f6:a2:b1:8c:ed:7a:
+    3f:d7:84:58:97:95:8f:e2:e9:5f:56:cb:3b:4a:f2:
+    be:23:9b:02:7c:4d:d3:6b:5b:6f:7b:45:51:89:b4:
+    cc:63:47:87:8d:3b:7e:18:03
 prime2:
-    00:e6:5c:43:cc:a4:3d:6a:f1:19:0c:bd:5c:13:c7:
-    4d:48:17:7b:7c:8c:42:cf:2f:81:15:13:34:ba:1a:
-    43:d3:6c:10:e4:5d:e2:3d:98:9c:ad:33:68:df:f3:
-    42:69:10:84:88:f7:78:d9:82:6c:39:1f:4d:c6:e6:
-    24:d8:e3:00:6d:aa:be:6e:df:6e:53:0f:66:36:44:
-    c4:e7:a6:01:58:a4:a9:03:ce:8b:dd:b4:52:2f:96:
-    f4:6c:ad:ed:17:ae:c2:70:86:b7:59:e2:c8:03:38:
-    68:74:5e:1e:ab:d5:71:2e:72:4d:11:ea:10:84:d5:
-    c4:63:22:fa:49:04:0b:6b:75
+    00:d0:0c:f1:08:a4:50:4c:91:97:00:ca:6c:af:a7:
+    76:c4:fa:3f:4f:a0:85:e1:01:99:d0:95:12:77:02:
+    14:b1:1f:77:8b:41:95:be:5b:c2:23:f3:d5:55:c8:
+    b6:15:7f:ee:89:7c:ed:47:0e:70:00:07:f8:e9:b2:
+    ae:b4:35:cf:ad:ad:49:94:02:f0:17:43:95:45:f7:
+    3f:30:5d:24:9b:4e:5f:8c:46:80:97:bf:91:5b:20:
+    47:11:76:44:8a:1a:0a:03:f0:8e:93:97:13:77:f4:
+    12:d2:cf:68:16:9b:97:59:fe:8a:aa:2b:62:23:4a:
+    57:02:d3:c7:12:e7:8e:4b:47
 exponent1:
-    00:d1:3a:34:73:48:90:e5:80:70:7c:59:d5:55:b9:
-    d7:e1:66:8f:af:df:75:9f:e3:26:1f:5c:29:fd:be:
-    bf:de:06:6e:d5:ca:35:5d:23:2e:29:07:f2:5f:b5:
-    a1:8a:c3:17:d1:0e:39:eb:45:0b:5a:75:74:d1:66:
-    d4:8f:ac:bf:f1:68:4d:68:2e:3c:d3:e7:f0:63:1d:
-    ab:f9:9a:b1:7f:af:98:fe:38:77:c4:5a:70:f6:2d:
-    20:78:21:cf:1b:ce:fb:39:b9:14:72:4b:7d:3b:fd:
-    5e:f7:ff:ab:7d:ef:b9:9d:22:c2:79:e7:97:c1:20:
-    0c:7a:ac:c1:56:85:60:1e:71
+    43:ca:23:c1:88:e2:00:7a:70:f3:a4:57:5b:22:eb:
+    4c:e2:c2:38:d0:b7:8e:97:9c:93:09:c2:75:2b:7e:
+    54:86:a6:bb:c3:92:35:cb:7d:98:7b:17:b7:bb:f8:
+    e6:d1:7e:13:d8:53:06:af:20:69:a9:73:a3:e9:ad:
+    87:5f:f3:0e:90:40:94:49:b1:78:05:3a:b2:7d:e9:
+    1e:c5:3b:5f:1a:43:06:27:71:15:2c:68:71:03:ea:
+    55:6f:ed:1d:eb:5f:44:1a:6c:04:5b:43:f8:ba:1b:
+    51:86:a4:3f:95:69:09:4e:eb:e7:0e:0d:92:65:78:
+    0d:f3:b3:77:c6:2e:b9:41
 exponent2:
-    32:fb:28:66:19:d3:1d:df:cd:d3:6b:f4:fc:cb:96:
-    e6:e5:8b:86:bc:e3:ec:46:6f:22:e2:e5:40:6a:9f:
-    a8:22:ba:7a:4f:ec:ca:05:04:67:b0:80:fd:4f:30:
-    db:5f:b4:75:3b:8f:9b:53:a9:ef:da:65:b4:27:2a:
-    f0:75:0c:9b:38:b6:7c:83:26:3f:6b:a1:0b:51:9c:
-    e2:47:72:f4:d3:3c:34:83:79:a0:cf:4f:81:08:bf:
-    7f:6d:de:92:e7:32:51:04:ff:7e:fd:19:96:dc:dd:
-    01:23:f3:55:c4:1f:10:50:6b:8e:13:67:24:7e:ca:
-    bf:c5:f5:ee:42:de:e4:21
+    30:5f:b1:f3:76:71:0d:3c:94:c5:a4:4b:5d:14:2c:
+    f3:63:d4:30:a9:7c:37:72:ed:d6:a7:b2:a1:65:24:
+    76:82:80:83:2a:7e:ac:c2:1d:03:cb:00:01:70:27:
+    96:1c:26:d4:64:ed:ae:a5:d6:b8:cb:21:bf:04:c2:
+    c6:37:f4:cf:c7:08:e2:97:44:47:c4:79:02:c9:98:
+    31:a0:96:90:5d:ca:ad:8c:fe:fd:49:97:7c:7e:a6:
+    c7:92:9e:21:16:28:d9:fd:a6:c8:fe:49:92:8c:77:
+    8b:f8:99:95:18:1c:3a:da:8a:57:42:bb:10:c5:8a:
+    31:a8:18:13:77:2f:88:a5
 coefficient:
-    7c:cc:19:27:a1:44:22:5b:0f:07:53:6c:2f:e0:b6:
-    8b:a6:24:d0:42:57:b0:c9:5f:dd:0d:f9:3a:9d:34:
-    60:f2:a2:83:20:2f:fa:73:58:df:1c:3d:92:43:47:
-    f3:fb:cc:53:10:1f:be:76:3f:cb:e8:09:52:7a:1c:
-    46:fc:02:5f:64:6f:76:6d:f5:c8:cf:64:15:48:d2:
-    d3:e9:e6:ba:c2:f6:01:60:fc:79:b8:cc:4b:d5:2e:
-    0b:49:f0:29:52:27:f2:78:b1:79:07:a5:2a:b8:78:
-    a1:6a:5d:a3:6d:79:a7:ab:a5:5f:07:d8:02:49:79:
-    d8:ee:73:16:d2:f3:1c:7c
+    54:25:3a:4b:a8:8d:be:ea:99:b5:67:e9:31:32:aa:
+    73:1e:99:81:33:f6:6a:a9:37:70:3c:27:19:4f:d4:
+    18:80:1d:32:29:5b:2c:30:05:9e:b7:30:42:48:c8:
+    a7:cd:ca:12:dc:21:9d:f4:b0:db:e5:c0:8e:a6:51:
+    28:62:1c:7d:f5:f4:f1:7f:cc:45:86:9d:65:57:ee:
+    d5:3b:d0:5e:fd:06:98:7e:2b:d2:91:93:75:b8:25:
+    11:b9:cd:27:4d:7a:66:1a:f5:85:36:ac:cd:23:de:
+    c8:70:1c:e4:11:4f:f8:e3:dc:b5:39:85:b9:d8:00:
+    f1:4a:b1:c0:87:bb:bd:ca
 -----BEGIN RSA PRIVATE KEY-----
-MIIEowIBAAKCAQEA3cHghyPokTyQq/6crGkI4X26EKy3fetHriX/bav00kcvvRbJ
-IQniHuGaqiQMeo75v3JWDbf4DrZbAdGWPeRB2XFX0zTZhcKG7ylUffdqOpCcAPRO
-dy7hMi/FFI6r2+w27LGqErYnduPfiAhA5U5r+iDdKGghUP0coBBTOSGWgYjNS5rm
-sdE8KTAO7djnxinHciz4Uf7OH3JlDQOjq166kD8J99/1N+RN1k0tKGrV4sade0H4
-t19EPidhraydYFsCsv92a4N15mSN7j5oFw65GMZH4Mp3muJubnFkf6L6+zN0Qo+N
-wUNpTW6jllcmVH1SRdhrfl1KIPGJpXCnPC6YJQIDAQABAoIBABLLBW4uet0kFtac
-o0ZxOFFzyDr1iC9hqxd1HOp8cikH42HQ9oaYQdOAJw1YNL6GM2AoHmbXOmx0w82p
-p2PjXjlBQ8IgbnbJf4nxJLnwJ86CxtXF3oh3LpqENd2CIcpngFgazmD7kuiecyki
-Ge3U8Y2nD1cHTBuC99QQzhy/XfPoLaVylcVY0SxwKryETDwpGW2sXaQQma+y79t5
-3XaArEb7SFetfqOrp4EDP9O65Bd4uvPdXEGPT02bjesdXRphpfUxYj7z8/k7L+4c
-MYvwr4sdJ7LtcTsyzAmyEn+jTP/YjUdUR6/8PUpiz/5MK/8eIl0cUKeoscNYHm6Q
-XMjmdYECgYEA9nB7XeepdPm14fwrq4E+JCWaj5KPY669EEGiQEv1n7aXdEiw0ddo
-TJ/QoJc15HY4AygL295oK/0SC061NIHWGHNP5bMRZ+yyJLc0YNDSlgXT8NLcO0nY
-pYOYD80ErWjDYHppt5ciMj6v+SXGnY9EHuIUEoFW8BDrndvYk3HJ0/ECgYEA5lxD
-zKQ9avEZDL1cE8dNSBd7fIxCzy+BFRM0uhpD02wQ5F3iPZicrTNo3/NCaRCEiPd4
-2YJsOR9NxuYk2OMAbaq+bt9uUw9mNkTE56YBWKSpA86L3bRSL5b0bK3tF67CcIa3
-WeLIAzhodF4eq9VxLnJNEeoQhNXEYyL6SQQLa3UCgYEA0To0c0iQ5YBwfFnVVbnX
-4WaPr991n+MmH1wp/b6/3gZu1co1XSMuKQfyX7WhisMX0Q4560ULWnV00WbUj6y/
-8WhNaC480+fwYx2r+Zqxf6+Y/jh3xFpw9i0geCHPG877ObkUckt9O/1e9/+rfe+5
-nSLCeeeXwSAMeqzBVoVgHnECgYAy+yhmGdMd383Ta/T8y5bm5YuGvOPsRm8i4uVA
-ap+oIrp6T+zKBQRnsID9TzDbX7R1O4+bU6nv2mW0JyrwdQybOLZ8gyY/a6ELUZzi
-R3L00zw0g3mgz0+BCL9/bd6S5zJRBP9+/RmW3N0BI/NVxB8QUGuOE2ckfsq/xfXu
-Qt7kIQKBgHzMGSehRCJbDwdTbC/gtoumJNBCV7DJX90N+TqdNGDyooMgL/pzWN8c
-PZJDR/P7zFMQH752P8voCVJ6HEb8Al9kb3Zt9cjPZBVI0tPp5rrC9gFg/Hm4zEvV
-LgtJ8ClSJ/J4sXkHpSq4eKFqXaNteaerpV8H2AJJedjucxbS8xx8
+MIIEogIBAAKCAQEAmETEFTSHw0D0sOYrcZixzN5W74xRSTUXCxUJ6a1FLPDDDiCZ
+bkaSU3/N7P5iYB5vfj73z8/g3u1n2fkLWdjItYxVaOMq1LxrczhCI0FFBfrKlOeY
+1kdndRZrUUblZvG04f4YB63mPeDwa8kOhy4SJ3zBNc2Z+o3cgAWFCi6fncCHdn7I
+qpQqw5EHZyV/srHc4ZKb2yA+dQU2ptClj1RMRfbJXBUW6fukpKdHoxubGAgRgP1i
+w29D96hs+BqcS4/+ZC0nnMUR5N7qfTmqYtUJTcL9etgYhekH3kustwP/bcrXliwz
+Tc2pCsF7StFcB5Cy/9ZIVC6XABMik8Vrd6uJ1QIDAQABAoIBACJfB2oH+Qtcmr9h
+vXW/c4ccu0AIiwK87q4sOhga6i4KTOVf+3JWkMozY7727yrmQ+GaAiNRN9/qdBJS
+crr9wdSlUFRETxNFUvXnwZomrhd69IanPqtD4/kcre3jVH4n2l5XFoKJQRs/rtWN
+xW9DOYrbUNu9xN+3bQoi9NSHELWxekDIRIAwgemyMz/GPhqitMmMbj3E+j7nhdTC
+AFigHtkBuntCUZtlN/qWHFceFY7CjCdgVc/NhZdg6crl6fzLgnXYJB9vu2YVXj6k
+DjJYNuwa8z1cfNTxrTn1bP+WssAvWPANGTW7Z+S98qia2xQomJvjdKanxLGgbAk/
+O4enAzMCgYEAu1yre9FmBHPsdbFZeTOLvoLBEzSwiEhTYByPtS6BNZpgwp2wd9s+
+OqcKkVBUrCkqNMEybeK1/Ve4+cCewk4Epd2dlmTxKbPZ6G14MN4UbhiNTjD2orGM
+7Xo/14RYl5WP4ulfVss7SvK+I5sCfE3Ta1tve0VRibTMY0eHjTt+GAMCgYEA0Azx
+CKRQTJGXAMpsr6d2xPo/T6CF4QGZ0JUSdwIUsR93i0GVvlvCI/PVVci2FX/uiXzt
+Rw5wAAf46bKutDXPra1JlALwF0OVRfc/MF0km05fjEaAl7+RWyBHEXZEihoKA/CO
+k5cTd/QS0s9oFpuXWf6KqitiI0pXAtPHEueOS0cCgYBDyiPBiOIAenDzpFdbIutM
+4sI40LeOl5yTCcJ1K35Uhqa7w5I1y32Yexe3u/jm0X4T2FMGryBpqXOj6a2HX/MO
+kECUSbF4BTqyfekexTtfGkMGJ3EVLGhxA+pVb+0d619EGmwEW0P4uhtRhqQ/lWkJ
+TuvnDg2SZXgN87N3xi65QQKBgDBfsfN2cQ08lMWkS10ULPNj1DCpfDdy7dansqFl
+JHaCgIMqfqzCHQPLAAFwJ5YcJtRk7a6l1rjLIb8EwsY39M/HCOKXREfEeQLJmDGg
+lpBdyq2M/v1Jl3x+pseSniEWKNn9psj+SZKMd4v4mZUYHDraildCuxDFijGoGBN3
+L4ilAoGAVCU6S6iNvuqZtWfpMTKqcx6ZgTP2aqk3cDwnGU/UGIAdMilbLDAFnrcw
+QkjIp83KEtwhnfSw2+XAjqZRKGIcffX08X/MRYadZVfu1TvQXv0GmH4r0pGTdbgl
+EbnNJ016Zhr1hTaszSPeyHAc5BFP+OPctTmFudgA8UqxwIe7vco=
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/revoked.pem
+++ b/spec/fixtures/ssl/revoked.pem
@@ -1,66 +1,67 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 7 (0x7)
+        Serial Number: 8 (0x8)
         Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA Subauthority
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Jun 15 01:19:37 2031 GMT
+            Not After : Jun 24 21:18:00 2033 GMT
         Subject: CN=revoked
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                RSA Public-Key: (2048 bit)
+                Public-Key: (2048 bit)
                 Modulus:
-                    00:dd:c1:e0:87:23:e8:91:3c:90:ab:fe:9c:ac:69:
-                    08:e1:7d:ba:10:ac:b7:7d:eb:47:ae:25:ff:6d:ab:
-                    f4:d2:47:2f:bd:16:c9:21:09:e2:1e:e1:9a:aa:24:
-                    0c:7a:8e:f9:bf:72:56:0d:b7:f8:0e:b6:5b:01:d1:
-                    96:3d:e4:41:d9:71:57:d3:34:d9:85:c2:86:ef:29:
-                    54:7d:f7:6a:3a:90:9c:00:f4:4e:77:2e:e1:32:2f:
-                    c5:14:8e:ab:db:ec:36:ec:b1:aa:12:b6:27:76:e3:
-                    df:88:08:40:e5:4e:6b:fa:20:dd:28:68:21:50:fd:
-                    1c:a0:10:53:39:21:96:81:88:cd:4b:9a:e6:b1:d1:
-                    3c:29:30:0e:ed:d8:e7:c6:29:c7:72:2c:f8:51:fe:
-                    ce:1f:72:65:0d:03:a3:ab:5e:ba:90:3f:09:f7:df:
-                    f5:37:e4:4d:d6:4d:2d:28:6a:d5:e2:c6:9d:7b:41:
-                    f8:b7:5f:44:3e:27:61:ad:ac:9d:60:5b:02:b2:ff:
-                    76:6b:83:75:e6:64:8d:ee:3e:68:17:0e:b9:18:c6:
-                    47:e0:ca:77:9a:e2:6e:6e:71:64:7f:a2:fa:fb:33:
-                    74:42:8f:8d:c1:43:69:4d:6e:a3:96:57:26:54:7d:
-                    52:45:d8:6b:7e:5d:4a:20:f1:89:a5:70:a7:3c:2e:
-                    98:25
+                    00:98:44:c4:15:34:87:c3:40:f4:b0:e6:2b:71:98:
+                    b1:cc:de:56:ef:8c:51:49:35:17:0b:15:09:e9:ad:
+                    45:2c:f0:c3:0e:20:99:6e:46:92:53:7f:cd:ec:fe:
+                    62:60:1e:6f:7e:3e:f7:cf:cf:e0:de:ed:67:d9:f9:
+                    0b:59:d8:c8:b5:8c:55:68:e3:2a:d4:bc:6b:73:38:
+                    42:23:41:45:05:fa:ca:94:e7:98:d6:47:67:75:16:
+                    6b:51:46:e5:66:f1:b4:e1:fe:18:07:ad:e6:3d:e0:
+                    f0:6b:c9:0e:87:2e:12:27:7c:c1:35:cd:99:fa:8d:
+                    dc:80:05:85:0a:2e:9f:9d:c0:87:76:7e:c8:aa:94:
+                    2a:c3:91:07:67:25:7f:b2:b1:dc:e1:92:9b:db:20:
+                    3e:75:05:36:a6:d0:a5:8f:54:4c:45:f6:c9:5c:15:
+                    16:e9:fb:a4:a4:a7:47:a3:1b:9b:18:08:11:80:fd:
+                    62:c3:6f:43:f7:a8:6c:f8:1a:9c:4b:8f:fe:64:2d:
+                    27:9c:c5:11:e4:de:ea:7d:39:aa:62:d5:09:4d:c2:
+                    fd:7a:d8:18:85:e9:07:de:4b:ac:b7:03:ff:6d:ca:
+                    d7:96:2c:33:4d:cd:a9:0a:c1:7b:4a:d1:5c:07:90:
+                    b2:ff:d6:48:54:2e:97:00:13:22:93:c5:6b:77:ab:
+                    89:d5
                 Exponent: 65537 (0x10001)
     Signature Algorithm: sha256WithRSAEncryption
-         45:2e:85:90:41:98:ce:10:47:80:a0:94:f7:54:cc:d0:92:03:
-         77:6d:e8:e4:0c:da:8c:a1:50:c4:7a:02:24:5f:96:aa:5b:e5:
-         8e:1f:a1:e6:31:8f:eb:d9:98:c0:a3:25:93:c0:0d:cd:ea:02:
-         17:65:cf:10:bd:31:34:09:bd:eb:98:09:d4:09:68:94:41:df:
-         69:4f:a8:cc:f5:b2:3a:c8:22:9c:24:2a:24:6f:64:65:c6:85:
-         f3:3b:65:14:b6:14:ca:17:56:9e:71:9f:9c:13:6a:8b:e5:37:
-         15:f1:53:93:89:2f:17:0c:49:d7:76:a5:a9:5d:e3:6f:09:b2:
-         8d:59:1b:3c:17:7d:e8:29:bc:bf:27:1b:eb:20:7e:38:b0:ce:
-         55:5a:e3:47:08:1e:66:d5:aa:f6:50:10:c9:33:0d:0d:41:79:
-         14:f4:95:2f:81:be:84:37:88:5a:d5:08:3a:a5:e8:79:0b:e3:
-         e0:24:68:b0:b3:5d:95:3e:a5:4c:a9:7a:f5:d1:3c:cb:2b:a0:
-         85:19:b2:6d:8f:11:5f:09:d7:10:51:fb:70:64:b2:79:29:b5:
-         56:21:a0:1d:04:5f:94:02:40:98:b7:43:d9:21:7a:5c:b2:9b:
-         50:37:58:bf:76:e8:d4:c5:13:f4:b2:a3:4b:e7:b6:3f:91:a6:
-         a8:ab:6c:07
+    Signature Value:
+        9b:26:09:f6:c7:a3:a7:35:2f:b2:55:db:8d:84:91:2a:5c:9b:
+        74:30:84:d3:36:a1:e0:2e:2f:e4:46:be:85:08:67:08:3c:6f:
+        63:06:e9:e3:60:2c:b6:26:86:37:81:56:6a:5c:d3:3a:79:f0:
+        d7:98:cb:07:e8:ef:14:35:e6:d2:42:ba:97:2d:76:38:3a:e1:
+        63:59:ee:c5:8e:f6:bf:57:88:9e:e9:03:c9:a2:cc:70:b9:1b:
+        ea:74:2d:5d:64:8d:63:3b:ed:26:ce:c6:7a:f9:37:8b:09:e2:
+        7a:e9:c2:17:c5:8d:7a:99:e4:19:4e:87:8f:62:ac:d8:e1:a7:
+        28:9d:1d:ec:e7:4b:26:97:a1:c2:82:d5:26:81:00:ee:34:26:
+        21:fe:58:8e:78:04:c6:a1:77:08:32:cc:f3:cf:5a:19:fe:6c:
+        5d:2d:92:b5:7c:fa:41:0e:73:23:9c:70:28:9d:d5:e6:7e:9b:
+        df:fe:bf:09:ac:86:81:ea:42:b0:12:a9:d8:a1:c7:65:74:7d:
+        d3:0e:bb:dd:5a:7e:84:6f:8e:24:6c:27:a7:c3:ad:ee:c5:c8:
+        cd:ef:df:29:01:4f:e0:75:af:e1:3c:0c:19:a6:5f:e3:7f:6f:
+        53:15:cc:ca:d9:11:6e:96:ee:97:0e:16:33:e9:a8:9d:db:c1:
+        d0:a3:d8:d6
 -----BEGIN CERTIFICATE-----
-MIICqjCCAZKgAwIBAgIBBzANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0
-IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zMTA2MTUwMTE5Mzda
+MIICqjCCAZKgAwIBAgIBCDANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0
+IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zMzA2MjQyMTE4MDBa
 MBIxEDAOBgNVBAMMB3Jldm9rZWQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
-AoIBAQDdweCHI+iRPJCr/pysaQjhfboQrLd960euJf9tq/TSRy+9FskhCeIe4Zqq
-JAx6jvm/clYNt/gOtlsB0ZY95EHZcVfTNNmFwobvKVR992o6kJwA9E53LuEyL8UU
-jqvb7DbssaoStid249+ICEDlTmv6IN0oaCFQ/RygEFM5IZaBiM1Lmuax0TwpMA7t
-2OfGKcdyLPhR/s4fcmUNA6OrXrqQPwn33/U35E3WTS0oatXixp17Qfi3X0Q+J2Gt
-rJ1gWwKy/3Zrg3XmZI3uPmgXDrkYxkfgynea4m5ucWR/ovr7M3RCj43BQ2lNbqOW
-VyZUfVJF2Gt+XUog8YmlcKc8LpglAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAEUu
-hZBBmM4QR4CglPdUzNCSA3dt6OQM2oyhUMR6AiRflqpb5Y4foeYxj+vZmMCjJZPA
-Dc3qAhdlzxC9MTQJveuYCdQJaJRB32lPqMz1sjrIIpwkKiRvZGXGhfM7ZRS2FMoX
-Vp5xn5wTaovlNxXxU5OJLxcMSdd2pald428Jso1ZGzwXfegpvL8nG+sgfjiwzlVa
-40cIHmbVqvZQEMkzDQ1BeRT0lS+BvoQ3iFrVCDql6HkL4+AkaLCzXZU+pUypevXR
-PMsroIUZsm2PEV8J1xBR+3BksnkptVYhoB0EX5QCQJi3Q9khelyym1A3WL926NTF
-E/Syo0vntj+RpqirbAc=
+AoIBAQCYRMQVNIfDQPSw5itxmLHM3lbvjFFJNRcLFQnprUUs8MMOIJluRpJTf83s
+/mJgHm9+PvfPz+De7WfZ+QtZ2Mi1jFVo4yrUvGtzOEIjQUUF+sqU55jWR2d1FmtR
+RuVm8bTh/hgHreY94PBryQ6HLhInfME1zZn6jdyABYUKLp+dwId2fsiqlCrDkQdn
+JX+ysdzhkpvbID51BTam0KWPVExF9slcFRbp+6Skp0ejG5sYCBGA/WLDb0P3qGz4
+GpxLj/5kLSecxRHk3up9Oapi1QlNwv162BiF6QfeS6y3A/9tyteWLDNNzakKwXtK
+0VwHkLL/1khULpcAEyKTxWt3q4nVAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAJsm
+CfbHo6c1L7JV242EkSpcm3QwhNM2oeAuL+RGvoUIZwg8b2MG6eNgLLYmhjeBVmpc
+0zp58NeYywfo7xQ15tJCupctdjg64WNZ7sWO9r9XiJ7pA8mizHC5G+p0LV1kjWM7
+7SbOxnr5N4sJ4nrpwhfFjXqZ5BlOh49irNjhpyidHeznSyaXocKC1SaBAO40JiH+
+WI54BMahdwgyzPPPWhn+bF0tkrV8+kEOcyOccCid1eZ+m9/+vwmshoHqQrASqdih
+x2V0fdMOu91afoRvjiRsJ6fDre7FyM3v3ykBT+B1r+E8DBmmX+N/b1MVzMrZEW6W
+7pcOFjPpqJ3bwdCj2NY=
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/signed-key.pem
+++ b/spec/fixtures/ssl/signed-key.pem
@@ -1,117 +1,117 @@
-RSA Private-Key: (2048 bit, 2 primes)
+Private-Key: (2048 bit, 2 primes)
 modulus:
-    00:94:3b:fc:18:7e:09:d6:93:10:9a:d7:df:84:49:
-    74:7d:9a:0e:91:ff:31:ca:9f:c0:c0:cf:4a:6b:1e:
-    be:77:b0:82:9f:a6:17:fc:f3:99:f1:e5:ed:c4:d3:
-    e1:f4:e8:ee:d2:70:3b:98:b1:21:55:9a:9e:6d:89:
-    f1:82:ba:82:43:00:af:e6:05:7e:0f:a1:50:ff:ec:
-    77:88:28:92:a2:f0:f9:29:1d:cb:86:ca:63:a9:c7:
-    9e:01:99:6e:56:c8:39:f1:c6:33:b9:b4:96:b2:05:
-    5e:e1:f7:1c:55:58:23:ec:bd:bb:4d:a0:54:3c:09:
-    d0:c9:83:27:9b:3c:f5:50:8c:1e:54:22:b3:0a:0f:
-    97:c1:68:d5:07:b7:0d:b9:16:d6:f8:d0:2c:87:25:
-    5e:53:65:31:d5:d6:94:ab:8b:77:29:a2:78:4e:c7:
-    cf:66:f2:79:f2:66:ca:ce:c9:9a:04:a2:0d:47:6f:
-    a0:1c:cc:39:7d:f2:01:73:3d:9c:56:0f:15:f6:06:
-    92:98:19:9b:52:ed:43:f8:84:6c:1f:96:0b:dd:8e:
-    c7:0f:dc:13:08:7b:1a:07:c1:ac:de:ba:dc:ce:1b:
-    a8:c5:c5:d5:c8:6c:32:6a:e2:2c:aa:e2:56:ba:55:
-    b4:3c:2b:7f:87:99:3e:d0:0c:47:ba:6e:60:86:2b:
-    3d:51
+    00:c4:7f:b6:dd:ab:a8:58:7f:49:48:9d:bd:6f:91:
+    9a:ea:bc:8c:3c:20:5f:ec:3b:30:4e:c2:c5:98:8e:
+    52:27:74:d9:d1:28:7e:6a:09:b1:fc:ea:d2:28:a7:
+    48:30:b8:bc:93:11:e8:56:93:bf:02:86:1c:78:16:
+    0b:b8:c3:ce:aa:b1:27:de:c6:96:20:f8:d4:8e:63:
+    58:b3:05:c6:df:a7:eb:eb:85:14:98:04:0e:d7:99:
+    17:81:0c:15:0b:c7:f0:bf:14:a5:8e:e9:5b:88:65:
+    e9:b4:3e:9f:77:f4:77:60:dd:aa:75:e9:f2:75:07:
+    a8:47:17:a3:79:f1:e5:ea:01:80:25:5a:5a:1b:fb:
+    8d:6e:17:c7:b8:7d:bb:1d:ec:67:bf:c9:83:8f:28:
+    02:99:83:16:f4:2c:f0:94:25:1b:7f:f0:99:fb:ec:
+    75:63:88:97:2f:1d:f8:bf:14:92:3b:df:ed:a0:56:
+    0c:94:c6:92:b4:91:e2:85:88:de:99:93:00:17:b0:
+    f1:ed:45:03:8f:07:2e:5a:e5:82:6a:99:6f:45:00:
+    54:2a:37:93:77:23:06:c3:99:fa:c1:1f:4c:59:63:
+    e1:35:b9:f7:f6:ab:81:a5:11:ef:9c:a1:e6:64:ab:
+    2f:fc:f9:cd:b3:d0:b7:33:81:4c:36:13:03:3a:5e:
+    e6:e5
 publicExponent: 65537 (0x10001)
 privateExponent:
-    0b:61:af:b1:91:bb:df:a5:db:18:88:8a:b8:f5:8a:
-    e4:39:f7:f4:6d:cb:bc:eb:17:39:b6:b0:d8:18:bc:
-    37:24:6e:63:23:b5:a3:ce:70:7b:8a:53:ff:50:e5:
-    80:90:82:05:d6:68:3d:09:1c:ae:1d:f9:1c:20:03:
-    53:2e:4e:e2:26:23:5b:5e:00:97:e2:a2:fd:83:82:
-    8a:09:d3:78:7f:58:22:38:0f:70:82:09:b4:f7:86:
-    c2:48:ad:98:2c:37:86:c0:d9:27:e1:1d:d0:fd:68:
-    93:a1:0d:a3:df:e8:a2:3c:cf:2c:de:aa:99:11:87:
-    de:71:1b:91:67:d4:ce:22:56:27:a3:7d:4d:58:5c:
-    d3:76:80:54:b6:28:ed:60:e7:ba:ef:da:4a:f5:86:
-    b9:f7:7e:c5:94:5f:87:55:d0:5c:6b:8c:ea:4e:82:
-    ca:3d:bc:23:b5:1c:77:4c:bd:57:98:db:1f:ec:af:
-    0d:70:e0:a0:fa:86:d6:ac:cf:2f:a2:55:24:2e:98:
-    60:b0:f5:cf:60:db:bf:97:b8:e2:c0:1f:03:b5:5c:
-    af:ce:fd:5b:2b:97:cd:d5:eb:95:ef:17:bc:19:69:
-    5a:12:1f:28:24:d2:8e:cd:91:8f:90:7c:54:bf:31:
-    75:bd:66:31:eb:61:20:b1:7f:5f:3b:3a:af:48:8d:
-    81
+    02:ae:22:f2:7d:43:2a:53:da:ce:20:02:ae:63:d1:
+    75:b6:b5:2b:4e:73:68:7f:8f:d8:df:2c:be:a2:e0:
+    54:29:47:f2:f8:fc:57:c4:c2:95:ff:d0:f6:87:7e:
+    43:55:dd:bd:46:cf:01:11:4f:ac:c0:8e:0b:b0:47:
+    4a:d1:a1:94:6f:f3:ff:d9:fc:6b:13:8c:78:ab:0f:
+    bc:6a:0d:81:f8:4d:23:95:03:88:7a:f3:b0:8a:a6:
+    1e:01:ea:19:3d:f4:ac:1d:38:bb:37:e1:22:52:e6:
+    35:69:c3:97:3e:b1:25:d3:d8:32:f6:b4:dd:2b:9f:
+    26:bb:17:e5:29:00:c3:bd:e9:36:1a:19:b2:df:0c:
+    42:d0:9d:e0:c4:9a:6e:73:00:fc:57:c5:32:62:da:
+    0e:67:0e:bc:10:de:80:17:cd:bc:39:80:d2:d8:d9:
+    c1:11:c0:ac:6d:32:11:3a:e1:7d:64:c7:d9:5e:f0:
+    c8:e0:3f:ae:c2:8b:07:0a:da:a8:15:58:e0:2e:c1:
+    f5:f5:1a:4e:c5:bc:e8:c7:63:bf:28:84:0d:1d:e4:
+    8d:8c:9b:74:7b:9f:2b:f8:ba:9d:ee:d6:c4:9f:d6:
+    3d:90:d6:18:34:84:82:d2:12:4c:be:55:13:54:6b:
+    d1:9e:39:e9:62:6f:30:de:9d:c2:06:49:4d:78:04:
+    11
 prime1:
-    00:c2:f2:79:65:6e:d5:61:bd:e0:6a:fb:67:89:ba:
-    23:fa:db:e4:fc:0f:58:9e:63:37:c4:ad:d8:80:c6:
-    a6:3f:9b:20:a5:70:48:20:f4:37:f3:36:01:8f:47:
-    ff:00:fe:b6:50:6a:56:f4:08:37:0a:0f:7f:28:42:
-    60:f8:01:a9:53:37:29:9c:24:83:14:1c:c3:56:b9:
-    18:33:5a:44:99:fe:b8:ab:45:26:71:b7:c5:1e:56:
-    a1:49:3c:71:5b:b5:c1:7c:bb:64:68:fe:af:24:3d:
-    60:6a:eb:de:d7:58:1d:bd:ff:56:92:5f:05:e6:8f:
-    57:88:5e:71:08:ce:12:e5:ad
+    00:db:85:36:5e:39:8e:46:b4:d2:ab:09:db:b1:c4:
+    d9:56:3c:c2:44:92:b7:60:74:e7:6d:07:75:ea:78:
+    bf:32:86:05:71:ab:e3:ad:22:b5:70:45:e7:26:49:
+    07:2a:92:1c:a0:31:c3:42:7e:7a:34:72:a0:c5:32:
+    92:65:17:bf:59:0a:59:41:d5:63:e8:ea:df:ae:1b:
+    e2:d8:b6:eb:bb:76:41:45:26:21:ac:de:4d:70:e1:
+    d4:bb:ce:30:c9:3b:a3:a9:96:95:7a:21:a3:6b:a1:
+    ea:e2:12:07:d9:0e:00:26:24:ee:91:2a:a5:69:ed:
+    d4:1c:03:c5:9d:80:35:5f:95
 prime2:
-    00:c2:a8:65:15:66:07:a2:14:75:17:ab:ed:f4:f5:
-    e6:cc:0b:70:6a:ee:a6:d0:3e:69:37:94:e8:3f:41:
-    02:f1:70:98:f4:5a:0d:0e:75:f5:37:4c:68:7a:cb:
-    1a:f2:57:69:5c:5d:b7:73:ce:95:48:92:1a:8a:2c:
-    33:08:a1:a6:3a:e2:7d:16:3b:c2:f7:86:68:da:18:
-    94:e5:9e:32:04:31:a4:07:2d:d4:4c:8c:e5:db:77:
-    72:ef:d9:e8:c2:0d:4e:17:83:7d:09:c5:df:83:35:
-    3b:bc:31:ae:a4:f7:d0:44:f1:98:7d:ad:2d:08:ae:
-    76:11:20:d7:cd:36:81:82:b5
+    00:e5:27:20:94:a0:f1:36:3f:97:ea:86:ed:4c:21:
+    8f:23:2b:09:49:7d:58:48:9f:c4:44:3f:8b:67:4b:
+    d4:1e:c2:87:fc:09:c6:06:d3:8b:82:e2:17:95:a6:
+    89:7c:df:43:2c:5b:fe:bb:ea:85:32:a7:59:eb:41:
+    31:81:e6:d2:8a:e8:1f:65:9e:dd:91:55:75:52:09:
+    e5:90:6a:44:22:99:47:e6:57:bb:f9:e6:df:f2:42:
+    b0:dd:1a:8f:6c:93:04:70:35:a9:3b:05:a9:04:78:
+    5a:97:39:53:d2:4c:3d:74:9a:d1:36:4c:98:9b:1a:
+    ba:1c:46:d0:46:5d:f9:d6:11
 exponent1:
-    68:16:6f:1a:e9:82:a5:1d:6c:a5:b2:76:25:e3:6d:
-    32:94:16:3f:3f:32:61:df:37:f7:9b:9a:ed:a7:23:
-    3c:f2:e7:0b:6e:58:14:c0:50:df:5b:06:9a:2a:26:
-    cd:b1:32:46:dd:80:6f:eb:b2:f7:7c:2e:b8:a0:38:
-    86:32:dc:e5:c1:9e:45:f0:78:cc:54:4f:38:0e:bc:
-    0d:2f:35:51:c3:df:76:13:05:e3:d1:eb:3d:b7:a3:
-    86:26:ef:9f:b7:fc:07:4d:46:df:88:9c:9b:0c:ea:
-    5e:2c:72:5f:28:7d:38:e5:0c:a4:3a:78:3c:12:6c:
-    fa:32:f2:c7:70:c0:46:41
+    27:ad:ce:83:fd:97:50:04:83:47:d3:42:58:c1:a2:
+    1f:4a:60:3b:10:e2:00:97:60:f5:7e:31:bc:2e:13:
+    31:48:b4:57:35:a0:b3:bc:e0:5a:e8:e7:bd:2d:da:
+    13:c1:d1:56:cb:67:e5:ef:02:9b:d4:54:67:10:9b:
+    11:96:d7:49:7a:eb:63:50:f4:fc:36:e8:33:8a:6a:
+    d8:8d:47:d2:dc:af:33:96:8e:e3:b6:52:fd:22:74:
+    d7:75:8f:af:f0:0d:c7:2b:a6:dd:2a:93:65:73:21:
+    07:b8:06:9f:1f:3e:bb:a6:55:50:fc:0a:66:39:4c:
+    eb:bb:6a:ce:eb:4b:ba:79
 exponent2:
-    4c:f2:27:d3:07:9b:e8:d3:d1:5d:64:17:12:07:ca:
-    0d:ca:4f:cb:d5:3e:97:7e:b4:34:c6:65:ef:eb:10:
-    f0:c3:a3:92:a3:ae:19:93:43:35:72:bc:b2:1d:6b:
-    2f:74:a2:2f:62:d4:4b:b0:d3:8d:f6:43:0b:6f:61:
-    54:fe:21:29:91:b2:04:81:e7:15:d5:49:c9:3c:82:
-    4f:29:f3:77:78:ef:ef:ee:8b:c7:1e:c3:15:b7:e7:
-    f5:2b:dc:38:28:ee:3f:99:38:6a:0e:8f:c5:db:db:
-    1b:0f:40:8b:f1:71:a0:6f:27:ea:35:f4:61:44:25:
-    63:ab:e9:e2:32:b3:8b:29
+    5f:ff:5f:3f:c4:98:a8:70:45:b5:23:67:3f:d0:83:
+    45:69:5f:0f:a1:6a:1d:aa:88:af:4a:ab:9c:cf:80:
+    82:8e:5e:27:70:f4:bb:a1:5d:bd:ab:f7:d3:62:9c:
+    10:6a:fb:9a:16:c4:05:77:3e:eb:b4:7e:0f:f7:14:
+    c5:65:ac:68:32:cc:0c:67:5c:4c:e9:2f:27:fa:2b:
+    68:af:8b:f1:ae:a3:17:55:43:d3:72:2b:f9:32:85:
+    23:6b:60:10:4d:1a:bb:e3:4f:0d:01:d7:07:9f:5f:
+    dc:20:51:04:35:9a:3d:42:2a:49:04:17:9e:4a:b9:
+    12:e5:7b:95:2f:03:5d:f1
 coefficient:
-    0d:ae:36:95:c9:a2:b3:6a:3d:d4:38:01:ce:e4:10:
-    da:e9:0e:c5:58:dd:0f:cf:9e:ac:cd:fc:68:9b:24:
-    6c:58:76:2b:78:57:ef:03:e5:d9:d6:e8:9a:15:9e:
-    15:c8:21:8c:34:19:9a:7c:e3:bf:dd:a1:c0:dd:ad:
-    50:69:2a:d8:36:60:b2:c0:b3:ab:14:19:f9:4e:8b:
-    b1:f9:2c:5c:28:9c:ce:64:74:07:80:20:15:e1:a1:
-    b6:dc:8f:2a:be:bd:20:f0:62:22:4e:03:a2:aa:a0:
-    fd:46:bf:e1:89:30:ac:1a:09:0a:fe:5b:20:d5:59:
-    72:a1:ce:75:32:a8:70:b4
+    56:b9:68:ee:96:8e:20:df:9c:e5:3c:29:41:a0:e9:
+    32:8f:a1:e9:de:1a:c5:e2:cd:c6:0c:b7:63:e6:9c:
+    f6:b4:0e:f4:fb:6a:7f:a7:7b:3f:fe:6c:0b:d6:da:
+    c4:9d:ef:59:72:da:0e:14:4f:e2:37:78:b0:34:00:
+    58:05:48:cb:0d:e8:c6:67:6f:2b:76:20:5f:93:36:
+    bc:6e:1b:b0:6d:67:fd:67:71:4c:18:08:73:52:95:
+    59:11:39:f3:4c:73:93:37:57:53:5d:30:32:75:99:
+    46:a1:b9:d8:84:86:32:5c:0d:93:95:46:f4:17:3f:
+    38:15:ac:eb:eb:51:79:68
 -----BEGIN RSA PRIVATE KEY-----
-MIIEogIBAAKCAQEAlDv8GH4J1pMQmtffhEl0fZoOkf8xyp/AwM9Kax6+d7CCn6YX
-/POZ8eXtxNPh9Oju0nA7mLEhVZqebYnxgrqCQwCv5gV+D6FQ/+x3iCiSovD5KR3L
-hspjqceeAZluVsg58cYzubSWsgVe4fccVVgj7L27TaBUPAnQyYMnmzz1UIweVCKz
-Cg+XwWjVB7cNuRbW+NAshyVeU2Ux1daUq4t3KaJ4TsfPZvJ58mbKzsmaBKINR2+g
-HMw5ffIBcz2cVg8V9gaSmBmbUu1D+IRsH5YL3Y7HD9wTCHsaB8Gs3rrczhuoxcXV
-yGwyauIsquJWulW0PCt/h5k+0AxHum5ghis9UQIDAQABAoIBAAthr7GRu9+l2xiI
-irj1iuQ59/Rty7zrFzm2sNgYvDckbmMjtaPOcHuKU/9Q5YCQggXWaD0JHK4d+Rwg
-A1MuTuImI1teAJfiov2DgooJ03h/WCI4D3CCCbT3hsJIrZgsN4bA2SfhHdD9aJOh
-DaPf6KI8zyzeqpkRh95xG5Fn1M4iViejfU1YXNN2gFS2KO1g57rv2kr1hrn3fsWU
-X4dV0FxrjOpOgso9vCO1HHdMvVeY2x/srw1w4KD6htaszy+iVSQumGCw9c9g27+X
-uOLAHwO1XK/O/Vsrl83V65XvF7wZaVoSHygk0o7NkY+QfFS/MXW9ZjHrYSCxf187
-Oq9IjYECgYEAwvJ5ZW7VYb3gavtniboj+tvk/A9YnmM3xK3YgMamP5sgpXBIIPQ3
-8zYBj0f/AP62UGpW9Ag3Cg9/KEJg+AGpUzcpnCSDFBzDVrkYM1pEmf64q0UmcbfF
-HlahSTxxW7XBfLtkaP6vJD1gauve11gdvf9Wkl8F5o9XiF5xCM4S5a0CgYEAwqhl
-FWYHohR1F6vt9PXmzAtwau6m0D5pN5ToP0EC8XCY9FoNDnX1N0xoessa8ldpXF23
-c86VSJIaiiwzCKGmOuJ9FjvC94Zo2hiU5Z4yBDGkBy3UTIzl23dy79nowg1OF4N9
-CcXfgzU7vDGupPfQRPGYfa0tCK52ESDXzTaBgrUCgYBoFm8a6YKlHWylsnYl420y
-lBY/PzJh3zf3m5rtpyM88ucLblgUwFDfWwaaKibNsTJG3YBv67L3fC64oDiGMtzl
-wZ5F8HjMVE84DrwNLzVRw992EwXj0es9t6OGJu+ft/wHTUbfiJybDOpeLHJfKH04
-5QykOng8Emz6MvLHcMBGQQKBgEzyJ9MHm+jT0V1kFxIHyg3KT8vVPpd+tDTGZe/r
-EPDDo5KjrhmTQzVyvLIday90oi9i1Euw0432QwtvYVT+ISmRsgSB5xXVSck8gk8p
-83d47+/ui8cewxW35/Ur3Dgo7j+ZOGoOj8Xb2xsPQIvxcaBvJ+o19GFEJWOr6eIy
-s4spAoGADa42lcmis2o91DgBzuQQ2ukOxVjdD8+erM38aJskbFh2K3hX7wPl2dbo
-mhWeFcghjDQZmnzjv92hwN2tUGkq2DZgssCzqxQZ+U6LsfksXCiczmR0B4AgFeGh
-ttyPKr69IPBiIk4Doqqg/Ua/4YkwrBoJCv5bINVZcqHOdTKocLQ=
+MIIEogIBAAKCAQEAxH+23auoWH9JSJ29b5Ga6ryMPCBf7DswTsLFmI5SJ3TZ0Sh+
+agmx/OrSKKdIMLi8kxHoVpO/AoYceBYLuMPOqrEn3saWIPjUjmNYswXG36fr64UU
+mAQO15kXgQwVC8fwvxSljulbiGXptD6fd/R3YN2qdenydQeoRxejefHl6gGAJVpa
+G/uNbhfHuH27Hexnv8mDjygCmYMW9CzwlCUbf/CZ++x1Y4iXLx34vxSSO9/toFYM
+lMaStJHihYjemZMAF7Dx7UUDjwcuWuWCaplvRQBUKjeTdyMGw5n6wR9MWWPhNbn3
+9quBpRHvnKHmZKsv/PnNs9C3M4FMNhMDOl7m5QIDAQABAoIBAAKuIvJ9QypT2s4g
+Aq5j0XW2tStOc2h/j9jfLL6i4FQpR/L4/FfEwpX/0PaHfkNV3b1GzwERT6zAjguw
+R0rRoZRv8//Z/GsTjHirD7xqDYH4TSOVA4h687CKph4B6hk99KwdOLs34SJS5jVp
+w5c+sSXT2DL2tN0rnya7F+UpAMO96TYaGbLfDELQneDEmm5zAPxXxTJi2g5nDrwQ
+3oAXzbw5gNLY2cERwKxtMhE64X1kx9le8MjgP67CiwcK2qgVWOAuwfX1Gk7FvOjH
+Y78ohA0d5I2Mm3R7nyv4up3u1sSf1j2Q1hg0hILSEky+VRNUa9GeOelibzDencIG
+SU14BBECgYEA24U2XjmORrTSqwnbscTZVjzCRJK3YHTnbQd16ni/MoYFcavjrSK1
+cEXnJkkHKpIcoDHDQn56NHKgxTKSZRe/WQpZQdVj6Orfrhvi2Lbru3ZBRSYhrN5N
+cOHUu84wyTujqZaVeiGja6Hq4hIH2Q4AJiTukSqlae3UHAPFnYA1X5UCgYEA5Scg
+lKDxNj+X6obtTCGPIysJSX1YSJ/ERD+LZ0vUHsKH/AnGBtOLguIXlaaJfN9DLFv+
+u+qFMqdZ60ExgebSiugfZZ7dkVV1UgnlkGpEIplH5le7+ebf8kKw3RqPbJMEcDWp
+OwWpBHhalzlT0kw9dJrRNkyYmxq6HEbQRl351hECgYAnrc6D/ZdQBINH00JYwaIf
+SmA7EOIAl2D1fjG8LhMxSLRXNaCzvOBa6Oe9LdoTwdFWy2fl7wKb1FRnEJsRltdJ
+eutjUPT8NugzimrYjUfS3K8zlo7jtlL9InTXdY+v8A3HK6bdKpNlcyEHuAafHz67
+plVQ/ApmOUzru2rO60u6eQKBgF//Xz/EmKhwRbUjZz/Qg0VpXw+hah2qiK9Kq5zP
+gIKOXidw9LuhXb2r99NinBBq+5oWxAV3Puu0fg/3FMVlrGgyzAxnXEzpLyf6K2iv
+i/GuoxdVQ9NyK/kyhSNrYBBNGrvjTw0B1wefX9wgUQQ1mj1CKkkEF55KuRLle5Uv
+A13xAoGAVrlo7paOIN+c5TwpQaDpMo+h6d4axeLNxgy3Y+ac9rQO9Ptqf6d7P/5s
+C9baxJ3vWXLaDhRP4jd4sDQAWAVIyw3oxmdvK3YgX5M2vG4bsG1n/WdxTBgIc1KV
+WRE580xzkzdXU10wMnWZRqG52ISGMlwNk5VG9Bc/OBWs6+tReWg=
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/signed.pem
+++ b/spec/fixtures/ssl/signed.pem
@@ -6,61 +6,62 @@ Certificate:
         Issuer: CN=Test CA Subauthority
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Jun 15 01:19:37 2031 GMT
+            Not After : Jun 24 21:18:00 2033 GMT
         Subject: CN=signed
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                RSA Public-Key: (2048 bit)
+                Public-Key: (2048 bit)
                 Modulus:
-                    00:94:3b:fc:18:7e:09:d6:93:10:9a:d7:df:84:49:
-                    74:7d:9a:0e:91:ff:31:ca:9f:c0:c0:cf:4a:6b:1e:
-                    be:77:b0:82:9f:a6:17:fc:f3:99:f1:e5:ed:c4:d3:
-                    e1:f4:e8:ee:d2:70:3b:98:b1:21:55:9a:9e:6d:89:
-                    f1:82:ba:82:43:00:af:e6:05:7e:0f:a1:50:ff:ec:
-                    77:88:28:92:a2:f0:f9:29:1d:cb:86:ca:63:a9:c7:
-                    9e:01:99:6e:56:c8:39:f1:c6:33:b9:b4:96:b2:05:
-                    5e:e1:f7:1c:55:58:23:ec:bd:bb:4d:a0:54:3c:09:
-                    d0:c9:83:27:9b:3c:f5:50:8c:1e:54:22:b3:0a:0f:
-                    97:c1:68:d5:07:b7:0d:b9:16:d6:f8:d0:2c:87:25:
-                    5e:53:65:31:d5:d6:94:ab:8b:77:29:a2:78:4e:c7:
-                    cf:66:f2:79:f2:66:ca:ce:c9:9a:04:a2:0d:47:6f:
-                    a0:1c:cc:39:7d:f2:01:73:3d:9c:56:0f:15:f6:06:
-                    92:98:19:9b:52:ed:43:f8:84:6c:1f:96:0b:dd:8e:
-                    c7:0f:dc:13:08:7b:1a:07:c1:ac:de:ba:dc:ce:1b:
-                    a8:c5:c5:d5:c8:6c:32:6a:e2:2c:aa:e2:56:ba:55:
-                    b4:3c:2b:7f:87:99:3e:d0:0c:47:ba:6e:60:86:2b:
-                    3d:51
+                    00:c4:7f:b6:dd:ab:a8:58:7f:49:48:9d:bd:6f:91:
+                    9a:ea:bc:8c:3c:20:5f:ec:3b:30:4e:c2:c5:98:8e:
+                    52:27:74:d9:d1:28:7e:6a:09:b1:fc:ea:d2:28:a7:
+                    48:30:b8:bc:93:11:e8:56:93:bf:02:86:1c:78:16:
+                    0b:b8:c3:ce:aa:b1:27:de:c6:96:20:f8:d4:8e:63:
+                    58:b3:05:c6:df:a7:eb:eb:85:14:98:04:0e:d7:99:
+                    17:81:0c:15:0b:c7:f0:bf:14:a5:8e:e9:5b:88:65:
+                    e9:b4:3e:9f:77:f4:77:60:dd:aa:75:e9:f2:75:07:
+                    a8:47:17:a3:79:f1:e5:ea:01:80:25:5a:5a:1b:fb:
+                    8d:6e:17:c7:b8:7d:bb:1d:ec:67:bf:c9:83:8f:28:
+                    02:99:83:16:f4:2c:f0:94:25:1b:7f:f0:99:fb:ec:
+                    75:63:88:97:2f:1d:f8:bf:14:92:3b:df:ed:a0:56:
+                    0c:94:c6:92:b4:91:e2:85:88:de:99:93:00:17:b0:
+                    f1:ed:45:03:8f:07:2e:5a:e5:82:6a:99:6f:45:00:
+                    54:2a:37:93:77:23:06:c3:99:fa:c1:1f:4c:59:63:
+                    e1:35:b9:f7:f6:ab:81:a5:11:ef:9c:a1:e6:64:ab:
+                    2f:fc:f9:cd:b3:d0:b7:33:81:4c:36:13:03:3a:5e:
+                    e6:e5
                 Exponent: 65537 (0x10001)
     Signature Algorithm: sha256WithRSAEncryption
-         0a:bb:98:88:03:a0:98:98:74:30:d6:fd:27:ee:e9:52:51:14:
-         c8:27:d9:4c:e6:83:c6:ca:dc:7f:c1:9e:81:ab:6f:d2:1c:f5:
-         e9:ec:39:d5:24:2f:9b:43:15:47:6a:be:f4:fa:65:ad:08:ac:
-         be:5b:f9:3e:c1:4b:74:d6:d5:72:23:74:5e:87:b2:df:e2:f8:
-         e3:94:07:14:a5:5c:a6:69:0c:48:1d:ac:bd:2d:85:e2:5c:41:
-         9d:02:29:13:d1:30:05:2c:d2:f7:15:91:e5:70:de:5e:16:f1:
-         1c:c6:62:d3:2b:92:2a:69:40:74:23:60:e6:ce:6c:65:3a:22:
-         1b:66:c7:53:c9:07:95:29:fd:8f:d0:02:e4:a2:e4:72:2e:38:
-         54:3d:60:ad:6e:35:83:cc:f8:9d:db:fd:e9:68:21:42:db:7a:
-         58:db:c3:bc:bc:e9:a7:d4:6b:b9:b0:24:eb:e2:9d:d7:4d:61:
-         a7:0c:57:0c:f1:12:2f:48:a7:1b:e6:f9:37:32:10:56:5a:78:
-         4f:3e:9b:1b:6d:db:01:11:13:31:68:2c:ce:a5:41:c5:36:3d:
-         1a:29:3b:15:cd:09:51:82:07:7a:f2:98:0d:bd:dd:2e:02:8d:
-         18:39:2a:ee:5b:9b:c8:49:71:3a:2b:38:07:c0:3a:03:cf:67:
-         b4:ff:c9:97
+    Signature Value:
+        a5:35:e3:d1:e0:28:58:6d:a9:cb:9c:34:e8:1d:4a:a6:98:bd:
+        8c:25:07:56:93:bc:03:14:bd:5c:88:e7:dd:a8:84:64:6c:9f:
+        7e:78:7f:b2:cb:1c:a7:c5:6d:30:3e:9b:61:88:4a:94:80:6c:
+        35:09:23:0c:e2:1e:67:08:13:f6:a9:71:0c:b4:9b:38:b4:20:
+        83:18:83:3c:ae:ad:31:b1:9b:2e:29:30:60:e8:7a:bb:53:41:
+        cc:7c:f7:ed:e7:9f:3a:0a:18:5a:9f:01:c8:f7:27:18:11:28:
+        1c:40:a2:e1:58:74:0a:13:e9:f7:67:e8:df:07:44:cf:c8:71:
+        ad:90:ad:3d:7b:8a:1f:23:63:8d:c4:7f:be:d8:f1:ad:59:28:
+        ab:be:f9:84:dd:3b:77:97:29:63:56:99:60:1d:1f:5c:ac:d2:
+        a3:74:50:4b:04:46:ba:37:3c:a2:99:40:33:34:a4:b5:d6:a6:
+        02:47:bb:2d:cb:a9:4a:a4:53:85:bc:6c:d7:7e:54:d0:d4:96:
+        31:99:74:55:08:b3:15:62:c0:25:51:04:58:f9:33:24:80:fa:
+        80:5e:4a:3c:d1:b5:41:00:39:20:d1:e3:c7:14:a6:fb:fc:64:
+        17:be:97:aa:06:88:01:1e:0e:fd:b6:97:f8:6a:3a:0c:9c:bc:
+        8f:6d:a3:9b
 -----BEGIN CERTIFICATE-----
 MIICqTCCAZGgAwIBAgIBBDANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0
-IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zMTA2MTUwMTE5Mzda
+IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zMzA2MjQyMTE4MDBa
 MBExDzANBgNVBAMMBnNpZ25lZDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC
-ggEBAJQ7/Bh+CdaTEJrX34RJdH2aDpH/McqfwMDPSmsevnewgp+mF/zzmfHl7cTT
-4fTo7tJwO5ixIVWanm2J8YK6gkMAr+YFfg+hUP/sd4gokqLw+Skdy4bKY6nHngGZ
-blbIOfHGM7m0lrIFXuH3HFVYI+y9u02gVDwJ0MmDJ5s89VCMHlQiswoPl8Fo1Qe3
-DbkW1vjQLIclXlNlMdXWlKuLdymieE7Hz2byefJmys7JmgSiDUdvoBzMOX3yAXM9
-nFYPFfYGkpgZm1LtQ/iEbB+WC92Oxw/cEwh7GgfBrN663M4bqMXF1chsMmriLKri
-VrpVtDwrf4eZPtAMR7puYIYrPVECAwEAATANBgkqhkiG9w0BAQsFAAOCAQEACruY
-iAOgmJh0MNb9J+7pUlEUyCfZTOaDxsrcf8Gegatv0hz16ew51SQvm0MVR2q+9Ppl
-rQisvlv5PsFLdNbVciN0Xoey3+L445QHFKVcpmkMSB2svS2F4lxBnQIpE9EwBSzS
-9xWR5XDeXhbxHMZi0yuSKmlAdCNg5s5sZToiG2bHU8kHlSn9j9AC5KLkci44VD1g
-rW41g8z4ndv96WghQtt6WNvDvLzpp9RrubAk6+Kd101hpwxXDPESL0inG+b5NzIQ
-Vlp4Tz6bG23bARETMWgszqVBxTY9Gik7Fc0JUYIHevKYDb3dLgKNGDkq7lubyElx
-Ois4B8A6A89ntP/Jlw==
+ggEBAMR/tt2rqFh/SUidvW+Rmuq8jDwgX+w7ME7CxZiOUid02dEofmoJsfzq0iin
+SDC4vJMR6FaTvwKGHHgWC7jDzqqxJ97GliD41I5jWLMFxt+n6+uFFJgEDteZF4EM
+FQvH8L8UpY7pW4hl6bQ+n3f0d2DdqnXp8nUHqEcXo3nx5eoBgCVaWhv7jW4Xx7h9
+ux3sZ7/Jg48oApmDFvQs8JQlG3/wmfvsdWOIly8d+L8Ukjvf7aBWDJTGkrSR4oWI
+3pmTABew8e1FA48HLlrlgmqZb0UAVCo3k3cjBsOZ+sEfTFlj4TW59/argaUR75yh
+5mSrL/z5zbPQtzOBTDYTAzpe5uUCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEApTXj
+0eAoWG2py5w06B1Kppi9jCUHVpO8AxS9XIjn3aiEZGyffnh/ssscp8VtMD6bYYhK
+lIBsNQkjDOIeZwgT9qlxDLSbOLQggxiDPK6tMbGbLikwYOh6u1NBzHz37eefOgoY
+Wp8ByPcnGBEoHECi4Vh0ChPp92fo3wdEz8hxrZCtPXuKHyNjjcR/vtjxrVkoq775
+hN07d5cpY1aZYB0fXKzSo3RQSwRGujc8oplAMzSktdamAke7LcupSqRThbxs135U
+0NSWMZl0VQizFWLAJVEEWPkzJID6gF5KPNG1QQA5INHjxxSm+/xkF76XqgaIAR4O
+/baX+Go6DJy8j22jmw==
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/tampered-cert.pem
+++ b/spec/fixtures/ssl/tampered-cert.pem
@@ -1,66 +1,67 @@
 Certificate:
     Data:
         Version: 3 (0x2)
-        Serial Number: 12 (0xc)
+        Serial Number: 13 (0xd)
         Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA Subauthority
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Jun 15 01:19:37 2031 GMT
+            Not After : Jun 24 21:18:00 2033 GMT
         Subject: CN=signed
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                RSA Public-Key: (2048 bit)
+                Public-Key: (2048 bit)
                 Modulus:
-                    00:e5:d1:41:c2:76:00:ff:d2:26:73:88:6b:06:e8:
-                    4e:6e:f6:76:b0:94:bf:71:b4:26:1b:1d:05:e9:ea:
-                    b2:e9:8b:cf:81:8d:93:3e:82:27:a0:ef:61:b6:78:
-                    e3:5a:70:58:b0:56:ed:2f:3c:fd:80:67:e7:a7:49:
-                    39:c0:3f:a8:f1:15:86:e3:b6:9b:d8:5d:af:e3:9c:
-                    b1:e3:dc:4a:81:60:60:f8:7d:ef:01:4e:84:5c:64:
-                    64:35:bb:52:8f:d9:d0:c4:74:90:a4:27:ab:0d:2e:
-                    df:1c:1d:9e:62:43:4e:f5:e4:04:a7:9e:45:6d:61:
-                    11:e5:ff:9d:fe:8a:5e:55:19:96:ed:de:a4:a0:f5:
-                    44:ea:14:06:af:8b:eb:62:c6:f5:78:27:36:3b:e6:
-                    9d:fc:65:b3:57:5a:52:b1:e9:f6:4a:13:a4:fa:8a:
-                    dc:60:8a:a3:8e:15:db:24:8c:61:03:62:ea:6a:a4:
-                    b6:47:82:8d:34:48:5b:0e:bb:0f:5d:3e:9d:05:38:
-                    f8:6c:da:01:45:66:19:bc:a9:a1:5d:f5:42:1d:12:
-                    5e:b1:93:12:db:87:19:06:35:b6:39:18:b9:d1:c8:
-                    dc:9e:3f:d6:28:b1:07:cf:e0:af:bc:19:bd:50:e2:
-                    0f:f6:36:77:a9:84:b7:08:92:f4:47:9a:f5:ea:73:
-                    46:c5
+                    00:8e:3c:2d:0d:df:a2:22:72:23:7b:71:32:48:34:
+                    e7:8e:09:7d:ef:da:b3:d6:b9:c7:7b:83:21:07:f0:
+                    1c:ec:a9:80:a1:28:cb:9d:7f:ff:95:d8:c0:06:27:
+                    ee:24:ce:85:3e:4d:3c:5a:d1:fe:42:b9:89:b2:a3:
+                    4c:ff:55:6a:8c:d4:1f:66:79:e4:b9:e2:a0:7b:16:
+                    09:57:98:46:76:c6:ef:5b:69:7c:99:39:ee:e7:39:
+                    cf:09:ca:c6:05:da:fe:9b:0f:c9:0c:27:a8:5a:bd:
+                    e7:71:e5:e1:16:1a:3e:ec:ea:78:82:4d:da:db:63:
+                    3b:96:6f:f6:21:25:7c:28:b8:a6:7a:de:19:a2:1d:
+                    1d:95:5f:f8:16:3d:11:3c:c6:59:88:dc:e5:52:70:
+                    e6:ae:f8:ba:9a:7b:7a:07:c4:d1:cb:7b:2e:4f:5b:
+                    28:40:ca:6f:88:62:e4:2b:2c:a2:65:01:f9:68:81:
+                    2b:bf:b0:41:90:8f:2f:09:24:51:9a:a7:77:cb:a4:
+                    6a:a6:52:12:0f:1d:35:10:c5:05:02:cf:7f:c6:08:
+                    39:bf:2c:a7:90:0b:1b:5e:04:30:95:21:3c:e4:2e:
+                    c5:98:a4:d3:b7:2d:9a:77:3b:8a:75:11:9c:a6:d8:
+                    f5:b7:6f:17:93:18:22:9b:50:fa:e5:b3:e7:be:94:
+                    14:c3
                 Exponent: 65537 (0x10001)
     Signature Algorithm: sha256WithRSAEncryption
-         4c:37:72:d9:ee:d3:8a:75:a6:f8:36:01:50:95:e6:75:a7:b0:
-         67:14:a6:88:ab:e3:a3:ea:c4:5c:20:2b:12:e4:8a:fb:9d:88:
-         33:1e:17:dc:91:bc:4a:dc:45:b9:ac:88:67:db:ba:12:ec:4d:
-         9b:b1:58:87:ef:af:b6:be:1a:4b:44:0e:7c:70:68:50:90:93:
-         db:a2:ee:73:2b:75:cc:27:8f:60:11:15:c6:19:7b:12:d3:43:
-         68:63:02:d3:2c:10:37:2a:f1:fe:6f:46:45:d4:81:15:0b:93:
-         0d:ae:6f:23:4f:71:e8:42:45:f7:3d:f8:56:66:79:91:06:3b:
-         01:71:f6:1f:dd:e7:59:a1:c5:48:35:a4:80:b6:40:14:20:47:
-         85:21:92:3a:83:19:ba:bd:b5:ab:ab:92:c6:a7:f2:f0:e6:d6:
-         00:fd:ec:91:34:46:72:bf:57:ec:c0:d8:68:4c:19:89:6d:4f:
-         a2:51:e8:a6:6f:b1:a1:ff:b0:55:46:b7:cc:51:39:38:ba:c2:
-         22:b2:57:19:02:f4:00:92:bc:ad:2b:e3:43:2b:1a:f2:36:55:
-         1f:c7:97:4b:0f:65:8e:33:00:e8:ed:44:56:82:b5:8b:57:dc:
-         bd:a6:c5:61:86:49:9a:82:a5:e5:8c:01:62:9d:18:cb:9e:05:
-         d3:03:51:50
+    Signature Value:
+        54:ba:cd:b4:a4:c0:c8:be:3b:bc:f1:4b:ac:f4:25:50:0f:bb:
+        ed:95:f5:fa:c7:09:95:47:9a:26:40:36:31:99:a9:31:ed:30:
+        4c:58:64:66:77:03:3e:e8:9c:9a:af:98:26:41:c2:4c:0a:48:
+        36:f9:fb:95:68:d1:ce:3e:3d:1c:05:dd:9e:b5:91:3a:15:e5:
+        99:49:5a:16:94:37:10:6e:0d:c5:8e:86:ba:08:44:01:e6:5a:
+        a2:4a:46:2c:03:8a:65:86:b1:04:78:d7:0d:fc:94:a2:ba:96:
+        fa:a7:fa:9f:e7:02:91:40:01:54:b2:49:1c:80:33:9d:82:d7:
+        61:0c:b7:0b:50:f7:bf:46:89:de:c7:c8:c4:ae:c7:41:0d:2b:
+        c5:f7:77:b5:a0:b4:cc:79:87:1a:db:8a:a1:38:09:44:b7:9c:
+        cf:5e:4f:4e:0a:55:2d:55:2c:52:94:d7:08:c5:51:9d:1c:1d:
+        7a:8f:fe:2a:62:73:2d:9b:4d:96:66:fb:67:7a:dc:a1:ed:d3:
+        ce:b4:a1:99:f2:59:d8:2e:54:4b:83:6d:a8:47:10:57:ad:dc:
+        ea:ea:9e:db:03:71:46:8a:6a:43:16:31:6d:55:ff:70:0d:2c:
+        eb:48:fa:65:1b:69:d4:df:ad:70:2a:af:6f:d3:dd:96:87:0a:
+        1a:78:0a:ab
 -----BEGIN CERTIFICATE-----
-MIICqTCCAZGgAwIBAgIBDDANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0
-IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zMTA2MTUwMTE5Mzda
+MIICqTCCAZGgAwIBAgIBDTANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0
+IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zMzA2MjQyMTE4MDBa
 MBExDzANBgNVBAMMBnNpZ25lZDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC
-ggEBAOXRQcJ2AP/SJnOIawboTm72drCUv3G0JhsdBenqsumLz4GNkz6CJ6DvYbZ4
-41pwWLBW7S88/YBn56dJOcA/qPEVhuO2m9hdr+OcsePcSoFgYPh97wFOhFxkZDW7
-Uo/Z0MR0kKQnqw0u3xwdnmJDTvXkBKeeRW1hEeX/nf6KXlUZlu3epKD1ROoUBq+L
-62LG9XgnNjvmnfxls1daUrHp9koTpPqK3GCKo44V2ySMYQNi6mqktkeCjTRIWw67
-D10+nQU4+GzaAUVmGbypoV31Qh0SXrGTEtuHGQY1tjkYudHI3J4/1iixB8/gr7wZ
-vVDiD/Y2d6mEtwiS9Eea9epzRsUCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEATDdy
-2e7TinWm+DYBUJXmdaewZxSmiKvjo+rEXCArEuSK+52IMx4X3JG8StxFuayIZ9u6
-EuxNm7FYh++vtr4aS0QOfHBoUJCT26Lucyt1zCePYBEVxhl7EtNDaGMC0ywQNyrx
-/m9GRdSBFQuTDa5vI09x6EJF9z34VmZ5kQY7AXH2H93nWaHFSDWkgLZAFCBHhSGS
-OoMZur21q6uSxqfy8ObWAP3skTRGcr9X7MDYaEwZiW1PolHopm+xof+wVUa3zFE5
-OLrCIrJXGQL0AJK8rSvjQysa8jZVH8eXSw9ljjMA6O1EVoK1i1fcvabFYYZJmoKl
-5YwBYp0Yy54F0wNRUA==
+ggEBAI48LQ3foiJyI3txMkg0544Jfe/as9a5x3uDIQfwHOypgKEoy51//5XYwAYn
+7iTOhT5NPFrR/kK5ibKjTP9VaozUH2Z55LnioHsWCVeYRnbG71tpfJk57uc5zwnK
+xgXa/psPyQwnqFq953Hl4RYaPuzqeIJN2ttjO5Zv9iElfCi4pnreGaIdHZVf+BY9
+ETzGWYjc5VJw5q74upp7egfE0ct7Lk9bKEDKb4hi5CssomUB+WiBK7+wQZCPLwkk
+UZqnd8ukaqZSEg8dNRDFBQLPf8YIOb8sp5ALG14EMJUhPOQuxZik07ctmnc7inUR
+nKbY9bdvF5MYIptQ+uWz576UFMMCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAVLrN
+tKTAyL47vPFLrPQlUA+77ZX1+scJlUeaJkA2MZmpMe0wTFhkZncDPuicmq+YJkHC
+TApINvn7lWjRzj49HAXdnrWROhXlmUlaFpQ3EG4NxY6GughEAeZaokpGLAOKZYax
+BHjXDfyUorqW+qf6n+cCkUABVLJJHIAznYLXYQy3C1D3v0aJ3sfIxK7HQQ0rxfd3
+taC0zHmHGtuKoTgJRLecz15PTgpVLVUsUpTXCMVRnRwdeo/+KmJzLZtNlmb7Z3rc
+oe3TzrShmfJZ2C5US4NtqEcQV63c6uqe2wNxRopqQxYxbVX/cA0s60j6ZRtp1N+t
+cCqvb9PdlocKGngKqw==
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/tampered-csr.pem
+++ b/spec/fixtures/ssl/tampered-csr.pem
@@ -1,60 +1,62 @@
 Certificate Request:
     Data:
-        Version: 3 (0x2)
+        Version: Unknown (2)
         Subject: CN=signed
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                RSA Public-Key: (2048 bit)
+                Public-Key: (2048 bit)
                 Modulus:
-                    00:d1:3e:20:3f:c0:5e:64:78:1f:f6:a8:60:c7:c8:
-                    0d:7b:a7:c9:c1:f5:7e:c2:76:b7:cc:0f:c2:77:e4:
-                    ba:3d:41:81:dc:b3:a1:9a:de:83:6c:80:29:78:17:
-                    b9:cf:2b:0e:b5:5e:74:04:e5:c6:ad:66:4a:cf:6f:
-                    f8:ec:1c:41:c9:c0:4a:28:74:17:1f:85:1f:11:d2:
-                    5a:36:c0:bd:08:a3:72:ba:00:1e:d7:f8:fd:44:23:
-                    21:b7:ba:67:7c:fc:c1:5c:ac:fe:ce:d7:72:8b:17:
-                    3a:2b:0f:a0:d6:d3:2f:ed:6d:28:e9:00:f7:a4:4d:
-                    4a:cd:42:e3:fe:6f:44:7a:cd:69:bb:50:90:51:4d:
-                    83:ad:04:5d:91:48:2b:7a:86:29:4d:19:5a:03:98:
-                    8c:e9:12:61:99:db:6b:c6:ca:f7:e5:e0:c5:0c:63:
-                    fb:d9:d0:f7:7e:ea:e2:38:e5:8e:13:7e:63:6b:7f:
-                    26:ff:5e:da:a5:bc:0a:b7:80:c9:58:3e:f5:28:5c:
-                    dc:a2:62:56:80:64:30:67:ab:f7:d1:d3:b4:51:61:
-                    51:14:a1:8b:82:ae:35:f9:cd:8b:7e:3b:b1:0d:3c:
-                    6b:7b:aa:50:53:3b:3f:44:1c:51:3b:91:01:d2:c3:
-                    38:31:1a:26:89:ba:8e:58:76:66:fb:4d:02:ff:e6:
-                    dd:1d
+                    00:95:70:64:7f:b5:26:4a:bc:50:e9:46:d1:d9:15:
+                    25:5f:9d:85:68:7b:16:eb:25:ac:84:f7:1d:96:a6:
+                    11:c3:cf:11:94:e4:5b:e5:b4:fe:d3:84:21:18:10:
+                    82:16:71:5d:1d:b8:7f:55:1b:99:65:57:9d:25:ea:
+                    e6:75:14:7e:92:ca:d9:2f:14:4b:89:b7:0a:fc:11:
+                    6e:76:5e:30:bc:da:f1:4d:a2:7b:53:aa:21:87:d2:
+                    25:f4:b4:08:d4:3d:a4:5e:f5:88:70:24:3f:ef:5d:
+                    9f:31:41:30:d0:71:5c:af:fc:be:3a:bc:d2:4f:a3:
+                    8d:5d:71:8c:46:67:51:6d:09:ad:3e:5b:86:4c:42:
+                    83:e4:45:35:37:3e:3e:39:52:8a:ea:f1:27:53:6a:
+                    ee:2a:a2:ed:de:e0:63:5b:1d:8c:a1:9c:7e:24:4f:
+                    fe:6e:1f:0d:d3:04:df:ff:42:d5:1a:9d:e1:89:50:
+                    ff:80:c5:1a:23:33:3c:34:8c:91:74:09:99:a1:dc:
+                    a2:16:4f:80:8a:cd:a7:38:ca:fc:ea:b2:af:b7:01:
+                    c6:1b:3a:c6:da:ef:86:72:f9:72:7b:0b:fb:58:e2:
+                    b7:61:9a:ae:20:f1:37:77:d5:f6:f1:ab:19:45:c1:
+                    6e:f4:63:4b:78:c1:71:02:59:0e:e6:4d:5e:1f:88:
+                    1a:69
                 Exponent: 65537 (0x10001)
         Attributes:
-            a0:00
+            (none)
+            Requested Extensions:
     Signature Algorithm: sha256WithRSAEncryption
-         10:3f:46:8b:31:46:fb:0d:a1:00:4a:1e:3c:27:16:92:29:b7:
-         73:a1:2e:69:a0:a3:1b:dc:4c:9f:63:81:ee:02:9b:78:bf:46:
-         94:f4:2a:80:03:5a:da:15:51:91:bc:16:27:61:c7:2f:17:15:
-         c8:af:6e:87:26:bb:1e:8e:32:92:f8:45:1e:86:f6:f1:eb:17:
-         02:11:75:6e:e8:9f:cd:05:d7:43:35:bd:17:42:ef:df:f9:55:
-         cc:a3:3f:4c:dd:f1:9b:2f:10:55:a4:d4:cf:9c:e5:af:85:6a:
-         98:eb:7d:83:e7:68:af:32:7f:d9:90:d7:ed:62:07:6e:47:13:
-         e1:6f:a2:6c:1a:4e:47:7a:f8:10:a9:4e:45:0c:64:39:b5:8d:
-         6f:ff:e6:b0:76:b0:b3:79:4b:a1:fa:26:96:63:7c:c5:58:c9:
-         f9:46:bc:ab:0d:a8:be:e5:c0:29:f8:d1:ca:bc:ca:0b:8e:90:
-         8d:68:50:92:79:30:51:da:58:68:b2:16:1d:e0:1c:e1:1e:f4:
-         4b:aa:8e:14:ac:fc:33:59:c4:23:2f:85:6d:6e:76:cf:fe:04:
-         3d:45:d1:62:e4:68:c5:ff:25:f3:6e:cb:10:21:cc:13:84:e9:
-         e5:53:c2:ca:b5:34:43:38:14:ec:b8:66:3d:69:1c:bc:cb:82:
-         b5:d0:84:ac
+    Signature Value:
+        ac:48:97:68:71:48:98:58:56:c7:4e:3e:28:10:66:09:67:28:
+        b5:e1:09:56:bf:20:76:ea:45:87:2f:48:36:0c:00:1b:4e:5a:
+        43:ca:25:a6:59:70:89:8a:19:7b:93:f9:19:9a:a0:29:57:b6:
+        eb:37:b5:1e:97:83:67:d8:a4:ee:e7:50:fc:5c:92:ff:0a:20:
+        85:f2:5c:82:e4:45:65:e5:9f:1a:e9:9f:24:ce:b6:6a:d4:6a:
+        77:da:65:10:e2:9d:03:d1:0e:9f:73:05:80:06:e4:37:99:70:
+        f7:a1:ee:8e:f2:6e:ac:ec:b2:0b:89:0c:c5:7d:d2:6b:3b:e4:
+        07:70:14:5c:90:3d:27:d6:3d:a6:9f:b4:b8:17:8c:ea:a5:3a:
+        ff:6e:6e:bc:98:02:5d:ae:f8:fe:6f:0c:97:62:36:24:bd:74:
+        7f:2f:61:8a:76:d2:b3:3e:ee:82:75:b8:c8:8f:41:e7:3a:3b:
+        f5:a6:6e:20:0c:f1:ea:2a:ba:17:ba:02:f5:5f:dd:63:06:f1:
+        86:ab:c8:8f:b4:85:e0:68:42:b8:86:32:4e:00:49:ca:a4:59:
+        b7:4a:87:98:39:d2:21:d1:41:7c:3c:25:ae:97:4d:06:82:93:
+        38:6b:9f:b2:d5:96:2f:6f:7b:f0:31:44:be:24:82:48:70:1a:
+        6b:5a:ec:e7
 -----BEGIN CERTIFICATE REQUEST-----
 MIICVjCCAT4CAQIwETEPMA0GA1UEAwwGc2lnbmVkMIIBIjANBgkqhkiG9w0BAQEF
-AAOCAQ8AMIIBCgKCAQEA0T4gP8BeZHgf9qhgx8gNe6fJwfV+wna3zA/Cd+S6PUGB
-3LOhmt6DbIApeBe5zysOtV50BOXGrWZKz2/47BxBycBKKHQXH4UfEdJaNsC9CKNy
-ugAe1/j9RCMht7pnfPzBXKz+ztdyixc6Kw+g1tMv7W0o6QD3pE1KzULj/m9Ees1p
-u1CQUU2DrQRdkUgreoYpTRlaA5iM6RJhmdtrxsr35eDFDGP72dD3furiOOWOE35j
-a38m/17apbwKt4DJWD71KFzcomJWgGQwZ6v30dO0UWFRFKGLgq41+c2LfjuxDTxr
-e6pQUzs/RBxRO5EB0sM4MRomibqOWHZm+00C/+bdHQIDAQABoAAwDQYJKoZIhvcN
-AQELBQADggEBABA/RosxRvsNoQBKHjwnFpIpt3OhLmmgoxvcTJ9jge4Cm3i/RpT0
-KoADWtoVUZG8Fidhxy8XFcivbocmux6OMpL4RR6G9vHrFwIRdW7on80F10M1vRdC
-79/5VcyjP0zd8ZsvEFWk1M+c5a+FapjrfYPnaK8yf9mQ1+1iB25HE+FvomwaTkd6
-+BCpTkUMZDm1jW//5rB2sLN5S6H6JpZjfMVYyflGvKsNqL7lwCn40cq8yguOkI1o
-UJJ5MFHaWGiyFh3gHOEe9EuqjhSs/DNZxCMvhW1uds/+BD1F0WLkaMX/JfNuyxAh
-zBOE6eVTwsq1NEM4FOy4Zj1pHLzLgrXQhKw=
+AAOCAQ8AMIIBCgKCAQEAlXBkf7UmSrxQ6UbR2RUlX52FaHsW6yWshPcdlqYRw88R
+lORb5bT+04QhGBCCFnFdHbh/VRuZZVedJermdRR+ksrZLxRLibcK/BFudl4wvNrx
+TaJ7U6ohh9Il9LQI1D2kXvWIcCQ/712fMUEw0HFcr/y+OrzST6ONXXGMRmdRbQmt
+PluGTEKD5EU1Nz4+OVKK6vEnU2ruKqLt3uBjWx2MoZx+JE/+bh8N0wTf/0LVGp3h
+iVD/gMUaIzM8NIyRdAmZodyiFk+Ais2nOMr86rKvtwHGGzrG2u+Gcvlyewv7WOK3
+YZquIPE3d9X28asZRcFu9GNLeMFxAlkO5k1eH4gaaQIDAQABoAAwDQYJKoZIhvcN
+AQELBQADggEBAKxIl2hxSJhYVsdOPigQZglnKLXhCVa/IHbqRYcvSDYMABtOWkPK
+JaZZcImKGXuT+RmaoClXtus3tR6Xg2fYpO7nUPxckv8KIIXyXILkRWXlnxrpnyTO
+tmrUanfaZRDinQPRDp9zBYAG5DeZcPeh7o7ybqzssguJDMV90ms75AdwFFyQPSfW
+PaaftLgXjOqlOv9ubryYAl2u+P5vDJdiNiS9dH8vYYp20rM+7oJ1uMiPQec6O/Wm
+biAM8eoquhe6AvVf3WMG8YaryI+0heBoQriGMk4AScqkWbdKh5g50iHRQXw8Ja6X
+TQaCkzhrn7LVli9ve/AxRL4kgkhwGmta7Oc=
 -----END CERTIFICATE REQUEST-----

--- a/spec/fixtures/ssl/unknown-127.0.0.1-key.pem
+++ b/spec/fixtures/ssl/unknown-127.0.0.1-key.pem
@@ -1,117 +1,117 @@
-RSA Private-Key: (2048 bit, 2 primes)
+Private-Key: (2048 bit, 2 primes)
 modulus:
-    00:b4:5f:1a:9d:71:c7:2d:1b:5d:b7:3a:5d:c7:3c:
-    e9:8f:f4:b3:0d:fa:03:91:f1:60:70:e6:6e:8c:e9:
-    bc:12:6e:ef:f0:fb:e1:7b:7f:bf:54:00:8a:4d:96:
-    8c:6b:2c:ad:a9:2a:33:ee:20:ec:ea:18:c2:d0:26:
-    43:d9:5d:2f:15:3a:72:42:b7:28:18:23:9d:ed:6f:
-    fe:f1:6b:66:d4:eb:f8:13:22:ce:48:f8:b3:58:75:
-    2c:ca:4f:30:24:45:a2:9d:bc:bc:3a:da:47:28:82:
-    07:0f:b2:8d:17:17:68:db:89:cc:2c:de:3e:44:d0:
-    d0:09:a8:6c:f6:2d:d9:16:18:8c:35:de:36:ac:83:
-    fe:4f:cb:20:44:f0:0b:7a:a7:64:12:b1:aa:5d:74:
-    87:95:0e:38:42:4f:68:7e:48:66:31:5f:aa:43:ae:
-    25:db:f0:56:73:89:72:11:fe:13:7c:09:e0:50:3a:
-    d3:53:95:90:a7:e6:7d:59:f5:dc:6c:00:a7:de:7c:
-    b4:23:b5:b7:3e:27:83:c3:89:68:df:0b:1e:8e:df:
-    b9:e7:9b:ff:19:ed:c7:22:b1:e1:66:78:10:12:c8:
-    f9:e8:e6:a7:02:29:8f:a1:33:a0:be:68:90:b3:eb:
-    3c:8e:cd:ef:51:de:5f:ae:4d:2d:50:bd:9d:51:2d:
-    9a:8d
+    00:a1:6e:59:aa:03:84:68:6a:a4:1e:2f:6c:92:b4:
+    4c:2d:bc:7a:65:3a:77:0b:20:06:15:63:70:48:3b:
+    98:08:cb:03:7f:6f:18:be:19:28:e7:7d:e7:3f:f6:
+    c4:c3:02:71:0c:3b:0f:5b:a7:14:36:7b:aa:93:08:
+    16:ec:46:a8:d2:d2:35:78:2c:83:9d:dc:6b:53:27:
+    7d:c6:1d:5d:5a:1b:78:28:ae:c4:86:52:a0:b2:e1:
+    5e:3e:c6:d3:63:2d:a9:f7:cd:8c:1d:bd:d5:88:81:
+    0c:a1:93:9d:36:ca:d7:88:93:30:da:a3:40:40:0e:
+    0b:98:ce:05:4d:de:02:1d:9d:05:8d:c4:ac:8b:28:
+    08:6e:39:1c:66:de:8d:02:27:66:32:96:a5:03:58:
+    7e:d1:ab:bb:f6:42:c2:76:5a:59:ad:b1:4e:c5:fb:
+    93:51:ff:4e:87:c6:74:45:19:55:b9:02:dc:08:4d:
+    12:37:64:1a:e8:3f:14:1b:f7:bc:bf:57:99:b3:bd:
+    6d:87:b6:d9:45:a6:07:24:20:6d:7f:9b:fc:5d:8f:
+    43:9e:b7:fb:ff:8a:b4:d3:11:9e:95:c3:af:7c:a3:
+    09:2d:98:9e:0b:a1:c0:4b:ff:4c:03:41:c1:a2:fe:
+    57:26:6f:1c:39:4d:d9:38:61:02:02:8b:8d:fa:d2:
+    c4:31
 publicExponent: 65537 (0x10001)
 privateExponent:
-    00:ec:bb:e6:32:bf:22:ac:11:3e:ef:3d:ab:d7:d4:
-    1a:b8:d6:72:2b:e5:f8:c9:94:05:00:29:70:ef:81:
-    d7:56:5a:44:92:06:05:ec:11:bf:0c:81:a9:04:2c:
-    94:20:16:83:d7:83:8c:a4:fe:91:f4:ae:8b:02:a7:
-    36:66:13:e7:b7:f4:fe:02:92:62:0d:4c:b1:fa:f1:
-    03:ab:d9:4b:1e:2a:97:6e:86:40:39:86:31:dd:e7:
-    ec:e1:9b:0d:94:8d:d0:e1:36:d5:d6:68:a6:fc:83:
-    ac:c0:ed:98:40:b6:78:e9:ab:f2:4e:f1:62:c8:ef:
-    48:1d:64:f1:9e:2a:8e:c2:6f:41:75:a5:47:35:97:
-    e3:43:9d:ac:87:4d:fe:48:a6:b4:ae:cb:2f:19:9e:
-    1f:1e:37:1b:8c:87:62:c6:f6:0d:05:60:b9:45:d6:
-    62:ab:0d:0d:ed:34:e9:ba:4e:ea:1d:84:6a:77:4c:
-    ad:eb:c9:90:ca:a7:7a:8c:79:f2:85:2e:63:98:2d:
-    40:c3:46:fc:96:17:39:ac:ad:bb:e6:9d:d3:8d:79:
-    74:3f:72:f8:47:d7:8f:ae:54:f7:e5:66:32:42:0d:
-    34:bb:77:ee:fc:a7:23:f7:0d:72:15:49:f1:a3:f2:
-    40:e9:48:20:5a:59:26:a3:c1:7c:90:87:78:78:ae:
-    c1
+    03:e9:0b:e3:f9:e4:d5:b0:ab:9c:0d:93:08:34:b4:
+    d9:b0:c4:98:3a:23:d3:11:aa:04:0f:9e:13:29:da:
+    63:70:23:7c:0d:41:60:ad:74:57:b3:2d:8c:57:9a:
+    69:8c:e0:17:27:41:16:7b:c4:1a:13:c1:cc:80:f8:
+    29:2e:06:fd:e0:58:aa:3a:0d:d0:1f:9c:3b:ed:eb:
+    76:86:94:91:cf:b3:87:ec:bf:d6:ef:1e:74:66:d0:
+    25:1e:24:d5:b4:af:f6:d0:34:52:2e:1c:83:8b:78:
+    b6:5b:40:86:28:c0:b2:ce:b9:f2:b9:dc:9f:10:98:
+    08:52:09:3f:db:1e:5b:00:3e:58:99:c9:14:c1:d2:
+    07:89:cc:ef:ae:00:f6:38:81:e7:38:22:a9:d2:1b:
+    5b:ce:ad:5a:6e:8a:ce:75:9a:77:c5:dd:77:9b:6c:
+    1f:fd:1c:7a:9d:b3:17:30:f5:5d:9f:30:ef:05:b2:
+    a7:4d:92:5c:c3:c2:ba:82:fb:84:b6:77:f5:ac:5c:
+    39:de:7f:8a:be:1a:0f:5c:4c:a9:44:ae:cc:20:6e:
+    db:e7:95:6b:25:50:89:72:27:4b:2d:68:7e:7d:29:
+    5d:81:8b:9f:f5:19:ff:ee:ef:16:58:1c:8a:db:7e:
+    35:05:b9:b1:6c:78:4a:33:d2:1d:0f:62:ff:7b:bc:
+    e1
 prime1:
-    00:da:16:0f:12:2c:5b:07:2c:d8:de:91:ad:e7:72:
-    23:56:aa:e8:9c:a9:c3:ba:31:da:a1:a3:78:54:3e:
-    4f:94:ca:f7:bd:f7:91:54:4e:67:14:e0:15:cd:2a:
-    da:ae:e4:7f:b3:43:03:31:e1:6d:5c:85:4c:55:e9:
-    1c:e8:7c:48:1b:ef:b6:37:5d:35:bb:48:a9:23:a1:
-    53:7e:57:cf:47:cc:d9:7e:1a:49:ce:33:b9:cf:48:
-    5e:3f:6c:dd:df:5f:66:80:5f:31:5f:fa:8b:57:38:
-    62:08:68:6e:ad:97:56:fd:07:29:f0:2c:10:ec:5f:
-    68:48:4e:76:43:8d:d1:04:27
+    00:d9:99:ee:70:ef:a3:d8:c3:c4:5c:e0:eb:09:dc:
+    27:a7:c2:0c:41:cb:49:9f:cc:68:dc:7b:d2:fb:db:
+    aa:f7:56:cf:e8:68:37:b1:23:cc:8d:7b:49:12:be:
+    e6:11:d7:77:6d:8a:c5:6c:61:73:1d:da:24:61:75:
+    71:d0:d2:2c:d0:90:0f:b5:0a:b8:4c:ce:e3:46:f3:
+    4f:e4:a2:68:46:b9:80:b8:2e:0a:01:21:57:54:8c:
+    d1:f5:4d:ae:ce:eb:ce:d9:04:54:20:3d:c5:83:22:
+    2e:f2:65:2b:c6:e9:d9:7b:ab:a0:b5:c5:40:ee:8b:
+    d5:57:0d:f0:05:5c:40:69:79
 prime2:
-    00:d3:ba:8d:0e:84:11:45:b8:a8:66:29:5e:b2:0f:
-    a4:d2:7b:f9:ea:bc:39:03:af:22:a7:8f:e1:08:96:
-    90:91:69:e3:8b:cd:35:75:bd:34:22:5a:df:31:e7:
-    bb:48:d7:35:f6:35:0d:9d:77:e5:8c:13:32:54:3d:
-    12:7a:cb:d0:3c:1a:88:e3:ad:b7:08:40:dc:fe:c9:
-    e7:20:f1:a2:24:57:e3:f1:58:d2:c9:7c:71:0a:80:
-    80:da:2e:a7:d5:88:87:74:5e:87:0e:4d:44:37:f0:
-    4a:6c:cd:cc:26:f9:9d:78:c7:fe:a2:79:40:1d:38:
-    de:b4:00:be:2e:55:87:d8:2b
+    00:bd:ea:f2:43:42:ad:95:71:8f:09:a0:15:c1:d7:
+    a1:b5:9d:48:b1:6f:e4:1b:bf:ab:fd:0d:47:d3:57:
+    f0:24:46:37:8d:f5:c5:37:80:52:72:65:e1:2a:df:
+    ee:f6:61:fa:9c:7e:e1:1e:60:96:a8:04:54:06:dd:
+    65:e8:1a:f7:8e:d2:30:d7:55:20:82:1a:bd:23:73:
+    c2:95:07:3c:3e:e7:58:7c:10:e6:87:b1:02:a5:69:
+    b1:f4:b2:a4:4a:49:c4:cf:b3:66:a8:4b:af:e6:3d:
+    18:59:69:52:63:b5:59:41:a2:a5:f8:49:ef:73:cc:
+    37:1d:df:52:3b:50:f7:ba:79
 exponent1:
-    29:6a:93:06:22:82:4f:04:87:53:0d:5b:77:5e:c7:
-    b3:47:d5:d1:1a:b4:5f:01:e4:c1:59:a8:1a:67:92:
-    f9:70:ea:47:9b:62:70:1e:4b:99:3d:4d:26:9f:82:
-    d4:3f:f4:b8:78:7b:7c:d7:90:cb:47:4d:4d:eb:6d:
-    60:01:6a:38:53:f7:c8:df:dc:ba:6a:7c:24:96:18:
-    a3:1f:cd:ef:96:c9:9f:17:22:f9:13:fd:af:8d:d0:
-    c8:3e:c6:8c:0b:34:0e:21:05:e1:72:55:50:05:17:
-    28:fd:9c:37:3f:4c:77:d5:0a:73:e0:0a:7e:b9:47:
-    b6:a3:9f:f6:08:52:af:75
+    5a:76:e2:68:55:58:7a:cf:b8:9d:1c:6c:da:a6:8a:
+    5d:f6:10:7e:71:f3:63:d9:e9:66:70:9c:20:55:0c:
+    d8:d3:60:90:30:73:a6:d3:49:41:30:96:0a:93:0e:
+    b7:30:2a:d8:81:ae:de:06:0d:83:c5:a3:06:59:7b:
+    3d:e3:82:fa:1a:4a:4d:6b:ed:7f:11:2b:ef:dd:4b:
+    c3:b3:b9:42:5d:f0:a3:a1:90:4b:33:ff:48:89:5a:
+    e8:6e:a9:54:21:38:d7:84:33:2d:4c:41:06:e9:79:
+    37:10:d4:88:57:c4:30:e4:03:66:4e:61:56:4b:10:
+    20:a7:0c:b8:4d:c8:01:91
 exponent2:
-    00:8c:47:74:3f:a2:d6:c2:c7:e6:a2:d1:54:11:4b:
-    76:1b:92:d2:71:68:c5:a9:a0:36:a8:a8:16:23:97:
-    86:2f:21:e6:05:f1:2f:33:53:e9:1f:bd:ef:54:e4:
-    40:dc:b0:e1:ea:bf:19:c7:33:f1:dd:4d:b6:b1:c3:
-    48:e4:1c:f7:59:6b:07:39:3a:16:23:9c:be:0e:fd:
-    7c:6a:02:4e:38:20:17:41:07:65:98:e3:1f:0e:23:
-    37:bb:d6:df:92:05:84:21:60:a3:c0:a1:06:ca:bd:
-    24:c2:53:d3:a8:1b:07:ef:47:2a:79:41:36:6e:66:
-    08:7f:60:62:a0:d6:40:4b:c3
+    4e:94:e1:4a:fd:52:ef:ab:fe:20:60:71:c0:34:25:
+    c0:0c:e5:60:2d:c8:f7:c6:56:36:ad:81:13:ac:a6:
+    3b:8c:26:3e:81:fb:e9:5c:1a:41:25:70:86:9a:03:
+    b9:44:8f:3a:a3:b1:28:2d:95:08:ce:49:aa:51:7f:
+    72:0b:7e:75:44:f9:5a:8f:e9:94:8b:d5:c8:ce:84:
+    2b:bf:c3:a8:cf:76:a8:57:21:db:f1:5d:03:ee:78:
+    e8:a3:e6:20:aa:e7:59:7d:84:b3:8c:25:ab:21:8a:
+    6a:ac:8e:9f:9d:10:e2:7c:97:29:e6:05:c3:27:33:
+    83:13:bd:65:b7:b9:d9:19
 coefficient:
-    03:04:c6:62:fd:21:9b:5b:d4:95:ea:6c:fd:7d:56:
-    28:09:97:19:ba:b2:12:0d:6c:6f:0b:0d:ed:41:59:
-    c4:6b:5d:67:3d:72:b9:f1:0b:2b:2d:e2:8c:d5:6d:
-    b0:ad:bc:55:32:77:87:60:b7:64:99:58:49:ed:3d:
-    bc:cd:6a:05:51:d3:e0:00:a7:b2:fc:fa:c7:fe:fa:
-    92:69:2e:b2:84:80:56:c7:27:bb:ff:8a:7f:7e:d4:
-    38:b9:75:c3:f3:f5:ec:d6:57:1a:c8:ff:de:35:5e:
-    93:50:20:7c:b4:71:1a:5a:43:3a:20:58:58:e1:58:
-    f0:fb:78:e1:ab:98:c7:ca
+    5a:93:09:c2:93:ac:b7:00:01:72:38:a9:d1:d7:6f:
+    28:48:bd:91:f3:72:af:5c:5a:6f:33:14:45:b4:61:
+    7b:26:ab:1a:2a:44:1c:46:00:1c:56:23:df:2b:38:
+    46:4d:fc:af:42:a7:f6:35:55:df:90:fd:26:33:0d:
+    5a:74:f1:37:20:0b:10:d4:63:5e:54:bd:58:4c:3c:
+    25:18:e3:f2:2d:69:c0:b6:d8:05:b4:4b:10:c0:4f:
+    03:61:9e:eb:4f:a1:c0:82:1c:35:82:fc:43:d9:1d:
+    1a:95:92:62:cd:70:1f:1f:94:6d:76:94:96:69:83:
+    50:89:24:6b:c3:00:c8:4a
 -----BEGIN RSA PRIVATE KEY-----
-MIIEowIBAAKCAQEAtF8anXHHLRtdtzpdxzzpj/SzDfoDkfFgcOZujOm8Em7v8Pvh
-e3+/VACKTZaMayytqSoz7iDs6hjC0CZD2V0vFTpyQrcoGCOd7W/+8Wtm1Ov4EyLO
-SPizWHUsyk8wJEWinby8OtpHKIIHD7KNFxdo24nMLN4+RNDQCahs9i3ZFhiMNd42
-rIP+T8sgRPALeqdkErGqXXSHlQ44Qk9ofkhmMV+qQ64l2/BWc4lyEf4TfAngUDrT
-U5WQp+Z9WfXcbACn3ny0I7W3PieDw4lo3wsejt+555v/Ge3HIrHhZngQEsj56Oan
-AimPoTOgvmiQs+s8js3vUd5frk0tUL2dUS2ajQIDAQABAoIBAADsu+YyvyKsET7v
-PavX1Bq41nIr5fjJlAUAKXDvgddWWkSSBgXsEb8MgakELJQgFoPXg4yk/pH0rosC
-pzZmE+e39P4CkmINTLH68QOr2UseKpduhkA5hjHd5+zhmw2UjdDhNtXWaKb8g6zA
-7ZhAtnjpq/JO8WLI70gdZPGeKo7Cb0F1pUc1l+NDnayHTf5IprSuyy8Znh8eNxuM
-h2LG9g0FYLlF1mKrDQ3tNOm6TuodhGp3TK3ryZDKp3qMefKFLmOYLUDDRvyWFzms
-rbvmndONeXQ/cvhH14+uVPflZjJCDTS7d+78pyP3DXIVSfGj8kDpSCBaWSajwXyQ
-h3h4rsECgYEA2hYPEixbByzY3pGt53IjVqronKnDujHaoaN4VD5PlMr3vfeRVE5n
-FOAVzSraruR/s0MDMeFtXIVMVekc6HxIG++2N101u0ipI6FTflfPR8zZfhpJzjO5
-z0heP2zd319mgF8xX/qLVzhiCGhurZdW/Qcp8CwQ7F9oSE52Q43RBCcCgYEA07qN
-DoQRRbioZilesg+k0nv56rw5A68ip4/hCJaQkWnji801db00IlrfMee7SNc19jUN
-nXfljBMyVD0SesvQPBqI4623CEDc/snnIPGiJFfj8VjSyXxxCoCA2i6n1YiHdF6H
-Dk1EN/BKbM3MJvmdeMf+onlAHTjetAC+LlWH2CsCgYApapMGIoJPBIdTDVt3Xsez
-R9XRGrRfAeTBWagaZ5L5cOpHm2JwHkuZPU0mn4LUP/S4eHt815DLR01N621gAWo4
-U/fI39y6anwklhijH83vlsmfFyL5E/2vjdDIPsaMCzQOIQXhclVQBRco/Zw3P0x3
-1Qpz4Ap+uUe2o5/2CFKvdQKBgQCMR3Q/otbCx+ai0VQRS3YbktJxaMWpoDaoqBYj
-l4YvIeYF8S8zU+kfve9U5EDcsOHqvxnHM/HdTbaxw0jkHPdZawc5OhYjnL4O/Xxq
-Ak44IBdBB2WY4x8OIze71t+SBYQhYKPAoQbKvSTCU9OoGwfvRyp5QTZuZgh/YGKg
-1kBLwwKBgAMExmL9IZtb1JXqbP19VigJlxm6shINbG8LDe1BWcRrXWc9crnxCyst
-4ozVbbCtvFUyd4dgt2SZWEntPbzNagVR0+AAp7L8+sf++pJpLrKEgFbHJ7v/in9+
-1Di5dcPz9ezWVxrI/941XpNQIHy0cRpaQzogWFjhWPD7eOGrmMfK
+MIIEogIBAAKCAQEAoW5ZqgOEaGqkHi9skrRMLbx6ZTp3CyAGFWNwSDuYCMsDf28Y
+vhko533nP/bEwwJxDDsPW6cUNnuqkwgW7Eao0tI1eCyDndxrUyd9xh1dWht4KK7E
+hlKgsuFePsbTYy2p982MHb3ViIEMoZOdNsrXiJMw2qNAQA4LmM4FTd4CHZ0FjcSs
+iygIbjkcZt6NAidmMpalA1h+0au79kLCdlpZrbFOxfuTUf9Oh8Z0RRlVuQLcCE0S
+N2Qa6D8UG/e8v1eZs71th7bZRaYHJCBtf5v8XY9Dnrf7/4q00xGelcOvfKMJLZie
+C6HAS/9MA0HBov5XJm8cOU3ZOGECAouN+tLEMQIDAQABAoIBAAPpC+P55NWwq5wN
+kwg0tNmwxJg6I9MRqgQPnhMp2mNwI3wNQWCtdFezLYxXmmmM4BcnQRZ7xBoTwcyA
++CkuBv3gWKo6DdAfnDvt63aGlJHPs4fsv9bvHnRm0CUeJNW0r/bQNFIuHIOLeLZb
+QIYowLLOufK53J8QmAhSCT/bHlsAPliZyRTB0geJzO+uAPY4gec4IqnSG1vOrVpu
+is51mnfF3XebbB/9HHqdsxcw9V2fMO8FsqdNklzDwrqC+4S2d/WsXDnef4q+Gg9c
+TKlErswgbtvnlWslUIlyJ0staH59KV2Bi5/1Gf/u7xZYHIrbfjUFubFseEoz0h0P
+Yv97vOECgYEA2ZnucO+j2MPEXODrCdwnp8IMQctJn8xo3HvS+9uq91bP6Gg3sSPM
+jXtJEr7mEdd3bYrFbGFzHdokYXVx0NIs0JAPtQq4TM7jRvNP5KJoRrmAuC4KASFX
+VIzR9U2uzuvO2QRUID3FgyIu8mUrxunZe6ugtcVA7ovVVw3wBVxAaXkCgYEAvery
+Q0KtlXGPCaAVwdehtZ1IsW/kG7+r/Q1H01fwJEY3jfXFN4BScmXhKt/u9mH6nH7h
+HmCWqARUBt1l6Br3jtIw11Ugghq9I3PClQc8PudYfBDmh7ECpWmx9LKkSknEz7Nm
+qEuv5j0YWWlSY7VZQaKl+Envc8w3Hd9SO1D3unkCgYBaduJoVVh6z7idHGzapopd
+9hB+cfNj2elmcJwgVQzY02CQMHOm00lBMJYKkw63MCrYga7eBg2DxaMGWXs944L6
+GkpNa+1/ESvv3UvDs7lCXfCjoZBLM/9IiVrobqlUITjXhDMtTEEG6Xk3ENSIV8Qw
+5ANmTmFWSxAgpwy4TcgBkQKBgE6U4Ur9Uu+r/iBgccA0JcAM5WAtyPfGVjatgROs
+pjuMJj6B++lcGkElcIaaA7lEjzqjsSgtlQjOSapRf3ILfnVE+VqP6ZSL1cjOhCu/
+w6jPdqhXIdvxXQPueOij5iCq51l9hLOMJashimqsjp+dEOJ8lynmBcMnM4MTvWW3
+udkZAoGAWpMJwpOstwABcjip0ddvKEi9kfNyr1xabzMURbRheyarGipEHEYAHFYj
+3ys4Rk38r0Kn9jVV35D9JjMNWnTxNyALENRjXlS9WEw8JRjj8i1pwLbYBbRLEMBP
+A2Ge60+hwIIcNYL8Q9kdGpWSYs1wHx+UbXaUlmmDUIkka8MAyEo=
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/unknown-127.0.0.1.pem
+++ b/spec/fixtures/ssl/unknown-127.0.0.1.pem
@@ -6,64 +6,65 @@ Certificate:
         Issuer: CN=Unknown CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Jun 15 01:19:37 2031 GMT
+            Not After : Jun 24 21:18:00 2033 GMT
         Subject: CN=127.0.0.1
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                RSA Public-Key: (2048 bit)
+                Public-Key: (2048 bit)
                 Modulus:
-                    00:b4:5f:1a:9d:71:c7:2d:1b:5d:b7:3a:5d:c7:3c:
-                    e9:8f:f4:b3:0d:fa:03:91:f1:60:70:e6:6e:8c:e9:
-                    bc:12:6e:ef:f0:fb:e1:7b:7f:bf:54:00:8a:4d:96:
-                    8c:6b:2c:ad:a9:2a:33:ee:20:ec:ea:18:c2:d0:26:
-                    43:d9:5d:2f:15:3a:72:42:b7:28:18:23:9d:ed:6f:
-                    fe:f1:6b:66:d4:eb:f8:13:22:ce:48:f8:b3:58:75:
-                    2c:ca:4f:30:24:45:a2:9d:bc:bc:3a:da:47:28:82:
-                    07:0f:b2:8d:17:17:68:db:89:cc:2c:de:3e:44:d0:
-                    d0:09:a8:6c:f6:2d:d9:16:18:8c:35:de:36:ac:83:
-                    fe:4f:cb:20:44:f0:0b:7a:a7:64:12:b1:aa:5d:74:
-                    87:95:0e:38:42:4f:68:7e:48:66:31:5f:aa:43:ae:
-                    25:db:f0:56:73:89:72:11:fe:13:7c:09:e0:50:3a:
-                    d3:53:95:90:a7:e6:7d:59:f5:dc:6c:00:a7:de:7c:
-                    b4:23:b5:b7:3e:27:83:c3:89:68:df:0b:1e:8e:df:
-                    b9:e7:9b:ff:19:ed:c7:22:b1:e1:66:78:10:12:c8:
-                    f9:e8:e6:a7:02:29:8f:a1:33:a0:be:68:90:b3:eb:
-                    3c:8e:cd:ef:51:de:5f:ae:4d:2d:50:bd:9d:51:2d:
-                    9a:8d
+                    00:a1:6e:59:aa:03:84:68:6a:a4:1e:2f:6c:92:b4:
+                    4c:2d:bc:7a:65:3a:77:0b:20:06:15:63:70:48:3b:
+                    98:08:cb:03:7f:6f:18:be:19:28:e7:7d:e7:3f:f6:
+                    c4:c3:02:71:0c:3b:0f:5b:a7:14:36:7b:aa:93:08:
+                    16:ec:46:a8:d2:d2:35:78:2c:83:9d:dc:6b:53:27:
+                    7d:c6:1d:5d:5a:1b:78:28:ae:c4:86:52:a0:b2:e1:
+                    5e:3e:c6:d3:63:2d:a9:f7:cd:8c:1d:bd:d5:88:81:
+                    0c:a1:93:9d:36:ca:d7:88:93:30:da:a3:40:40:0e:
+                    0b:98:ce:05:4d:de:02:1d:9d:05:8d:c4:ac:8b:28:
+                    08:6e:39:1c:66:de:8d:02:27:66:32:96:a5:03:58:
+                    7e:d1:ab:bb:f6:42:c2:76:5a:59:ad:b1:4e:c5:fb:
+                    93:51:ff:4e:87:c6:74:45:19:55:b9:02:dc:08:4d:
+                    12:37:64:1a:e8:3f:14:1b:f7:bc:bf:57:99:b3:bd:
+                    6d:87:b6:d9:45:a6:07:24:20:6d:7f:9b:fc:5d:8f:
+                    43:9e:b7:fb:ff:8a:b4:d3:11:9e:95:c3:af:7c:a3:
+                    09:2d:98:9e:0b:a1:c0:4b:ff:4c:03:41:c1:a2:fe:
+                    57:26:6f:1c:39:4d:d9:38:61:02:02:8b:8d:fa:d2:
+                    c4:31
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Subject Alternative Name: 
                 DNS:127.0.0.1, DNS:127.0.0.2
     Signature Algorithm: sha256WithRSAEncryption
-         41:9d:8f:0b:f2:ab:e2:9e:c1:90:3d:ae:b2:63:2d:94:bb:18:
-         86:84:df:a1:ef:c4:06:70:41:73:59:71:67:f5:0e:58:14:2b:
-         0f:43:65:7b:f0:12:aa:24:f4:4e:33:e7:43:e5:0b:ed:8c:51:
-         5d:9e:a6:51:68:76:3f:e0:4c:f1:09:90:6e:9b:96:ae:03:c5:
-         e1:ca:b8:5c:d8:c5:cd:d5:e8:38:2e:59:78:10:3a:43:b0:3c:
-         07:e5:f3:66:2a:6a:29:9d:81:74:27:a1:86:2a:cc:7f:0a:c4:
-         c4:96:71:b1:08:ba:07:9d:90:28:01:8a:7f:fe:f8:db:f0:fa:
-         45:0b:ed:c5:81:84:96:aa:ce:49:90:99:ca:b2:d2:af:0a:ff:
-         02:a4:4e:fa:5c:5e:d4:60:42:d1:d2:fc:17:b5:aa:c0:e5:8b:
-         d4:e2:26:ee:d2:dc:6a:74:35:c5:67:f3:a7:9a:ed:9d:e2:c2:
-         d0:27:88:12:d2:2f:b1:42:67:bd:17:48:1f:cd:6d:9a:00:ff:
-         0d:ff:02:24:fd:8f:57:1e:d4:87:3e:5d:71:f0:b6:58:6a:46:
-         56:48:aa:94:09:85:a7:54:99:58:8e:a6:a8:ad:43:76:8a:63:
-         e0:45:78:2e:8b:3c:f2:46:e9:a5:0c:0c:2c:8f:57:ac:cf:8d:
-         90:93:26:87
+    Signature Value:
+        4e:fc:85:4d:87:e0:ae:d2:16:d0:1a:a9:cc:83:d5:46:e6:bc:
+        ea:41:ab:59:fb:72:93:f0:2a:71:44:ef:82:8c:4f:1b:67:33:
+        2f:f8:f7:47:10:fc:80:de:d8:4c:33:f6:f9:cc:c6:16:99:3e:
+        5b:d8:33:91:0c:dc:0f:59:45:b4:fe:ae:d0:b3:17:a3:e8:0a:
+        f8:17:0e:84:d6:32:59:ee:3f:57:21:f4:db:ca:79:01:ae:24:
+        56:50:c7:bd:00:12:8c:59:73:47:f3:3a:37:5f:2a:37:48:08:
+        6c:63:d8:e9:9d:8c:bb:18:e7:36:f1:9f:e6:43:47:50:d2:03:
+        30:b2:2e:7c:27:65:79:fe:84:20:da:69:78:fa:ec:8d:8d:ae:
+        a9:82:be:f8:3f:e5:84:8e:3a:37:a5:8b:ed:45:22:ba:d6:1e:
+        2e:6f:a1:ab:e7:aa:7b:1d:28:19:bc:0c:9a:89:9d:94:15:70:
+        70:2b:24:a6:24:4d:79:00:89:7d:51:e2:5f:fa:c6:25:01:dc:
+        8f:e0:72:90:e2:5f:1c:5d:1f:a5:a9:1e:d7:2a:e8:6f:03:69:
+        c8:e6:a9:b5:fe:c7:60:96:a1:e5:18:e7:9e:af:9f:68:6e:52:
+        60:c0:bc:a1:3e:74:51:16:12:3f:a4:53:fc:5d:a1:01:68:31:
+        82:8a:67:c9
 -----BEGIN CERTIFICATE-----
 MIICxzCCAa+gAwIBAgIBATANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDDApVbmtu
-b3duIENBMB4XDTcwMDEwMTAwMDAwMFoXDTMxMDYxNTAxMTkzN1owFDESMBAGA1UE
-AwwJMTI3LjAuMC4xMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtF8a
-nXHHLRtdtzpdxzzpj/SzDfoDkfFgcOZujOm8Em7v8Pvhe3+/VACKTZaMayytqSoz
-7iDs6hjC0CZD2V0vFTpyQrcoGCOd7W/+8Wtm1Ov4EyLOSPizWHUsyk8wJEWinby8
-OtpHKIIHD7KNFxdo24nMLN4+RNDQCahs9i3ZFhiMNd42rIP+T8sgRPALeqdkErGq
-XXSHlQ44Qk9ofkhmMV+qQ64l2/BWc4lyEf4TfAngUDrTU5WQp+Z9WfXcbACn3ny0
-I7W3PieDw4lo3wsejt+555v/Ge3HIrHhZngQEsj56OanAimPoTOgvmiQs+s8js3v
-Ud5frk0tUL2dUS2ajQIDAQABoyMwITAfBgNVHREEGDAWggkxMjcuMC4wLjGCCTEy
-Ny4wLjAuMjANBgkqhkiG9w0BAQsFAAOCAQEAQZ2PC/Kr4p7BkD2usmMtlLsYhoTf
-oe/EBnBBc1lxZ/UOWBQrD0Nle/ASqiT0TjPnQ+UL7YxRXZ6mUWh2P+BM8QmQbpuW
-rgPF4cq4XNjFzdXoOC5ZeBA6Q7A8B+XzZipqKZ2BdCehhirMfwrExJZxsQi6B52Q
-KAGKf/742/D6RQvtxYGElqrOSZCZyrLSrwr/AqRO+lxe1GBC0dL8F7WqwOWL1OIm
-7tLcanQ1xWfzp5rtneLC0CeIEtIvsUJnvRdIH81tmgD/Df8CJP2PVx7Uhz5dcfC2
-WGpGVkiqlAmFp1SZWI6mqK1Ddopj4EV4Los88kbppQwMLI9XrM+NkJMmhw==
+b3duIENBMB4XDTcwMDEwMTAwMDAwMFoXDTMzMDYyNDIxMTgwMFowFDESMBAGA1UE
+AwwJMTI3LjAuMC4xMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAoW5Z
+qgOEaGqkHi9skrRMLbx6ZTp3CyAGFWNwSDuYCMsDf28Yvhko533nP/bEwwJxDDsP
+W6cUNnuqkwgW7Eao0tI1eCyDndxrUyd9xh1dWht4KK7EhlKgsuFePsbTYy2p982M
+Hb3ViIEMoZOdNsrXiJMw2qNAQA4LmM4FTd4CHZ0FjcSsiygIbjkcZt6NAidmMpal
+A1h+0au79kLCdlpZrbFOxfuTUf9Oh8Z0RRlVuQLcCE0SN2Qa6D8UG/e8v1eZs71t
+h7bZRaYHJCBtf5v8XY9Dnrf7/4q00xGelcOvfKMJLZieC6HAS/9MA0HBov5XJm8c
+OU3ZOGECAouN+tLEMQIDAQABoyMwITAfBgNVHREEGDAWggkxMjcuMC4wLjGCCTEy
+Ny4wLjAuMjANBgkqhkiG9w0BAQsFAAOCAQEATvyFTYfgrtIW0BqpzIPVRua86kGr
+Wftyk/AqcUTvgoxPG2czL/j3RxD8gN7YTDP2+czGFpk+W9gzkQzcD1lFtP6u0LMX
+o+gK+BcOhNYyWe4/VyH028p5Aa4kVlDHvQASjFlzR/M6N18qN0gIbGPY6Z2Muxjn
+NvGf5kNHUNIDMLIufCdlef6EINppePrsjY2uqYK++D/lhI46N6WL7UUiutYeLm+h
+q+eqex0oGbwMmomdlBVwcCskpiRNeQCJfVHiX/rGJQHcj+BykOJfHF0fpake1yro
+bwNpyOaptf7HYJah5Rjnnq+faG5SYMC8oT50URYSP6RT/F2hAWgxgopnyQ==
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/unknown-ca-key.pem
+++ b/spec/fixtures/ssl/unknown-ca-key.pem
@@ -1,117 +1,117 @@
-RSA Private-Key: (2048 bit, 2 primes)
+Private-Key: (2048 bit, 2 primes)
 modulus:
-    00:b4:79:b0:16:e7:9b:22:20:17:4b:36:87:eb:38:
-    03:1f:df:88:00:1b:37:40:5e:1f:1d:89:1f:3e:f4:
-    fa:69:90:9c:d8:68:df:c8:71:07:07:4e:01:1d:f0:
-    a8:9a:67:94:af:47:f2:b8:60:f5:ca:fb:bb:ac:7c:
-    23:58:59:bc:95:b0:ad:b2:c7:a0:28:e1:4f:1e:c4:
-    ef:5f:2b:a3:4e:f2:6a:95:c8:4f:f5:af:bc:fa:36:
-    10:f9:a9:62:7a:04:d5:01:cd:9b:ba:97:32:4c:99:
-    e5:88:fc:05:84:34:f5:4a:f2:f1:ec:04:c7:c7:63:
-    28:eb:9e:ee:91:cd:95:8b:60:9e:5f:51:a1:2b:5a:
-    cd:02:b2:a7:52:6c:d1:8a:ab:b1:c4:52:cd:10:ce:
-    9e:56:24:6c:63:84:2c:15:6c:c0:62:ea:c2:d9:04:
-    88:e2:e2:0f:ff:ce:87:51:eb:77:50:83:33:1c:c7:
-    88:5b:08:d4:3a:22:2f:13:a6:89:f7:4b:a0:2e:30:
-    c1:12:7a:bb:37:1f:aa:87:56:44:2f:5a:63:4b:b2:
-    36:f6:29:5e:b8:67:52:6f:63:2a:ad:3d:c3:a5:45:
-    af:97:e9:85:9e:76:1e:51:9c:68:36:58:32:ad:cf:
-    3e:4d:f0:92:e2:ad:d6:f0:e1:5d:af:08:ca:2a:82:
-    0e:a3
+    00:a8:08:cd:22:aa:fa:a1:38:0e:d8:be:2f:57:b6:
+    fb:f5:e2:9b:04:72:49:56:15:71:42:1d:12:a8:8f:
+    29:03:63:e1:2a:1f:ec:4d:67:3d:7d:5e:27:a5:21:
+    fe:16:38:a0:f5:de:5c:76:ec:71:7d:6c:ae:ca:8a:
+    30:5d:fe:39:c5:4a:d0:14:13:76:b5:89:d8:58:7a:
+    11:76:54:3e:4d:e3:be:f9:fb:72:80:bc:19:07:0f:
+    e0:53:46:5b:f1:45:8c:d2:5c:af:e4:0f:ab:7d:bc:
+    22:3c:7a:b1:95:7d:6a:04:4b:fa:d2:e8:1e:c4:39:
+    4b:bd:dc:7e:69:ba:8e:a9:96:a5:17:e4:ae:4e:3e:
+    98:ad:2b:55:95:ac:6d:40:4b:20:55:51:31:98:9e:
+    4e:de:b4:37:31:5b:d9:3a:6c:e4:b1:0a:19:ce:5e:
+    a8:e2:29:97:de:3d:c7:50:54:fb:f2:8f:2a:a4:58:
+    a5:52:82:0b:52:c8:4e:6c:5d:78:10:c6:4b:05:36:
+    02:e4:df:bc:95:4a:47:b7:e8:e4:8b:6d:46:ab:fb:
+    fb:41:6b:bb:90:c4:1b:5a:7d:3b:2e:19:2d:0d:95:
+    70:d2:10:f9:7a:1a:ee:8f:20:cb:8d:8d:bf:23:75:
+    11:dd:02:ab:e3:fd:9e:b1:05:3b:63:2e:ab:87:93:
+    63:a3
 publicExponent: 65537 (0x10001)
 privateExponent:
-    00:9b:ce:8e:a2:47:93:5b:b3:be:c8:75:2c:84:7a:
-    97:df:f5:78:11:37:6d:cc:c9:35:2d:a7:8a:ed:2c:
-    4b:df:c5:34:53:74:be:f5:e9:f6:7a:6c:f2:73:e9:
-    a7:75:9d:c4:f4:4a:36:16:cd:c6:85:56:2c:a0:ed:
-    8f:0a:20:76:b9:f8:8d:0c:d2:60:c7:ca:34:27:49:
-    37:aa:bf:1e:be:f2:73:e8:19:c6:46:42:50:f0:e6:
-    aa:63:0f:c3:ef:b9:aa:37:63:4d:75:9a:40:97:77:
-    29:7d:c8:ad:ee:84:55:dc:3d:bf:73:d6:70:af:07:
-    41:75:a1:81:2f:29:00:59:11:3e:98:49:12:ec:e9:
-    9d:ca:ca:71:1e:bc:2f:9f:13:9c:5c:01:54:6d:69:
-    6b:85:6f:2a:2f:96:a5:38:37:e3:0c:7d:9f:6c:12:
-    a4:13:1b:bf:cb:35:16:88:a6:c6:47:6f:0b:61:22:
-    c2:de:00:7a:b1:70:f6:1e:01:99:70:87:1d:23:21:
-    0f:bf:41:59:16:75:40:8e:7c:50:73:bb:ce:17:7c:
-    07:ec:f2:83:12:95:4e:6a:ac:79:89:8f:32:58:61:
-    af:55:df:30:1d:3a:d1:f3:fa:ee:74:27:73:62:f8:
-    c4:e2:b2:e3:a5:64:e4:6b:4b:86:13:44:00:3d:51:
-    45:d9
+    12:00:67:61:98:69:a3:4d:eb:21:43:36:b5:31:f0:
+    4a:46:4d:8f:2b:63:39:ea:b0:28:82:0e:d6:aa:07:
+    9d:ca:5c:7b:f3:d1:8f:f5:48:7c:1e:d3:26:78:be:
+    cc:c8:a2:4d:d4:d5:99:13:f9:90:93:4d:22:7b:ad:
+    74:d4:60:82:07:62:c5:53:d4:7a:dc:5a:a6:17:e5:
+    b9:04:8b:6c:32:c2:e9:eb:0b:38:49:6e:70:f8:3d:
+    73:0e:6d:99:2a:77:4c:ae:0b:55:e6:6b:db:db:84:
+    db:6f:d5:88:8b:58:09:3f:ce:8e:3b:b9:d8:11:bf:
+    50:86:c7:b0:32:01:48:9f:a3:5d:c2:dc:9a:67:2f:
+    94:70:99:08:31:bf:a3:e3:89:de:e2:f1:8c:4d:73:
+    5c:68:ac:76:36:4f:0d:ce:e8:62:5a:32:44:7a:13:
+    fa:9a:46:2e:30:aa:66:10:43:81:5d:57:65:99:3c:
+    82:0c:65:83:44:36:6a:e1:0d:44:16:74:e1:c6:a8:
+    9a:3d:a5:fa:a2:7e:cb:a1:76:c0:21:e0:4c:ea:a2:
+    f2:d9:a7:53:a8:41:39:db:51:c7:5d:31:b2:04:86:
+    4b:7d:cf:11:10:16:b3:b1:22:37:29:c4:20:7e:b0:
+    0c:7b:ac:89:78:6b:ef:3b:98:29:c2:23:29:9f:4e:
+    89
 prime1:
-    00:da:9b:01:67:9b:20:66:3b:69:da:ce:9e:ac:fa:
-    03:84:8e:da:fb:04:8d:9b:f0:ff:c9:55:a4:26:c4:
-    b8:e3:1c:47:7d:fb:f5:2e:f6:50:22:75:63:ac:b7:
-    2d:f0:d5:75:0f:04:d5:e6:ee:75:9c:15:9f:e4:5c:
-    76:2c:0b:df:7f:9d:5f:16:3a:8a:82:36:6b:c9:fc:
-    49:e1:83:fe:cf:85:e1:fc:80:60:06:33:b2:e6:54:
-    6c:ba:29:6e:e4:3a:ee:d7:e6:0a:d6:bd:27:5d:40:
-    e0:89:97:89:2a:3e:cf:a5:ec:ae:5f:db:df:3e:e8:
-    c4:b0:9a:77:96:4d:a1:5e:5d
+    00:c0:6f:d4:87:c5:6a:30:aa:2a:5e:a1:f9:0c:0e:
+    c8:14:8e:56:8a:57:15:13:a9:10:31:a4:c9:62:21:
+    60:a0:98:a9:fa:82:8e:c6:c7:3a:1f:bb:2b:db:32:
+    e9:fc:9e:93:8e:d7:4c:1a:3a:87:11:76:a7:e9:7b:
+    1f:5c:2a:8f:22:d5:24:e1:5b:7d:fe:15:cd:af:43:
+    20:52:c8:2f:b1:a9:7c:11:5d:7a:61:71:d5:a8:e7:
+    22:66:4f:40:08:bf:75:b5:c4:7a:db:83:52:6c:88:
+    f9:27:6b:fd:8c:0d:05:f7:30:6f:0f:f7:7c:21:58:
+    aa:45:34:b1:73:12:63:45:af
 prime2:
-    00:d3:58:ea:f8:aa:9b:e0:95:aa:81:27:f4:1a:5e:
-    ae:60:bf:0f:37:be:b8:64:78:d4:ce:47:7e:21:82:
-    49:a7:f6:ff:15:62:1c:87:e8:c2:d5:d2:9b:d2:21:
-    87:36:36:66:bc:03:23:8f:5e:09:2b:4f:a2:8a:7f:
-    ea:c8:ea:fb:21:54:4a:ba:b8:14:74:59:50:fa:31:
-    cf:31:c3:22:32:4a:db:05:b6:3c:f5:9f:6b:cd:3c:
-    6b:1b:48:b0:b5:13:5d:c7:b6:13:4e:09:85:e2:db:
-    38:ac:ee:27:42:d8:49:47:9e:0c:59:95:97:e7:c2:
-    78:0a:65:c9:ee:29:e8:50:ff
+    00:df:89:89:3a:49:8a:0f:91:87:04:b4:aa:73:d6:
+    b7:03:60:20:60:2e:b8:c0:eb:c4:70:ef:19:d6:ce:
+    72:ae:4c:b6:bb:c4:45:20:e7:8d:1a:44:4a:e4:1a:
+    67:67:42:28:93:32:b7:f2:90:04:53:88:46:1b:8a:
+    79:b8:18:fb:11:92:a3:fc:7e:b0:75:29:99:ee:89:
+    d9:5d:4e:fa:09:e0:cf:9f:e4:23:bc:72:97:32:99:
+    fc:14:78:ca:bc:b5:73:08:f8:cc:9b:81:ea:ae:71:
+    5b:f7:b0:f8:1b:16:0a:28:4e:01:11:40:e1:68:10:
+    5c:26:84:74:a7:a3:a8:f2:4d
 exponent1:
-    50:f7:12:19:1e:72:6c:8a:da:d4:e8:ac:0a:62:fb:
-    04:90:a8:78:4a:22:6c:bc:60:f0:5f:e0:d1:5f:11:
-    1f:44:ad:11:f3:4c:c7:1d:01:67:11:d5:5d:f5:e6:
-    75:09:8a:36:8a:d2:f2:9a:25:43:2f:1b:2e:48:34:
-    98:71:b9:50:99:a7:cb:22:d9:84:0a:c5:f7:64:92:
-    b4:8c:df:c6:5a:ce:ed:67:5a:a9:51:62:94:3e:76:
-    9a:a8:97:e2:be:15:12:2f:a8:9a:0a:2a:d7:36:1d:
-    33:b8:c5:5b:b9:31:cd:41:90:ff:fd:fe:7c:5d:57:
-    e4:15:01:ef:d0:46:d1:1d
+    00:86:75:9d:2a:c0:e5:d1:db:14:7f:ca:ed:19:5f:
+    ba:ad:a2:47:15:a2:83:37:99:89:97:26:6d:10:04:
+    02:60:34:4b:90:9e:68:e4:bb:90:01:5b:e6:e8:e2:
+    4a:5c:18:f1:41:7d:6d:cf:65:d5:ba:7e:0e:15:35:
+    d2:53:b3:e9:0f:8d:9e:97:58:36:50:b3:2b:64:aa:
+    a2:8b:35:15:1e:2e:2e:62:73:ce:6f:07:fb:22:69:
+    5d:bf:de:df:ff:3c:c8:22:99:86:be:9a:a3:9c:f2:
+    98:24:d3:6f:f5:cb:a3:bf:74:38:26:0f:e6:cb:e6:
+    08:13:13:1e:6a:29:0e:f4:41
 exponent2:
-    00:91:f0:d9:b8:c2:df:06:b3:72:dc:e3:00:fd:e0:
-    99:9b:76:f3:84:33:ef:d2:79:59:c1:e3:be:66:57:
-    38:93:82:cc:dc:30:36:b1:66:fa:7b:7a:86:5d:11:
-    07:f4:58:96:92:87:bc:5b:78:bc:ee:2a:7c:7c:15:
-    1e:c4:84:f6:cb:2a:10:bc:64:f6:c2:ed:16:2c:de:
-    8e:4b:b7:8a:7a:9e:14:26:1a:94:77:ac:11:5d:d4:
-    b5:c5:4e:69:af:70:63:16:d0:54:fe:53:37:1f:d2:
-    ef:8d:02:9b:1b:de:8c:a3:a6:b0:b2:7f:c9:38:a1:
-    a2:10:d3:ff:1f:b5:d2:95:73
+    00:b3:dc:7a:6a:47:d9:aa:85:31:da:7b:73:db:19:
+    1c:d0:be:7b:ce:68:49:88:11:2c:52:a2:50:6c:22:
+    58:ec:1e:15:ba:27:46:68:1f:67:cd:86:bd:ab:a4:
+    03:27:76:78:27:58:5b:e1:f4:37:46:ef:13:59:fd:
+    a5:ca:97:6f:0c:c8:ac:e1:f1:1e:12:67:92:cf:f8:
+    62:c9:4d:4e:aa:bc:14:d3:56:41:da:d3:69:0c:f2:
+    11:7e:77:62:c9:4c:46:6f:25:a1:9c:4e:80:82:33:
+    fc:07:e4:80:fd:6a:52:69:f3:b9:b0:24:40:39:f7:
+    4f:ee:3e:0d:8f:05:84:5e:d1
 coefficient:
-    00:bb:0a:77:ec:98:3c:fe:92:2b:66:06:7a:2a:80:
-    a6:41:bb:d8:60:7e:fa:90:41:f3:4d:e4:4e:95:1e:
-    48:19:33:49:9a:24:09:6c:17:98:ce:72:09:ad:96:
-    43:3a:16:6c:16:cd:38:39:13:58:3e:dc:89:98:08:
-    38:d3:e5:d8:c1:34:8c:71:a9:88:a1:79:23:af:ad:
-    94:04:7a:ca:20:82:76:af:84:2a:43:c4:d6:96:b0:
-    c8:f7:e6:be:4c:e8:d8:7c:bb:79:7a:c8:d9:32:72:
-    81:63:9f:2c:45:33:e3:6a:6a:42:3d:d6:19:b4:0d:
-    0d:15:1b:44:67:47:ef:b6:2e
+    6d:a8:08:7a:ad:94:c8:0f:dc:07:57:71:1b:a7:3a:
+    4d:b9:a5:39:81:36:75:c3:ff:b5:ed:7c:6a:df:28:
+    f6:22:1e:33:a6:48:31:8f:dc:ba:03:72:e6:51:39:
+    d1:ce:c5:0a:7c:a3:dd:44:9b:1b:38:94:44:ce:1e:
+    c5:6b:f1:4d:c8:e8:6d:ed:ad:1e:8c:86:50:98:fb:
+    90:4a:25:d5:3d:2f:66:a7:b9:d6:5d:84:e7:77:25:
+    69:0b:89:4b:30:53:7c:74:01:72:37:91:31:2b:aa:
+    54:92:9e:41:18:a1:8c:0e:c6:74:c9:0b:1e:be:76:
+    06:54:29:52:c6:a1:26:01
 -----BEGIN RSA PRIVATE KEY-----
-MIIEpQIBAAKCAQEAtHmwFuebIiAXSzaH6zgDH9+IABs3QF4fHYkfPvT6aZCc2Gjf
-yHEHB04BHfCommeUr0fyuGD1yvu7rHwjWFm8lbCtssegKOFPHsTvXyujTvJqlchP
-9a+8+jYQ+aliegTVAc2bupcyTJnliPwFhDT1SvLx7ATHx2Mo657ukc2Vi2CeX1Gh
-K1rNArKnUmzRiquxxFLNEM6eViRsY4QsFWzAYurC2QSI4uIP/86HUet3UIMzHMeI
-WwjUOiIvE6aJ90ugLjDBEnq7Nx+qh1ZEL1pjS7I29ileuGdSb2MqrT3DpUWvl+mF
-nnYeUZxoNlgyrc8+TfCS4q3W8OFdrwjKKoIOowIDAQABAoIBAQCbzo6iR5Nbs77I
-dSyEepff9XgRN23MyTUtp4rtLEvfxTRTdL716fZ6bPJz6ad1ncT0SjYWzcaFViyg
-7Y8KIHa5+I0M0mDHyjQnSTeqvx6+8nPoGcZGQlDw5qpjD8Pvuao3Y011mkCXdyl9
-yK3uhFXcPb9z1nCvB0F1oYEvKQBZET6YSRLs6Z3KynEevC+fE5xcAVRtaWuFbyov
-lqU4N+MMfZ9sEqQTG7/LNRaIpsZHbwthIsLeAHqxcPYeAZlwhx0jIQ+/QVkWdUCO
-fFBzu84XfAfs8oMSlU5qrHmJjzJYYa9V3zAdOtHz+u50J3Ni+MTisuOlZORrS4YT
-RAA9UUXZAoGBANqbAWebIGY7adrOnqz6A4SO2vsEjZvw/8lVpCbEuOMcR3379S72
-UCJ1Y6y3LfDVdQ8E1ebudZwVn+RcdiwL33+dXxY6ioI2a8n8SeGD/s+F4fyAYAYz
-suZUbLopbuQ67tfmCta9J11A4ImXiSo+z6Xsrl/b3z7oxLCad5ZNoV5dAoGBANNY
-6viqm+CVqoEn9BpermC/Dze+uGR41M5HfiGCSaf2/xViHIfowtXSm9IhhzY2ZrwD
-I49eCStPoop/6sjq+yFUSrq4FHRZUPoxzzHDIjJK2wW2PPWfa808axtIsLUTXce2
-E04JheLbOKzuJ0LYSUeeDFmVl+fCeAplye4p6FD/AoGAUPcSGR5ybIra1OisCmL7
-BJCoeEoibLxg8F/g0V8RH0StEfNMxx0BZxHVXfXmdQmKNorS8polQy8bLkg0mHG5
-UJmnyyLZhArF92SStIzfxlrO7WdaqVFilD52mqiX4r4VEi+omgoq1zYdM7jFW7kx
-zUGQ//3+fF1X5BUB79BG0R0CgYEAkfDZuMLfBrNy3OMA/eCZm3bzhDPv0nlZweO+
-Zlc4k4LM3DA2sWb6e3qGXREH9FiWkoe8W3i87ip8fBUexIT2yyoQvGT2wu0WLN6O
-S7eKep4UJhqUd6wRXdS1xU5pr3BjFtBU/lM3H9LvjQKbG96Mo6awsn/JOKGiENP/
-H7XSlXMCgYEAuwp37Jg8/pIrZgZ6KoCmQbvYYH76kEHzTeROlR5IGTNJmiQJbBeY
-znIJrZZDOhZsFs04ORNYPtyJmAg40+XYwTSMcamIoXkjr62UBHrKIIJ2r4QqQ8TW
-lrDI9+a+TOjYfLt5esjZMnKBY58sRTPjampCPdYZtA0NFRtEZ0fvti4=
+MIIEpAIBAAKCAQEAqAjNIqr6oTgO2L4vV7b79eKbBHJJVhVxQh0SqI8pA2PhKh/s
+TWc9fV4npSH+Fjig9d5cduxxfWyuyoowXf45xUrQFBN2tYnYWHoRdlQ+TeO++fty
+gLwZBw/gU0Zb8UWM0lyv5A+rfbwiPHqxlX1qBEv60ugexDlLvdx+abqOqZalF+Su
+Tj6YrStVlaxtQEsgVVExmJ5O3rQ3MVvZOmzksQoZzl6o4imX3j3HUFT78o8qpFil
+UoILUshObF14EMZLBTYC5N+8lUpHt+jki21Gq/v7QWu7kMQbWn07LhktDZVw0hD5
+ehrujyDLjY2/I3UR3QKr4/2esQU7Yy6rh5NjowIDAQABAoIBABIAZ2GYaaNN6yFD
+NrUx8EpGTY8rYznqsCiCDtaqB53KXHvz0Y/1SHwe0yZ4vszIok3U1ZkT+ZCTTSJ7
+rXTUYIIHYsVT1HrcWqYX5bkEi2wywunrCzhJbnD4PXMObZkqd0yuC1Xma9vbhNtv
+1YiLWAk/zo47udgRv1CGx7AyAUifo13C3JpnL5RwmQgxv6Pjid7i8YxNc1xorHY2
+Tw3O6GJaMkR6E/qaRi4wqmYQQ4FdV2WZPIIMZYNENmrhDUQWdOHGqJo9pfqifsuh
+dsAh4EzqovLZp1OoQTnbUcddMbIEhkt9zxEQFrOxIjcpxCB+sAx7rIl4a+87mCnC
+IymfTokCgYEAwG/Uh8VqMKoqXqH5DA7IFI5WilcVE6kQMaTJYiFgoJip+oKOxsc6
+H7sr2zLp/J6TjtdMGjqHEXan6XsfXCqPItUk4Vt9/hXNr0MgUsgvsal8EV16YXHV
+qOciZk9ACL91tcR624NSbIj5J2v9jA0F9zBvD/d8IViqRTSxcxJjRa8CgYEA34mJ
+OkmKD5GHBLSqc9a3A2AgYC64wOvEcO8Z1s5yrky2u8RFIOeNGkRK5BpnZ0IokzK3
+8pAEU4hGG4p5uBj7EZKj/H6wdSmZ7onZXU76CeDPn+QjvHKXMpn8FHjKvLVzCPjM
+m4HqrnFb97D4GxYKKE4BEUDhaBBcJoR0p6Oo8k0CgYEAhnWdKsDl0dsUf8rtGV+6
+raJHFaKDN5mJlyZtEAQCYDRLkJ5o5LuQAVvm6OJKXBjxQX1tz2XVun4OFTXSU7Pp
+D42el1g2ULMrZKqiizUVHi4uYnPObwf7Imldv97f/zzIIpmGvpqjnPKYJNNv9cuj
+v3Q4Jg/my+YIExMeaikO9EECgYEAs9x6akfZqoUx2ntz2xkc0L57zmhJiBEsUqJQ
+bCJY7B4VuidGaB9nzYa9q6QDJ3Z4J1hb4fQ3Ru8TWf2lypdvDMis4fEeEmeSz/hi
+yU1OqrwU01ZB2tNpDPIRfndiyUxGbyWhnE6AgjP8B+SA/WpSafO5sCRAOfdP7j4N
+jwWEXtECgYBtqAh6rZTID9wHV3EbpzpNuaU5gTZ1w/+17Xxq3yj2Ih4zpkgxj9y6
+A3LmUTnRzsUKfKPdRJsbOJREzh7Fa/FNyOht7a0ejIZQmPuQSiXVPS9mp7nWXYTn
+dyVpC4lLMFN8dAFyN5ExK6pUkp5BGKGMDsZ0yQsevnYGVClSxqEmAQ==
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/unknown-ca.pem
+++ b/spec/fixtures/ssl/unknown-ca.pem
@@ -6,30 +6,30 @@ Certificate:
         Issuer: CN=Unknown CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Jun 15 01:19:37 2031 GMT
+            Not After : Jun 24 21:18:00 2033 GMT
         Subject: CN=Unknown CA
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                RSA Public-Key: (2048 bit)
+                Public-Key: (2048 bit)
                 Modulus:
-                    00:b4:79:b0:16:e7:9b:22:20:17:4b:36:87:eb:38:
-                    03:1f:df:88:00:1b:37:40:5e:1f:1d:89:1f:3e:f4:
-                    fa:69:90:9c:d8:68:df:c8:71:07:07:4e:01:1d:f0:
-                    a8:9a:67:94:af:47:f2:b8:60:f5:ca:fb:bb:ac:7c:
-                    23:58:59:bc:95:b0:ad:b2:c7:a0:28:e1:4f:1e:c4:
-                    ef:5f:2b:a3:4e:f2:6a:95:c8:4f:f5:af:bc:fa:36:
-                    10:f9:a9:62:7a:04:d5:01:cd:9b:ba:97:32:4c:99:
-                    e5:88:fc:05:84:34:f5:4a:f2:f1:ec:04:c7:c7:63:
-                    28:eb:9e:ee:91:cd:95:8b:60:9e:5f:51:a1:2b:5a:
-                    cd:02:b2:a7:52:6c:d1:8a:ab:b1:c4:52:cd:10:ce:
-                    9e:56:24:6c:63:84:2c:15:6c:c0:62:ea:c2:d9:04:
-                    88:e2:e2:0f:ff:ce:87:51:eb:77:50:83:33:1c:c7:
-                    88:5b:08:d4:3a:22:2f:13:a6:89:f7:4b:a0:2e:30:
-                    c1:12:7a:bb:37:1f:aa:87:56:44:2f:5a:63:4b:b2:
-                    36:f6:29:5e:b8:67:52:6f:63:2a:ad:3d:c3:a5:45:
-                    af:97:e9:85:9e:76:1e:51:9c:68:36:58:32:ad:cf:
-                    3e:4d:f0:92:e2:ad:d6:f0:e1:5d:af:08:ca:2a:82:
-                    0e:a3
+                    00:a8:08:cd:22:aa:fa:a1:38:0e:d8:be:2f:57:b6:
+                    fb:f5:e2:9b:04:72:49:56:15:71:42:1d:12:a8:8f:
+                    29:03:63:e1:2a:1f:ec:4d:67:3d:7d:5e:27:a5:21:
+                    fe:16:38:a0:f5:de:5c:76:ec:71:7d:6c:ae:ca:8a:
+                    30:5d:fe:39:c5:4a:d0:14:13:76:b5:89:d8:58:7a:
+                    11:76:54:3e:4d:e3:be:f9:fb:72:80:bc:19:07:0f:
+                    e0:53:46:5b:f1:45:8c:d2:5c:af:e4:0f:ab:7d:bc:
+                    22:3c:7a:b1:95:7d:6a:04:4b:fa:d2:e8:1e:c4:39:
+                    4b:bd:dc:7e:69:ba:8e:a9:96:a5:17:e4:ae:4e:3e:
+                    98:ad:2b:55:95:ac:6d:40:4b:20:55:51:31:98:9e:
+                    4e:de:b4:37:31:5b:d9:3a:6c:e4:b1:0a:19:ce:5e:
+                    a8:e2:29:97:de:3d:c7:50:54:fb:f2:8f:2a:a4:58:
+                    a5:52:82:0b:52:c8:4e:6c:5d:78:10:c6:4b:05:36:
+                    02:e4:df:bc:95:4a:47:b7:e8:e4:8b:6d:46:ab:fb:
+                    fb:41:6b:bb:90:c4:1b:5a:7d:3b:2e:19:2d:0d:95:
+                    70:d2:10:f9:7a:1a:ee:8f:20:cb:8d:8d:bf:23:75:
+                    11:dd:02:ab:e3:fd:9e:b1:05:3b:63:2e:ab:87:93:
+                    63:a3
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Basic Constraints: critical
@@ -37,45 +37,45 @@ Certificate:
             X509v3 Key Usage: critical
                 Certificate Sign, CRL Sign
             X509v3 Subject Key Identifier: 
-                D0:CD:40:49:88:F6:74:BB:B4:D7:05:37:74:33:B1:C2:27:73:81:CB
+                EC:86:9A:24:5D:36:4B:28:24:DD:DF:75:52:D1:83:19:33:37:46:E9
             Netscape Comment: 
                 Puppet Server Internal Certificate
             X509v3 Authority Key Identifier: 
-                keyid:D0:CD:40:49:88:F6:74:BB:B4:D7:05:37:74:33:B1:C2:27:73:81:CB
-
+                EC:86:9A:24:5D:36:4B:28:24:DD:DF:75:52:D1:83:19:33:37:46:E9
     Signature Algorithm: sha256WithRSAEncryption
-         51:79:86:29:27:07:e5:fc:59:83:2d:15:ae:5f:c4:bc:0a:71:
-         2c:71:74:20:14:ce:47:8f:cf:79:03:76:bd:df:c9:e9:7f:12:
-         b2:4e:5a:c5:4f:e1:0b:c3:17:44:92:37:af:10:08:75:9a:d9:
-         c5:0d:66:e9:24:2b:ec:00:aa:de:2f:ce:df:04:fa:49:d9:bd:
-         bd:5e:7b:e4:e7:1e:9e:20:d3:85:70:b4:95:b5:1d:2e:fa:0c:
-         b4:47:5a:38:ec:b0:bd:7e:34:5f:4d:9d:1f:81:81:8a:6c:a6:
-         94:fb:f8:41:d6:a3:e4:64:3a:b7:12:4f:9e:4e:60:4a:12:a9:
-         d1:87:a5:a8:31:91:16:96:50:73:87:64:46:f1:f2:f9:99:80:
-         a2:89:e9:99:57:48:8a:56:08:d7:8d:a9:1d:69:7c:8f:73:e5:
-         53:2d:28:ee:70:d7:f8:fe:41:25:3e:4c:6c:de:31:3f:9e:7d:
-         c4:f0:67:e9:fc:a3:02:c7:39:19:f5:6f:59:6a:ca:bb:8c:c8:
-         e6:01:43:ad:95:67:3f:c0:d6:35:18:b1:6e:9f:e1:ce:c7:be:
-         35:f0:7b:65:e7:79:82:c3:b6:f7:48:28:98:d0:5c:3c:97:f3:
-         69:b3:5e:c3:a0:c5:82:02:6f:20:d0:1b:cd:43:b0:85:7e:4f:
-         71:b9:f3:8f
+    Signature Value:
+        5a:5d:26:6a:dc:aa:0e:66:c5:9c:b8:15:09:20:25:0a:46:be:
+        6b:b9:b4:6d:a9:74:e3:cd:a4:40:4a:dc:71:d2:fa:50:3c:b9:
+        6e:0d:4b:c8:b9:d3:26:06:1b:3a:d7:e5:02:fd:ec:ad:e2:4b:
+        ad:19:49:57:11:a3:4c:0e:67:5c:46:63:7a:aa:8f:ca:f0:f5:
+        5e:ad:bf:85:3d:1b:88:b8:a8:21:da:25:9c:27:96:70:60:83:
+        0e:de:09:c3:a8:20:5f:9a:47:47:70:c8:94:aa:a5:2b:2d:bc:
+        c3:74:ee:ff:63:88:95:84:83:fe:66:99:e8:90:c0:ed:3b:1d:
+        00:84:1a:29:43:15:53:9d:71:13:71:bf:5b:9a:7d:4e:e1:e2:
+        28:1e:38:55:92:f8:16:28:8d:9b:1e:9a:fb:a7:7a:6e:b7:66:
+        56:ed:b6:36:ef:f8:f6:21:c9:20:f3:f4:13:9e:a6:21:2e:2c:
+        ca:55:b0:2b:6d:2d:4a:58:f5:30:d8:70:eb:66:ac:ea:a8:64:
+        23:0d:e8:39:28:34:f5:16:22:f0:84:c1:2a:9b:89:55:8f:72:
+        c2:6c:f0:62:bf:39:04:2c:fc:c1:f5:40:ad:fc:b0:c9:0f:ae:
+        8d:f4:ce:1b:24:27:06:21:8e:9a:9a:56:40:d8:fe:b2:46:46:
+        44:61:43:7c
 -----BEGIN CERTIFICATE-----
 MIIDPTCCAiWgAwIBAgIBADANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDDApVbmtu
-b3duIENBMB4XDTcwMDEwMTAwMDAwMFoXDTMxMDYxNTAxMTkzN1owFTETMBEGA1UE
-AwwKVW5rbm93biBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALR5
-sBbnmyIgF0s2h+s4Ax/fiAAbN0BeHx2JHz70+mmQnNho38hxBwdOAR3wqJpnlK9H
-8rhg9cr7u6x8I1hZvJWwrbLHoCjhTx7E718ro07yapXIT/WvvPo2EPmpYnoE1QHN
-m7qXMkyZ5Yj8BYQ09Ury8ewEx8djKOue7pHNlYtgnl9RoStazQKyp1Js0YqrscRS
-zRDOnlYkbGOELBVswGLqwtkEiOLiD//Oh1Hrd1CDMxzHiFsI1DoiLxOmifdLoC4w
-wRJ6uzcfqodWRC9aY0uyNvYpXrhnUm9jKq09w6VFr5fphZ52HlGcaDZYMq3PPk3w
-kuKt1vDhXa8IyiqCDqMCAwEAAaOBlzCBlDAPBgNVHRMBAf8EBTADAQH/MA4GA1Ud
-DwEB/wQEAwIBBjAdBgNVHQ4EFgQU0M1ASYj2dLu01wU3dDOxwidzgcswMQYJYIZI
+b3duIENBMB4XDTcwMDEwMTAwMDAwMFoXDTMzMDYyNDIxMTgwMFowFTETMBEGA1UE
+AwwKVW5rbm93biBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKgI
+zSKq+qE4Dti+L1e2+/XimwRySVYVcUIdEqiPKQNj4Sof7E1nPX1eJ6Uh/hY4oPXe
+XHbscX1srsqKMF3+OcVK0BQTdrWJ2Fh6EXZUPk3jvvn7coC8GQcP4FNGW/FFjNJc
+r+QPq328Ijx6sZV9agRL+tLoHsQ5S73cfmm6jqmWpRfkrk4+mK0rVZWsbUBLIFVR
+MZieTt60NzFb2Tps5LEKGc5eqOIpl949x1BU+/KPKqRYpVKCC1LITmxdeBDGSwU2
+AuTfvJVKR7fo5IttRqv7+0Fru5DEG1p9Oy4ZLQ2VcNIQ+Xoa7o8gy42NvyN1Ed0C
+q+P9nrEFO2Muq4eTY6MCAwEAAaOBlzCBlDAPBgNVHRMBAf8EBTADAQH/MA4GA1Ud
+DwEB/wQEAwIBBjAdBgNVHQ4EFgQU7IaaJF02Sygk3d91UtGDGTM3RukwMQYJYIZI
 AYb4QgENBCQWIlB1cHBldCBTZXJ2ZXIgSW50ZXJuYWwgQ2VydGlmaWNhdGUwHwYD
-VR0jBBgwFoAU0M1ASYj2dLu01wU3dDOxwidzgcswDQYJKoZIhvcNAQELBQADggEB
-AFF5hiknB+X8WYMtFa5fxLwKcSxxdCAUzkePz3kDdr3fyel/ErJOWsVP4QvDF0SS
-N68QCHWa2cUNZukkK+wAqt4vzt8E+knZvb1ee+TnHp4g04VwtJW1HS76DLRHWjjs
-sL1+NF9NnR+BgYpsppT7+EHWo+RkOrcST55OYEoSqdGHpagxkRaWUHOHZEbx8vmZ
-gKKJ6ZlXSIpWCNeNqR1pfI9z5VMtKO5w1/j+QSU+TGzeMT+efcTwZ+n8owLHORn1
-b1lqyruMyOYBQ62VZz/A1jUYsW6f4c7HvjXwe2XneYLDtvdIKJjQXDyX82mzXsOg
-xYICbyDQG81DsIV+T3G5848=
+VR0jBBgwFoAU7IaaJF02Sygk3d91UtGDGTM3RukwDQYJKoZIhvcNAQELBQADggEB
+AFpdJmrcqg5mxZy4FQkgJQpGvmu5tG2pdOPNpEBK3HHS+lA8uW4NS8i50yYGGzrX
+5QL97K3iS60ZSVcRo0wOZ1xGY3qqj8rw9V6tv4U9G4i4qCHaJZwnlnBggw7eCcOo
+IF+aR0dwyJSqpSstvMN07v9jiJWEg/5mmeiQwO07HQCEGilDFVOdcRNxv1uafU7h
+4igeOFWS+BYojZsemvunem63Zlbttjbv+PYhySDz9BOepiEuLMpVsCttLUpY9TDY
+cOtmrOqoZCMN6DkoNPUWIvCEwSqbiVWPcsJs8GK/OQQs/MH1QK38sMkPro30zhsk
+JwYhjpqaVkDY/rJGRkRhQ3w=
 -----END CERTIFICATE-----

--- a/spec/lib/puppet/test_ca.rb
+++ b/spec/lib/puppet/test_ca.rb
@@ -135,16 +135,7 @@ module Puppet
               key = OpenSSL::PKey::RSA.new(2048)
             end
       cert = OpenSSL::X509::Certificate.new
-      cert.public_key = if key.is_a?(OpenSSL::PKey::EC)
-                         # EC#public_key doesn't following the PKey API,
-                         # see https://github.com/ruby/openssl/issues/29
-                         point = key.public_key
-                         pubkey = OpenSSL::PKey::EC.new(point.group)
-                         pubkey.public_key = point
-                         pubkey
-                       else
-                         key.public_key
-                       end
+      cert.public_key = key
       cert.subject = OpenSSL::X509::Name.new([["CN", name]])
       cert.issuer = issuer
       cert.version = 2

--- a/spec/lib/puppet/test_ca.rb
+++ b/spec/lib/puppet/test_ca.rb
@@ -131,6 +131,8 @@ module Puppet
     def build_cert(name, issuer, opts = {})
       key = if opts[:key_type] == :ec
               key = OpenSSL::PKey::EC.generate('prime256v1')
+            elsif opts[:reuse_key]
+              key = opts[:reuse_key]
             else
               key = OpenSSL::PKey::RSA.new(2048)
             end

--- a/tasks/generate_cert_fixtures.rake
+++ b/tasks/generate_cert_fixtures.rake
@@ -94,6 +94,10 @@ task(:gen_cert_fixtures) do
   save(dir, 'signed.pem', signed[:cert])
   save(dir, 'signed-key.pem', signed[:private_key])
 
+  # Create a cert for host "renewed" and issued by "Test CA Subauthority"
+  renewed = ca.create_cert('renewed', inter[:cert], inter[:private_key], reuse_key: signed[:private_key])
+  save(dir, 'renewed.pem', renewed[:cert])
+
   # Create an encrypted version of the above private key for host "signed"
   save(dir, 'encrypted-key.pem', signed[:private_key]) do |x509|
     # private key password was chosen at random


### PR DESCRIPTION
This commit adds a new NeedRenewedCert class and related logic to the state machine to handle automatic host/client certificate renewal.