### PR TITLE
Correct Red Hat service providers

### DIFF
--- a/lib/puppet/provider/service/redhat.rb
+++ b/lib/puppet/provider/service/redhat.rb
@@ -10,7 +10,7 @@ Puppet::Type.type(:service).provide :redhat, :parent => :init, :source => :init 
 
   commands :chkconfig => "/sbin/chkconfig", :service => "/sbin/service"
 
-  defaultfor 'os.family' => :redhat
+  defaultfor 'os.name' => :amazon, 'os.release.major' => ["2017", "2018"]
   defaultfor 'os.name' => :redhat, 'os.release.major' => (4..6).to_a
   defaultfor 'os.family' => :suse, 'os.release.major' => ["10", "11"]
 

--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -16,13 +16,13 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   confine :true => Puppet::FileSystem.exist?('/proc/1/comm') && Puppet::FileSystem.read('/proc/1/comm').include?('systemd')
 
   defaultfor 'os.family' => [:archlinux]
-  defaultfor 'os.name' => :redhat
-  defaultfor 'os.family' => :redhat, 'os.release.major' => ["7", "8", "9"]
+  defaultfor 'os.family' => :redhat
   notdefaultfor 'os.name' => :redhat, 'os.release.major' => (4..6).to_a # Use the "RedHat" service provider
   defaultfor 'os.family' => :redhat, 'os.name' => :fedora
   defaultfor 'os.family' => :suse
   defaultfor 'os.family' => :coreos
   defaultfor 'os.family' => :gentoo
+  notdefaultfor 'os.name' => :amazon, 'os.release.major' => ["2017", "2018"]
   defaultfor 'os.name' => :amazon, 'os.release.major' => ["2", "2023"]
   defaultfor 'os.name' => :debian
   notdefaultfor 'os.name' => :debian, 'os.release.major' => ["5", "6", "7"] # These are using the "debian" method

--- a/spec/unit/provider/service/redhat_spec.rb
+++ b/spec/unit/provider/service/redhat_spec.rb
@@ -21,6 +21,7 @@ describe 'Puppet::Type::Service::Provider::Redhat',
 
   [4, 5, 6].each do |ver|
     it "should be the default provider on rhel#{ver}" do
+      allow(Facter).to receive(:value).with('os.name').and_return(:redhat)
       allow(Facter).to receive(:value).with('os.release.major').and_return(ver)
       expect(provider_class.default?).to be_truthy
     end


### PR DESCRIPTION
SystemD has been the default init system for Red Hat Enterprise Linux and its derivatives since RHEL 7 was released in 2014. In 928cf67, we attempted to reflect this in Puppet's service providers.

However, this change did not have the desired effect as the RedHat service provider was still specified as the default for systems with the os.family fact of "redhat." Tests relating to services started failing after 928cf67.

I do not believe that this change will have any undesired effects on Red Hat derivatives like Alma or Rocky because those distributions also use SystemD as their init system and use the same versioning scheme as upstream.