### PR TITLE
(PUP-11974) Use Ruby warn for deprecation

### DIFF
--- a/lib/puppet/util/monkey_patches.rb
+++ b/lib/puppet/util/monkey_patches.rb
@@ -33,7 +33,7 @@ end
 unless Dir.singleton_methods.include?(:exists?)
   class Dir
     def self.exists?(file_name)
-      Puppet.warning('exists? is a deprecated name, use exist? instead')
+      warn('exists? is a deprecated name, use exist? instead')
       Dir.exist?(file_name)
     end
   end
@@ -42,7 +42,7 @@ end
 unless File.singleton_methods.include?(:exists?)
   class File
     def self.exists?(file_name)
-      Puppet.warning('exists? is a deprecated name, use exist? instead')
+      warn('exists? is a deprecated name, use exist? instead')
       File.exist?(file_name)
     end
   end

--- a/spec/unit/util/monkey_patches_spec.rb
+++ b/spec/unit/util/monkey_patches_spec.rb
@@ -14,7 +14,7 @@ describe Dir do
 
     if RUBY_VERSION >= '3.2' 
       it 'logs a warning message' do
-        expect(Puppet).to receive(:warning).with('exists? is a deprecated name, use exist? instead')
+        expect(Dir).to receive(:warn).with('exists? is a deprecated name, use exist? instead')
         Dir.exists?(__dir__)
       end
     end
@@ -33,7 +33,7 @@ describe File do
 
     if RUBY_VERSION >= '3.2'
       it 'logs a warning message' do
-        expect(Puppet).to receive(:warning).with('exists? is a deprecated name, use exist? instead')
+        expect(File).to receive(:warn).with('exists? is a deprecated name, use exist? instead')
         File.exists?(__FILE__)
       end
     end


### PR DESCRIPTION
1341b92 added monkey patches for File.exists? and Dir.exists? and used Puppet's warning method to indicated that the methods are deprecated.

This commit updates those monkey patches to instead use the less verbose Kernel#warn.