### PR TITLE
Fix failing to install packages with `-noarch` in name

### DIFF
--- a/lib/puppet/util/rpm_compare.rb
+++ b/lib/puppet/util/rpm_compare.rb
@@ -6,7 +6,7 @@ module Puppet::Util::RpmCompare
     armv5tejl armv6l armv7l m68kmint s390 s390x ia64 x86_64 sh3 sh4
   ).freeze
 
-  ARCH_REGEX = Regexp.new(ARCH_LIST.join('|\.'))
+  ARCH_REGEX = Regexp.new('\.' + ARCH_LIST.join('|\.'))
 
   # This is an attempt at implementing RPM's
   # lib/rpmvercmp.c rpmvercmp(a, b) in Ruby.


### PR DESCRIPTION
We're missing a `\.` at the beginning, since `.join()` only puts `|\.` in between items:

```
>> ARCH_REGEX = Regexp.new(ARCH_LIST.join('|\.'))
=> /noarch|\.i386|\.i686|\.ppc|\.ppc64|\.armv3l|\.armv4b|\.armv4l|\.armv4tl|\.armv5tel|\.armv5tejl|\.armv6l|\.armv7l|\.m68kmint|\.s390|\.s390x|\.ia64|\.x86_64|\.sh3|\.sh4/
```

Currently puppet is failing to install package with `-noarch` string in its name because of the invalid ARCH_REGEX:

```
package { 'package-name-noarch':
  ensure => '1.0.0.el8'
}
```

```
Debug: Executing: '/bin/dnf -d 0 -e 1 -y install package-name--1.0.0.el8noarch'
Error: Could not update: Execution of '/bin/dnf -d 0 -e 1 -y install package-name--1.0.0.el8noarch' returned 1: Error: Unable to find a match: package-name--1.0.0.el7noarch
```