### PR TITLE
(PUP-11981) Add test for non-literal class params in ClassInfoService spec

### DIFF
--- a/lib/puppet/pops/evaluator/literal_evaluator.rb
+++ b/lib/puppet/pops/evaluator/literal_evaluator.rb
@@ -73,7 +73,7 @@ class LiteralEvaluator
   def literal_AccessExpression(o)
     # to prevent parameters with [[]] like Optional[[String]]
     throw :not_literal if o.keys.size == 1 && o.keys[0].is_a?(Model::LiteralList)
-    o.keys.map {|v| literal(v) }
+    o.keys.map { |v| literal(v) }
   end
 
   def literal_ConcatenatedString(o)

--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -491,7 +491,7 @@ class Checker4_0 < Evaluator::LiteralEvaluator
       catch :not_literal do
         type = literal(p.type_expr)
       end
-      acceptor.accept(Issues::ILLEGAL_NONLITERAL_PARAMETER_TYPE, p, {name: p.name, type_class: p.type_expr.class}) if type.nil?
+      acceptor.accept(Issues::ILLEGAL_NONLITERAL_PARAMETER_TYPE, p, { name: p.name, type_class: p.type_expr.class }) if type.nil?
     end
   end
 


### PR DESCRIPTION
Additional testing for #9190 