### PR TITLE
(PUP-11895) ssl application's clean shouldn't allow extra args

### DIFF
--- a/lib/puppet/application/ssl.rb
+++ b/lib/puppet/application/ssl.rb
@@ -146,6 +146,16 @@ HELP
     when 'verify'
       verify(certname)
     when 'clean'
+      possible_extra_args = command_line.args.drop(1)
+      unless possible_extra_args.empty?
+        raise Puppet::Error, _(<<END) % { args: possible_extra_args.join(' ')}
+Extra arguments detected: %{args}
+Did you mean to run:
+  puppetserver ca clean --certname <name>
+Or:
+  puppet ssl clean --target <name>
+END
+      end
       clean(certname)
     when 'bootstrap'
       if !Puppet::Util::Log.sendlevel?(:info)

--- a/spec/unit/application/ssl_spec.rb
+++ b/spec/unit/application/ssl_spec.rb
@@ -391,6 +391,11 @@ describe Puppet::Application::Ssl, unless: Puppet::Util::Platform.jruby? do
       expects_command_to_fail(%r{Failed to connect to the CA to determine if certificate #{name} has been cleaned})
     end
 
+    it 'raises if we have extra args' do
+      ssl.command_line.args << 'hostname.example.biz'
+      expects_command_to_fail(/Extra arguments detected: hostname.example.biz/)
+    end
+
     context 'when deleting local CA' do
       before do
         ssl.command_line.args << '--localca'


### PR DESCRIPTION
If a user attempts to get rid of some certs and confuses `puppetserver ca clean` with `puppet ssl clean`, there is a chance it will wipe out keys/certs that were not intended. This commit adds some safeguards to the ssl clean subcommand to try to avoid that scenario.