### PR TITLE
(PUP-9964) Add Puppetserver CA CLI Authoriziation OID to Puppet

### DIFF
--- a/lib/puppet/ssl/oids.rb
+++ b/lib/puppet/ssl/oids.rb
@@ -72,6 +72,7 @@ module Puppet::SSL::Oids
 
     ["1.3.6.1.4.1.34380.1.3.1",  'pp_authorization', 'Certificate Extension Authorization'],
     ["1.3.6.1.4.1.34380.1.3.13", 'pp_auth_role', 'Puppet Node Role Name for Authorization'],
+    ["1.3.6.1.4.1.34380.1.3.39", 'pp_cli_auth', 'Puppetserver CA CLI Authorization'],
   ]
 
   @did_register_puppet_oids = false


### PR DESCRIPTION
This commit adds the pp_cli_auth OID, which is a certificate extension that allows the puppetserver CA CLI tool to submit requests to the puppet-CA API that change the status of certificates. The OID was created in SERVER-2287 but was never added to Puppet.