### PR TITLE
Update issues URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ See [LICENSE](https://github.com/puppetlabs/puppet/blob/main/LICENSE) file. Pupp
 
 ## Support
 
-Please log tickets and issues at our [JIRA tracker](https://tickets.puppetlabs.com). A [mailing
+Please log issues in this project's [GitHub Issues](https://github.com/puppetlabs/puppet/issues). A [mailing
 list](https://groups.google.com/forum/?fromgroups#!forum/puppet-users) is
 available for asking questions and getting help from others, or if you prefer chat, we also have a [Puppet Community slack.](https://puppetcommunity.slack.com/)
 
@@ -58,9 +58,9 @@ Bug fixes and ongoing development will occur in minor releases for the current
 major version. Security fixes will be backported to a previous major version on
 a best-effort basis, until the previous major version is no longer maintained.
 
-For example: If a security vulnerability is discovered in Puppet 6.1.1, we
-would fix it in the 6 series, most likely as 6.1.2. Maintainers would then make
-a best effort to backport that fix onto the latest Puppet 5 release.
+For example: If a security vulnerability is discovered in Puppet 8.1.1, we
+would fix it in the 8 series, most likely as 8.1.2. Maintainers would then make
+a best effort to backport that fix onto the latest Puppet 7 release.
 
 Long-term support, including security patches and bug fixes, is available for
 commercial customers. Please see the following page for more details:


### PR DESCRIPTION
This commit updates the README's references to Jira to use GitHub issues instead. I have also updated references to Puppet versions in the README to more current versions.