### PR TITLE
[7.x] Avoid downcasing facts in service provider

### DIFF
--- a/lib/puppet/provider/service/init.rb
+++ b/lib/puppet/provider/service/init.rb
@@ -19,12 +19,9 @@ Puppet::Type.type(:service).provide :init, :parent => :base do
   end
 
   # Debian and Ubuntu should use the Debian provider.
+  confine :false => ['Debian', 'Ubuntu'].include?(Puppet.runtime[:facter].value('operatingsystem'))
   # RedHat systems should use the RedHat provider.
-  confine :true => begin
-      os = Puppet.runtime[:facter].value(:operatingsystem)
-      family = Puppet.runtime[:facter].value(:osfamily)
-      !(os == 'Debian' || os == 'Ubuntu' || family == 'RedHat')
-  end
+  confine :false => Puppet.runtime[:facter].value('osfamily') == 'RedHat'
 
   # We can't confine this here, because the init path can be overridden.
   #confine :exists => defpath

--- a/lib/puppet/provider/service/init.rb
+++ b/lib/puppet/provider/service/init.rb
@@ -21,9 +21,9 @@ Puppet::Type.type(:service).provide :init, :parent => :base do
   # Debian and Ubuntu should use the Debian provider.
   # RedHat systems should use the RedHat provider.
   confine :true => begin
-      os = Puppet.runtime[:facter].value(:operatingsystem).downcase
-      family = Puppet.runtime[:facter].value(:osfamily).downcase
-      !(os == 'debian' || os == 'ubuntu' || family == 'redhat')
+      os = Puppet.runtime[:facter].value(:operatingsystem)
+      family = Puppet.runtime[:facter].value(:osfamily)
+      !(os == 'Debian' || os == 'Ubuntu' || family == 'RedHat')
   end
 
   # We can't confine this here, because the init path can be overridden.


### PR DESCRIPTION
This is the same PR as https://github.com/puppetlabs/puppet/pull/9082 but applied to the 7.x branch. In 7.x the code uses legacy facts, while main uses modern facts (`osfamily` vs `os.family`).