### PR TITLE
(PUP-11986) Add Amazon Linux package mapping

### DIFF
--- a/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
+++ b/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
@@ -17,6 +17,7 @@ confine :to, {}, agents.select { |agent| supports_systemd?(agent) }
 package_name = {'el'     => 'httpd',
                 'centos' => 'httpd',
                 'fedora' => 'httpd',
+                'amazon' => 'httpd',
                 'sles'   => 'apache2',
                 'debian' => 'cron', # apache2 does not create systemd service symlinks in Debian
                 'ubuntu' => 'cron', # See https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1447807

--- a/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
+++ b/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
@@ -43,13 +43,6 @@ agents.each do |agent|
     package { '#{package_name[platform]}':
       ensure => present,
     }
-    if ($::operatingsystem == 'Fedora') and ($::operatingsystemmajrelease == '23') {
-      package{'libnghttp2':
-        ensure => latest,
-        install_options => '--best',
-        before => Package['httpd'],
-      }
-    }
   }
   manifest_service_masked = %Q{
     service { '#{package_name[platform]}':


### PR DESCRIPTION
This commit adds a mapping for a package for Amazon Linux to use for the systemd masked services test.