### PR TITLE
Add backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,19 @@
+name: Backport merged pull request
+on:
+  pull_request_target:
+    types: [labeled]
+permissions:
+  contents: write      # so it can comment
+  pull-requests: write # so it can create pull requests
+jobs:
+  backport:
+    name: Backport merged pull request
+    runs-on: ubuntu-latest
+    # For security reasons, we don't want to checkout and run arbitrary code when
+    # using the pull_request_target trigger. So restrict this to cases where the
+    # backport label is applied to an already merged PR.
+    if: github.event.pull_request.merged && contains(github.event.label.name, 'backport')
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create backport pull requests
+        uses: korthout/backport-action@v1


### PR DESCRIPTION
If a label starting with "backport <branch>" is applied to an already merged PR then create a new PR against <branch> where the commits are cherry picked from the original PR using the '-x' flag to include the original git ref.

Note the pull_request_target trigger comes with a security warning[1]:

    you should make sure that you do not check out, build, or run untrusted
    code from the pull request with this event.

To guard against this we only run if the label is applied to an already merged PR and not a closed, but unmerged PR.

[1] https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target