### PR TITLE
Use singular pull_request event type

### DIFF
--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -4,7 +4,7 @@ name: Export issue to Jira
 on:
   issues:
     types: [labeled]
-  pull_requests:
+  pull_request:
     types: [labeled]
 
 permissions:


### PR DESCRIPTION
Confusingly, the permission 'pull-requests' is plural and has dashes.