### PR TITLE
(PUP-11945) Add patches for File and Dir exists? methods

### DIFF
--- a/lib/puppet/util/monkey_patches.rb
+++ b/lib/puppet/util/monkey_patches.rb
@@ -30,6 +30,24 @@ class Object
   end
 end
 
+unless Dir.singleton_methods.include?(:exists?)
+  class Dir
+    def self.exists?(file_name)
+      Puppet.warning('exists? is a deprecated name, use exist? instead')
+      Dir.exist?(file_name)
+    end
+  end
+end
+
+unless File.singleton_methods.include?(:exists?)
+  class File
+    def self.exists?(file_name)
+      Puppet.warning('exists? is a deprecated name, use exist? instead')
+      File.exist?(file_name)
+    end
+  end
+end
+
 require_relative '../../puppet/ssl/openssl_loader'
 unless Puppet::Util::Platform.jruby_fips?
   class OpenSSL::SSL::SSLContext

--- a/spec/unit/util/monkey_patches_spec.rb
+++ b/spec/unit/util/monkey_patches_spec.rb
@@ -2,6 +2,44 @@ require 'spec_helper'
 
 require 'puppet/util/monkey_patches'
 
+describe Dir do
+  describe '.exists?' do
+    it 'returns false if the directory does not exist' do
+      expect(Dir.exists?('/madeupdirectory')).to be false
+    end
+
+    it 'returns true if the directory exists' do
+      expect(Dir.exists?(__dir__)).to be true
+    end
+
+    if RUBY_VERSION >= '3.2' 
+      it 'logs a warning message' do
+        expect(Puppet).to receive(:warning).with('exists? is a deprecated name, use exist? instead')
+        Dir.exists?(__dir__)
+      end
+    end
+  end
+end
+
+describe File do
+  describe '.exists?' do
+    it 'returns false if the directory does not exist' do
+      expect(File.exists?('spec/unit/util/made_up_file')).to be false
+    end
+
+    it 'returns true if the file exists' do
+      expect(File.exists?(__FILE__)).to be true
+    end
+
+    if RUBY_VERSION >= '3.2'
+      it 'logs a warning message' do
+        expect(Puppet).to receive(:warning).with('exists? is a deprecated name, use exist? instead')
+        File.exists?(__FILE__)
+      end
+    end
+  end
+end
+
 describe Symbol do
   after :all do
     $unique_warnings.delete('symbol_comparison') if $unique_warnings


### PR DESCRIPTION
We should handle cases where the deprecated exists? methods are called for File or Dir, and give a warning but still allow things to proceed.