### PR TITLE
(PUP-11938) Handle more errors around Windows SID and ASID

### DIFF
--- a/lib/puppet/util/windows/adsi.rb
+++ b/lib/puppet/util/windows/adsi.rb
@@ -175,6 +175,13 @@ module Puppet::Util::Windows::ADSI
         sids = []
         adsi_child_collection.each do |m|
           sids << Puppet::Util::Windows::SID.ads_to_principal(m)
+        rescue Puppet::Util::Windows::Error => e
+          case e.code
+          when Puppet::Util::Windows::SID::ERROR_TRUSTED_RELATIONSHIP_FAILURE, Puppet::Util::Windows::SID::ERROR_TRUSTED_DOMAIN_FAILURE
+            sids << Puppet::Util::Windows::SID.unresolved_principal(m.name, m.sid)
+          else
+            raise e
+          end
         end
 
         sids

--- a/lib/puppet/util/windows/sid.rb
+++ b/lib/puppet/util/windows/sid.rb
@@ -6,8 +6,10 @@ module Puppet::Util::Windows
     extend FFI::Library
 
     # missing from Windows::Error
-    ERROR_NONE_MAPPED           = 1332
-    ERROR_INVALID_SID_STRUCTURE = 1337
+    ERROR_NONE_MAPPED                  = 1332
+    ERROR_INVALID_SID_STRUCTURE        = 1337
+    ERROR_TRUSTED_DOMAIN_FAILURE       = 1788
+    ERROR_TRUSTED_RELATIONSHIP_FAILURE = 1789
 
     # Well Known SIDs
     Null                        = 'S-1-0'


### PR DESCRIPTION
This commit introduces two new errors, ERROR_TRUSTED_DOMAIN_FAILURE and ERROR_TRUSTED_RELATIONSHIP_FAILURE. Those two errors can occur when looking up a SID and the a host fails a trust call with the AD. We can still recover and should attept to.

(cherry picked from commit 9d6c9c968b12bf416e1d06d909526b8d9784a271)