### PR TITLE
Make ParsedFile provider work with composite namevars

### DIFF
--- a/lib/puppet/transaction.rb
+++ b/lib/puppet/transaction.rb
@@ -361,7 +361,7 @@ class Puppet::Transaction
       @catalog.vertices.each do |resource|
         if resource.class.attrclass(:provider)
           prov = resource.provider && resource.provider.class.name
-          @resources_by_provider[resource.type][prov][resource.name] = resource
+          @resources_by_provider[resource.type][prov][resource.title] = resource
         end
       end
     end


### PR DESCRIPTION
Previously it was assumed that the name was the key. This changes the implementation to instead match on the key attributes. This allows it to work with composite namevars. While there was previously code for multiple target support, this makes it possible to use the same key in multiple files.

It also gets rid of some code that wasn't needed.

To achieve this, it also needs to use resource titles as identifiers in preloading

When using composite namevars for resources then `resource.name` always `nil`. Prior to this it was used as a key in a hash when prefetching resources. By using the title it should work, since that's guaranteed to be set and unique.

This can break providers where the name is different from the title.

Right now there are no tests, but I tested it locally with puppetlabs-postgresql.