### PR TITLE
Fix `Puppet::HTTP::Client` example with system store

### DIFF
--- a/docs/http.md
+++ b/docs/http.md
@@ -260,7 +260,7 @@ possible to additionally trust the system store when making HTTPS requests:
 
 ```ruby
 client = Puppet::HTTP::Client.new
-response = http.get("https://artifactory.example.com/java.tar.gz", trust_system_store: true)
+response = client.get("https://artifactory.example.com/java.tar.gz", options: { include_system_store: true })
 response.read_body do |data|
   puts "Read #{data.bytes}"
 end


### PR DESCRIPTION
The evolution of that part of the code has seen multiple iterations, and
the doc does not reflect the current usage so fix it.

While here, also fix the wrong variable name typo.
