### PR TITLE
(PUP-11899) Log which server we request a catalog from

### DIFF
--- a/lib/puppet/indirector/catalog/rest.rb
+++ b/lib/puppet/indirector/catalog/rest.rb
@@ -13,6 +13,14 @@ class Puppet::Resource::Catalog::Rest < Puppet::Indirector::REST
 
     session = Puppet.lookup(:http_session)
     api = session.route_to(:puppet)
+
+    ip_address = begin
+      " (#{Resolv.getaddress(api.url.host)})"
+    rescue Resolv::ResolvError
+      nil
+    end
+    Puppet.notice("Requesting catalog from #{api.url.host}:#{api.url.port}#{ip_address}")
+
     _, catalog = api.post_catalog(
       request.key,
       facts: request.options[:facts_for_catalog],

--- a/spec/unit/indirector/catalog/rest_spec.rb
+++ b/spec/unit/indirector/catalog/rest_spec.rb
@@ -25,6 +25,23 @@ describe Puppet::Resource::Catalog::Rest do
     expect(described_class.indirection.find(certname)).to be_a(Puppet::Resource::Catalog)
   end
 
+  it 'logs a notice when requesting a catalog' do
+    expect(Puppet).to receive(:notice).with("Requesting catalog from compiler.example.com:8140")
+
+    stub_request(:post, uri).to_return(**catalog_response(catalog))
+
+    described_class.indirection.find(certname)
+  end
+
+  it 'logs a notice when the IP address is resolvable when requesting a catalog' do
+    allow(Resolv).to receive_message_chain(:getaddress).and_return('192.0.2.0')
+    expect(Puppet).to receive(:notice).with("Requesting catalog from compiler.example.com:8140 (192.0.2.0)")
+
+    stub_request(:post, uri).to_return(**catalog_response(catalog))
+
+    described_class.indirection.find(certname)
+  end
+
   it "serializes the environment" do
     stub_request(:post, uri)
       .with(query: hash_including('environment' => 'outerspace'))


### PR DESCRIPTION
When a catalog is requested, log which server is attempted to be used and if an IP address is resolvable display that.