### PR TITLE
Revert labeling pull requests

### DIFF
--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -4,7 +4,7 @@ name: Export issue to Jira
 on:
   issues:
     types: [labeled]
-  pull_request:
+  pull_requests:
     types: [labeled]
 
 permissions:

--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -4,12 +4,9 @@ name: Export issue to Jira
 on:
   issues:
     types: [labeled]
-  pull_requests:
-    types: [labeled]
 
 permissions:
   issues: write
-  pull-requests: write
 
 jobs:
   export:


### PR DESCRIPTION
From github, secrets and variables for actions "are not passed to workflows that are triggered by a pull request from a fork". As a result, we cannot trigger the jira workflow in the same way as GH issues, so revert those changes.