### PR TITLE
(PUP-11930) log openssl version

### DIFF
--- a/lib/puppet/application.rb
+++ b/lib/puppet/application.rb
@@ -503,8 +503,12 @@ class Application
     runtime_info = {
       'puppet_version' => Puppet.version,
       'ruby_version'   => RUBY_VERSION,
-      'run_mode'       => self.class.run_mode.name,
+      'run_mode'       => self.class.run_mode.name
     }
+    unless Puppet::Util::Platform.jruby_fips?
+      runtime_info['openssl_version'] = "'#{OpenSSL::OPENSSL_VERSION}'"
+      runtime_info['openssl_fips'] = OpenSSL::OPENSSL_FIPS
+    end
     runtime_info['default_encoding'] = Encoding.default_external
     runtime_info.merge!(extra_info) unless extra_info.nil?
 


### PR DESCRIPTION
Log the openssl version and whether FIPS is enabled. The version contains spaces, so quote it. This is omitted on JRuby, because we don't require openssl, see puppet/ssl/openssl_loader.rb for details.

    Debug: Runtime environment: puppet_version=8.1.0 ... \
    openssl_version='OpenSSL 1.1.1f  31 Mar 2020', openssl_fips=false