### PR TITLE
(PUP-11900) Notify when `X-Puppet-Compiler-Name` header found

### DIFF
--- a/lib/puppet/http/service/compiler.rb
+++ b/lib/puppet/http/service/compiler.rb
@@ -120,6 +120,10 @@ class Puppet::HTTP::Service::Compiler < Puppet::HTTP::Service
       params: { environment: environment },
     )
 
+    if (compiler = response['X-Puppet-Compiler-Name'])
+      Puppet.notice("Catalog compiled by #{compiler}")
+    end
+
     process_response(response)
 
     [response, deserialize(response, Puppet::Resource::Catalog)]

--- a/spec/integration/application/agent_spec.rb
+++ b/spec/integration/application/agent_spec.rb
@@ -33,6 +33,19 @@ describe "puppet agent", unless: Puppet::Util::Platform.jruby? do
     end
   end
 
+  context 'server identification' do
+    it 'emits a notice if the server sends the X-Puppet-Compiler-Name header' do
+      server.start_server do |port|
+        Puppet[:serverport] = port
+        expect {
+          agent.command_line.args << '--test'
+          agent.run
+        }.to exit_with(0)
+               .and output(%r{Notice: Catalog compiled by test-compiler-hostname}).to_stdout
+      end
+    end
+  end
+
   context 'server_list' do
     it "uses the first server in the list" do
       Puppet[:server_list] = '127.0.0.1'

--- a/spec/lib/puppet_spec/puppetserver.rb
+++ b/spec/lib/puppet_spec/puppetserver.rb
@@ -19,6 +19,7 @@ class PuppetSpec::Puppetserver
   class CatalogServlet < WEBrick::HTTPServlet::AbstractServlet
     def do_POST request, response
       response['Content-Type'] = 'application/json'
+      response['X-Puppet-Compiler-Name'] = 'test-compiler-hostname'
       catalog = Puppet::Resource::Catalog.new(Puppet[:certname], 'production')
       response.body = catalog.render(:json)
     end


### PR DESCRIPTION
This change will emit a notice when http traffic from a puppetserver sends the `X-Puppet-Compiler-Name` header; this should help for debugging purposes when troubleshooting compilation issues and several compilers are behind a load balancer.