### PR TITLE
(PUP-10589) Add a generate_request option to puppet ssl

### DIFF
--- a/lib/puppet/application/ssl.rb
+++ b/lib/puppet/application/ssl.rb
@@ -169,13 +169,7 @@ HELP
   def submit_request(ssl_context)
     key = @cert_provider.load_private_key(Puppet[:certname])
     unless key
-      if Puppet[:key_type] == 'ec'
-        Puppet.info _("Creating a new EC SSL key for %{name} using curve %{curve}") % { name: Puppet[:certname], curve: Puppet[:named_curve] }
-        key = OpenSSL::PKey::EC.generate(Puppet[:named_curve])
-      else
-        Puppet.info _("Creating a new SSL key for %{name}") % { name: Puppet[:certname] }
-        key = OpenSSL::PKey::RSA.new(Puppet[:keylength].to_i)
-      end
+      key = create_key(Puppet[:certname])
       @cert_provider.save_private_key(Puppet[:certname], key)
     end
 
@@ -197,13 +191,7 @@ HELP
   def generate_request(certname)
     key = @cert_provider.load_private_key(certname)
     unless key
-      if Puppet[:key_type] == 'ec'
-        Puppet.info _("Creating a new EC SSL key for %{name} using curve %{curve}") % { name: certname, curve: Puppet[:named_curve] }
-        key = OpenSSL::PKey::EC.generate(Puppet[:named_curve])
-      else
-        Puppet.info _("Creating a new SSL key for %{name}") % { name: certname }
-        key = OpenSSL::PKey::RSA.new(Puppet[:keylength].to_i)
-      end
+      key = create_key(certname)
       @cert_provider.save_private_key(certname, key)
     end
 
@@ -311,5 +299,15 @@ END
 
   def create_route(ssl_context)
     @session.route_to(:ca, ssl_context: ssl_context)
+  end
+
+  def create_key(certname)
+    if Puppet[:key_type] == 'ec'
+      Puppet.info _("Creating a new EC SSL key for %{name} using curve %{curve}") % { name: certname, curve: Puppet[:named_curve] }
+      OpenSSL::PKey::EC.generate(Puppet[:named_curve])
+    else
+      Puppet.info _("Creating a new SSL key for %{name}") % { name: certname }
+      OpenSSL::PKey::RSA.new(Puppet[:keylength].to_i)
+    end
   end
 end

--- a/lib/puppet/application/ssl.rb
+++ b/lib/puppet/application/ssl.rb
@@ -209,7 +209,7 @@ HELP
 
     csr = @cert_provider.create_request(certname, key)
     @cert_provider.save_request(certname, csr)
-    Puppet.notice _("Generated certificate request for '%{name}' at %{requestdir}") % { name: certname, requestdir: Puppet[:requestdir] }
+    Puppet.notice _("Generated certificate request in '%{path}'") % { path: @cert_provider.to_path(Puppet[:requestdir], certname) }
   rescue => e
     raise Puppet::Error.new(_("Failed to generate certificate request: %{message}") % { message: e.message }, e)
   end

--- a/lib/puppet/application/ssl.rb
+++ b/lib/puppet/application/ssl.rb
@@ -59,6 +59,11 @@ ACTIONS
   the CSR. Otherwise a new key pair will be generated. If a CSR has already
   been submitted with the given `certname`, then the operation will fail.
 
+* generate_request:
+  Generate a certificate signing request (CSR). If
+  a private and public key pair already exist, they will be used to generate
+  the CSR. Otherwise a new key pair will be generated.
+
 * download_cert:
   Download a certificate for this host. If the current private key matches
   the downloaded certificate, then the certificate will be saved and used
@@ -136,6 +141,8 @@ HELP
       unless cert
         raise Puppet::Error, _("The certificate for '%{name}' has not yet been signed") % { name: certname }
       end
+    when 'generate_request'
+      generate_request(certname)
     when 'verify'
       verify(certname)
     when 'clean'
@@ -185,6 +192,26 @@ HELP
     end
   rescue => e
     raise Puppet::Error.new(_("Failed to submit certificate request: %{message}") % { message: e.message }, e)
+  end
+
+  def generate_request(certname)
+    key = @cert_provider.load_private_key(certname)
+    unless key
+      if Puppet[:key_type] == 'ec'
+        Puppet.info _("Creating a new EC SSL key for %{name} using curve %{curve}") % { name: certname, curve: Puppet[:named_curve] }
+        key = OpenSSL::PKey::EC.generate(Puppet[:named_curve])
+      else
+        Puppet.info _("Creating a new SSL key for %{name}") % { name: certname }
+        key = OpenSSL::PKey::RSA.new(Puppet[:keylength].to_i)
+      end
+      @cert_provider.save_private_key(certname, key)
+    end
+
+    csr = @cert_provider.create_request(certname, key)
+    @cert_provider.save_request(certname, csr)
+    Puppet.notice _("Generated certificate request for '%{name}' at %{requestdir}") % { name: certname, requestdir: Puppet[:requestdir] }
+  rescue => e
+    raise Puppet::Error.new(_("Failed to generate certificate request: %{message}") % { message: e.message }, e)
   end
 
   def download_cert(ssl_context)

--- a/lib/puppet/x509/cert_provider.rb
+++ b/lib/puppet/x509/cert_provider.rb
@@ -346,12 +346,16 @@ class Puppet::X509::CertProvider
     OpenSSL::X509::Request.new(pem)
   end
 
-  private
-
+  # Return the path to the cert related object (key, CSR, cert, etc).
+  #
+  # @param base [String] base directory
+  # @param name [String] the name associated with the cert related object
   def to_path(base, name)
     raise _("Certname %{name} must not contain unprintable or non-ASCII characters") % { name: name.inspect } unless name =~ VALID_CERTNAME
     File.join(base, "#{name.downcase}.pem")
   end
+
+  private
 
   def permissions_for_setting(name)
     setting = Puppet.settings.setting(name)

--- a/spec/unit/application/ssl_spec.rb
+++ b/spec/unit/application/ssl_spec.rb
@@ -171,6 +171,50 @@ describe Puppet::Application::Ssl, unless: Puppet::Util::Platform.jruby? do
     end
   end
 
+  context 'when generating a CSR' do
+    let(:csr_path) { Puppet[:hostcsr] }
+    let(:requestdir) { Puppet[:requestdir] }
+
+    before do
+      ssl.command_line.args << 'generate_request'
+    end
+
+    it 'generates an RSA private key' do
+      File.unlink(Puppet[:hostprivkey])
+
+      expects_command_to_pass(%r{Generated certificate request for '#{name}' at #{requestdir}})
+    end
+
+    it 'generates an EC private key' do
+      Puppet[:key_type] = 'ec'
+      File.unlink(Puppet[:hostprivkey])
+
+      expects_command_to_pass(%r{Generated certificate request for '#{name}' at #{requestdir}})
+    end
+
+    it 'registers OIDs' do
+      expect(Puppet::SSL::Oids).to receive(:register_puppet_oids)
+
+      expects_command_to_pass(%r{Generated certificate request for '#{name}' at #{requestdir}})
+    end
+
+    it 'saves the CSR locally' do
+      expects_command_to_pass(%r{Generated certificate request for '#{name}' at #{requestdir}})
+
+      expect(Puppet::FileSystem).to be_exist(csr_path)
+    end
+
+    it 'accepts dns alt names' do
+      Puppet[:dns_alt_names] = 'majortom'
+
+      expects_command_to_pass
+
+      csr = Puppet::SSL::CertificateRequest.new(name)
+      csr.read(csr_path)
+      expect(csr.subject_alt_names).to include('DNS:majortom')
+    end
+  end
+
   context 'when downloading a certificate' do
     before do
       ssl.command_line.args << 'download_cert'

--- a/spec/unit/application/ssl_spec.rb
+++ b/spec/unit/application/ssl_spec.rb
@@ -182,24 +182,24 @@ describe Puppet::Application::Ssl, unless: Puppet::Util::Platform.jruby? do
     it 'generates an RSA private key' do
       File.unlink(Puppet[:hostprivkey])
 
-      expects_command_to_pass(%r{Generated certificate request for '#{name}' at #{requestdir}})
+      expects_command_to_pass(%r{Generated certificate request in '#{csr_path}'})
     end
 
     it 'generates an EC private key' do
       Puppet[:key_type] = 'ec'
       File.unlink(Puppet[:hostprivkey])
 
-      expects_command_to_pass(%r{Generated certificate request for '#{name}' at #{requestdir}})
+      expects_command_to_pass(%r{Generated certificate request in '#{csr_path}'})
     end
 
     it 'registers OIDs' do
       expect(Puppet::SSL::Oids).to receive(:register_puppet_oids)
 
-      expects_command_to_pass(%r{Generated certificate request for '#{name}' at #{requestdir}})
+      expects_command_to_pass(%r{Generated certificate request in '#{csr_path}'})
     end
 
     it 'saves the CSR locally' do
-      expects_command_to_pass(%r{Generated certificate request for '#{name}' at #{requestdir}})
+      expects_command_to_pass(%r{Generated certificate request in '#{csr_path}'})
 
       expect(Puppet::FileSystem).to be_exist(csr_path)
     end


### PR DESCRIPTION
Adds a command `puppet ssl generate_request` to generate a CSR but not submit it. This is useful when boostrapping an offline agent.