### PR TITLE
[Backport] (PUP-11981) Syntactically incorrect types cause nil types in Puppet::InfoService::ClassInformationService

### DIFF
--- a/lib/puppet/pops/evaluator/literal_evaluator.rb
+++ b/lib/puppet/pops/evaluator/literal_evaluator.rb
@@ -10,9 +10,8 @@ module Evaluator
 # QualifiedName
 # Default (produced :default)
 # Regular Expression (produces ruby regular expression)
-#
-# Not considered literal
-# QualifiedReference  # i.e. File, FooBar
+# QualifiedReference
+# AccessExpresion
 #
 class LiteralEvaluator
 
@@ -64,6 +63,16 @@ class LiteralEvaluator
 
   def literal_LiteralRegularExpression(o)
     o.value
+  end
+
+  def literal_QualifiedReference(o)
+    o.value
+  end
+
+  def literal_AccessExpression(o)
+    # to prevent parameters with [[]] like Optional[[String]]
+    throw :not_literal if o.keys.size == 1 && o.keys[0].is_a?(Model::LiteralList)
+    o.keys.map { |v| literal(v) }
   end
 
   def literal_ConcatenatedString(o)

--- a/lib/puppet/pops/issues.rb
+++ b/lib/puppet/pops/issues.rb
@@ -206,6 +206,10 @@ module Issues
     _("The numeric parameter name '$%{name}' cannot be used (clashes with numeric match result variables)") % { name: name }
   end
 
+  ILLEGAL_NONLITERAL_PARAMETER_TYPE = issue :ILLEGAL_NONLITERAL_PARAMETER_TYPE, :name, :type_class do
+    _("The parameter '$%{name}' must be a literal type, not %{type_class}") % { name: name, type_class: label.a_an(type_class) }
+  end
+
   # In certain versions of Puppet it may be allowed to assign to a not already assigned key
   # in an array or a hash. This is an optional validation that may be turned on to prevent accidental
   # mutation.

--- a/lib/puppet/pops/validation/checker4_0.rb
+++ b/lib/puppet/pops/validation/checker4_0.rb
@@ -468,6 +468,7 @@ class Checker4_0 < Evaluator::LiteralEvaluator
     internal_check_parameter_name_uniqueness(o)
     internal_check_reserved_params(o)
     internal_check_no_idem_last(o)
+    internal_check_parameter_type_literal(o)
   end
 
   def check_ResourceTypeDefinition(o)
@@ -476,6 +477,18 @@ class Checker4_0 < Evaluator::LiteralEvaluator
     internal_check_parameter_name_uniqueness(o)
     internal_check_reserved_params(o)
     internal_check_no_idem_last(o)
+  end
+
+  def internal_check_parameter_type_literal(o)
+    o.parameters.each do |p|
+      next unless p.type_expr
+
+      type = nil
+      catch :not_literal do
+        type = literal(p.type_expr)
+      end
+      acceptor.accept(Issues::ILLEGAL_NONLITERAL_PARAMETER_TYPE, p, { name: p.name, type_class: p.type_expr.class }) if type.nil?
+    end
   end
 
   def internal_check_return_type(o)

--- a/spec/unit/pops/evaluator/literal_evaluator_spec.rb
+++ b/spec/unit/pops/evaluator/literal_evaluator_spec.rb
@@ -16,6 +16,8 @@ describe "Puppet::Pops::Evaluator::LiteralEvaluator" do
     '"a"'     => 'a',
     'a'       => 'a',
     'a::b'    => 'a::b',
+    'Integer[1]' => [1],
+    'File' => "file",
 
     # special values
     'default' => :default,
@@ -35,9 +37,9 @@ describe "Puppet::Pops::Evaluator::LiteralEvaluator" do
     expect(leval.literal(parser.parse_string('undef'))).to be_nil
   end
 
-  ['1+1', 'File', '[1,2, 1+2]', '{a=>1+1}', 'Integer[1]', '"x$y"', '"x${y}z"'].each do |source|
+  ['1+1', '[1,2, 1+2]', '{a=>1+1}', '"x$y"', '"x${y}z"', 'Integer[1-3]', 'Optional[[String]]'].each do |source|
     it "throws :not_literal for non literal expression '#{source}'" do
-      expect{leval.literal(parser.parse_string('1+1'))}.to throw_symbol(:not_literal)
+      expect{leval.literal(parser.parse_string(source))}.to throw_symbol(:not_literal)
     end
   end
 end


### PR DESCRIPTION
Backport of #9190 and #9210 to 7.x