### PR TITLE
(PUP-11429) Make split() sensitive-aware

### DIFF
--- a/lib/puppet/functions/split.rb
+++ b/lib/puppet/functions/split.rb
@@ -35,6 +35,21 @@ Puppet::Functions.create_function(:split) do
     param 'Type[Regexp]', :pattern
   end
 
+  dispatch :split_String_sensitive do
+    param 'Sensitive[String]', :sensitive
+    param 'String', :pattern
+  end
+
+  dispatch :split_Regexp_sensitive do
+    param 'Sensitive[String]', :sensitive
+    param 'Regexp', :pattern
+  end
+
+  dispatch :split_RegexpType_sensitive do
+    param 'Sensitive[String]', :sensitive
+    param 'Type[Regexp]', :pattern
+  end
+
   def split_String(str, pattern)
     str.split(Regexp.compile(pattern))
   end
@@ -45,5 +60,17 @@ Puppet::Functions.create_function(:split) do
 
   def split_RegexpType(str, pattern)
     str.split(pattern.regexp)
+  end
+
+  def split_String_sensitive(sensitive, pattern)
+    Puppet::Pops::Types::PSensitiveType::Sensitive.new(split_String(sensitive.unwrap, pattern))
+  end
+
+  def split_Regexp_sensitive(sensitive, pattern)
+    Puppet::Pops::Types::PSensitiveType::Sensitive.new(split_Regexp(sensitive.unwrap, pattern))
+  end
+
+  def split_RegexpType_sensitive(sensitive, pattern)
+    Puppet::Pops::Types::PSensitiveType::Sensitive.new(split_RegexpType(sensitive.unwrap, pattern))
   end
 end

--- a/spec/unit/functions/split_spec.rb
+++ b/spec/unit/functions/split_spec.rb
@@ -50,4 +50,10 @@ describe 'the split function' do
   it 'should handle pattern in Regexp Type form with missing regular expression' do
     expect(split('ab',type_parser.parse('Regexp'))).to eql(['a', 'b'])
   end
+
+  it 'should handle sensitive String' do
+    expect(split(Puppet::Pops::Types::PSensitiveType::Sensitive.new('a,b'), ',')).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
+    expect(split(Puppet::Pops::Types::PSensitiveType::Sensitive.new('a,b'), /,/)).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
+    expect(split(Puppet::Pops::Types::PSensitiveType::Sensitive.new('a,b'), type_parser.parse('Regexp[/,/]'))).to be_a(Puppet::Pops::Types::PSensitiveType::Sensitive)
+  end
 end


### PR DESCRIPTION
Let split() accept Values of Type Sensitive.
In this Case the Returnvalue will also be of Type Sensitive.

(cherry picked from commit 940db71b63f8ee91e3d150fa1112506be4a32eeb)