### PR TITLE
(maint) Bump JRuby in tests

### DIFF
--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -19,7 +19,7 @@ jobs:
           - {os: ubuntu-latest, ruby: '3.1'}
           - {os: ubuntu-20.04, ruby: '3.2'} # openssl 1.1.1
           - {os: ubuntu-22.04, ruby: '3.2'} # openssl 3
-          - {os: ubuntu-latest, ruby: 'jruby-9.4.2.0'}
+          - {os: ubuntu-latest, ruby: 'jruby-9.4.3.0'}
           - {os: windows-2019, ruby: '3.1'}
           - {os: windows-2019, ruby: '3.2'} # openssl 3
 


### PR DESCRIPTION
For PE-36375 puppetserver 8 bumped its JRuby version from 9.4.2.0 to 9.4.3.0.

This commit mirrors that change in the rspec test matrix.