### PR TITLE
(PUP-11928) Give more specific error messages for /puppet/v3/tasks API

### DIFF
--- a/lib/puppet/info_service/task_information_service.rb
+++ b/lib/puppet/info_service/task_information_service.rb
@@ -13,7 +13,7 @@ class Puppet::InfoService::TaskInformationService
           task.validate
           {:module => {:name => task.module.name}, :name => task.name, :metadata => task.metadata}
         rescue Puppet::Module::Task::Error => err
-          Puppet.log_exception(err, 'Failed to validate task')
+          Puppet.log_exception(err)
           nil
         end
       end

--- a/spec/unit/info_service_spec.rb
+++ b/spec/unit/info_service_spec.rb
@@ -47,7 +47,7 @@ describe "Puppet::InfoService" do
                                                                              :content => metadata.to_json}]]})
           File.write("#{modpath}/#{mod_name}/tasks/atask.json", "NOT JSON")
 
-          expect(Puppet).to receive(:send_log).with(:err, 'Failed to validate task')
+          expect(Puppet).to receive(:send_log).with(:err, /unexpected token at 'NOT JSON'/)
 
           @tasks = Puppet::InfoService.tasks_per_environment(env_name)
           expect(@tasks.map{|t| t[:name]}).to contain_exactly('test1::btask', 'test1::ctask')


### PR DESCRIPTION
Currently, when a task is omitted due to a failure, Puppet Server logs an exception with a generic error message and provides no details on how to resolve the error: `ERROR [qtp1527520408-905] [puppetserver] Puppet Failed to validate task`

This commit removes the generic message that overrides the original error message in the rescued error. Instead, the rescued error message is logged.