### PR TITLE
(PUP-11593) Gentoo: Set systemd as default provider

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -18,6 +18,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   defaultfor :osfamily => :redhat, :operatingsystem => :fedora
   defaultfor :osfamily => :suse
   defaultfor :osfamily => :coreos
+  defaultfor :osfamily => :gentoo
   defaultfor :operatingsystem => :amazon, :operatingsystemmajrelease => ["2", "2023"]
   defaultfor :operatingsystem => :debian
   notdefaultfor :operatingsystem => :debian, :operatingsystemmajrelease => ["5", "6", "7"] # These are using the "debian" method

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -18,7 +18,7 @@ describe 'Puppet::Type::Service::Provider::Systemd',
     Puppet::Util::Execution::ProcessOutput.new('', 0)
   end
 
-  osfamilies = [ 'archlinux', 'coreos' ]
+  osfamilies = [ 'archlinux', 'coreos', 'gentoo' ]
 
   osfamilies.each do |osfamily|
     it "should be the default provider on #{osfamily}" do


### PR DESCRIPTION
Systemd is available on Gentoo since a long time (although Gentoo supports multiple init systems). This change marks the provider as default for Gentoo.

Cherrypicked from main. Original PR: https://github.com/puppetlabs/puppet/pull/8919