### PR TITLE
(PA-5932) Add name to Jira workflow

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Update rubygems and install gems
         run: |
-          gem update --system 3.3.26 --silent --no-document
+          gem update --system --silent --no-document
           bundle config set without packaging documentation
           bundle install --jobs 4 --retry 3
 

--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -1,3 +1,6 @@
+---
+name: Export issue to Jira
+
 on:
   issues:
     types: [labeled]

--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Update rubygems and install gems
         run: |
-          gem update --system 3.3.26 --silent --no-document
+          gem update --system --silent --no-document
           bundle config set without packaging documentation
           bundle install --jobs 4 --retry 3
 


### PR DESCRIPTION
This PR:

- Adds a friendly name to the GitHub Actions workflow that exports GitHub Issues to Jira.
- Removes a pin to a Ruby-2.5-compatible version of Rubygems in our GitHub Actions workflows that is no longer needed.