### PR TITLE
(PUP-10589) Add a `generate_request` option to `puppet ssl`

### DIFF
--- a/man/man8/puppet-ssl.8
+++ b/man/man8/puppet-ssl.8
@@ -42,6 +42,10 @@ submit_request
 Generate a certificate signing request (CSR) and submit it to the CA\. If a private and public key pair already exist, they will be used to generate the CSR\. Otherwise a new key pair will be generated\. If a CSR has already been submitted with the given \fBcertname\fR, then the operation will fail\.
 .
 .TP
+generate_request
+Generate a certificate signing request (CSR)\. If a private and public key pair already exist, they will be used to generate the CSR\. Otherwise a new key pair will be generated\.
+.
+.TP
 download_cert
 Download a certificate for this host\. If the current private key matches the downloaded certificate, then the certificate will be saved and used for subsequent requests\. If there is already an existing certificate, it will be overwritten\.
 .

--- a/spec/unit/application/ssl_spec.rb
+++ b/spec/unit/application/ssl_spec.rb
@@ -184,32 +184,23 @@ describe Puppet::Application::Ssl, unless: Puppet::Util::Platform.jruby? do
     it 'generates an RSA private key' do
       File.unlink(Puppet[:hostprivkey])
 
-      stub_request(:put, %r{puppet-ca/v1/certificate_request/#{name}}).to_return(status: 200)
-      stub_request(:get, %r{puppet-ca/v1/certificate/#{name}}).to_return(status: 404)
-
-      expects_command_to_pass(%r{Submitted certificate request for '#{name}' to https://.*})
+      expects_command_to_pass(%r{Generated certificate request for '#{name}' at #{requestdir}})
     end
 
     it 'generates an EC private key' do
       Puppet[:key_type] = 'ec'
       File.unlink(Puppet[:hostprivkey])
 
-      stub_request(:put, %r{puppet-ca/v1/certificate_request/#{name}}).to_return(status: 200)
-      stub_request(:get, %r{puppet-ca/v1/certificate/#{name}}).to_return(status: 404)
-
-      expects_command_to_pass(%r{Submitted certificate request for '#{name}' to https://.*})
+      expects_command_to_pass(%r{Generated certificate request for '#{name}' at #{requestdir}})
     end
 
     it 'registers OIDs' do
-      stub_request(:put, %r{puppet-ca/v1/certificate_request/#{name}}).to_return(status: 200)
-      stub_request(:get, %r{puppet-ca/v1/certificate/#{name}}).to_return(status: 404)
-
       expect(Puppet::SSL::Oids).to receive(:register_puppet_oids)
-      expects_command_to_pass(%r{Submitted certificate request for '#{name}' to https://.*})
+
+      expects_command_to_pass(%r{Generated certificate request for '#{name}' at #{requestdir}})
     end
 
     it 'saves the CSR locally' do
-
       expects_command_to_pass(%r{Generated certificate request for '#{name}' at #{requestdir}})
 
       expect(Puppet::FileSystem).to be_exist(csr_path)


### PR DESCRIPTION
The `puppet ssl` command currently does not have a command to just generate a CSR and write it to disk. This adds it. 

I believe this is the associated jira ticket: https://tickets.puppetlabs.com/browse/PUP-10589 but I lost viewer access on the old jira and can't log into the new jira.