### PR TITLE
(docs) Updated find_file.rb. Now it includes where the file searching is done

### DIFF
--- a/lib/puppet/functions/find_file.rb
+++ b/lib/puppet/functions/find_file.rb
@@ -8,7 +8,8 @@
 #
 # This function can also accept:
 #
-# * An absolute String path, which checks for the existence of a file from anywhere on disk.
+# * An absolute String path, which checks for the existence of a file from anywhere
+#   on the disk of the puppet instance responsible for catalog compiling.
 # * Multiple String arguments, which returns the path of the **first** file
 #   found, skipping nonexistent files.
 # * An array of string paths, which returns the path of the **first** file


### PR DESCRIPTION
After looking for a solution to a noop problem. We turned to this build-in function. After extensive testing I noticed that the file finding (find_file) is not executed on the puppet node perse. 

When executing puppet like: `puppet apply -v test_file.pp` the find_file functions like expected with the current documentation.

However when running puppet via `puppet agent -t`. The find_file function only finds files that are located on the compiler.
This is differs from the current documentation.
