### PR TITLE
(PUP-11947) Pin FFI to 1.15.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ group(:features) do
 end
 
 group(:test) do
-  gem "ffi", require: false
+  gem "ffi", '1.15.5', require: false
   gem "json-schema", "~> 2.0", require: false
   gem "rake", *location_for(ENV['RAKE_LOCATION'] || '~> 13.0')
   gem "rspec", "~> 3.1", require: false

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -40,11 +40,11 @@ gem_platform_dependencies:
       CFPropertyList: '~> 2.2'
   x86-mingw32:
     gem_runtime_dependencies:
-      ffi: ['> 1.9.24', '< 2']
+      ffi: '1.15.5'
       minitar: '~> 0.9'
   x64-mingw32:
     gem_runtime_dependencies:
-      ffi: ['> 1.9.24', '< 2']
+      ffi: '1.15.5'
       minitar: '~> 0.9'
 bundle_platforms:
   universal-darwin: all


### PR DESCRIPTION
FFI >= 1.16.0 breaks FFI modules in Facter, which is a dependency of Puppet. While the latest release of Facter (4.5.0) pins FFI to 1.15.5, Puppet's gemspec adds a Windows-specific runtime dependency on FFI set to > 1.9.24 < 2, which currently resolves to the latest version of FFI (1.16.2).

This commit pins FFI to 1.15.5 to address the incompatibility between Facter and FFI >=1.16.0.