### PR TITLE
Correct user <-> group relationship on removal

### DIFF
--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -19,7 +19,15 @@ module Puppet
       provided in the `gid` attribute) or any group listed in the `groups`
       attribute then the user resource will autorequire that group. If Puppet
       is managing any role accounts corresponding to the user's roles, the
-      user resource will autorequire those role accounts."
+      user resource will autorequire those role accounts.
+      Only when the resource is ensured to be present.
+
+      **Autobefores:** If Puppet is managing the user's primary group (as
+      provided in the `gid` attribute) or any group listed in the `groups`
+      attribute then the user resource will autobefore that group. If Puppet
+      is managing any role accounts corresponding to the user's roles, the
+      user resource will autorequire those role accounts.
+      Only when the resource is ensured to be absent."
 
     feature :allows_duplicates,
       "The provider supports duplicate users with the same UID."
@@ -463,20 +471,44 @@ module Puppet
     autorequire(:group) do
       autos = []
 
-      if @parameters[:gid]&.shouldorig
-        groups_in_catalog = catalog.resources.filter { |r| r.is_a?(Puppet::Type.type(:group)) }
-        autos += @parameters[:gid].shouldorig.filter_map do |group|
-          if (group.is_a?(String) && group.match?(/^\d+$/)) || group.is_a?(Integer)
-            gid = Integer(group)
-            groups_in_catalog.find { |r| r.should(:gid) == gid }
-          else
-            group
+      if self[:ensure] != :absent
+        if @parameters[:gid]&.shouldorig
+          groups_in_catalog = catalog.resources.filter { |r| r.is_a?(Puppet::Type.type(:group)) }
+          autos += @parameters[:gid].shouldorig.filter_map do |group|
+            if (group.is_a?(String) && group.match?(/^\d+$/)) || group.is_a?(Integer)
+              gid = Integer(group)
+              groups_in_catalog.find { |r| r.should(:gid) == gid }
+            else
+              group
+            end
           end
+        end
+
+        if @parameters[:groups]&.should
+          autos += @parameters[:groups].should.split(",")
         end
       end
 
-      if @parameters[:groups]&.should
-        autos += @parameters[:groups].should.split(",")
+      autos
+    end
+
+    # Autobefore the primary group, if it's around. Otherwise group removal
+    # fails when that group is also ensured absent.
+    autobefore(:group) do
+      autos = []
+
+      if self[:ensure] == :absent
+        if @parameters[:gid]&.shouldorig
+          groups_in_catalog = catalog.resources.filter { |r| r.is_a?(Puppet::Type.type(:group)) }
+          autos += @parameters[:gid].shouldorig.filter_map do |group|
+            if (group.is_a?(String) && group.match?(/^\d+$/)) || group.is_a?(Integer)
+              gid = Integer(group)
+              groups_in_catalog.find { |r| r.should(:gid) == gid }
+            else
+              group
+            end
+          end
+        end
       end
 
       autos

--- a/spec/unit/type/user_spec.rb
+++ b/spec/unit/type/user_spec.rb
@@ -257,6 +257,10 @@ describe Puppet::Type.type(:user) do
           it "has no autorequire" do
             expect(testuser.autorequire).to be_empty
           end
+
+          it "has no autobefore" do
+            expect(testuser.autobefore).to be_empty
+          end
         end
 
         context 'when gid specified as number-looking string' do
@@ -264,6 +268,10 @@ describe Puppet::Type.type(:user) do
 
           it "autorequires the group" do
             expect(testuser.autorequire).to match_array([an_object_having_attributes(source: testgroup, target: testuser)])
+          end
+
+          it "has no autobefore" do
+            expect(testuser.autobefore).to be_empty
           end
         end
 
@@ -273,6 +281,10 @@ describe Puppet::Type.type(:user) do
           it "autorequires the group" do
             expect(testuser.autorequire).to match_array([an_object_having_attributes(source: testgroup, target: testuser)])
           end
+
+          it "has no autobefore" do
+            expect(testuser.autobefore).to be_empty
+          end
         end
 
         context 'when gid specified as name' do
@@ -280,6 +292,60 @@ describe Puppet::Type.type(:user) do
 
           it "autorequires the group" do
             expect(testuser.autorequire).to match_array([an_object_having_attributes(source: testgroup, target: testuser)])
+          end
+
+          it "has no autobefore" do
+            expect(testuser.autobefore).to be_empty
+          end
+        end
+      end
+
+      context 'when ensure => absent' do
+        context 'when gid specified as :absent' do
+          let(:testuser) { described_class.new(:name => "testuser", :ensure => :absent, :gid => :absent) }
+
+          it "has no autorequire" do
+            expect(testuser.autorequire).to be_empty
+          end
+
+          it "has no autobefore" do
+            expect(testuser.autobefore).to be_empty
+          end
+        end
+
+        context 'when gid specified as number-looking string' do
+          let(:testuser) { described_class.new(:name => "testuser", :ensure => :absent, :gid => '50') }
+
+          it "has no autorequire" do
+            expect(testuser.autorequire).to be_empty
+          end
+
+          it "autobefores the group" do
+            expect(testuser.autobefore).to match_array([an_object_having_attributes(source: testuser, target: testgroup)])
+          end
+        end
+
+        context 'when gid specified as integer' do
+          let(:testuser) { described_class.new(:name => "testuser", :ensure => :absent, :gid => 50) }
+
+          it "has no autorequire" do
+            expect(testuser.autorequire).to be_empty
+          end
+
+          it "autobefores the group" do
+            expect(testuser.autobefore).to match_array([an_object_having_attributes(source: testuser, target: testgroup)])
+          end
+        end
+
+        context 'when gid specified as name' do
+          let(:testuser) { described_class.new(:name => "testuser", :ensure => :absent, :gid => 'foo') }
+
+          it "has no autorequire" do
+            expect(testuser.autorequire).to be_empty
+          end
+
+          it "autobefores the group" do
+            expect(testuser.autobefore).to match_array([an_object_having_attributes(source: testuser, target: testgroup)])
           end
         end
       end

--- a/spec/unit/type/user_spec.rb
+++ b/spec/unit/type/user_spec.rb
@@ -239,6 +239,51 @@ describe Puppet::Type.type(:user) do
         resource.parameter(:gid).sync
       end
     end
+
+    context 'automatic relations' do
+      let(:testgroup) { Puppet::Type.type(:group).new(:name => 'foo', :gid => 50) }
+
+      before do
+        Puppet::Resource::Catalog.new :testing do |conf|
+          conf.add_resource(testuser)
+          conf.add_resource(testgroup)
+        end
+      end
+
+      context 'when ensure => present' do
+        context 'when gid specified as :absent' do
+          let(:testuser) { described_class.new(:name => "testuser", :gid => :absent) }
+
+          it "has no autorequire" do
+            expect(testuser.autorequire).to be_empty
+          end
+        end
+
+        context 'when gid specified as number-looking string' do
+          let(:testuser) { described_class.new(:name => "testuser", :gid => '50') }
+
+          it "autorequires the group" do
+            expect(testuser.autorequire).to match_array([an_object_having_attributes(source: testgroup, target: testuser)])
+          end
+        end
+
+        context 'when gid specified as integer' do
+          let(:testuser) { described_class.new(:name => "testuser", :gid => 50) }
+
+          it "autorequires the group" do
+            expect(testuser.autorequire).to match_array([an_object_having_attributes(source: testgroup, target: testuser)])
+          end
+        end
+
+        context 'when gid specified as name' do
+          let(:testuser) { described_class.new(:name => "testuser", :gid => 'foo') }
+
+          it "autorequires the group" do
+            expect(testuser.autorequire).to match_array([an_object_having_attributes(source: testgroup, target: testuser)])
+          end
+        end
+      end
+    end
   end
 
   describe "when managing groups" do


### PR DESCRIPTION
When a group needs to be removed, it can't be the primary group of a user.  So if a user is ensured absent, it needs to happen before the group is removed.

This PR first adds tests to the existing code, before refactoring it. Then in the last commit it adds autobefore and makes sure autorequires is empty when ensure is absent.