### PR TITLE
(PUP-11944) Update `hostcert_renewal_interval` puppet setting docs

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1247,11 +1247,11 @@ EOT
     :hostcert_renewal_interval => {
       :default => "30d",
       :type    => :duration,
-      :desc    => "How often the Puppet agent refreshes its client certificate.
-         By default the client certificate is refreshed once every 30 days. If
-         a different duration is specified, then the agent will refresh its
-         client certificate whenever it next runs and the elapsed time since the
-         client certificate was last refreshed exceeds the duration.
+      :desc    => "When the Puppet agent refreshes its client certificate.
+         By default the client certificate will refresh 30 days before the certificate
+         expires. If a different duration is specified, then the agent will refresh its
+         client certificate whenever it next runs and if the client certificate expires
+         within the duration specified.
 
          In general, the duration should be greater than the `runinterval`.
          Setting it to 0 will disable automatic renewal.


### PR DESCRIPTION
Currently, the documentation of the setting implies that the certificate will be refreshed every N days (N = specified duration). However, it actually only renews the client cert if the cert expires within N days from now.

This commit updates the documentation for hostcert_renewal_interval in defaults.rb to more closely reflect how the setting behaves.