### PR TITLE
Update Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ require:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 3.1
   Include:
     - 'lib/**/*.rb'
     - 'ext/**/*.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -22,6 +22,15 @@ I18n/GetText/DecorateStringFormattingUsingPercent:
 I18n/RailsI18n/DecorateString:
   Enabled: false
 
+Lint/AmbiguousAssignment: # new in 1.7
+  Enabled: false
+
+Lint/AmbiguousOperatorPrecedence: # new in 1.21
+  Enabled: false
+
+Lint/AmbiguousRange: # new in 1.19
+  Enabled: false
+
 # Configuration parameters: AllowedMethods.
 # AllowedMethods: enums
 Lint/ConstantDefinitionInBlock:
@@ -42,7 +51,49 @@ Lint/ConstantDefinitionInBlock:
     - 'lib/puppet/type/schedule.rb'
     - 'lib/puppet/type/tidy.rb'
 
+Lint/ConstantOverwrittenInRescue: # new in 1.31
+  Enabled: false
+
+Lint/DeprecatedConstants: # new in 1.8
+  Enabled: false
+
+Lint/DuplicateBranch: # new in 1.3
+  Enabled: false
+
+Lint/DuplicateMagicComment: # new in 1.37
+  Enabled: false
+
+Lint/DuplicateMatchPattern: # new in 1.50
+  Enabled: false
+
+Lint/DuplicateRegexpCharacterClassElement: # new in 1.1
+  Enabled: false
+
+Lint/EmptyBlock: # new in 1.1
+  Enabled: false
+
+Lint/EmptyClass: # new in 1.3
+  Enabled: false
+
+Lint/EmptyInPattern: # new in 1.16
+  Enabled: false
+
+Lint/IncompatibleIoSelectWithFiberScheduler: # new in 1.21
+  Enabled: false
+
+Lint/ItWithoutArgumentsInBlock: # new in 1.59
+  Enabled: false
+
+Lint/LambdaWithoutLiteralBlock: # new in 1.8
+  Enabled: false
+
+Lint/LiteralAssignmentInCondition: # new in 1.58
+  Enabled: false
+
 Lint/MissingSuper:
+  Enabled: false
+
+Lint/MixedCaseRange: # new in 1.53
   Enabled: false
 
 Lint/NestedMethodDefinition:
@@ -58,6 +109,33 @@ Lint/NestedMethodDefinition:
     - 'lib/puppet/pops/types/p_uri_type.rb'
     - 'lib/puppet/pops/types/types.rb'
     - 'lib/puppet/type.rb'
+
+Lint/NonAtomicFileOperation: # new in 1.31
+  Enabled: false
+
+Lint/NoReturnInBeginEndBlocks: # new in 1.2
+  Enabled: false
+
+Lint/NumberedParameterAssignment: # new in 1.9
+  Enabled: false
+
+Lint/OrAssignmentToConstant: # new in 1.9
+  Enabled: false
+
+Lint/RedundantDirGlobSort: # new in 1.8
+  Enabled: false
+
+Lint/RedundantRegexpQuantifiers: # new in 1.53
+  Enabled: false
+
+Lint/RefinementImportMethods: # new in 1.27
+  Enabled: false
+
+Lint/RequireRangeParentheses: # new in 1.32
+  Enabled: false
+
+Lint/RequireRelativeSelfPath: # new in 1.22
+  Enabled: false
 
 Lint/RescueException:
   Exclude:
@@ -88,6 +166,12 @@ Lint/SuppressedException:
     - 'lib/puppet/util/execution.rb'
     - 'util/rspec_grouper'
 
+Lint/SymbolConversion: # new in 1.9
+  Enabled: false
+
+Lint/ToEnumArguments: # new in 1.1
+  Enabled: false
+
 # This cop supports safe auto-correction (--auto-correct).
 Lint/ToJSON:
   Exclude:
@@ -95,9 +179,24 @@ Lint/ToJSON:
     - 'lib/puppet/network/http/error.rb'
     - 'lib/puppet/pops/serialization/json.rb'
 
+Lint/TripleQuotes: # new in 1.9
+  Enabled: false
+
+Lint/UnexpectedBlockArity: # new in 1.5
+  Enabled: false
+
+Lint/UnmodifiedReduceAccumulator: # new in 1.1
+  Enabled: false
+
 # This cop supports safe auto-correction (--auto-correct).
 # Configuration parameters: AllowUnusedKeywordArguments, IgnoreEmptyMethods, IgnoreNotImplementedMethods.
 Lint/UnusedMethodArgument:
+  Enabled: false
+
+Lint/UselessRescue: # new in 1.43
+  Enabled: false
+
+Lint/UselessRuby2Keywords: # new in 1.23
   Enabled: false
 
 Performance/BlockGivenWithExplicitBlock: # new in 1.9

--- a/Gemfile
+++ b/Gemfile
@@ -47,11 +47,11 @@ group(:test) do
   gem 'webrick', '~> 1.7', require: false
   gem 'yard', require: false
 
-  gem 'rubocop', '1.28.0', require: false, platforms: [:ruby]
+  gem 'rubocop', '~> 1.0', require: false, platforms: [:ruby]
   gem 'rubocop-i18n', '~> 3.0', require: false, platforms: [:ruby]
-  gem 'rubocop-performance', '1.13.3', require: false, platforms: [:ruby]
-  gem 'rubocop-rake', '0.6.0', require: false, platforms: [:ruby]
-  gem 'rubocop-rspec', '2.10.0', require: false, platforms: [:ruby]
+  gem 'rubocop-performance', '~> 1.0', require: false, platforms: [:ruby]
+  gem 'rubocop-rake', '~> 0.6', require: false, platforms: [:ruby]
+  gem 'rubocop-rspec', '~> 2.0', require: false, platforms: [:ruby]
 end
 
 group(:development, optional: true) do

--- a/lib/puppet/application/agent.rb
+++ b/lib/puppet/application/agent.rb
@@ -410,6 +410,7 @@ class Puppet::Application::Agent < Puppet::Application
     end
   end
 
+  # rubocop:disable Lint/RedundantStringCoercion
   def fingerprint
     Puppet::Util::Log.newdestination(:console)
     cert_provider = Puppet::X509::CertProvider.new
@@ -429,6 +430,7 @@ class Puppet::Application::Agent < Puppet::Application
     Puppet.log_exception(e, _("Failed to generate fingerprint: %{message}") % { message: e.message })
     exit(1)
   end
+  # rubocop:enable Lint/RedundantStringCoercion
 
   def onetime(daemon)
     begin

--- a/lib/puppet/application/face_base.rb
+++ b/lib/puppet/application/face_base.rb
@@ -3,7 +3,6 @@
 require_relative '../../puppet/application'
 require_relative '../../puppet/face'
 require 'optparse'
-require 'pp'
 
 class Puppet::Application::FaceBase < Puppet::Application
   option("--debug", "-d") do |_arg|

--- a/lib/puppet/application/filebucket.rb
+++ b/lib/puppet/application/filebucket.rb
@@ -13,7 +13,7 @@ class Puppet::Application::Filebucket < Puppet::Application
   option("--remote", "-r")
   option("--verbose", "-v")
 
-  attr :args
+  attr_reader :args
 
   def summary
     _("Store and retrieve files in a filebucket")

--- a/lib/puppet/file_bucket/file.rb
+++ b/lib/puppet/file_bucket/file.rb
@@ -13,7 +13,7 @@ class Puppet::FileBucket::File
   extend Puppet::Indirector
   indirects :file_bucket_file, :terminus_class => :selector
 
-  attr :bucket_path
+  attr_reader :bucket_path
 
   def self.supported_formats
     [:binary]

--- a/lib/puppet/functions/getvar.rb
+++ b/lib/puppet/functions/getvar.rb
@@ -69,7 +69,7 @@ Puppet::Functions.create_function(:getvar, Puppet::Functions::InternalFunction) 
     matches = navigation.match(/^((::)?(\w+::)*\w+)(.*)\z/)
     navigation = matches[4]
     if navigation[0] == '.'
-      navigation = navigation[1..-1]
+      navigation = navigation[1..]
     else
       unless navigation.empty?
         raise ArgumentError, _("First character after var name in get string must be a '.' - got %{char}") % { char: navigation[0] }

--- a/lib/puppet/metatype/manager.rb
+++ b/lib/puppet/metatype/manager.rb
@@ -28,7 +28,7 @@ module Manager
   #
   def clear_misses
     unless @types.nil?
-      @types.delete_if { |_, v| v.nil? }
+      @types.compact
     end
   end
 

--- a/lib/puppet/module_tool/errors/shared.rb
+++ b/lib/puppet/module_tool/errors/shared.rb
@@ -106,7 +106,7 @@ module Puppet::ModuleTool::Errors
       @requested_module  = options[:requested_module]
       @requested_version = options[:requested_version]
       @conditions        = options[:conditions]
-      @source            = options[:source][1..-1]
+      @source            = options[:source][1..]
 
       super _("'%{module_name}' (%{version}) requested; Invalid dependency cycle") % { module_name: @requested_module, version: v(@requested_version) }
     end
@@ -114,7 +114,7 @@ module Puppet::ModuleTool::Errors
     def multiline
       dependency_list = []
       dependency_list << _("You specified '%{name}' (%{version})") % { name: @source.first[:name], version: v(@requested_version) }
-      dependency_list += @source[1..-1].map do |m|
+      dependency_list += @source[1..].map do |m|
         # TRANSLATORS This message repeats as separate lines as a list under the heading "You specified '%{name}' (%{version})\n"
         _("This depends on '%{name}' (%{version})") % { name: m[:name], version: v(m[:version]) }
       end

--- a/lib/puppet/network/http/api/indirected_routes.rb
+++ b/lib/puppet/network/http/api/indirected_routes.rb
@@ -57,7 +57,7 @@ class Puppet::Network::HTTP::API::IndirectedRoutes
 
   def uri2indirection(http_method, uri, params)
     # the first field is always nil because of the leading slash,
-    indirection_type, version, indirection_name, key = uri.split("/", 5)[1..-1]
+    indirection_type, version, indirection_name, key = uri.split("/", 5)[1..]
     url_prefix = "/#{indirection_type}/#{version}"
     environment = params.delete(:environment)
 

--- a/lib/puppet/network/http/connection.rb
+++ b/lib/puppet/network/http/connection.rb
@@ -266,7 +266,7 @@ class Puppet::Network::HTTP::Connection
 
   def normalize_path(path)
     if path[0] == '/'
-      path[1..-1]
+      path[1..]
     else
       path
     end

--- a/lib/puppet/parser/functions/sprintf.rb
+++ b/lib/puppet/parser/functions/sprintf.rb
@@ -45,7 +45,7 @@ Puppet::Parser::Functions.newfunction(
   This statement produces a notice of `value is : 42`."
 ) do |args|
   fmt = args[0]
-  args = args[1..-1]
+  args = args[1..]
   begin
     return sprintf(fmt, *args)
   rescue KeyError => e

--- a/lib/puppet/parser/scope.rb
+++ b/lib/puppet/parser/scope.rb
@@ -496,7 +496,7 @@ class Puppet::Parser::Scope
     # If name has '::' in it, it is resolved as a qualified variable
     unless (idx = name.index('::')).nil?
       # Always drop leading '::' if present as that is how the values are keyed.
-      return lookup_qualified_variable(idx == 0 ? name[2..-1] : name, options)
+      return lookup_qualified_variable(idx == 0 ? name[2..] : name, options)
     end
 
     # At this point, search is for a non qualified (simple) name
@@ -609,7 +609,7 @@ class Puppet::Parser::Scope
     # not found - search inherited scope for class
     leaf_index = fqn.rindex('::')
     unless leaf_index.nil?
-      leaf_name = fqn[(leaf_index + 2)..-1]
+      leaf_name = fqn[(leaf_index + 2)..]
       class_name = fqn[0, leaf_index]
       begin
         qs = qualified_scope(class_name)
@@ -898,9 +898,9 @@ class Puppet::Parser::Scope
     # check module paths first since they may be in the environment (i.e. they are longer)
     module_path = environment.full_modulepath.detect { |m_path| path.start_with?(m_path) }
     if module_path
-      path = "<module>" + path[module_path.length..-1]
+      path = "<module>" + path[module_path.length..]
     elsif env_path && path && path.start_with?(env_path)
-      path = "<env>" + path[env_path.length..-1]
+      path = "<env>" + path[env_path.length..]
     end
     # Make the output appear as "Scope(path, line)"
     "Scope(#{[path, detail[1]].join(', ')})"

--- a/lib/puppet/pops/evaluator/access_operator.rb
+++ b/lib/puppet/pops/evaluator/access_operator.rb
@@ -703,7 +703,7 @@ class AccessOperator
 
         name = c.downcase
         # Remove leading '::' since all references are global, and 3x runtime does the wrong thing
-        name = name[2..-1] if name[0, 2] == NS
+        name = name[2..] if name[0, 2] == NS
 
         fail(Issues::ILLEGAL_NAME, @semantic.keys[i], { :name => c }) unless name =~ Patterns::NAME
 

--- a/lib/puppet/pops/evaluator/closure.rb
+++ b/lib/puppet/pops/evaluator/closure.rb
@@ -266,7 +266,7 @@ module Evaluator
             given_argument = args[index]
             if param_captures
               # get excess arguments
-              value = args[(parameter_count - 1)..-1]
+              value = args[(parameter_count - 1)..]
               # If the input was a single nil, or undef, and there is a default, use the default
               # This supports :undef in case it was used in a 3x data structure and it is passed as an arg
               #

--- a/lib/puppet/pops/evaluator/deferred_resolver.rb
+++ b/lib/puppet/pops/evaluator/deferred_resolver.rb
@@ -161,7 +161,7 @@ class DeferredResolver
     mapped_arguments = map_arguments(f.arguments)
     # if name starts with $ then this is a call to dig
     if func_name[0] == DOLLAR
-      var_name = func_name[1..-1]
+      var_name = func_name[1..]
       func_name = DIG
       mapped_arguments.insert(0, @scope[var_name])
     end

--- a/lib/puppet/pops/evaluator/epp_evaluator.rb
+++ b/lib/puppet/pops/evaluator/epp_evaluator.rb
@@ -86,7 +86,7 @@ class Puppet::Pops::Evaluator::EppEvaluator
     filtered_args = {}
     template_args.each_pair do |k, v|
       if k =~ /::/
-        k = k[2..-1] if k.start_with?('::')
+        k = k[2..] if k.start_with?('::')
         scope[k] = v
       else
         filtered_args[k] = v

--- a/lib/puppet/pops/functions/dispatch.rb
+++ b/lib/puppet/pops/functions/dispatch.rb
@@ -95,7 +95,7 @@ class Dispatch < Evaluator::CallableSignature
           # parameter values in the received
           if knit < 0
             idx = -knit - 1
-            new_args += args[idx..-1] if idx < args.size
+            new_args += args[idx..] if idx < args.size
           else
             new_args << args[knit] if knit < args.size
           end

--- a/lib/puppet/pops/loader/loader_paths.rb
+++ b/lib/puppet/pops/loader/loader_paths.rb
@@ -147,7 +147,7 @@ module LoaderPaths
       if start_index_in_name > 0
         return nil if start_index_in_name >= parts.size
 
-        parts = parts[start_index_in_name..-1]
+        parts = parts[start_index_in_name..]
       end
       "#{File.join(generic_path, parts)}#{extension}"
     end
@@ -371,7 +371,7 @@ module LoaderPaths
       if start_index_in_name > 0
         return nil if start_index_in_name >= parts.size
 
-        parts = parts[start_index_in_name..-1]
+        parts = parts[start_index_in_name..]
       end
       basename = File.join(generic_path, parts)
       @extensions.map { |ext| "#{basename}#{ext}" }

--- a/lib/puppet/pops/loader/typed_name.rb
+++ b/lib/puppet/pops/loader/typed_name.rb
@@ -21,7 +21,7 @@ class TypedName
     parts = name.to_s.split(DOUBLE_COLON)
     if parts[0].empty?
       parts.shift
-      @name = name[2..-1]
+      @name = name[2..]
     else
       @name = name
     end

--- a/lib/puppet/pops/lookup/lookup_adapter.rb
+++ b/lib/puppet/pops/lookup/lookup_adapter.rb
@@ -111,7 +111,7 @@ class LookupAdapter < DataAdapter
       end
     end
     begin
-      result = lookup_invocation.scope.call_function(NEW, [convert_to[0], result, *convert_to[1..-1]])
+      result = lookup_invocation.scope.call_function(NEW, [convert_to[0], result, *convert_to[1..]])
       # TRANSLATORS 'lookup_options', 'convert_to' and args_string variable should not be translated,
       args_string = Puppet::Pops::Types::StringConverter.singleton.convert(convert_to)
       lookup_invocation.report_text { _("Applying convert_to lookup_option with arguments %{args}") % { args: args_string } }

--- a/lib/puppet/pops/parser/lexer2.rb
+++ b/lib/puppet/pops/parser/lexer2.rb
@@ -458,7 +458,7 @@ class Lexer2
         before = scn.pos
         value = scn.scan(PATTERN_DOLLAR_VAR)
         if value
-          emit_completed([:VARIABLE, value[1..-1].freeze, scn.pos - before], before)
+          emit_completed([:VARIABLE, value[1..].freeze, scn.pos - before], before)
         else
           # consume the $ and let higher layer complain about the error instead of getting a syntax error
           emit(TOKEN_VARIABLE_EMPTY, before)

--- a/lib/puppet/pops/serialization/to_data_converter.rb
+++ b/lib/puppet/pops/serialization/to_data_converter.rb
@@ -66,7 +66,7 @@ module Serialization
 
     def path_to_s
       s = String.new(@message_prefix || '')
-      s << JsonPath.to_json_path(@path)[1..-1]
+      s << JsonPath.to_json_path(@path)[1..]
       s
     end
 

--- a/lib/puppet/pops/serialization/to_stringified_converter.rb
+++ b/lib/puppet/pops/serialization/to_stringified_converter.rb
@@ -58,7 +58,7 @@ module Serialization
 
     def path_to_s
       s = @message_prefix || ''
-      s << JsonPath.to_json_path(@path)[1..-1]
+      s << JsonPath.to_json_path(@path)[1..]
       s
     end
 

--- a/lib/puppet/pops/types/ruby_generator.rb
+++ b/lib/puppet/pops/types/ruby_generator.rb
@@ -116,7 +116,7 @@ class RubyGenerator < TypeFormatter
     start_module(common_prefix, comment, bld)
     class_names = []
     names_by_prefix.each_pair do |seg_array, index_and_name_array|
-      added_to_common_prefix = seg_array[common_prefix.length..-1]
+      added_to_common_prefix = seg_array[common_prefix.length..]
       added_to_common_prefix.each { |name| bld << 'module ' << name << "\n" }
       index_and_name_array.each do |idx, name, full_name|
         scoped_class_definition(object_types[idx], name, bld, full_name, *impl_subst)

--- a/lib/puppet/pops/types/type_asserter.rb
+++ b/lib/puppet/pops/types/type_asserter.rb
@@ -39,7 +39,7 @@ module TypeAsserter
 
   def self.report_type_mismatch(subject, expected_type, actual_type, what = 'has wrong type')
     subject = yield(subject) if block_given?
-    subject = subject[0] % subject[1..-1] if subject.is_a?(Array)
+    subject = subject[0] % subject[1..] if subject.is_a?(Array)
     raise TypeAssertionError.new(
       TypeMismatchDescriber.singleton.describe_mismatch("#{subject} #{what},", expected_type, actual_type), expected_type, actual_type
     )

--- a/lib/puppet/pops/types/type_parser.rb
+++ b/lib/puppet/pops/types/type_parser.rb
@@ -404,7 +404,7 @@ class TypeParser
         if param_start.nil?
           type = type_str
         else
-          tps = interpret_any(@parser.parse_string(type_str[param_start..-1]).model, context)
+          tps = interpret_any(@parser.parse_string(type_str[param_start..]).model, context)
           raise_invalid_parameters_error(type.to_s, '1', tps.size) unless tps.size == 1
           type = type_str[0..param_start - 1]
           parameters = [type] + tps

--- a/lib/puppet/pops/utils.rb
+++ b/lib/puppet/pops/utils.rb
@@ -115,7 +115,7 @@ module Utils
   end
 
   def self.relativize_name name
-    is_absolute?(name) ? name[2..-1] : name
+    is_absolute?(name) ? name[2..] : name
   end
 end
 end

--- a/lib/puppet/provider/package/apt.rb
+++ b/lib/puppet/provider/package/apt.rb
@@ -157,11 +157,13 @@ Puppet::Type.type(:package).provide :apt, :parent => :dpkg, :source => :dpkg do
     cmd += install_options if @resource[:install_options]
     cmd << :install
 
+    # rubocop:disable Style/RedundantCondition
     if source
       cmd << source
     else
       cmd << str
     end
+    # rubocop:enable Style/RedundantCondition
 
     self.unhold if self.properties[:mark] == :hold
     begin

--- a/lib/puppet/provider/package/blastwave.rb
+++ b/lib/puppet/provider/package/blastwave.rb
@@ -41,13 +41,13 @@ Puppet::Type.type(:package).provide :blastwave, :parent => :sun, :source => :sun
 
     output = Puppet::Util.withenv(:PAGER => "/usr/bin/cat") { pkgget command }
 
-    list = output.split("\n").collect do |line|
+    list = output.split("\n").filter_map do |line|
       next if line =~ /^#/
       next if line =~ /^WARNING/
       next if line =~ /localrev\s+remoterev/
 
       blastsplit(line)
-    end.compact
+    end
 
     if hash[:justme]
       return list[0]

--- a/lib/puppet/provider/package/gem.rb
+++ b/lib/puppet/provider/package/gem.rb
@@ -120,8 +120,7 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package::
 
     begin
       list = execute_gem_command(options[:command], command_options).lines
-                                                                    .map { |set| gemsplit(set) }
-                                                                    .compact
+                                                                    .filter_map { |set| gemsplit(set) }
     rescue Puppet::ExecutionFailure => detail
       raise Puppet::Error, _("Could not list gems: %{detail}") % { detail: detail }, detail.backtrace
     end

--- a/lib/puppet/provider/package/pkgutil.rb
+++ b/lib/puppet/provider/package/pkgutil.rb
@@ -65,7 +65,7 @@ Puppet::Type.type(:package).provide :pkgutil, :parent => :sun, :source => :sun d
   def self.availlist
     output = pkguti ["-a"]
 
-    output.split("\n").collect do |line|
+    output.split("\n").filter_map do |line|
       next if line =~ /^common\s+package/ # header of package list
       next if noise?(line)
 
@@ -74,7 +74,7 @@ Puppet::Type.type(:package).provide :pkgutil, :parent => :sun, :source => :sun d
       else
         Puppet.warning _("Cannot match %{line}") % { line: line }
       end
-    end.compact
+    end
   end
 
   # Turn our pkgutil -c listing into a hash for a single package.
@@ -94,12 +94,12 @@ Puppet::Type.type(:package).provide :pkgutil, :parent => :sun, :source => :sun d
       return nil
     end
 
-    list = output.collect do |line|
+    list = output.filter_map do |line|
       next if line =~ /installed\s+catalog/ # header of package list
       next if noise?(line)
 
       pkgsplit(line)
-    end.compact
+    end
 
     if hash[:justme]
       # Single queries may have been for an alias so return the name requested

--- a/lib/puppet/provider/package/portage.rb
+++ b/lib/puppet/provider/package/portage.rb
@@ -180,7 +180,7 @@ Puppet::Type.type(:package).provide :portage, :parent => Puppet::Provider::Packa
       end
 
       if @resource[:name] =~ /^@/
-        if package_sets.include?(@resource[:name][1..-1].to_s)
+        if package_sets.include?(@resource[:name][1..].to_s)
           return({ :name => "#{@resource[:name]}", :ensure => '9999', :version_available => nil, :installed_versions => nil, :installable_versions => "9999," })
         end
       end

--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -112,6 +112,7 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
   # @param disableexcludes [Array<String>] A list of repository excludes to disable for this query
   # @return [Hash<String, Array<Hash<String, String>>>] All packages that were
   #   found with a list of found versions for each package.
+  # rubocop:disable Layout/SingleLineBlockChain
   def self.check_updates(disablerepo, enablerepo, disableexcludes)
     args = [command(:cmd), 'check-update']
     args.concat(disablerepo.map { |repo| ["--disablerepo=#{repo}"] }.flatten)
@@ -131,6 +132,7 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
     end
     updates
   end
+  # rubocop:enable Layout/SingleLineBlockChain
 
   def self.parse_updates(str)
     # Strip off all content that contains Obsoleting, Security: or Update
@@ -231,6 +233,7 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
     end
   end
 
+  # rubocop:disable Layout/SingleLineBlockChain
   def available_versions(package_name, disablerepo, enablerepo, disableexcludes)
     args = [command(:cmd), 'list', package_name, '--showduplicates']
     args.concat(disablerepo.map { |repo| ["--disablerepo=#{repo}"] }.flatten)
@@ -240,6 +243,7 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
     output = execute("#{args.compact.join(' ')} | sed -e '1,/Available Packages/ d' | awk '{print $2}'")
     output.split("\n")
   end
+  # rubocop:enable Layout/SingleLineBlockChain
 
   def install
     wanted = @resource[:name]

--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -643,7 +643,7 @@ class Puppet::Resource
       type.title_patterns.each do |regexp, symbols_and_lambdas|
         captures = regexp.match(title.to_s)
         if captures
-          symbols_and_lambdas.zip(captures[1..-1]).each do |symbol_and_lambda, capture|
+          symbols_and_lambdas.zip(captures[1..]).each do |symbol_and_lambda, capture|
             symbol, proc = symbol_and_lambda
             # Many types pass "identity" as the proc; we might as well give
             # them a shortcut to delivering that without the extra cost.

--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -453,10 +453,12 @@ class Puppet::Resource
       attr.unshift(:ensure)
     end
 
+    # rubocop:disable Lint/FormatParameterMismatch
     attributes = attr.collect { |k|
       v = parameters[k]
       "    %-#{attr_max}s: %s\n" % [k, Puppet::Parameter.format_value_for_display(v)]
     }.join
+    # rubocop:enable Lint/FormatParameterMismatch
 
     "  %s:\n%s" % [self.title, attributes]
   end
@@ -488,10 +490,12 @@ class Puppet::Resource
       attr.unshift(:ensure)
     end
 
+    # rubocop:disable Lint/FormatParameterMismatch
     attributes = attr.collect { |k|
       v = parameters[k]
       "  %-#{attr_max}s => %s,\n" % [k, Puppet::Parameter.format_value_for_display(v)]
     }.join
+    # rubocop:enable Lint/FormatParameterMismatch
 
     escaped = self.title.gsub(/'/, "\\\\'")
     "%s { '%s':\n%s}" % [self.type.to_s.downcase, escaped, attributes]

--- a/lib/puppet/resource/type_collection.rb
+++ b/lib/puppet/resource/type_collection.rb
@@ -192,7 +192,7 @@ class Puppet::Resource::TypeCollection
     @environment.lock.synchronize do
       @lock.synchronize do
         # Name is always absolute, but may start with :: which must be removed
-        fqname = (name[0, 2] == COLON_COLON ? name[2..-1] : name)
+        fqname = (name[0, 2] == COLON_COLON ? name[2..] : name)
 
         result = send(type, fqname)
         unless result

--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -434,7 +434,7 @@ module Puppet
         run.
 
         Note that on Windows, this manages creation/deletion of the user profile instead of the
-        home directory. The user profile is stored in the `C:\Users\<username>` directory."
+        home directory. The user profile is stored in the `C:\\Users\\<username>` directory."
 
       defaultto false
 

--- a/lib/puppet/util/at_fork/solaris.rb
+++ b/lib/puppet/util/at_fork/solaris.rb
@@ -42,7 +42,7 @@ class Puppet::Util::AtFork::Solaris
     libhandle = Fiddle::Handle.new(library)
 
     functions.each do |f|
-      define_method f[0], Fiddle::Function.new(libhandle[f[0].to_s], f[2..-1], f[1]).method(:call).to_proc
+      define_method f[0], Fiddle::Function.new(libhandle[f[0].to_s], f[2..], f[1]).method(:call).to_proc
     end
   end
 

--- a/lib/puppet/util/command_line.rb
+++ b/lib/puppet/util/command_line.rb
@@ -56,7 +56,7 @@ module Puppet
         if subcommand_name.nil?
           @argv
         else
-          @argv[1..-1]
+          @argv[1..]
         end
       end
 

--- a/lib/puppet/util/command_line/trollop.rb
+++ b/lib/puppet/util/command_line/trollop.rb
@@ -570,12 +570,12 @@ class CommandLine
 
       until i >= args.length
         if @stop_words.member? args[i]
-          remains += args[i..-1]
+          remains += args[i..]
           return remains
         end
         case args[i]
         when /^--$/ # arg terminator
-          remains += args[(i + 1)..-1]
+          remains += args[(i + 1)..]
           return remains
         when /^--(\S+?)=(.*)$/ # long argument with equals
           yield "--#{$1}", [$2]
@@ -586,7 +586,7 @@ class CommandLine
             num_params_taken = yield args[i], params
             unless num_params_taken
               if @stop_on_unknown
-                remains += args[i + 1..-1]
+                remains += args[i + 1..]
                 return remains
               else
                 remains += params
@@ -606,7 +606,7 @@ class CommandLine
                 num_params_taken = yield "-#{a}", params
                 unless num_params_taken
                   if @stop_on_unknown
-                    remains += args[i + 1..-1]
+                    remains += args[i + 1..]
                     return remains
                   else
                     remains += params
@@ -623,7 +623,7 @@ class CommandLine
           end
         else
           if @stop_on_unknown
-            remains += args[i..-1]
+            remains += args[i..]
             return remains
           else
             remains << args[i]

--- a/lib/puppet/util/docs.rb
+++ b/lib/puppet/util/docs.rb
@@ -20,9 +20,9 @@ module Puppet::Util::Docs
 
   # Generate the full doc string.
   def doc
-    extra = methods.find_all { |m| m.to_s =~ /^dochook_.+/ }.sort.collect { |m|
+    extra = methods.find_all { |m| m.to_s =~ /^dochook_.+/ }.sort.filter_map { |m|
       self.send(m)
-    }.compact.collect { |r| "* #{r}" }.join("\n")
+    }.collect { |r| "* #{r}" }.join("\n")
 
     if @doc
       scrub(@doc) + (extra.empty? ? '' : "\n\n#{extra}")

--- a/lib/puppet/util/docs.rb
+++ b/lib/puppet/util/docs.rb
@@ -22,7 +22,7 @@ module Puppet::Util::Docs
   def doc
     extra = methods.find_all { |m| m.to_s =~ /^dochook_.+/ }.sort.collect { |m|
       self.send(m)
-    }.delete_if { |r| r.nil? }.collect { |r| "* #{r}" }.join("\n")
+    }.compact.collect { |r| "* #{r}" }.join("\n")
 
     if @doc
       scrub(@doc) + (extra.empty? ? '' : "\n\n#{extra}")

--- a/lib/puppet/util/fileparsing.rb
+++ b/lib/puppet/util/fileparsing.rb
@@ -105,7 +105,7 @@ module Puppet::Util::FileParsing
     def join(details)
       joinchar = self.joiner
 
-      fields.collect { |field|
+      fields.filter_map { |field|
         # If the field is marked absent, use the appropriate replacement
         if details[field] == :absent or details[field] == [:absent] or details[field].nil?
           if self.optional.include?(field)
@@ -116,7 +116,7 @@ module Puppet::Util::FileParsing
         else
           details[field].to_s
         end
-      }.compact.join(joinchar)
+      }.join(joinchar)
     end
 
     # Customize this so we can do a bit of validation.

--- a/lib/puppet/util/rpm_compare.rb
+++ b/lib/puppet/util/rpm_compare.rb
@@ -36,8 +36,8 @@ module Puppet::Util::RpmCompare
       # "handle the tilde separator, it sorts before everything else"
       if str1 =~ /^~/ && str2 =~ /^~/
         # if they both have ~, strip it
-        str1 = str1[1..-1]
-        str2 = str2[1..-1]
+        str1 = str1[1..]
+        str2 = str2[1..]
         next
       elsif str1 =~ /^~/
         return -1

--- a/lib/puppet/util/run_mode.rb
+++ b/lib/puppet/util/run_mode.rb
@@ -9,7 +9,7 @@ module Puppet
         @name = name.to_sym
       end
 
-      attr :name
+      attr_reader :name
 
       def self.[](name)
         @run_modes ||= {}

--- a/lib/puppet/util/windows/daemon.rb
+++ b/lib/puppet/util/windows/daemon.rb
@@ -156,7 +156,7 @@ module Puppet::Util::Windows
 
         # Args passed to Service.start
         if (dwArgc > 1)
-          @@Argv = argv[1..-1]
+          @@Argv = argv[1..]
         else
           @@Argv = nil
         end


### PR DESCRIPTION
This PR updates Rubocop, its extensions, and the TargetRubyVersion to reflect that Puppet 8's minimum required Ruby version is 3.1.

Additionally, this PR addresses any new Rubocop offenses that this update causes.