### PR TITLE
(docs) update filebucket doc to reflect cryptographic checksum instead of md5

### DIFF
--- a/lib/puppet/type/filebucket.rb
+++ b/lib/puppet/type/filebucket.rb
@@ -4,7 +4,7 @@ module Puppet
 
   Type.newtype(:filebucket) do
     @doc = <<-EOT
-      A repository for storing and retrieving file content by MD5 checksum. Can
+      A repository for storing and retrieving file content by cryptographic checksum. Can
       be local to each agent node, or centralized on a primary Puppet server. All
       puppet servers provide a filebucket service that agent nodes can access
       via HTTP, but you must declare a filebucket resource before any agents


### PR DESCRIPTION
Default digest_algorithm changed in Puppet 7.0.0; update filebucket documentation to reflect no longer md5 by default.

The algorithm used is specified by the digest_algorithm setting; md5 was the default for Puppet6 and earlier; from Puppet 7.0.0 onwards the default was changed to sha256 - ref: https://www.puppet.com/docs/puppet/7/release_notes_puppet.html#enhancements_puppet_7-0-0-pup-10583