### PR TITLE
(maint) Restore macOS group test

### DIFF
--- a/acceptance/tests/resource/group/should_query_all.rb
+++ b/acceptance/tests/resource/group/should_query_all.rb
@@ -8,17 +8,6 @@ agents.each do |agent|
   skip_test('this test fails on windows French due to Cygwin/UTF Issues - PUP-8319,IMAGES-492') if agent['platform'] =~ /windows/ && agent['locale'] == 'fr'
   step "query natively"
 
-  # [PA-4555] Added below code to enable SSH permissions before test starts if they are disabled by default
-  if (agent['platform'] =~ /osx-12-arm64/ || agent['platform'] =~ /osx-13-arm64/)
-    on(agent, 'dscl . list /Groups | grep com.apple.access_ssh') do
-      stdout.each_line do |line|
-        if line =~ /com.apple.access_ssh-disabled/
-          on(agent, 'dscl . change /Groups/com.apple.access_ssh-disabled RecordName com.apple.access_ssh-disabled com.apple.access_ssh')
-        end
-      end
-    end
-  end
-
   groups = agent.group_list
 
   fail_test("No groups found") unless groups


### PR DESCRIPTION
In 8e9f9cb, we disabled macOS 12 and 13 ARM from running the test to query all groups due to an issue with those images in Puppet's CI system.

This issue was resolved in ITHELP-70197 and the test can be re-enabled for these platforms.