### PR TITLE
Pin Windows Ruby to 3.2.2

### DIFF
--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -18,10 +18,10 @@ jobs:
         cfg:
           - {os: ubuntu-latest, ruby: '3.1'}
           - {os: ubuntu-20.04, ruby: '3.2'} # openssl 1.1.1
-          - {os: ubuntu-22.04, ruby: '3.2'} # openssl 3
+          - {os: ubuntu-22.04, ruby: '3.2'} # openssl 3.0
           - {os: ubuntu-latest, ruby: 'jruby-9.4.3.0'}
           - {os: windows-2019, ruby: '3.1'}
-          - {os: windows-2019, ruby: '3.2'} # openssl 3
+          - {os: windows-2019, ruby: '3.2.2'} # openssl 3.0
 
     runs-on: ${{ matrix.cfg.os }}
     steps:


### PR DESCRIPTION
A recent update to the Ruby GitHub Action added Ruby 3.2.3 for Windows: https://github.com/ruby/setup-ruby/pull/566/commits/591bd21fa67511786e99952dc1381fbd56353efe

That version of Ruby for Windows bundles OpenSSL 3.2. We bundle OpenSSL 3.0 in puppet-agent and the discrepancy between the two versions of
  OpenSSL is causing some SSL tests to fail.

This commit pins the Ruby version for GitHub runners used in spec tests to 3.2.2.