### PR TITLE
(maint) Manual mergeup July 31 2023

### DIFF
--- a/acceptance/tests/resource/group/should_query_all.rb
+++ b/acceptance/tests/resource/group/should_query_all.rb
@@ -1,5 +1,6 @@
 test_name "should query all groups"
 skip_test if agents.any? {|agent| agent['platform'] =~ /osx-12-arm64/ || agent['platform'] =~ /osx-13-arm64/  } # See PA-4555
+
 tag 'audit:high',
     'audit:refactor',   # Use block style `test_name`
     'audit:integration' # Does not modify system running test


### PR DESCRIPTION
In CI, automatic mergeup from 7.x to main failed with this:
```
14:24:26 fatal: Exiting because of an unresolved conflict.
14:24:26 U	acceptance/tests/resource/group/should_query_all.rb
14:24:27 + echo 'Couldn'\''t automatically resolve conflicts while merging 5baa68a4c22c0fa16d98696072cca38690611033 into main; Merge-up must be done manually.'
```
This was due to a newline existing in `should_query_all.rb` in 7.x, but not main.