### PR TITLE
(PUP-11985) correctly enable module:stream without default profile with dnfmodule

### DIFF
--- a/lib/puppet/provider/package/dnfmodule.rb
+++ b/lib/puppet/provider/package/dnfmodule.rb
@@ -93,7 +93,7 @@ Puppet::Type.type(:package).provide :dnfmodule, :parent => :dnf do
         # module has no default profile and no profile was requested, so just enable the stream
         # DNF versions prior to 4.2.8 do not need this workaround
         # see https://bugzilla.redhat.com/show_bug.cgi?id=1669527
-        if @resource[:flavor] == nil && e.message =~ /^(?:missing|broken) groups or modules: #{Regexp.quote(@resource[:name])}$/
+        if @resource[:flavor] == nil && e.message =~ /^(?:missing|broken) groups or modules: #{Regexp.quote(args)}$/
           enable(args)
         else
           raise

--- a/spec/unit/provider/package/dnfmodule_spec.rb
+++ b/spec/unit/provider/package/dnfmodule_spec.rb
@@ -123,7 +123,7 @@ describe Puppet::Type.type(:package).provider(:dnfmodule) do
         provider.install
       end
 
-      it "should just enable the module if it has no default profile(missing groups or modules)" do
+      it "should just enable the module if it has no default profile (missing groups or modules)" do
         dnf_exception = Puppet::ExecutionFailure.new("Error: Problems in request:\nmissing groups or modules: #{resource[:name]}")
         allow(provider).to receive(:execute).with(array_including('install')).and_raise(dnf_exception)
         resource[:ensure] = :present
@@ -132,10 +132,30 @@ describe Puppet::Type.type(:package).provider(:dnfmodule) do
         provider.install
       end
 
-      it "should just enable the module if it has no default profile(broken groups or modules)" do
+      it "should just enable the module with the right stream if it has no default profile (missing groups or modules)" do
+        stream = '12.3'
+        dnf_exception = Puppet::ExecutionFailure.new("Error: Problems in request:\nmissing groups or modules: #{resource[:name]}:#{stream}")
+        allow(provider).to receive(:execute).with(array_including('install')).and_raise(dnf_exception)
+        resource[:ensure] = stream
+        expect(provider).to receive(:execute).with(array_including('install')).ordered
+        expect(provider).to receive(:execute).with(array_including('enable')).ordered
+        provider.install
+      end
+
+      it "should just enable the module if it has no default profile (broken groups or modules)" do
         dnf_exception = Puppet::ExecutionFailure.new("Error: Problems in request:\nbroken groups or modules: #{resource[:name]}")
         allow(provider).to receive(:execute).with(array_including('install')).and_raise(dnf_exception)
         resource[:ensure] = :present
+        expect(provider).to receive(:execute).with(array_including('install')).ordered
+        expect(provider).to receive(:execute).with(array_including('enable')).ordered
+        provider.install
+      end
+
+      it "should just enable the module with the right stream if it has no default profile (broken groups or modules)" do
+        stream = '12.3'
+        dnf_exception = Puppet::ExecutionFailure.new("Error: Problems in request:\nbroken groups or modules: #{resource[:name]}:#{stream}")
+        allow(provider).to receive(:execute).with(array_including('install')).and_raise(dnf_exception)
+        resource[:ensure] = stream
         expect(provider).to receive(:execute).with(array_including('install')).ordered
         expect(provider).to receive(:execute).with(array_including('enable')).ordered
         provider.install


### PR DESCRIPTION
the old code would work correctly for ensure => present, but not for ensure => 'some_stream', as dnf does include the whole module spec in the error message and the old regex didn't match anymore.

```
# dnf module install -d 0 -e 1 -y 389-ds
Error: Problems in request:
broken groups or modules: 389-ds

# dnf module install -d 0 -e 1 -y 389-ds:1.4
Error: Problems in request:
broken groups or modules: 389-ds:1.4
```