### PR TITLE
(PUP-11433) Use systemd by default in CentOS/RHEL

### DIFF
--- a/lib/puppet/provider/service/redhat.rb
+++ b/lib/puppet/provider/service/redhat.rb
@@ -11,6 +11,7 @@ Puppet::Type.type(:service).provide :redhat, :parent => :init, :source => :init 
   commands :chkconfig => "/sbin/chkconfig", :service => "/sbin/service"
 
   defaultfor 'os.family' => :redhat
+  defaultfor 'os.name' => :redhat, 'os.release.major' => (4..6).to_a
   defaultfor 'os.family' => :suse, 'os.release.major' => ["10", "11"]
 
   # Remove the symlinks

--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -16,7 +16,9 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   confine :true => Puppet::FileSystem.exist?('/proc/1/comm') && Puppet::FileSystem.read('/proc/1/comm').include?('systemd')
 
   defaultfor 'os.family' => [:archlinux]
+  defaultfor 'os.name' => :redhat
   defaultfor 'os.family' => :redhat, 'os.release.major' => ["7", "8", "9"]
+  notdefaultfor 'os.name' => :redhat, 'os.release.major' => (4..6).to_a # Use the "RedHat" service provider
   defaultfor 'os.family' => :redhat, 'os.name' => :fedora
   defaultfor 'os.family' => :suse
   defaultfor 'os.family' => :coreos

--- a/spec/unit/provider/service/redhat_spec.rb
+++ b/spec/unit/provider/service/redhat_spec.rb
@@ -19,11 +19,9 @@ describe 'Puppet::Type::Service::Provider::Redhat',
     allow(Facter).to receive(:value).with('os.family').and_return('RedHat')
   end
 
-  osfamilies = [ 'RedHat' ]
-
-  osfamilies.each do |osfamily|
-    it "should be the default provider on #{osfamily}" do
-      expect(Facter).to receive(:value).with('os.family').and_return(osfamily)
+  [4, 5, 6].each do |ver|
+    it "should be the default provider on rhel#{ver}" do
+      allow(Facter).to receive(:value).with('os.release.major').and_return(ver)
       expect(provider_class.default?).to be_truthy
     end
   end


### PR DESCRIPTION
Since CentOS7/RHEL7, systemd is used to manage services. This change changes the default provider in CentOS/RHEL from the old redhat provider based on init, to the systemd provider, so that we no longer need to update the provider code when adding support for a new version of CentOS/RHEL.

The old redhat provider is still used for CentOS/RHEL<7 which are using init to manage services.