### PR TITLE
(maint) Update beaker-hostgenerator

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -14,7 +14,7 @@ end
 
 gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 4.0')
 gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || ["~>1.0", ">= 1.18.4"])
-gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 1.1")
+gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 2")
 gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || "~> 0.4")
 gem "beaker-vagrant", *location_for(ENV['BEAKER_VAGRANT_VERSION'] || "~> 0")
 gem "beaker-vmpooler", *location_for(ENV['BEAKER_VMPOOLER_VERSION'] || "~> 1.3")


### PR DESCRIPTION
This commit updates beaker-hostgenerator to ~> 2 to enable compatibility with newer platforms, such as macOS 13.