### PR TITLE
(maint) Only resolve environment dirs if versioned dirs are enabled

### DIFF
--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -246,10 +246,8 @@ module Puppet::Environments
 
       configured_path = File.join(@environment_dir, name.to_s)
       env.configured_path = configured_path
-      if Puppet.settings[:report_configured_environmentpath]
+      if Puppet.settings[:versioned_environment_dirs]
         env.resolved_path = validated_directory(configured_path)
-      else
-        env.resolved_path = configured_path
       end
 
       env


### PR DESCRIPTION
The previous implementation would not set the resolved_path variable of an environment to the actual resolved path unless the "report_configured_environment" was set to false. This should not matter since the externalize_path method will check the
"report_configured_environment" setting.

The implementation should probably either always set the resolved_path to the resolved path, or only set it if "versioned_environment_dirs" is true. This patch sets it only if the "versioned_environment_dirs" setting is true.

-----

^ That is the commit message.

PR-wise, I came across this block while looking for something else and it looked wrong. It might be correct but I didn't find any meaningful reasoning that the jerk implementor left behind. I think we set Environment#resolved_path to _some_ value regardless lest nils creep into the system, but in retrospect giving it an obviously wrong value doesn't seem any better. It also may be an artifact of a development iteration where Environment#externalize_path didn't check if resolved_path was set before acting on it.

I'll need to run some manual acceptance tests in PE to validate the change, but I will have to do that later.