### PR TITLE
(maint) Compare Environment#name in compiler

### DIFF
--- a/spec/unit/indirector/catalog/compiler_spec.rb
+++ b/spec/unit/indirector/catalog/compiler_spec.rb
@@ -271,6 +271,23 @@ describe Puppet::Resource::Catalog::Compiler do
         expect(catalog).to have_resource('Stage[main]')
       end
 
+      # versioned environment directories can cause this
+      it 'allows environments with the same name but mismatched modulepaths' do
+        envs = Puppet.lookup(:environments)
+        env_server = envs.get!(:env_server)
+        v1_env = env_server.override_with({ modulepath: ['/code-v1/env-v1/'] })
+        v2_env = env_server.override_with({ modulepath: ['/code-v2/env-v2/'] })
+
+        @request.options[:check_environment] = "true"
+        @request.environment = v1_env
+        node.environment = v2_env
+
+        catalog = compiler.find(@request)
+
+        expect(catalog.environment).to eq('env_server')
+        expect(catalog).to have_resource('Stage[main]')
+      end
+
       it 'returns an empty catalog if asked to check the environment and they are mismatched' do
         @request.options[:check_environment] = "true"
         catalog = compiler.find(@request)


### PR DESCRIPTION
During catalog compilation, after loading the requested environment we load the node and server specified environment. Previously, We would then compare the Environment objects to determine if the requested environment matched the server specified environment. However, if the environment cache is flushed between those two environments being loaded they could be different object instances representing the same desired environment.

To resolve this race condition we now check the environment names (Environment#name canoncalizes to symbols to avoid symbol/string mismatch).