### PR TITLE
Clundquist/dpkg install options

### DIFF
--- a/lib/puppet/provider/package/dpkg.rb
+++ b/lib/puppet/provider/package/dpkg.rb
@@ -7,7 +7,7 @@ Puppet::Type.type(:package).provide :dpkg, :parent => Puppet::Provider::Package 
     and not `apt`, you must specify the source of any packages you want
     to manage."
 
-  has_feature :holdable, :virtual_packages, :install_options
+  has_feature :holdable, :virtual_packages, :install_options, :uninstall_options
   commands :dpkg => "/usr/bin/dpkg"
   commands :dpkg_deb => "/usr/bin/dpkg-deb"
   commands :dpkgquery => "/usr/bin/dpkg-query"
@@ -172,7 +172,11 @@ Puppet::Type.type(:package).provide :dpkg, :parent => Puppet::Provider::Package 
   end
 
   def uninstall
-    dpkg "-r", @resource[:name]
+    flags = "-r"
+    if @resource[:uninstall_options]
+      flags += @resource[:uninstall_options]
+    end
+    dpkg *flags, @resource[:name]
   end
 
   def purge

--- a/lib/puppet/provider/package/dpkg.rb
+++ b/lib/puppet/provider/package/dpkg.rb
@@ -7,7 +7,7 @@ Puppet::Type.type(:package).provide :dpkg, :parent => Puppet::Provider::Package 
     and not `apt`, you must specify the source of any packages you want
     to manage."
 
-  has_feature :holdable, :virtual_packages
+  has_feature :holdable, :virtual_packages, :install_options
   commands :dpkg => "/usr/bin/dpkg"
   commands :dpkg_deb => "/usr/bin/dpkg-deb"
   commands :dpkgquery => "/usr/bin/dpkg-query"
@@ -93,6 +93,10 @@ Puppet::Type.type(:package).provide :dpkg, :parent => Puppet::Provider::Package 
     end
 
     args = []
+
+    if @resource[:install_options]
+      args << @resource[:install_options]
+    end
 
     if @resource[:configfiles] == :keep
       args << '--force-confold'


### PR DESCRIPTION
I have a custom `.deb` that is a little wonky and installs into `/` so we have `/memcached`.
We need to set `--instdir` so that it ends up in the place we expect, however, _currently_ `install_options` has no effect for `dpkg`.

I want this to work as you expect:
```puppet
$memcached_debian_path = "/path/to/memcached/${memcached_debian}"
package { 'memcached':
    ensure          => latest,
    provider        => dpkg,
    source          => $memcached_debian_path,
    install_options => ['--instdir=/path/to/memcached'],
    # ...
```

Currently, `install_options` is ignored.
```
Debug: Executing '/usr/bin/dpkg-query -W --showformat '${Status} ${Package} ${Version}\n' memcached'
Debug: Executing 'dpkg --set-selections'
Debug: Executing '/usr/bin/dpkg --force-confold -i /path/to/memcached/memcached_1.6.19b.deb'
```

This _should_ honor `install_options` so that my resource works as intended.

This change is difficult for me to test as we are behind on puppet versions, so I'll need to rely on CI testing and additional testing from maintainers.