### PR TITLE
(PUP-11896) Send auto-renew attribute in CSR

### DIFF
--- a/lib/puppet/ssl/oids.rb
+++ b/lib/puppet/ssl/oids.rb
@@ -71,7 +71,7 @@ module Puppet::SSL::Oids
     ["1.3.6.1.4.1.34380.1.3", 'ppAuthCertExt', 'Puppet Certificate Authorization Extension'],
 
     ["1.3.6.1.4.1.34380.1.3.1",  'pp_authorization', 'Certificate Extension Authorization'],
-    ["1.3.6.1.4.1.34380.1.3.2", 'pp_auth_auto_renew', 'Auto-Renew Certificate Extension'],
+    ["1.3.6.1.4.1.34380.1.3.2", 'pp_auth_auto_renew', 'Auto-Renew Certificate Attribute'],
     ["1.3.6.1.4.1.34380.1.3.13", 'pp_auth_role', 'Puppet Node Role Name for Authorization'],
     ["1.3.6.1.4.1.34380.1.3.39", 'pp_cli_auth', 'Puppetserver CA CLI Authorization'],
   ]

--- a/lib/puppet/x509/cert_provider.rb
+++ b/lib/puppet/x509/cert_provider.rb
@@ -311,11 +311,11 @@ class Puppet::X509::CertProvider
       options[:extension_requests] = csr_attributes.extension_requests
     end
 
-    # Adds auto-renew extension to CSR if the agent supports auto-renewal of
+    # Adds auto-renew attribute to CSR if the agent supports auto-renewal of
     # certificates
     if Puppet[:hostcert_renewal_interval] && Puppet[:hostcert_renewal_interval] > 0
-      options[:extension_requests] ||= {}
-      options[:extension_requests].merge!({'1.3.6.1.4.1.34380.1.3.2' => 'true'})
+      options[:csr_attributes] ||= {}
+      options[:csr_attributes].merge!({'1.3.6.1.4.1.34380.1.3.2' => 'true'})
     end
 
     csr = Puppet::SSL::CertificateRequest.new(name)

--- a/spec/unit/ssl/state_machine_spec.rb
+++ b/spec/unit/ssl/state_machine_spec.rb
@@ -806,7 +806,7 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
         state.next_state
       end
 
-      it 'includes CSR attributes' do
+      it 'includes CSR attributes', :unless => RUBY_PLATFORM == 'java' do
         Puppet[:csr_attributes] = write_csr_attributes(
           'custom_attributes' => {
               '1.3.6.1.4.1.34380.1.2.1' => 'CSR specific info',
@@ -820,7 +820,8 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
             csr.custom_attributes
           ).to contain_exactly(
                  {'oid' => '1.3.6.1.4.1.34380.1.2.1', 'value' => 'CSR specific info'},
-                 {'oid' => '1.3.6.1.4.1.34380.1.2.2', 'value' => 'more CSR specific info'}
+                 {'oid' => '1.3.6.1.4.1.34380.1.2.2', 'value' => 'more CSR specific info'},
+                 {'oid' => 'pp_auth_auto_renew', 'value' => 'true'}
                )
         end.to_return(status: 200)
 
@@ -843,8 +844,7 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
             csr.request_extensions
           ).to contain_exactly(
                  {'oid' => '1.3.6.1.4.1.34380.1.1.31415', 'value' => 'pi'},
-                 {'oid' => '1.3.6.1.4.1.34380.1.1.2718', 'value' => 'e'},
-                 {'oid' => 'pp_auth_auto_renew', 'value' => 'true'}
+                 {'oid' => '1.3.6.1.4.1.34380.1.1.2718', 'value' => 'e'}
                )
         end.to_return(status: 200)
 

--- a/spec/unit/x509/cert_provider_spec.rb
+++ b/spec/unit/x509/cert_provider_spec.rb
@@ -586,25 +586,25 @@ describe Puppet::X509::CertProvider do
     end
   end
 
-  context 'when creating' do
+  context 'when creating', :unless => RUBY_PLATFORM == 'java' do
     context 'requests' do
       let(:name) { 'tom' }
       let(:requestdir) { tmpdir('cert_provider') }
       let(:provider) { create_provider(requestdir: requestdir) }
       let(:key) { OpenSSL::PKey::RSA.new(Puppet[:keylength]) }
 
-      it 'has the auto-renew extension by default for agents that support automatic renewal' do
+      it 'has the auto-renew attribute by default for agents that support automatic renewal' do
         csr = provider.create_request(name, key)
-        # need to create CertificateRequest instance from csr in order to use request_extensions()
+        # need to create CertificateRequest instance from csr in order to view CSR attributes
         wrapped_csr = Puppet::SSL::CertificateRequest.from_instance csr
-        expect(wrapped_csr.request_extensions).to include('oid' => 'pp_auth_auto_renew', 'value' => 'true')
+        expect(wrapped_csr.custom_attributes).to include('oid' => 'pp_auth_auto_renew', 'value' => 'true')
       end
 
-      it 'does not have the auto-renew extension for agents that do not support automatic renewal' do
+      it 'does not have the auto-renew attribute for agents that do not support automatic renewal' do
         Puppet[:hostcert_renewal_interval] = 0
         csr = provider.create_request(name, key)
         wrapped_csr = Puppet::SSL::CertificateRequest.from_instance csr
-        expect(wrapped_csr.request_extensions.length).to eq(0)
+        expect(wrapped_csr.custom_attributes.length).to eq(0)
       end
     end
   end


### PR DESCRIPTION
This commit adds an auto-renew attribute to the CSR when it is generated if the agent supports auto-renewal of certificates. Agents that either do not have the hostcert_renewal_interval setting or have it set to 0 do not support auto-renewal.

Originally, this was added as an auto-renew extension to the CSR (see #9076). However, in its default (FOSS) configuration,  puppetserver rejects extensions so the auto-renew will be implemented as an attribute instead.