### PR TITLE
Drop commits check

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -17,7 +17,6 @@ jobs:
       matrix:
         cfg:
           - {check: rubocop, os: ubuntu-latest, ruby: '3.1'}
-          - {check: commits, os: ubuntu-latest, ruby: '3.1'}
           - {check: warnings, os: ubuntu-latest, ruby: '3.1'}
 
     runs-on: ${{ matrix.cfg.os }}

--- a/Rakefile
+++ b/Rakefile
@@ -58,33 +58,6 @@ task(:rubocop) do
   raise "RuboCop detected offenses" if exit_code != 0
 end
 
-desc "verify that commit messages match CONTRIBUTING.md requirements"
-task(:commits) do
-  # This rake task looks at the summary from every commit from this branch not
-  # in the branch targeted for a PR.
-  commit_range = 'HEAD^..HEAD'
-  puts "Checking commits #{commit_range}"
-  %x{git log --no-merges --pretty=%s #{commit_range}}.each_line do |commit_summary|
-    # This regex tests for the currently supported commit summary tokens: maint, doc, packaging, or pup-<number>.
-    # The exception tries to explain it in more full.
-    if /^\((maint|doc|docs|packaging|l10n|pup-\d+)\)|revert/i.match(commit_summary).nil?
-      raise "\n\n\n\tThis commit summary didn't match CONTRIBUTING.md guidelines:\n" \
-        "\n\t\t#{commit_summary}\n" \
-        "\tThe commit summary (i.e. the first line of the commit message) should start with one of:\n"  \
-        "\t\t(PUP-<digits>) # this is most common and should be a ticket at tickets.puppet.com\n" \
-        "\t\t(docs)\n" \
-        "\t\t(docs)(DOCUMENT-<digits>)\n" \
-        "\t\t(maint)\n" \
-        "\t\t(packaging)\n" \
-        "\t\t(L10n)\n" \
-        "\n\tThis test for the commit summary is case-insensitive.\n\n\n"
-    else
-      puts "#{commit_summary}"
-    end
-    puts "...passed"
-  end
-end
-
 desc "verify that changed files are clean of Ruby warnings"
 task(:warnings) do
   # This rake task looks at all files modified in this branch.


### PR DESCRIPTION
Now that GH issues are the source of truth, we can drop the commits check.