### PR TITLE
Correct inaccurate comment in find_file() function.

### DIFF
--- a/lib/puppet/parser/files.rb
+++ b/lib/puppet/parser/files.rb
@@ -29,9 +29,10 @@ module Puppet::Parser::Files
   #   * modulename/filename selector: a file is found in the file directory
   #     of the named module.
   #
-  # In the second case a nil is returned if there isn't a file found. In the
-  # first case (absolute path), there is no existence check done and so the
-  # path will be returned even if there isn't a file available.
+  # The check for file existence is performed on the node compiling the
+  # manifest. A node running "puppet apply" compiles its own manifest, but
+  # a node running "puppet agent" depends on the configured puppetserver
+  # for compiling. In either case, a nil is returned if no file is found.
   #
   # @param template [String] the file selector
   # @param environment [Puppet::Node::Environment] the environment in which to search


### PR DESCRIPTION
Testing confirms that the `find_file()` function may indeed be used to verify the existence of a file specified by absolute path, with the caveat that this check appears to be performed prior to any resource changes made by the same code.

The following code-snippet accurately reports the existence or non-existence of a test file *before* deleting that file.

```
$testpath = '/tmp/testfile'
file { $testpath: ensure => absent }
if find_file($testpath) {
  notify { "$testpath exists.": }
} else {
  notify { "$testpath does not exist.": }
}
```