### PR TITLE
Avoid downcasing facts in service provider

### DIFF
--- a/lib/puppet/provider/service/init.rb
+++ b/lib/puppet/provider/service/init.rb
@@ -20,12 +20,9 @@ Puppet::Type.type(:service).provide :init, :parent => :base do
   end
 
   # Debian and Ubuntu should use the Debian provider.
+  confine :false => ['Debian', 'Ubuntu'].include?(Puppet.runtime[:facter].value('os.name'))
   # RedHat systems should use the RedHat provider.
-  confine :true => begin
-      os = Puppet.runtime[:facter].value('os.name')
-      family = Puppet.runtime[:facter].value('os.family')
-      !(os == 'Debian' || os == 'Ubuntu' || family == 'RedHat')
-  end
+  confine :false => Puppet.runtime[:facter].value('os.family') == 'RedHat'
 
   # We can't confine this here, because the init path can be overridden.
   #confine :exists => defpath

--- a/lib/puppet/provider/service/init.rb
+++ b/lib/puppet/provider/service/init.rb
@@ -22,9 +22,9 @@ Puppet::Type.type(:service).provide :init, :parent => :base do
   # Debian and Ubuntu should use the Debian provider.
   # RedHat systems should use the RedHat provider.
   confine :true => begin
-      os = Puppet.runtime[:facter].value('os.name').downcase
-      family = Puppet.runtime[:facter].value('os.family').downcase
-      !(os == 'debian' || os == 'ubuntu' || family == 'redhat')
+      os = Puppet.runtime[:facter].value('os.name')
+      family = Puppet.runtime[:facter].value('os.family')
+      !(os == 'Debian' || os == 'Ubuntu' || family == 'RedHat')
   end
 
   # We can't confine this here, because the init path can be overridden.


### PR DESCRIPTION
If the os.name or os.family fact is missing this will result in nil.downcase. In practice that's unlikely, but in some test scenarios it can happen. By using the properly cased values it removes the need to downcase, which is also slightly faster.