### PR TITLE
(PUP-11685) Update total fact count

### DIFF
--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -194,7 +194,6 @@ class Puppet::Configurer
         path.push(key)
         parse_fact_name_and_value_limits(value, path)
         path.pop
-        @number_of_facts += 1
       end
     when Array
       object.each_with_index do |e, idx|
@@ -205,6 +204,7 @@ class Puppet::Configurer
     else
       check_fact_name_length(path.join(), path.size)
       check_fact_values_length(object)
+      @number_of_facts += 1
     end
   end
 


### PR DESCRIPTION
Puppet calculates the total number of facts on an agent node to warn the user if it will cause performance issues with PuppetDB. PuppetDB performance can be impacted when the leaf count of a factset is too high.

Prior to this commit, Puppet inconsistently calculated facts when generating a warning. This did not count individual array elements; for example, the processor.models fact with a fact per processor core would only be counted once. Additionally, hash keys were incorrectly each counted as individual facts when they would not represent separate leaf counts in PuppetDB.

These behaviors lead to a slight discrepancy between what Puppet would report to the user and what the total fact count ended up being in PuppetDB.

This commit updates Puppet to more accurately count facts to reflect a factset's leaf count in PuppetDB.