### PR TITLE
(PUP-11841) Fix encoding of empty String

### DIFF
--- a/lib/puppet/application/doc.rb
+++ b/lib/puppet/application/doc.rb
@@ -152,7 +152,7 @@ HELP
   end
 
   def other
-    text = String.new
+    text = ''.dup
     with_contents = options[:references].length <= 1
     exit_code = 0
     require_relative '../../puppet/util/reference'

--- a/lib/puppet/face/config.rb
+++ b/lib/puppet/face/config.rb
@@ -82,7 +82,7 @@ Puppet::Face.define(:config, '0.0.1') do
     end
 
     when_rendering :console do |to_be_rendered|
-      output = String.new
+      output = ''.dup
       if to_be_rendered.keys.length > 1
         to_be_rendered.keys.sort.each do |setting|
           output << "#{setting} = #{to_be_rendered[setting]}\n"

--- a/lib/puppet/face/epp.rb
+++ b/lib/puppet/face/epp.rb
@@ -367,7 +367,7 @@ Puppet::Face.define(:epp, '0.0.1') do
   end
 
   def dump_parse(source, filename, options, show_filename = true)
-    output = String.new
+    output = ''.dup
     evaluating_parser = Puppet::Pops::Parser::EvaluatingParser::EvaluatingEppParser.new
     begin
       if options[:validate]
@@ -451,7 +451,7 @@ Puppet::Face.define(:epp, '0.0.1') do
 
   def render_file(epp_template_name, compiler, options, show_filename, file_nbr)
     template_args = get_values(compiler, options)
-    output = String.new
+    output = ''.dup
     begin
       if show_filename && options[:header]
         output << "\n" unless file_nbr == 1

--- a/lib/puppet/face/module/list.rb
+++ b/lib/puppet/face/module/list.rb
@@ -74,7 +74,7 @@ Puppet::Face.define(:module, '1.0.0') do
       environment     = result[:environment]
       modules_by_path = result[:modules_by_path]
 
-      output = String.new
+      output = ''.dup
 
       warn_unmet_dependencies(environment)
 
@@ -248,7 +248,7 @@ Puppet::Face.define(:module, '1.0.0') do
   # Returns a Hash
   #
   def list_build_node(mod, parent, params)
-    str = String.new
+    str = ''.dup
     str << (mod.forge_name ? mod.forge_name.tr('/', '-') : mod.name)
     str << ' (' + colorize(:cyan, mod.version ? "v#{mod.version}" : '???') + ')'
 

--- a/lib/puppet/face/parser.rb
+++ b/lib/puppet/face/parser.rb
@@ -174,7 +174,7 @@ Puppet::Face.define(:parser, '0.0.1') do
   end
 
   def dump_parse(source, filename, options, show_filename = true)
-    output = String.new
+    output = ''.dup
     evaluating_parser = Puppet::Pops::Parser::EvaluatingParser.new
     begin
       if options[:validate]

--- a/lib/puppet/indirector/facts/facter.rb
+++ b/lib/puppet/indirector/facts/facter.rb
@@ -105,7 +105,7 @@ class Puppet::Node::Facts::Facter < Puppet::Indirector::Code
 
   def find_with_options(request)
     options = request.options
-    options_for_facter = String.new
+    options_for_facter = ''.dup
     options_for_facter += options[:user_query].join(' ')
     options_for_facter += " --config #{options[:config_file]}" if options[:config_file]
     options_for_facter += " --show-legacy" if options[:show_legacy]

--- a/lib/puppet/indirector/file_bucket_file/file.rb
+++ b/lib/puppet/indirector/file_bucket_file/file.rb
@@ -58,7 +58,7 @@ module Puppet::FileBucketFile
       end
       # Setting hash's default value to [], needed by the following loop
       bucket = Hash.new {[]}
-      msg = String.new
+      msg = ''.dup
       # Get all files with mtime between 'from' and 'to'
       Pathname.new(request.options[:bucket_path]).find { |item|
         if item.file? and item.basename.to_s == "paths"

--- a/lib/puppet/indirector/indirection.rb
+++ b/lib/puppet/indirector/indirection.rb
@@ -81,7 +81,7 @@ class Puppet::Indirector::Indirection
 
   # Generate the full doc string.
   def doc
-    text = String.new
+    text = ''.dup
 
     text << scrub(@doc) << "\n\n" if @doc
 

--- a/lib/puppet/module_tool.rb
+++ b/lib/puppet/module_tool.rb
@@ -70,7 +70,7 @@ module Puppet
     # Builds a formatted tree from a list of node hashes containing +:text+
     # and +:dependencies+ keys.
     def self.format_tree(nodes, level = 0)
-      str = String.new
+      str = ''.dup
       nodes.each_with_index do |node, i|
         last_node = nodes.length - 1 == i
         deps = node[:dependencies] || []

--- a/lib/puppet/network/formats.rb
+++ b/lib/puppet/network/formats.rb
@@ -156,7 +156,7 @@ Puppet::Network::FormatHandler.create(:console,
 
     # Simple hash to table
     if datum.is_a?(Hash) && datum.keys.all? { |x| x.is_a?(String) || x.is_a?(Numeric) }
-      output = String.new
+      output = ''.dup
       column_a = datum.empty? ? 2 : datum.map{ |k,v| k.to_s.length }.max + 2
       datum.sort_by { |k,v| k.to_s } .each do |key, value|
         output << key.to_s.ljust(column_a)
@@ -169,7 +169,7 @@ Puppet::Network::FormatHandler.create(:console,
 
     # Print one item per line for arrays
     if datum.is_a? Array
-      output = String.new
+      output = ''.dup
       datum.each do |item|
         output << item.to_s
         output << "\n"
@@ -227,7 +227,7 @@ Puppet::Network::FormatHandler.create(:flat,
   end
 
   def construct_output(data)
-    output = String.new
+    output = ''.dup
     data.each do |key, value|
       output << "#{key}=#{value}"
       output << "\n"

--- a/lib/puppet/network/http/memory_response.rb
+++ b/lib/puppet/network/http/memory_response.rb
@@ -3,7 +3,7 @@ class Puppet::Network::HTTP::MemoryResponse
   attr_reader :code, :type, :body
 
   def initialize
-    @body = String.new
+    @body = ''.dup
   end
 
   def respond_with(code, type, body)

--- a/lib/puppet/parameter/value_collection.rb
+++ b/lib/puppet/parameter/value_collection.rb
@@ -31,7 +31,7 @@ class Puppet::Parameter::ValueCollection
   #
   def doc
     unless defined?(@doc)
-      @doc = String.new
+      @doc = ''.dup
       unless values.empty?
         @doc << "Valid values are "
         @doc << @strings.collect do |value|

--- a/lib/puppet/parser/functions.rb
+++ b/lib/puppet/parser/functions.rb
@@ -258,7 +258,7 @@ module Puppet::Parser::Functions
   def self.functiondocs(environment = Puppet.lookup(:current_environment))
     autoloader.delegatee.loadall(environment)
 
-    ret = String.new
+    ret = ''.dup
 
     merged_functions(environment).sort { |a,b| a[0].to_s <=> b[0].to_s }.each do |name, hash|
       ret << "#{name}\n#{"-" * name.to_s.length}\n"

--- a/lib/puppet/pops/loader/loader_paths.rb
+++ b/lib/puppet/pops/loader/loader_paths.rb
@@ -88,7 +88,7 @@ module LoaderPaths
 
     def typed_name(type, name_authority, relative_path, module_name)
       # Module name is assumed to be included in the path and therefore not added here
-      n = String.new
+      n = ''.dup
       unless extension.empty?
         # Remove extension
         relative_path = relative_path[0..-(extension.length+1)]
@@ -153,7 +153,7 @@ module LoaderPaths
     end
 
     def typed_name(type, name_authority, relative_path, module_name)
-      n = String.new
+      n = ''.dup
       n << module_name unless module_name.nil?
       unless extension.empty?
         # Remove extension
@@ -249,7 +249,7 @@ module LoaderPaths
     end
 
     def typed_name(type, name_authority, relative_path, module_name)
-      n = String.new
+      n = ''.dup
       n << module_name unless module_name.nil?
 
       # Remove the file extension, defined as everything after the *last* dot.
@@ -351,7 +351,7 @@ module LoaderPaths
       if @init_filenames.include?(relative_path) && !(module_name.nil? || module_name.empty?)
         TypedName.new(type, module_name, name_authority)
       else
-        n = String.new
+        n = ''.dup
         n << module_name unless module_name.nil?
         ext = @extensions.find { |extension| relative_path.end_with?(extension) }
         relative_path = relative_path[0..-(ext.length+1)]

--- a/lib/puppet/pops/lookup/explainer.rb
+++ b/lib/puppet/pops/lookup/explainer.rb
@@ -20,7 +20,7 @@ module Lookup
     end
 
     def explain
-      io = String.new
+      io = ''.dup
       dump_on(io, '', '')
       io
     end

--- a/lib/puppet/pops/lookup/hiera_config.rb
+++ b/lib/puppet/pops/lookup/hiera_config.rb
@@ -228,7 +228,7 @@ class HieraConfig
       line_number += 1
       next if line_number < start_line
       quote = nil
-      stripped = String.new
+      stripped = ''.dup
       line.each_codepoint do |cp|
         if cp == 0x22 || cp == 0x27 # double or single quote
           if quote == cp

--- a/lib/puppet/pops/model/factory.rb
+++ b/lib/puppet/pops/model/factory.rb
@@ -1112,7 +1112,7 @@ class Factory
   end
 
   def self.concat(*args)
-    result = String.new
+    result = ''.dup
     args.each do |e|
       if e.instance_of?(Factory) && e.model_class <= LiteralString
         result << e[KEY_VALUE]

--- a/lib/puppet/pops/model/tree_dumper.rb
+++ b/lib/puppet/pops/model/tree_dumper.rb
@@ -21,7 +21,7 @@ class Puppet::Pops::Model::TreeDumper
   end
 
   def format(x)
-    result = String.new
+    result = ''.dup
     parts = format_r(x)
     parts.each_index do |i|
       if i > 0

--- a/lib/puppet/pops/parser/epp_support.rb
+++ b/lib/puppet/pops/parser/epp_support.rb
@@ -183,7 +183,7 @@ module EppSupport
       @skip_leading = skip_leading
 
       return nil if scanner.eos?
-      s = String.new
+      s = ''.dup
       until scanner.eos?
         part = @scanner.scan_until(/(<%)|\z/)
         if @skip_leading

--- a/lib/puppet/pops/parser/evaluating_parser.rb
+++ b/lib/puppet/pops/parser/evaluating_parser.rb
@@ -125,7 +125,7 @@ class EvaluatingParser
   # @return [String] The quoted string
   #
   def self.quote(x)
-    escaped = String.new('"')
+    escaped = '"'.dup
     p = nil
     x.each_char do |c|
       case p

--- a/lib/puppet/pops/parser/pn_parser.rb
+++ b/lib/puppet/pops/parser/pn_parser.rb
@@ -218,7 +218,7 @@ class PNParser
 
   def consume_string
     s = @pos
-    b = String.new
+    b = ''.dup
     loop do
       c = next_cp
       case c

--- a/lib/puppet/pops/pn.rb
+++ b/lib/puppet/pops/pn.rb
@@ -20,7 +20,7 @@ module PN
   end
 
   def to_s
-    s = String.new
+    s = ''.dup
     format(nil, s)
     s
   end

--- a/lib/puppet/pops/serialization/json_path.rb
+++ b/lib/puppet/pops/serialization/json_path.rb
@@ -11,7 +11,7 @@ module JsonPath
   #
   # @api private
   def self.to_json_path(path)
-    p = String.new('$')
+    p = '$'.dup
     path.each do |seg|
       if seg.nil?
         p << '[null]'

--- a/lib/puppet/pops/time/timespan.rb
+++ b/lib/puppet/pops/time/timespan.rb
@@ -545,7 +545,7 @@ module Time
       end
 
       def format(timespan)
-        bld = String.new(timespan.negative? ? '-' : '')
+        bld = timespan.negative? ? '-'.dup : ''.dup
         @segments.each { |segment| segment.append_to(bld, timespan) }
         bld
       end
@@ -575,7 +575,7 @@ module Time
       end
 
       def build_regexp
-        bld = String.new('\A-?')
+        bld = '\A-?'.dup
         @segments.each { |segment| segment.append_regexp(bld) }
         bld << '\z'
         Regexp.new(bld)
@@ -613,7 +613,7 @@ module Time
 
       def append_literal(bld, codepoint)
         if bld.empty? || !bld.last.is_a?(Format::LiteralSegment)
-          bld << Format::LiteralSegment.new(String.new.concat(codepoint))
+          bld << Format::LiteralSegment.new(''.dup.concat(codepoint))
         else
           bld.last.concat(codepoint)
         end

--- a/lib/puppet/pops/types/ruby_generator.rb
+++ b/lib/puppet/pops/types/ruby_generator.rb
@@ -60,7 +60,7 @@ class RubyGenerator < TypeFormatter
       if cls.nil?
         rp = key.resolved_parent
         parent_class = rp.is_a?(PObjectType) ? rp.implementation_class : Object
-        class_def = String.new
+        class_def = ''.dup
         class_body(key, EMPTY_ARRAY, class_def)
         cls = Class.new(parent_class)
         cls.class_eval(class_def)
@@ -109,7 +109,7 @@ class RubyGenerator < TypeFormatter
     end
 
     # Create class definition of all contained types
-    bld = String.new
+    bld = ''.dup
     start_module(common_prefix, comment, bld)
     class_names = []
     names_by_prefix.each_pair do |seg_array, index_and_name_array|

--- a/lib/puppet/pops/types/string_converter.rb
+++ b/lib/puppet/pops/types/string_converter.rb
@@ -701,7 +701,7 @@ class StringConverter
   # Performs post-processing of literals to apply width and precision flags
   def apply_string_flags(f, literal_str)
     if f.left || f.width || f.prec
-      fmt = String.new('%')
+      fmt = '%'.dup
       fmt << '-' if f.left
       fmt << f.width.to_s if f.width
       fmt << '.' << f.prec.to_s if f.prec
@@ -853,7 +853,7 @@ class StringConverter
     end
 
     # Assume that the string can be single quoted
-    bld = String.new('\'')
+    bld = "'".dup
     bld.force_encoding(str.encoding)
     escaped = false
     str.each_codepoint do |codepoint|
@@ -879,12 +879,12 @@ class StringConverter
     # If string ended with a backslash, then that backslash must be escaped
     bld << 0x5c if escaped
 
-    bld << '\''
+    bld << "'"
     bld
   end
 
   def puppet_double_quote(str)
-    bld = String.new('"')
+    bld = '"'.dup
     str.each_codepoint do |codepoint|
       case codepoint
       when 0x09
@@ -940,7 +940,7 @@ class StringConverter
 
     case format.format
     when :a, :s, :p
-      buf = String.new
+      buf = ''.dup
       if indentation.breaks?
         buf << "\n"
         buf << indentation.padding
@@ -1055,7 +1055,7 @@ class StringConverter
 
     when :h, :s, :p
       indentation = indentation.indenting(format.alt? || indentation.is_indenting?)
-      buf = String.new
+      buf = ''.dup
       if indentation.breaks?
         buf << "\n"
         buf << indentation.padding

--- a/lib/puppet/pops/types/type_formatter.rb
+++ b/lib/puppet/pops/types/type_formatter.rb
@@ -50,7 +50,7 @@ class TypeFormatter
   # @api public
   #
   def string(t)
-    @bld = String.new
+    @bld = ''.dup
     append_string(t)
     @bld
   end
@@ -64,7 +64,7 @@ class TypeFormatter
   #
   # @api public
   def indented_string(t, indent = 0, indent_width = 2)
-    @bld = String.new
+    @bld = ''.dup
     append_indented_string(t, indent, indent_width)
     @bld
   end

--- a/lib/puppet/pops/types/types.rb
+++ b/lib/puppet/pops/types/types.rb
@@ -1713,7 +1713,7 @@ class PRegexpType < PScalarType
     if options == 0
       rx_string
     else
-      bld = String.new('(?')
+      bld = '(?'.dup
       bld << 'i' if (options & Regexp::IGNORECASE) != 0
       bld << 'm' if (options & Regexp::MULTILINE) != 0
       bld << 'x' if (options & Regexp::EXTENDED) != 0

--- a/lib/puppet/provider/nameservice/directoryservice.rb
+++ b/lib/puppet/provider/nameservice/directoryservice.rb
@@ -218,8 +218,8 @@ class Puppet::Provider::NameService::DirectoryService < Puppet::Provider::NameSe
         password_hash_plist = users_plist['ShadowHashData'][0]
         converted_hash_plist = convert_binary_to_hash(password_hash_plist)
       else
-        users_plist['ShadowHashData'] = String.new
-        converted_hash_plist = {'SALTED-SHA512' => String.new}
+        users_plist['ShadowHashData'] = ''.dup
+        converted_hash_plist = {'SALTED-SHA512' => ''.dup}
       end
 
       # converted_hash_plist['SALTED-SHA512'] expects a Base64 encoded

--- a/lib/puppet/provider/user/directoryservice.rb
+++ b/lib/puppet/provider/user/directoryservice.rb
@@ -637,7 +637,7 @@ Puppet::Type.type(:user).provide :directoryservice do
   def set_salted_sha512(users_plist, shadow_hash_data, value)
     unless shadow_hash_data
       shadow_hash_data = Hash.new
-      shadow_hash_data['SALTED-SHA512'] = String.new
+      shadow_hash_data['SALTED-SHA512'] = ''.dup
     end
     shadow_hash_data['SALTED-SHA512'] = base64_decode_string(value)
     binary_plist = self.class.convert_hash_to_binary(shadow_hash_data)

--- a/lib/puppet/reference/configuration.rb
+++ b/lib/puppet/reference/configuration.rb
@@ -5,7 +5,7 @@ config = Puppet::Util::Reference.newreference(:configuration, :depth => 1, :doc 
     docs[name] = object
   end
 
-  str = String.new
+  str = ''.dup
   docs.sort { |a, b|
     a[0].to_s <=> b[0].to_s
   }.each do |name, object|

--- a/lib/puppet/reference/indirection.rb
+++ b/lib/puppet/reference/indirection.rb
@@ -5,7 +5,7 @@ require_relative '../../puppet/file_serving/content'
 require_relative '../../puppet/file_serving/metadata'
 
 reference = Puppet::Util::Reference.newreference :indirection, :doc => "Indirection types and their terminus classes" do
-  text = String.new
+  text = ''.dup
   Puppet::Indirector::Indirection.instances.sort_by(&:to_s).each do |indirection|
     ind = Puppet::Indirector::Indirection.instance(indirection)
     name = indirection.to_s.capitalize

--- a/lib/puppet/reports.rb
+++ b/lib/puppet/reports.rb
@@ -71,7 +71,7 @@ class Puppet::Reports
   # Collects the docs for all reports.
   # @api private
   def self.reportdocs
-    docs = String.new
+    docs = ''.dup
 
     # Use this method so they all get loaded
     instance_loader(:report).loadall(Puppet.lookup(:current_environment))

--- a/lib/puppet/transaction/report.rb
+++ b/lib/puppet/transaction/report.rb
@@ -369,7 +369,7 @@ class Puppet::Transaction::Report
   def summary
     report = raw_summary
 
-    ret = String.new
+    ret = ''.dup
     report.keys.sort_by(&:to_s).each do |key|
       ret += "#{Puppet::Util::Metric.labelize(key)}:\n"
 

--- a/lib/puppet/util.rb
+++ b/lib/puppet/util.rb
@@ -409,8 +409,7 @@ module Util
   def uri_encode(path, opts = { :allow_fragment => false })
     raise ArgumentError.new(_('path may not be nil')) if path.nil?
 
-    # ensure string starts as UTF-8 for the sake of Ruby 1.9.3
-    encoded = String.new.encode!(Encoding::UTF_8)
+    encoded = ''.dup
 
     # parse uri into named matches, then reassemble properly encoded
     parts = path.match(RFC_3986_URI_REGEX)
@@ -454,7 +453,7 @@ module Util
 
   def rfc2396_escape(str)
     str.gsub(UNSAFE) do |match|
-      tmp = String.new
+      tmp = ''.dup
       match.each_byte do |uc|
         tmp << sprintf('%%%02X', uc)
       end

--- a/lib/puppet/util/diff.rb
+++ b/lib/puppet/util/diff.rb
@@ -34,7 +34,7 @@ module Puppet::Util::Diff
     data_old = data_old.split(/\n/).map! { |e| e.chomp }
     data_new = data_new.split(/\n/).map! { |e| e.chomp }
 
-    output = String.new
+    output = ''.dup
 
     diffs = ::Diff::LCS.diff(data_old, data_new)
     return output if diffs.empty?

--- a/lib/puppet/util/execution.rb
+++ b/lib/puppet/util/execution.rb
@@ -162,7 +162,7 @@ module Puppet::Util::Execution
     # do this after processing 'command' array or string
     command_str = '[redacted]' if options[:sensitive]
 
-    user_log_s = String.new
+    user_log_s = ''.dup
     if options[:uid]
       user_log_s << " uid=#{options[:uid]}"
     end
@@ -202,7 +202,7 @@ module Puppet::Util::Execution
       stderr = options[:combine] ? stdout : Puppet::FileSystem.open(null_file, nil, 'w')
 
       exec_args = [command, options, stdin, stdout, stderr]
-      output = String.new
+      output = ''.dup
 
       # We close stdin/stdout/stderr immediately after fork/exec as they're no longer needed by
       # this process. In most cases they could be closed later, but when `stdout` is the "writer"

--- a/lib/puppet/util/inifile.rb
+++ b/lib/puppet/util/inifile.rb
@@ -79,7 +79,7 @@ module Puppet::Util::IniConfig
     # written to file
     def format
       if @destroy
-        text = String.new
+        text = ''.dup
       else
         text = "[#{name}]\n"
         @entries.each do |entry|
@@ -208,7 +208,7 @@ module Puppet::Util::IniConfig
     end
 
     def format
-      text = String.new
+      text = ''.dup
 
       @contents.each do |content|
         if content.is_a? Section

--- a/lib/puppet/util/package/version/rpm.rb
+++ b/lib/puppet/util/package/version/rpm.rb
@@ -19,7 +19,7 @@ module Puppet::Util::Package::Version
     end
 
     def to_s
-      version_found = String.new
+      version_found = ''.dup
       version_found += "#{@epoch}:"   if @epoch
       version_found += @version
       version_found += "-#{@release}" if @release

--- a/lib/puppet/util/provider_features.rb
+++ b/lib/puppet/util/provider_features.rb
@@ -76,7 +76,7 @@ module Puppet::Util::ProviderFeatures
 
   # @return [String] Returns a string with documentation covering all features.
   def featuredocs
-    str = String.new
+    str = ''.dup
     @features ||= {}
     return nil if @features.empty?
     names = @features.keys.sort_by(&:to_s)

--- a/lib/puppet/util/selinux.rb
+++ b/lib/puppet/util/selinux.rb
@@ -227,7 +227,7 @@ module Puppet::Util::SELinux
 
   # Internal helper function to read and parse /proc/mounts
   def read_mounts
-    mounts = String.new
+    mounts = ''.dup
     begin
       if File.method_defined? "read_nonblock"
         # If possible we use read_nonblock in a loop rather than read to work-

--- a/lib/puppet/util/windows/access_control_entry.rb
+++ b/lib/puppet/util/windows/access_control_entry.rb
@@ -61,7 +61,7 @@ class Puppet::Util::Windows::AccessControlEntry
   end
 
   def inspect
-    inheritance = String.new
+    inheritance = ''.dup
     inheritance << '(I)' if inherited?
     inheritance << '(OI)' if object_inherit?
     inheritance << '(CI)' if container_inherit?

--- a/lib/puppet/util/windows/access_control_list.rb
+++ b/lib/puppet/util/windows/access_control_list.rb
@@ -98,7 +98,7 @@ class Puppet::Util::Windows::AccessControlList
   end
 
   def inspect
-    str = String.new
+    str = ''.dup
     @aces.each do |ace|
       str << "  #{ace.inspect}\n"
     end

--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -488,7 +488,7 @@ module Puppet::Util::Windows::ADSI
     # UNLEN from lmcons.h - https://stackoverflow.com/a/2155176
     MAX_USERNAME_LENGTH = 256
     def self.current_user_name
-      user_name = String.new
+      user_name = ''.dup
       max_length = MAX_USERNAME_LENGTH + 1 # NULL terminated
       FFI::MemoryPointer.new(max_length * 2) do |buffer| # wide string
         FFI::MemoryPointer.new(:dword, 1) do |buffer_size|
@@ -520,7 +520,7 @@ module Puppet::Util::Windows::ADSI
     NameSurname           = 14
 
     def self.current_user_name_with_format(format)
-      user_name = String.new
+      user_name = ''.dup
       max_length = 1024
 
       FFI::MemoryPointer.new(:lpwstr, max_length * 2 + 1) do |buffer|

--- a/lib/puppet/util/windows/error.rb
+++ b/lib/puppet/util/windows/error.rb
@@ -32,7 +32,7 @@ class Puppet::Util::Windows::Error < Puppet::Error
             FORMAT_MESSAGE_ARGUMENT_ARRAY |
             FORMAT_MESSAGE_IGNORE_INSERTS |
             FORMAT_MESSAGE_MAX_WIDTH_MASK
-    error_string = String.new
+    error_string = ''.dup
 
     # this pointer actually points to a :lpwstr (pointer) since we're letting Windows allocate for us
     FFI::MemoryPointer.new(:pointer, 1) do |buffer_ptr|

--- a/lib/puppet/util/windows/file.rb
+++ b/lib/puppet/util/windows/file.rb
@@ -245,7 +245,7 @@ module Puppet::Util::Windows::File
   module_function :readlink
 
   def get_long_pathname(path)
-    converted = String.new
+    converted = ''.dup
     FFI::Pointer.from_string_to_wide_string(path) do |path_ptr|
       # includes terminating NULL
       buffer_size = GetLongPathNameW(path_ptr, FFI::Pointer::NULL, 0)
@@ -263,7 +263,7 @@ module Puppet::Util::Windows::File
   module_function :get_long_pathname
 
   def get_short_pathname(path)
-    converted = String.new
+    converted = ''.dup
     FFI::Pointer.from_string_to_wide_string(path) do |path_ptr|
       # includes terminating NULL
       buffer_size = GetShortPathNameW(path_ptr, FFI::Pointer::NULL, 0)

--- a/lib/puppet/util/windows/process.rb
+++ b/lib/puppet/util/windows/process.rb
@@ -121,7 +121,7 @@ module Puppet::Util::Windows::Process
   module_function :with_process_token
 
   def get_process_image_name_by_pid(pid)
-    image_name = String.new
+    image_name = ''.dup
 
     Puppet::Util::Windows::Security.with_privilege(Puppet::Util::Windows::Security::SE_DEBUG_NAME) do
       open_process(PROCESS_QUERY_INFORMATION, false, pid) do |phandle|


### PR DESCRIPTION
In 2077971499d3cfc3e33b6eba4c91f43f82f1214c empty string literals where replaced by a call to `String.new` in preparation for moving to frozen/immutable strings.

However, as stated in the String#new documentation, when no value is passed to `#new` the returned string has the 'ASCII-8BIT' encoding instead of the default one (which is assumed to be 'UTF-8' by Puppet).

This cause regressions in some areas of the code, for example when using the concat module with exported resource built using epp templates, the incorrect encoding cause the fragment to be misinterpreted and is base64 encoded.  When collected, the base64 representation of the string is used instead of the actual value of the string, as reported here:
https://github.com/voxpupuli/puppet-bacula/issues/189

Replace calls to `String.new` with `''.dup` which use the current encoding.  Do not change the few explicit but redundant occurrences of `String.new.force_encoding('ASCII-8BIT')` (so that the intent is clearly visible).  Where appropriate, slightly adjust the code for better
readability.
