### PR TITLE
(PUP-11935) Update JRuby in tests to 9.3.y.z

### DIFF
--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -20,7 +20,7 @@ jobs:
           - {os: ubuntu-latest, ruby: '2.6'}
           - {os: ubuntu-latest, ruby: '2.7'}
           - {os: ubuntu-latest, ruby: '3.0'}
-          - {os: ubuntu-latest, ruby: 'jruby-9.2.21.0'}
+          - {os: ubuntu-latest, ruby: 'jruby-9.3.9.0'}
           - {os: windows-2019, ruby: '2.5'}
           - {os: windows-2019, ruby: '2.6'}
           - {os: windows-2019, ruby: '2.7'}

--- a/spec/unit/ssl/certificate_signer_spec.rb
+++ b/spec/unit/ssl/certificate_signer_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe Puppet::SSL::CertificateSigner do
+  include PuppetSpec::Files
+
+  let(:wrong_key) { OpenSSL::PKey::RSA.new(512) }
+  let(:client_cert) { cert_fixture('signed.pem') }
+
+  # jruby-openssl >= 0.13.0 (JRuby >= 9.3.5.0) raises an error when signing a
+  # certificate when there is a discrepancy between the certificate and key.
+  it 'raises if client cert signature is invalid', if: Puppet::Util::Platform.jruby? && RUBY_VERSION.to_f >= 2.6 do
+    expect {
+      client_cert.sign(wrong_key, OpenSSL::Digest::SHA256.new)
+    }.to raise_error(OpenSSL::X509::CertificateError,
+                     'invalid public key data')
+  end
+end

--- a/spec/unit/ssl/ssl_provider_spec.rb
+++ b/spec/unit/ssl/ssl_provider_spec.rb
@@ -298,7 +298,7 @@ describe Puppet::SSL::SSLProvider do
       ).to eq(['CN=signed', 'CN=Test CA Subauthority', 'CN=Test CA'])
     end
 
-    it 'raises if client cert signature is invalid' do
+    it 'raises if client cert signature is invalid', unless: Puppet::Util::Platform.jruby? && RUBY_VERSION.to_f >= 2.6 do
       client_cert.sign(wrong_key, OpenSSL::Digest::SHA256.new)
       expect {
         subject.create_context(**config.merge(client_cert: client_cert))
@@ -337,7 +337,7 @@ describe Puppet::SSL::SSLProvider do
       end
     end
 
-    it 'raises if intermediate CA signature is invalid' do
+    it 'raises if intermediate CA signature is invalid', unless: Puppet::Util::Platform.jruby? && RUBY_VERSION.to_f >= 2.6 do
       int = global_cacerts.last
       int.sign(wrong_key, OpenSSL::Digest::SHA256.new)
 


### PR DESCRIPTION
Puppetserver upgraded from the JRuby 9.2.y.z series to JRuby 9.3.y.z as part of SERVER-3133. This commit updates the JRuby version used in Rspec tests to match the most recent JRuby version used in the Puppetserver 7.x series.