### PR TITLE
Update test for ruby 3.2.3 and openssl 3.2

### DIFF
--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -18,10 +18,10 @@ jobs:
         cfg:
           - {os: ubuntu-latest, ruby: '3.1'}
           - {os: ubuntu-20.04, ruby: '3.2'} # openssl 1.1.1
-          - {os: ubuntu-22.04, ruby: '3.2'} # openssl 3.0
+          - {os: ubuntu-22.04, ruby: '3.2'} # openssl 3
           - {os: ubuntu-latest, ruby: 'jruby-9.4.3.0'}
           - {os: windows-2019, ruby: '3.1'}
-          - {os: windows-2019, ruby: '3.2.2'} # openssl 3.0
+          - {os: windows-2019, ruby: '3.2'} # openssl 3
 
     runs-on: ${{ matrix.cfg.os }}
     steps:

--- a/spec/fixtures/ssl/127.0.0.1-key.pem
+++ b/spec/fixtures/ssl/127.0.0.1-key.pem
@@ -1,117 +1,117 @@
-Private-Key: (2048 bit, 2 primes)
+RSA Private-Key: (2048 bit, 2 primes)
 modulus:
-    00:d0:13:11:3b:81:35:76:84:fb:b6:4e:c6:e2:7d:
-    1a:16:a5:88:08:dd:50:fd:08:04:a6:ea:a0:6d:09:
-    8c:f2:bf:68:4b:a0:7b:68:84:b3:e4:51:e1:62:3c:
-    68:06:c8:38:3b:0a:a5:8b:da:87:25:cd:2a:76:0b:
-    82:71:89:5b:11:57:cb:dd:b5:ec:75:56:06:a1:26:
-    57:08:54:2d:83:c9:2f:83:f6:d0:e0:c3:ee:78:14:
-    47:f4:5b:ed:54:6a:93:fe:f0:68:a4:fa:93:8c:72:
-    f0:4b:84:f9:94:a2:ed:d8:83:79:9a:0c:c7:d4:33:
-    8e:e6:76:fd:cc:93:e3:3a:b7:56:97:85:f9:87:7e:
-    a9:60:e2:fd:35:9e:31:6b:2e:cb:86:47:e2:67:08:
-    fe:13:52:aa:64:d4:7c:76:09:b5:99:17:19:ed:6b:
-    76:6c:e8:09:b5:98:06:59:c0:4a:1a:0a:a5:f9:0a:
-    73:7c:56:46:32:17:80:3f:09:fa:a7:00:bb:a6:8b:
-    d0:20:83:fe:ab:3c:a6:bf:ed:e6:e4:71:5e:8a:12:
-    da:65:2a:9a:c9:9a:bd:a7:d4:56:c5:42:b9:bc:0f:
-    0d:19:35:d1:72:37:30:e0:28:0f:36:91:a2:7b:e3:
-    62:37:0e:5c:ba:0d:26:dc:0a:66:b3:18:ed:6e:d1:
-    63:b7
+    00:b9:04:03:80:8d:8f:96:d7:90:83:c1:09:31:1e:
+    2b:03:c7:e3:98:28:27:ff:63:e9:03:6e:94:73:9e:
+    de:47:d4:c0:66:33:e6:e7:29:91:d4:4b:63:d3:8b:
+    ed:18:04:05:84:be:bc:97:6f:56:64:b7:03:f2:cd:
+    ff:fc:f5:1f:1b:72:82:62:fb:db:cd:84:99:a2:28:
+    a5:d7:fb:0a:e4:5c:22:7c:85:f3:2e:d7:e9:6f:4e:
+    4d:29:35:a2:bd:ae:15:7c:87:96:d5:51:23:57:8e:
+    cf:ba:51:e5:56:cb:3e:b5:cf:20:51:66:84:88:ec:
+    c8:96:2a:07:bf:db:be:cc:51:d4:21:6e:66:25:2f:
+    29:5a:a2:84:83:23:b1:2b:ed:93:b0:68:f3:e6:61:
+    0d:2b:e9:7b:58:f7:9a:b8:8a:d8:83:d7:7c:35:48:
+    e9:f0:cf:c4:c8:7d:36:30:2b:ab:e7:58:c9:f4:ea:
+    e5:35:5c:23:55:bd:84:a6:7b:ce:1d:e0:9a:0e:d8:
+    d3:41:52:24:10:a8:76:f7:58:3b:98:64:8b:a7:60:
+    ca:32:41:40:a4:28:bd:55:09:01:a7:32:3f:48:d7:
+    e1:39:14:32:45:1d:00:b4:a0:8b:0e:b2:0e:85:7f:
+    ae:8c:66:e6:8b:6f:6f:ee:c5:c5:ec:2c:65:62:e8:
+    83:0f
 publicExponent: 65537 (0x10001)
 privateExponent:
-    1a:08:60:ae:10:b6:e7:2a:b1:31:78:7e:b2:a4:93:
-    48:85:12:55:85:97:15:e9:54:67:ab:d0:41:84:21:
-    e1:d7:27:cd:da:78:c6:35:60:2a:6f:42:23:1f:ca:
-    a6:1a:93:ca:73:45:0e:0f:db:bb:d3:84:fd:fa:e7:
-    a9:9b:d5:4c:80:af:0d:80:ae:e2:69:4e:70:08:13:
-    78:83:cb:a4:02:de:52:84:e5:52:51:c1:3a:bd:d2:
-    d8:d4:4d:87:b3:c3:eb:70:19:af:96:78:32:68:c8:
-    fe:b1:d6:e6:0d:52:73:b5:d3:57:7e:44:dc:1c:4d:
-    43:31:5d:04:a4:f6:17:88:d1:c2:3c:05:a0:e9:06:
-    a4:00:0a:db:5d:1b:1d:77:64:fd:b5:23:57:27:9c:
-    91:2f:da:7a:81:a4:3e:fe:e0:f2:5e:00:b7:55:02:
-    84:b0:07:17:f9:64:4a:a2:61:4e:9b:48:85:d7:5b:
-    34:c3:e6:d2:01:9d:20:3f:76:db:7d:f0:96:f8:80:
-    2c:f0:f2:88:8a:99:be:49:20:05:8b:64:aa:54:4b:
-    5b:d5:75:d7:30:0d:29:4a:07:c2:06:77:f5:b6:bc:
-    68:8d:eb:98:30:6e:42:f6:1d:da:8d:0a:bd:ad:11:
-    eb:44:01:17:e8:a1:55:06:76:37:84:9c:af:ce:fd:
-    81
+    00:a1:84:34:7e:7c:96:b6:eb:b7:38:9e:43:a5:02:
+    9e:30:ad:c7:2d:e5:18:8d:e7:2d:db:96:24:b9:0f:
+    1f:23:fc:42:7e:b6:9e:c4:7d:50:d6:d1:7d:f3:87:
+    3b:53:74:e7:50:6c:a6:fd:58:f0:45:fa:53:d3:1b:
+    2d:78:2a:91:9e:87:87:f6:5b:c3:16:96:c4:fc:80:
+    99:cf:84:54:8c:e9:36:1e:19:5e:24:2d:cf:97:20:
+    f7:51:9b:86:58:2a:ea:8d:0d:5d:8b:1a:4b:4d:3b:
+    da:72:e0:dd:e2:b8:8a:25:74:0d:d5:a2:36:df:c6:
+    3e:92:81:5c:c4:8c:54:f3:ce:98:f7:aa:1f:33:b7:
+    b3:98:0d:31:cd:14:af:35:e2:03:78:fd:73:37:06:
+    9d:70:c5:16:4a:7c:5e:68:6c:72:d7:ed:06:ee:0e:
+    0e:dc:8e:27:67:d5:05:bb:41:06:6b:15:3a:81:6c:
+    15:de:0d:e8:44:33:f6:81:e3:cd:e5:bd:26:08:98:
+    a0:f7:c4:2e:31:a4:11:f0:33:7d:a3:bc:d7:ec:0d:
+    5c:41:de:12:ca:43:56:eb:61:db:af:42:93:5e:95:
+    18:3a:ab:77:71:6f:31:eb:6f:e8:65:6d:b2:43:7c:
+    06:6a:5a:fc:f0:bf:22:e2:30:66:a8:55:68:b0:df:
+    a2:a9
 prime1:
-    00:f8:0b:a4:03:60:bf:e6:54:b2:c3:8f:63:a4:71:
-    50:84:81:9b:80:fb:19:ce:f1:68:39:8b:0e:65:a6:
-    3a:f3:78:00:7b:83:bf:4a:dc:49:bc:9e:42:fd:7e:
-    69:e9:13:56:cb:f9:78:e1:8e:f5:13:fc:dd:a5:5a:
-    0d:24:2c:06:57:1d:fe:b4:23:88:6d:a1:91:53:72:
-    9c:95:4f:93:31:26:54:a2:49:c2:a7:ca:c7:a5:94:
-    0d:15:2e:8e:a3:54:3a:ee:6f:fd:2d:52:55:ed:22:
-    84:53:29:51:de:2d:98:3e:22:82:60:e8:96:34:a7:
-    d0:31:9a:19:f7:d2:db:27:37
+    00:f6:a5:33:76:e8:15:c6:98:f6:46:93:b7:1a:8b:
+    83:13:a4:7e:60:ea:cd:29:1e:4f:95:4f:f4:86:2c:
+    d0:e0:83:80:32:80:bf:ce:98:93:f3:d1:ff:d4:7f:
+    90:d3:3e:92:bc:db:30:c4:f5:56:78:e8:6e:6e:3d:
+    12:bf:e8:43:16:2d:c8:66:3c:00:61:ae:96:9a:c8:
+    4d:3a:e0:cb:7e:53:fa:66:bf:97:65:d7:85:a0:e6:
+    55:c5:d4:81:d3:68:08:ba:ae:30:ac:46:54:04:01:
+    f6:d9:51:28:cf:e9:32:33:bd:55:53:6a:73:6d:aa:
+    12:c9:01:58:89:76:24:47:a3
 prime2:
-    00:d6:bf:47:ab:68:ce:0b:0f:1a:13:fb:ce:ca:66:
-    e4:a5:dd:a0:7f:d2:77:89:66:5f:08:33:6c:1d:e1:
-    0d:b7:d5:88:bb:00:4b:0f:85:9c:83:42:9f:01:64:
-    e0:c5:0f:5d:19:4b:bc:af:71:7d:5e:eb:7b:aa:69:
-    75:11:75:81:4c:42:f4:b2:8a:29:7e:7a:1b:e6:a3:
-    b2:20:6f:07:b9:f9:03:8e:5a:2a:af:f5:5a:2d:a0:
-    00:db:b6:22:e8:8d:1d:d0:69:3d:01:e9:05:eb:8b:
-    2c:89:77:c3:a3:10:57:2c:7f:e3:70:72:d3:56:9f:
-    72:b9:ea:07:56:02:00:e7:81
+    00:c0:08:6b:ad:09:ff:09:d9:63:7e:fd:27:7d:e2:
+    70:db:5b:99:43:32:16:3f:c1:a6:05:0d:ed:33:4c:
+    ce:7a:8c:42:67:f1:8d:f2:d7:d8:b7:0d:10:f3:eb:
+    85:94:98:d8:91:8b:02:8e:d9:af:ca:1f:b8:4e:90:
+    21:a1:40:b3:f2:66:90:07:00:0f:a8:57:9d:bb:09:
+    0f:ba:85:24:22:7b:51:fb:bb:76:56:34:6c:3a:fc:
+    50:97:c6:0b:03:91:57:00:7e:0c:5c:9b:43:c5:3e:
+    14:91:93:7b:f9:7c:d0:72:f2:08:fd:c5:5e:57:a0:
+    88:5e:74:2c:1a:ef:01:bd:a5
 exponent1:
-    00:d0:80:70:78:ca:6d:e4:be:53:9a:21:40:ff:ec:
-    a4:63:0d:d3:5a:43:38:79:84:e1:38:65:94:4f:8b:
-    c0:c8:01:9a:5e:38:eb:a6:90:af:86:d6:7d:b7:39:
-    f8:eb:0b:ef:8c:fc:02:49:8f:f2:a0:bf:90:cc:ba:
-    7a:8b:6a:5a:56:06:87:a0:82:b1:de:7d:ce:7c:17:
-    be:59:a0:0f:39:64:60:06:1e:fc:7a:30:f1:4b:54:
-    bc:fe:8e:29:26:4f:da:4d:ad:63:63:22:6f:ca:2a:
-    96:92:95:0c:15:37:bc:5e:96:81:83:d6:5e:d4:9a:
-    2f:5e:52:8b:fb:8e:89:db:57
+    76:74:62:e2:21:96:8b:b9:dc:d5:8a:8d:ee:e6:bf:
+    fe:08:0b:56:1a:8e:8b:c7:ed:ea:c4:ea:a8:22:0f:
+    f3:33:d4:b6:ec:94:b1:f1:1f:65:83:1e:bd:fc:c2:
+    1e:62:37:f1:11:c8:3b:5f:a4:b7:0e:d2:32:89:8c:
+    5e:b4:7a:bb:c5:23:30:ce:72:54:77:98:07:20:59:
+    cf:04:35:57:27:97:e4:0e:f1:f4:4c:6c:f6:18:89:
+    6b:28:a3:6d:57:d2:91:6d:a5:1c:a7:ee:23:ba:99:
+    c6:47:2f:35:a3:46:a4:08:b3:59:0b:90:02:44:23:
+    1f:7c:50:fc:3b:cc:32:c7
 exponent2:
-    5b:99:de:05:64:c0:37:01:6b:1b:49:16:ed:49:34:
-    90:f7:d7:85:8e:8e:44:c2:b1:18:bb:6e:8b:d4:3a:
-    d8:c6:b1:fb:2a:65:da:2a:21:17:f0:6c:08:d9:31:
-    f3:7c:d9:36:78:12:f5:37:50:c6:13:66:7d:cb:5c:
-    0f:65:73:10:c7:a2:bf:21:a6:0f:78:20:bc:a1:e8:
-    d2:62:ea:05:cf:0d:50:44:6f:de:fc:a6:49:bd:ed:
-    7f:ca:d2:5b:26:0e:a8:9e:ab:52:4c:46:a5:31:89:
-    7e:dd:e2:4a:85:26:da:29:77:27:b9:23:22:d9:02:
-    c4:00:ea:be:2a:3e:9e:81
+    00:85:4c:53:12:06:82:56:9f:e4:04:de:4d:6f:80:
+    a3:be:60:d2:fe:65:e2:33:d7:84:1a:b6:14:15:2c:
+    17:97:d1:8c:b7:02:61:fa:54:02:46:ee:76:fa:1a:
+    5e:db:4b:4d:e9:99:88:e9:08:0a:92:4f:7a:6c:6e:
+    78:29:aa:f4:3e:2b:1b:87:00:6f:dd:f7:13:b2:25:
+    14:19:f1:19:a8:25:da:3e:d7:5d:c9:71:12:3f:cf:
+    ad:51:ed:52:ef:e3:0f:75:74:09:b8:ae:be:58:48:
+    43:96:d9:bd:90:ed:26:f4:e3:35:82:92:62:6e:89:
+    2c:a0:04:1c:29:86:06:bb:51
 coefficient:
-    08:16:69:41:c7:f5:15:7a:f9:0d:3d:b8:d2:4d:8f:
-    82:22:2f:89:76:11:5d:e9:7f:fc:d3:e4:76:ba:46:
-    44:eb:91:be:45:e1:1c:5c:75:1e:ff:c3:b2:5c:ae:
-    0f:a7:fb:16:2a:e2:9d:26:4f:ab:40:f2:d4:33:a3:
-    fd:c7:76:e0:f3:b9:f6:ff:05:92:8b:60:15:fc:76:
-    d1:f7:b2:45:8a:4e:4d:16:23:5a:d0:27:81:fb:61:
-    94:b1:aa:38:ea:1d:81:52:0b:e3:8f:59:40:e1:35:
-    d7:ee:cb:80:2d:28:15:b8:61:07:d0:50:da:89:83:
-    5b:88:5b:2e:fb:20:9b:fd
+    00:db:05:92:d8:a8:8d:77:ff:94:17:39:5b:3c:da:
+    b2:44:e6:11:98:c0:a0:fc:02:3a:92:01:e5:db:40:
+    98:51:87:09:4e:40:d1:8d:f0:3c:b9:83:0b:d6:c6:
+    20:f7:08:0c:c3:95:aa:cf:8f:8c:e4:21:cd:63:9d:
+    b9:81:88:25:00:fe:36:0b:f2:30:3b:de:09:e6:ff:
+    28:66:46:20:18:65:14:c0:f2:b7:07:f5:f5:92:be:
+    4e:f1:2c:4d:40:0f:a4:7f:61:25:c4:e1:ed:29:68:
+    38:ab:33:d2:2f:88:1a:22:f3:42:a8:99:65:cd:bb:
+    d0:26:58:c3:50:39:9e:bb:78
 -----BEGIN RSA PRIVATE KEY-----
-MIIEowIBAAKCAQEA0BMRO4E1doT7tk7G4n0aFqWICN1Q/QgEpuqgbQmM8r9oS6B7
-aISz5FHhYjxoBsg4Owqli9qHJc0qdguCcYlbEVfL3bXsdVYGoSZXCFQtg8kvg/bQ
-4MPueBRH9FvtVGqT/vBopPqTjHLwS4T5lKLt2IN5mgzH1DOO5nb9zJPjOrdWl4X5
-h36pYOL9NZ4xay7LhkfiZwj+E1KqZNR8dgm1mRcZ7Wt2bOgJtZgGWcBKGgql+Qpz
-fFZGMheAPwn6pwC7povQIIP+qzymv+3m5HFeihLaZSqayZq9p9RWxUK5vA8NGTXR
-cjcw4CgPNpGie+NiNw5cug0m3ApmsxjtbtFjtwIDAQABAoIBABoIYK4QtucqsTF4
-frKkk0iFElWFlxXpVGer0EGEIeHXJ83aeMY1YCpvQiMfyqYak8pzRQ4P27vThP36
-56mb1UyArw2AruJpTnAIE3iDy6QC3lKE5VJRwTq90tjUTYezw+twGa+WeDJoyP6x
-1uYNUnO101d+RNwcTUMxXQSk9heI0cI8BaDpBqQACttdGx13ZP21I1cnnJEv2nqB
-pD7+4PJeALdVAoSwBxf5ZEqiYU6bSIXXWzTD5tIBnSA/dtt98Jb4gCzw8oiKmb5J
-IAWLZKpUS1vVddcwDSlKB8IGd/W2vGiN65gwbkL2HdqNCr2tEetEARfooVUGdjeE
-nK/O/YECgYEA+AukA2C/5lSyw49jpHFQhIGbgPsZzvFoOYsOZaY683gAe4O/StxJ
-vJ5C/X5p6RNWy/l44Y71E/zdpVoNJCwGVx3+tCOIbaGRU3KclU+TMSZUoknCp8rH
-pZQNFS6Oo1Q67m/9LVJV7SKEUylR3i2YPiKCYOiWNKfQMZoZ99LbJzcCgYEA1r9H
-q2jOCw8aE/vOymbkpd2gf9J3iWZfCDNsHeENt9WIuwBLD4Wcg0KfAWTgxQ9dGUu8
-r3F9Xut7qml1EXWBTEL0soopfnob5qOyIG8HufkDjloqr/VaLaAA27Yi6I0d0Gk9
-AekF64ssiXfDoxBXLH/jcHLTVp9yueoHVgIA54ECgYEA0IBweMpt5L5TmiFA/+yk
-Yw3TWkM4eYThOGWUT4vAyAGaXjjrppCvhtZ9tzn46wvvjPwCSY/yoL+QzLp6i2pa
-VgaHoIKx3n3OfBe+WaAPOWRgBh78ejDxS1S8/o4pJk/aTa1jYyJvyiqWkpUMFTe8
-XpaBg9Ze1JovXlKL+46J21cCgYBbmd4FZMA3AWsbSRbtSTSQ99eFjo5EwrEYu26L
-1DrYxrH7KmXaKiEX8GwI2THzfNk2eBL1N1DGE2Z9y1wPZXMQx6K/IaYPeCC8oejS
-YuoFzw1QRG/e/KZJve1/ytJbJg6onqtSTEalMYl+3eJKhSbaKXcnuSMi2QLEAOq+
-Kj6egQKBgAgWaUHH9RV6+Q09uNJNj4IiL4l2EV3pf/zT5Ha6RkTrkb5F4RxcdR7/
-w7Jcrg+n+xYq4p0mT6tA8tQzo/3HduDzufb/BZKLYBX8dtH3skWKTk0WI1rQJ4H7
-YZSxqjjqHYFSC+OPWUDhNdfuy4AtKBW4YQfQUNqJg1uIWy77IJv9
+MIIEpQIBAAKCAQEAuQQDgI2PlteQg8EJMR4rA8fjmCgn/2PpA26Uc57eR9TAZjPm
+5ymR1Etj04vtGAQFhL68l29WZLcD8s3//PUfG3KCYvvbzYSZoiil1/sK5FwifIXz
+Ltfpb05NKTWiva4VfIeW1VEjV47PulHlVss+tc8gUWaEiOzIlioHv9u+zFHUIW5m
+JS8pWqKEgyOxK+2TsGjz5mENK+l7WPeauIrYg9d8NUjp8M/EyH02MCur51jJ9Orl
+NVwjVb2EpnvOHeCaDtjTQVIkEKh291g7mGSLp2DKMkFApCi9VQkBpzI/SNfhORQy
+RR0AtKCLDrIOhX+ujGbmi29v7sXF7CxlYuiDDwIDAQABAoIBAQChhDR+fJa267c4
+nkOlAp4wrcct5RiN5y3bliS5Dx8j/EJ+tp7EfVDW0X3zhztTdOdQbKb9WPBF+lPT
+Gy14KpGeh4f2W8MWlsT8gJnPhFSM6TYeGV4kLc+XIPdRm4ZYKuqNDV2LGktNO9py
+4N3iuIoldA3Vojbfxj6SgVzEjFTzzpj3qh8zt7OYDTHNFK814gN4/XM3Bp1wxRZK
+fF5obHLX7QbuDg7cjidn1QW7QQZrFTqBbBXeDehEM/aB483lvSYImKD3xC4xpBHw
+M32jvNfsDVxB3hLKQ1brYduvQpNelRg6q3dxbzHrb+hlbbJDfAZqWvzwvyLiMGao
+VWiw36KpAoGBAPalM3boFcaY9kaTtxqLgxOkfmDqzSkeT5VP9IYs0OCDgDKAv86Y
+k/PR/9R/kNM+krzbMMT1Vnjobm49Er/oQxYtyGY8AGGulprITTrgy35T+ma/l2XX
+haDmVcXUgdNoCLquMKxGVAQB9tlRKM/pMjO9VVNqc22qEskBWIl2JEejAoGBAMAI
+a60J/wnZY379J33icNtbmUMyFj/BpgUN7TNMznqMQmfxjfLX2LcNEPPrhZSY2JGL
+Ao7Zr8ofuE6QIaFAs/JmkAcAD6hXnbsJD7qFJCJ7Ufu7dlY0bDr8UJfGCwORVwB+
+DFybQ8U+FJGTe/l80HLyCP3FXlegiF50LBrvAb2lAoGAdnRi4iGWi7nc1YqN7ua/
+/ggLVhqOi8ft6sTqqCIP8zPUtuyUsfEfZYMevfzCHmI38RHIO1+ktw7SMomMXrR6
+u8UjMM5yVHeYByBZzwQ1VyeX5A7x9Exs9hiJayijbVfSkW2lHKfuI7qZxkcvNaNG
+pAizWQuQAkQjH3xQ/DvMMscCgYEAhUxTEgaCVp/kBN5Nb4CjvmDS/mXiM9eEGrYU
+FSwXl9GMtwJh+lQCRu52+hpe20tN6ZmI6QgKkk96bG54Kar0PisbhwBv3fcTsiUU
+GfEZqCXaPtddyXESP8+tUe1S7+MPdXQJuK6+WEhDltm9kO0m9OM1gpJiboksoAQc
+KYYGu1ECgYEA2wWS2KiNd/+UFzlbPNqyROYRmMCg/AI6kgHl20CYUYcJTkDRjfA8
+uYML1sYg9wgMw5Wqz4+M5CHNY525gYglAP42C/IwO94J5v8oZkYgGGUUwPK3B/X1
+kr5O8SxNQA+kf2ElxOHtKWg4qzPSL4gaIvNCqJllzbvQJljDUDmeu3g=
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/127.0.0.1.pem
+++ b/spec/fixtures/ssl/127.0.0.1.pem
@@ -6,65 +6,64 @@ Certificate:
         Issuer: CN=Test CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Jun 24 21:18:00 2033 GMT
+            Not After : Jan 27 18:43:32 2034 GMT
         Subject: CN=127.0.0.1
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                Public-Key: (2048 bit)
+                RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:d0:13:11:3b:81:35:76:84:fb:b6:4e:c6:e2:7d:
-                    1a:16:a5:88:08:dd:50:fd:08:04:a6:ea:a0:6d:09:
-                    8c:f2:bf:68:4b:a0:7b:68:84:b3:e4:51:e1:62:3c:
-                    68:06:c8:38:3b:0a:a5:8b:da:87:25:cd:2a:76:0b:
-                    82:71:89:5b:11:57:cb:dd:b5:ec:75:56:06:a1:26:
-                    57:08:54:2d:83:c9:2f:83:f6:d0:e0:c3:ee:78:14:
-                    47:f4:5b:ed:54:6a:93:fe:f0:68:a4:fa:93:8c:72:
-                    f0:4b:84:f9:94:a2:ed:d8:83:79:9a:0c:c7:d4:33:
-                    8e:e6:76:fd:cc:93:e3:3a:b7:56:97:85:f9:87:7e:
-                    a9:60:e2:fd:35:9e:31:6b:2e:cb:86:47:e2:67:08:
-                    fe:13:52:aa:64:d4:7c:76:09:b5:99:17:19:ed:6b:
-                    76:6c:e8:09:b5:98:06:59:c0:4a:1a:0a:a5:f9:0a:
-                    73:7c:56:46:32:17:80:3f:09:fa:a7:00:bb:a6:8b:
-                    d0:20:83:fe:ab:3c:a6:bf:ed:e6:e4:71:5e:8a:12:
-                    da:65:2a:9a:c9:9a:bd:a7:d4:56:c5:42:b9:bc:0f:
-                    0d:19:35:d1:72:37:30:e0:28:0f:36:91:a2:7b:e3:
-                    62:37:0e:5c:ba:0d:26:dc:0a:66:b3:18:ed:6e:d1:
-                    63:b7
+                    00:b9:04:03:80:8d:8f:96:d7:90:83:c1:09:31:1e:
+                    2b:03:c7:e3:98:28:27:ff:63:e9:03:6e:94:73:9e:
+                    de:47:d4:c0:66:33:e6:e7:29:91:d4:4b:63:d3:8b:
+                    ed:18:04:05:84:be:bc:97:6f:56:64:b7:03:f2:cd:
+                    ff:fc:f5:1f:1b:72:82:62:fb:db:cd:84:99:a2:28:
+                    a5:d7:fb:0a:e4:5c:22:7c:85:f3:2e:d7:e9:6f:4e:
+                    4d:29:35:a2:bd:ae:15:7c:87:96:d5:51:23:57:8e:
+                    cf:ba:51:e5:56:cb:3e:b5:cf:20:51:66:84:88:ec:
+                    c8:96:2a:07:bf:db:be:cc:51:d4:21:6e:66:25:2f:
+                    29:5a:a2:84:83:23:b1:2b:ed:93:b0:68:f3:e6:61:
+                    0d:2b:e9:7b:58:f7:9a:b8:8a:d8:83:d7:7c:35:48:
+                    e9:f0:cf:c4:c8:7d:36:30:2b:ab:e7:58:c9:f4:ea:
+                    e5:35:5c:23:55:bd:84:a6:7b:ce:1d:e0:9a:0e:d8:
+                    d3:41:52:24:10:a8:76:f7:58:3b:98:64:8b:a7:60:
+                    ca:32:41:40:a4:28:bd:55:09:01:a7:32:3f:48:d7:
+                    e1:39:14:32:45:1d:00:b4:a0:8b:0e:b2:0e:85:7f:
+                    ae:8c:66:e6:8b:6f:6f:ee:c5:c5:ec:2c:65:62:e8:
+                    83:0f
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Subject Alternative Name: 
                 DNS:127.0.0.1, DNS:127.0.0.2
     Signature Algorithm: sha256WithRSAEncryption
-    Signature Value:
-        4f:f7:58:a4:e1:bb:12:ea:e0:6b:e0:f0:ca:18:bd:f6:b8:5e:
-        f2:c4:0d:9d:1d:b1:d6:a1:96:7f:94:96:1a:c2:91:22:f4:2b:
-        e1:96:71:ce:83:0c:84:ff:72:f6:18:72:76:ee:26:9f:0a:92:
-        f4:d9:86:f7:62:90:77:6a:b9:a0:b9:61:53:64:f2:12:e9:23:
-        31:5a:ee:f7:f7:70:bb:f3:b6:89:b3:bc:64:f1:01:2f:c7:c8:
-        0c:70:a9:c6:1f:ca:95:d0:ec:25:43:e4:93:88:8b:c4:4b:50:
-        a0:77:79:f0:2f:81:4d:d3:71:93:2a:58:d1:d7:89:64:c0:30:
-        50:45:ae:36:e4:37:69:d8:d1:50:83:8d:a4:2f:55:ad:a1:c9:
-        ae:68:ac:4d:5f:1b:c9:bc:dc:ff:30:7b:10:da:16:fb:60:f9:
-        ba:73:26:44:7d:de:1e:2b:12:69:40:d4:c2:17:b2:76:d4:40:
-        fa:2c:b0:c5:54:4a:af:1a:94:b9:62:0c:81:42:9a:c3:bc:d6:
-        3a:f7:69:8e:82:91:24:48:46:be:10:bd:ed:c4:71:56:f2:e8:
-        73:64:18:d0:8b:7d:b0:66:2f:a6:e3:4d:23:68:11:b0:48:16:
-        db:8a:dd:bf:e5:de:5e:35:fa:7a:76:0e:ec:9d:e3:ee:d1:28:
-        58:bc:23:bf
+         0c:9f:98:df:3d:2c:3c:4a:09:fa:79:f1:02:b4:42:1b:c6:33:
+         78:68:b7:65:1a:f7:17:2d:ca:26:0e:cd:cd:ec:95:ee:35:6b:
+         44:9b:04:b8:60:e2:a5:1c:61:e6:2d:26:c4:fd:c4:43:48:d0:
+         99:8d:8d:bb:50:33:77:49:45:e3:88:2a:2d:9b:08:24:19:29:
+         12:bd:da:f4:bb:58:b3:cb:de:8a:32:28:7a:e9:44:27:a7:8d:
+         c3:ad:94:41:57:4c:18:6c:a6:39:c4:4c:d2:7f:80:71:b4:af:
+         2c:a7:fb:6d:61:ca:42:1d:22:b0:0b:0e:9b:cf:e2:38:35:74:
+         dc:24:82:c3:df:89:ad:8c:5c:1e:0e:fe:0a:70:2b:2d:8a:d1:
+         cf:3b:f4:e6:8c:c6:74:fc:ea:7e:a1:80:d2:55:4d:11:87:55:
+         1f:65:73:9b:9d:36:17:e1:42:b1:78:a2:e8:39:da:f6:8f:8d:
+         a0:f5:8d:b4:39:02:d6:d3:c5:5c:11:28:71:8e:c2:65:37:b2:
+         f3:c5:3c:df:79:23:e7:8c:ff:3e:8a:46:14:de:d3:d7:b5:f5:
+         cb:68:46:0a:8a:c9:e2:ae:d4:1b:8b:c3:19:a4:43:e7:84:c9:
+         41:a2:14:34:4f:7e:80:c6:dd:48:5a:54:69:69:b3:af:86:6b:
+         26:0c:20:83
 -----BEGIN CERTIFICATE-----
 MIICxDCCAaygAwIBAgIBBjANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
-IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMzMDYyNDIxMTgwMFowFDESMBAGA1UEAwwJ
-MTI3LjAuMC4xMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0BMRO4E1
-doT7tk7G4n0aFqWICN1Q/QgEpuqgbQmM8r9oS6B7aISz5FHhYjxoBsg4Owqli9qH
-Jc0qdguCcYlbEVfL3bXsdVYGoSZXCFQtg8kvg/bQ4MPueBRH9FvtVGqT/vBopPqT
-jHLwS4T5lKLt2IN5mgzH1DOO5nb9zJPjOrdWl4X5h36pYOL9NZ4xay7LhkfiZwj+
-E1KqZNR8dgm1mRcZ7Wt2bOgJtZgGWcBKGgql+QpzfFZGMheAPwn6pwC7povQIIP+
-qzymv+3m5HFeihLaZSqayZq9p9RWxUK5vA8NGTXRcjcw4CgPNpGie+NiNw5cug0m
-3ApmsxjtbtFjtwIDAQABoyMwITAfBgNVHREEGDAWggkxMjcuMC4wLjGCCTEyNy4w
-LjAuMjANBgkqhkiG9w0BAQsFAAOCAQEAT/dYpOG7Eurga+Dwyhi99rhe8sQNnR2x
-1qGWf5SWGsKRIvQr4ZZxzoMMhP9y9hhydu4mnwqS9NmG92KQd2q5oLlhU2TyEukj
-MVru9/dwu/O2ibO8ZPEBL8fIDHCpxh/KldDsJUPkk4iLxEtQoHd58C+BTdNxkypY
-0deJZMAwUEWuNuQ3adjRUIONpC9VraHJrmisTV8bybzc/zB7ENoW+2D5unMmRH3e
-HisSaUDUwheydtRA+iywxVRKrxqUuWIMgUKaw7zWOvdpjoKRJEhGvhC97cRxVvLo
-c2QY0It9sGYvpuNNI2gRsEgW24rdv+XeXjX6enYO7J3j7tEoWLwjvw==
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTM0MDEyNzE4NDMzMlowFDESMBAGA1UEAwwJ
+MTI3LjAuMC4xMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuQQDgI2P
+lteQg8EJMR4rA8fjmCgn/2PpA26Uc57eR9TAZjPm5ymR1Etj04vtGAQFhL68l29W
+ZLcD8s3//PUfG3KCYvvbzYSZoiil1/sK5FwifIXzLtfpb05NKTWiva4VfIeW1VEj
+V47PulHlVss+tc8gUWaEiOzIlioHv9u+zFHUIW5mJS8pWqKEgyOxK+2TsGjz5mEN
+K+l7WPeauIrYg9d8NUjp8M/EyH02MCur51jJ9OrlNVwjVb2EpnvOHeCaDtjTQVIk
+EKh291g7mGSLp2DKMkFApCi9VQkBpzI/SNfhORQyRR0AtKCLDrIOhX+ujGbmi29v
+7sXF7CxlYuiDDwIDAQABoyMwITAfBgNVHREEGDAWggkxMjcuMC4wLjGCCTEyNy4w
+LjAuMjANBgkqhkiG9w0BAQsFAAOCAQEADJ+Y3z0sPEoJ+nnxArRCG8YzeGi3ZRr3
+Fy3KJg7NzeyV7jVrRJsEuGDipRxh5i0mxP3EQ0jQmY2Nu1Azd0lF44gqLZsIJBkp
+Er3a9LtYs8veijIoeulEJ6eNw62UQVdMGGymOcRM0n+AcbSvLKf7bWHKQh0isAsO
+m8/iODV03CSCw9+JrYxcHg7+CnArLYrRzzv05ozGdPzqfqGA0lVNEYdVH2Vzm502
+F+FCsXii6Dna9o+NoPWNtDkC1tPFXBEocY7CZTey88U833kj54z/PopGFN7T17X1
+y2hGCorJ4q7UG4vDGaRD54TJQaIUNE9+gMbdSFpUaWmzr4ZrJgwggw==
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/bad-basic-constraints.pem
+++ b/spec/fixtures/ssl/bad-basic-constraints.pem
@@ -6,30 +6,30 @@ Certificate:
         Issuer: CN=Test CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Jun 24 21:18:00 2033 GMT
+            Not After : Jan 27 18:43:32 2034 GMT
         Subject: CN=Test CA
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                Public-Key: (2048 bit)
+                RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:f4:9a:3e:d9:2b:e1:1e:ea:3c:85:7d:27:87:f5:
-                    f7:50:c6:60:f0:79:3b:86:23:ce:c9:ba:42:22:1b:
-                    61:1a:bc:33:c7:cf:e2:56:8f:6c:84:3e:4e:d0:48:
-                    b5:27:7e:7b:49:de:2b:5d:b2:9c:e6:49:53:52:c8:
-                    89:92:cb:e1:6c:30:67:c6:74:25:e3:3f:7a:37:ef:
-                    54:b4:bd:80:07:a6:db:77:5c:8f:56:ed:1b:14:af:
-                    2a:12:f5:44:88:15:a3:63:f2:f9:44:fb:51:ed:9a:
-                    6d:9c:cf:48:69:f6:d0:c9:6c:57:ee:1b:be:04:91:
-                    b3:ad:16:ed:c8:d0:bf:b4:55:6b:e9:3c:2b:8c:57:
-                    19:bc:f1:76:6f:90:8d:e4:60:79:c7:03:e3:9d:83:
-                    42:ec:0e:79:78:3c:30:c4:d5:87:63:4d:2c:17:ad:
-                    c6:ea:3b:ff:e4:73:1a:12:bb:ed:d3:f6:9d:9d:d9:
-                    e7:05:7f:21:6c:27:0a:27:c5:6e:c8:53:6c:a3:bb:
-                    0e:11:fa:c4:ab:97:8f:a1:fd:bd:f3:5e:fb:80:1d:
-                    15:87:c7:b4:20:94:fc:cb:ac:06:a8:ae:b1:80:a0:
-                    5d:50:68:8d:49:63:1b:b2:77:a2:6b:81:21:b6:58:
-                    3a:f2:3d:21:ac:a5:91:bc:7d:36:46:f4:87:ea:ce:
-                    a3:0f
+                    00:bf:58:f9:d6:80:6e:15:94:3c:42:eb:4c:9a:74:
+                    a6:70:16:0e:31:aa:3b:94:06:d9:28:5e:21:5b:da:
+                    fc:b7:cc:3e:06:fb:f9:fe:4c:84:dd:d1:b0:a3:1a:
+                    68:20:99:2e:28:02:59:dc:03:12:5c:21:8b:2a:0b:
+                    92:8f:87:61:d0:2c:bd:4b:84:84:c2:e8:4b:cf:09:
+                    28:86:65:89:9d:f5:85:70:a0:58:29:aa:bd:f5:3d:
+                    b0:fe:98:5d:f2:50:f3:f1:1f:94:d5:f8:ff:25:92:
+                    14:a4:81:19:bc:1a:03:5b:b3:1b:ea:7b:9c:99:9a:
+                    f4:3f:2a:a5:96:b0:07:96:48:79:b0:52:d4:fc:f2:
+                    51:62:94:fa:b0:69:b8:86:11:ab:b8:02:4d:93:e5:
+                    2b:01:50:ef:fa:06:f6:91:4d:56:58:a3:11:f3:0f:
+                    16:87:de:42:0a:53:b0:07:73:07:6d:ed:cf:91:52:
+                    2b:b4:e8:93:7e:57:aa:39:a4:47:1f:f6:ff:7d:8f:
+                    73:16:b3:2e:cb:4c:5f:40:c0:0c:02:2c:c8:6c:1b:
+                    8c:ec:54:d9:e1:60:98:de:77:e7:ee:a9:95:80:83:
+                    39:de:44:c2:83:d6:46:a2:f7:ac:63:6e:f5:b8:30:
+                    c2:5c:63:8f:0a:47:3a:6f:be:ef:3e:21:0a:52:69:
+                    8f:35
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Basic Constraints: critical
@@ -37,45 +37,45 @@ Certificate:
             X509v3 Key Usage: critical
                 Certificate Sign, CRL Sign
             X509v3 Subject Key Identifier: 
-                83:68:26:16:4A:C3:88:0A:A6:48:43:98:E7:2D:4F:5F:70:8C:62:B2
+                58:D3:6E:35:36:97:04:91:6A:B6:DF:45:80:9A:53:B3:E4:36:C8:3D
             Netscape Comment: 
                 Puppet Server Internal Certificate
             X509v3 Authority Key Identifier: 
-                83:68:26:16:4A:C3:88:0A:A6:48:43:98:E7:2D:4F:5F:70:8C:62:B2
+                keyid:58:D3:6E:35:36:97:04:91:6A:B6:DF:45:80:9A:53:B3:E4:36:C8:3D
+
     Signature Algorithm: sha256WithRSAEncryption
-    Signature Value:
-        f2:d5:76:aa:ff:05:b2:63:2d:81:23:3d:d5:dc:8f:a8:eb:bc:
-        17:35:7f:64:1a:37:50:02:ac:54:4b:c9:74:fb:07:f8:ec:f7:
-        c2:6a:80:bd:f7:d1:43:1b:4d:d1:2c:c2:71:d9:28:46:01:0f:
-        14:ab:8e:20:14:93:e7:dc:a7:b1:6d:4a:7d:a9:f7:a2:5d:ea:
-        4d:89:5f:fb:45:4b:98:c8:93:12:d9:74:5e:a4:3e:25:13:2c:
-        92:96:3e:15:c6:d3:46:c7:03:5c:4b:70:65:9e:1f:89:ef:7e:
-        70:63:3c:78:d8:a2:92:53:2d:39:a3:f5:0d:36:aa:2a:7b:a8:
-        a9:63:66:39:e3:49:55:0f:45:d6:14:9e:f4:77:18:16:90:13:
-        41:6a:27:8f:84:c9:c5:0d:ad:cc:d9:bf:62:90:02:56:63:76:
-        76:bc:3f:36:5d:41:ad:07:5e:f9:e2:66:e9:63:e3:ba:79:b9:
-        07:b6:e8:b5:27:0f:18:4e:a4:6d:82:d7:e9:a9:40:ce:eb:d9:
-        6a:b8:d6:04:c4:b2:62:1f:c5:cb:fe:14:f3:c5:cd:0e:11:32:
-        b5:cf:ea:fc:98:3c:59:23:eb:69:c5:0b:f6:83:5b:dc:25:9c:
-        6d:93:29:c2:30:58:c1:10:80:49:86:67:09:fd:22:67:01:e5:
-        32:9a:a3:83
+         18:57:51:5d:eb:63:93:8d:25:5b:5d:8e:5c:67:b0:d2:c6:71:
+         63:82:73:2e:d0:14:32:28:f3:cc:27:13:bc:4c:55:66:6b:28:
+         78:b8:cb:5e:f8:95:29:9a:78:55:59:3e:e4:de:d1:ae:f0:68:
+         7e:bc:ff:32:d2:54:85:b2:eb:0c:4d:99:6a:28:a5:d8:a3:6e:
+         8a:71:86:70:fd:3e:36:2b:ad:fc:29:f9:de:c5:1f:d7:4c:66:
+         9d:4b:bc:ee:4d:95:60:a4:3a:ce:75:7c:5e:3b:42:f5:21:18:
+         42:43:f4:15:62:7a:c9:7f:3b:a1:dc:38:e5:f2:12:db:62:b6:
+         22:91:b6:06:90:e8:26:2a:c6:3e:2e:80:9d:c2:fe:1d:67:b6:
+         72:2b:37:aa:4a:1d:19:bb:74:80:0b:c8:bc:c1:d3:3c:51:34:
+         1c:30:0b:65:86:e9:96:38:01:b2:d7:ad:8f:37:eb:54:1a:83:
+         2a:ee:fb:e8:e3:fb:eb:c2:df:27:df:49:34:64:bb:8a:d9:f3:
+         35:58:f7:b6:81:d8:df:21:30:bd:6d:af:6e:b2:89:4a:1a:3f:
+         56:3c:e4:24:94:4b:f3:1f:2b:e6:06:78:f1:34:68:cd:c5:c1:
+         5f:23:da:c6:c9:95:82:a5:eb:3f:d2:d3:58:03:4b:df:63:13:
+         00:be:86:00
 -----BEGIN CERTIFICATE-----
 MIIDNDCCAhygAwIBAgIBDDANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
-IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMzMDYyNDIxMTgwMFowEjEQMA4GA1UEAwwH
-VGVzdCBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAPSaPtkr4R7q
-PIV9J4f191DGYPB5O4Yjzsm6QiIbYRq8M8fP4laPbIQ+TtBItSd+e0neK12ynOZJ
-U1LIiZLL4WwwZ8Z0JeM/ejfvVLS9gAem23dcj1btGxSvKhL1RIgVo2Py+UT7Ue2a
-bZzPSGn20MlsV+4bvgSRs60W7cjQv7RVa+k8K4xXGbzxdm+QjeRgeccD452DQuwO
-eXg8MMTVh2NNLBetxuo7/+RzGhK77dP2nZ3Z5wV/IWwnCifFbshTbKO7DhH6xKuX
-j6H9vfNe+4AdFYfHtCCU/MusBqiusYCgXVBojUljG7J3omuBIbZYOvI9Iaylkbx9
-Nkb0h+rOow8CAwEAAaOBlDCBkTAMBgNVHRMBAf8EAjAAMA4GA1UdDwEB/wQEAwIB
-BjAdBgNVHQ4EFgQUg2gmFkrDiAqmSEOY5y1PX3CMYrIwMQYJYIZIAYb4QgENBCQW
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTM0MDEyNzE4NDMzMlowEjEQMA4GA1UEAwwH
+VGVzdCBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL9Y+daAbhWU
+PELrTJp0pnAWDjGqO5QG2SheIVva/LfMPgb7+f5MhN3RsKMaaCCZLigCWdwDElwh
+iyoLko+HYdAsvUuEhMLoS88JKIZliZ31hXCgWCmqvfU9sP6YXfJQ8/EflNX4/yWS
+FKSBGbwaA1uzG+p7nJma9D8qpZawB5ZIebBS1PzyUWKU+rBpuIYRq7gCTZPlKwFQ
+7/oG9pFNVlijEfMPFofeQgpTsAdzB23tz5FSK7Tok35XqjmkRx/2/32PcxazLstM
+X0DADAIsyGwbjOxU2eFgmN535+6plYCDOd5EwoPWRqL3rGNu9bgwwlxjjwpHOm++
+7z4hClJpjzUCAwEAAaOBlDCBkTAMBgNVHRMBAf8EAjAAMA4GA1UdDwEB/wQEAwIB
+BjAdBgNVHQ4EFgQUWNNuNTaXBJFqtt9FgJpTs+Q2yD0wMQYJYIZIAYb4QgENBCQW
 IlB1cHBldCBTZXJ2ZXIgSW50ZXJuYWwgQ2VydGlmaWNhdGUwHwYDVR0jBBgwFoAU
-g2gmFkrDiAqmSEOY5y1PX3CMYrIwDQYJKoZIhvcNAQELBQADggEBAPLVdqr/BbJj
-LYEjPdXcj6jrvBc1f2QaN1ACrFRLyXT7B/js98JqgL330UMbTdEswnHZKEYBDxSr
-jiAUk+fcp7FtSn2p96Jd6k2JX/tFS5jIkxLZdF6kPiUTLJKWPhXG00bHA1xLcGWe
-H4nvfnBjPHjYopJTLTmj9Q02qip7qKljZjnjSVUPRdYUnvR3GBaQE0FqJ4+EycUN
-rczZv2KQAlZjdna8PzZdQa0HXvniZulj47p5uQe26LUnDxhOpG2C1+mpQM7r2Wq4
-1gTEsmIfxcv+FPPFzQ4RMrXP6vyYPFkj62nFC/aDW9wlnG2TKcIwWMEQgEmGZwn9
-ImcB5TKao4M=
+WNNuNTaXBJFqtt9FgJpTs+Q2yD0wDQYJKoZIhvcNAQELBQADggEBABhXUV3rY5ON
+JVtdjlxnsNLGcWOCcy7QFDIo88wnE7xMVWZrKHi4y174lSmaeFVZPuTe0a7waH68
+/zLSVIWy6wxNmWoopdijbopxhnD9PjYrrfwp+d7FH9dMZp1LvO5NlWCkOs51fF47
+QvUhGEJD9BViesl/O6HcOOXyEttitiKRtgaQ6CYqxj4ugJ3C/h1ntnIrN6pKHRm7
+dIALyLzB0zxRNBwwC2WG6ZY4AbLXrY8361Qagyru++jj++vC3yffSTRku4rZ8zVY
+97aB2N8hML1tr26yiUoaP1Y85CSUS/MfK+YGePE0aM3FwV8j2sbJlYKl6z/S01gD
+S99jEwC+hgA=
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/bad-int-basic-constraints.pem
+++ b/spec/fixtures/ssl/bad-int-basic-constraints.pem
@@ -6,30 +6,30 @@ Certificate:
         Issuer: CN=Test CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Jun 24 21:18:00 2033 GMT
+            Not After : Jan 27 18:43:32 2034 GMT
         Subject: CN=Test CA Subauthority
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                Public-Key: (2048 bit)
+                RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:c0:91:fc:98:ec:30:6b:f0:5c:d6:0b:ed:79:ab:
-                    69:80:c1:ca:5b:d5:4a:a3:e3:1b:3e:25:f1:47:0b:
-                    7b:9f:dc:1b:0a:8b:d6:0a:c1:e8:8b:ca:38:68:be:
-                    91:58:d7:ff:41:a1:00:48:59:a0:62:2e:1d:e7:2d:
-                    7a:c5:64:4d:be:48:30:eb:4f:e3:9e:3f:06:a4:ef:
-                    e4:95:5c:86:ff:54:24:49:75:16:84:41:78:c5:8d:
-                    ac:ff:af:95:91:ae:e1:f3:92:f0:a1:dd:18:e9:7c:
-                    8e:d0:86:e9:84:84:f3:cb:4c:9c:12:f6:a7:54:f0:
-                    9c:87:3b:f1:50:67:cf:12:04:11:c0:1b:e0:46:e4:
-                    03:73:9c:3c:ea:ed:3e:31:2f:bc:cf:bd:38:fb:1d:
-                    fa:f5:8d:66:e7:f2:0b:5f:df:0f:99:ec:45:c9:aa:
-                    e4:10:ad:5b:64:a5:da:af:27:e1:47:ac:4f:aa:aa:
-                    74:a5:0e:9c:14:c4:89:ef:ce:fb:50:38:b9:f9:09:
-                    d6:f9:ba:5b:49:1c:8c:70:9c:0d:4e:3c:94:6d:9e:
-                    63:24:c3:e8:49:74:7a:79:02:0d:b4:6f:f3:b9:e0:
-                    c0:4c:74:24:21:56:b5:57:e6:c9:29:08:1b:63:6d:
-                    2d:9c:e2:68:33:c1:cf:60:07:54:88:d4:da:6c:15:
-                    48:1b
+                    00:a4:f1:74:f2:db:24:84:39:da:26:5c:72:c8:2e:
+                    a6:3e:57:88:90:ab:41:04:7a:7a:f3:af:f7:43:b7:
+                    9b:d8:57:91:7e:15:d5:aa:cb:8d:d4:a5:de:54:4a:
+                    22:bb:e3:6f:1a:03:7f:27:42:8a:db:45:ee:79:0e:
+                    dd:c0:08:fc:f3:48:9e:ea:99:f9:08:cd:38:86:2d:
+                    ca:2c:9b:d0:02:f2:81:29:72:a1:aa:a3:ea:fc:5f:
+                    4a:a1:15:68:55:a9:ed:7d:3a:23:84:0c:0a:d8:10:
+                    c7:0b:8c:b3:93:9a:61:55:10:73:34:14:21:de:28:
+                    65:bf:6a:d3:dd:e8:3d:9e:69:78:1e:72:89:fd:73:
+                    7e:75:e7:9b:4c:f2:65:3c:d5:ed:d4:d1:53:96:52:
+                    b0:29:c1:e4:9d:5f:d7:62:d0:84:7b:e8:db:85:93:
+                    b9:8f:4a:01:c4:6e:6d:e2:a9:6d:ec:51:d7:51:48:
+                    fe:f4:83:45:a1:c1:b7:00:68:9c:02:92:a6:20:d4:
+                    40:a0:c8:ee:ab:96:40:53:10:f1:b5:2d:a8:f9:50:
+                    fe:eb:96:9a:9c:c1:31:2c:1f:70:d5:a7:37:ff:35:
+                    1a:ac:d7:fc:9d:4f:e1:67:20:e6:9d:4a:66:c8:ac:
+                    e0:0a:f5:4f:d4:43:56:d6:e1:6d:04:f4:ea:02:d5:
+                    af:a9
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Basic Constraints: critical
@@ -37,45 +37,45 @@ Certificate:
             X509v3 Key Usage: critical
                 Certificate Sign, CRL Sign
             X509v3 Subject Key Identifier: 
-                38:7E:66:C4:7A:8B:16:EC:8A:0C:76:FC:C4:A6:7F:79:E5:DD:9A:FB
+                EB:EA:7B:15:C9:4E:08:5B:87:27:09:E4:42:10:54:47:72:E9:38:29
             Netscape Comment: 
                 Puppet Server Internal Certificate
             X509v3 Authority Key Identifier: 
-                83:68:26:16:4A:C3:88:0A:A6:48:43:98:E7:2D:4F:5F:70:8C:62:B2
+                keyid:58:D3:6E:35:36:97:04:91:6A:B6:DF:45:80:9A:53:B3:E4:36:C8:3D
+
     Signature Algorithm: sha256WithRSAEncryption
-    Signature Value:
-        8c:4b:be:0e:b0:af:d0:14:7f:04:4d:99:65:3e:ec:43:6e:62:
-        5c:89:4e:60:74:c3:72:ae:2d:f1:9c:e6:5f:c6:2c:d3:d7:9b:
-        af:f2:8d:51:d3:7c:bc:34:4d:35:49:f5:78:6d:41:8c:c3:0d:
-        bf:4a:6f:dc:f0:d7:92:9d:2b:71:16:c8:20:40:b8:21:f8:2a:
-        6b:a0:f5:54:40:13:25:b9:fe:bf:29:0a:d3:b5:71:13:9d:92:
-        f9:db:c1:e6:fa:04:24:b6:1c:61:46:2d:6c:8e:18:c5:f2:30:
-        00:6e:f5:d3:4b:c0:2e:68:3e:6e:b6:5c:ee:e4:98:04:71:df:
-        b5:58:0b:3b:04:72:e2:1e:ea:cf:94:a2:d4:1e:60:a4:87:00:
-        5a:80:28:85:85:5e:98:d6:bc:7a:be:ce:68:cd:3f:d4:2d:b2:
-        e3:84:61:d5:4d:d1:86:74:3a:e1:47:ec:7d:0f:3f:88:e2:1b:
-        86:5a:01:03:6a:cb:1d:10:5b:0d:c7:c5:66:e4:e4:7e:02:ae:
-        d3:a9:3f:0a:66:70:48:65:f0:fa:53:bb:65:1c:dd:03:6c:ff:
-        3a:6d:47:7d:b1:a0:68:df:ff:59:05:84:e3:fb:de:59:a4:00:
-        7b:6b:8a:de:a2:d5:69:62:57:af:11:5e:12:40:6a:58:a1:8a:
-        f5:55:34:30
+         9d:ea:1a:42:b5:38:8e:65:0d:a5:83:21:8a:37:21:05:a8:30:
+         ea:e9:1b:51:31:21:72:44:8e:b0:2a:78:cc:1b:f0:95:01:c4:
+         6c:e1:74:93:cc:cc:2e:36:ba:11:31:a1:61:06:84:d4:03:d5:
+         3d:b3:6e:7d:42:da:71:92:01:fd:2c:22:21:ca:47:78:6c:c0:
+         ce:ac:bc:79:6d:fb:9c:28:77:6f:57:41:67:dc:0e:a6:8a:f3:
+         b1:1c:b9:60:19:36:7d:33:00:64:c0:b1:ea:8a:86:d5:3b:9f:
+         1f:39:32:33:77:cb:bf:95:50:79:18:84:2d:12:23:63:cf:78:
+         02:3e:1f:44:0c:a7:f5:2a:64:e4:64:7c:79:ba:99:84:f1:7d:
+         71:78:3d:70:a2:2b:a0:04:df:f2:9b:5d:ee:c7:08:49:4e:a1:
+         fa:39:b3:08:51:a1:22:64:a1:8e:61:44:aa:2f:db:7b:3f:e4:
+         77:9c:0a:35:ba:9b:e2:b4:87:92:52:60:fb:bb:01:bc:4a:c4:
+         ca:de:70:61:c4:bb:d3:9a:ad:25:47:73:d3:cf:cb:92:3e:ff:
+         09:b6:dc:22:32:fc:00:bf:c9:1c:9b:f7:49:6a:89:fb:91:09:
+         b4:f1:a2:89:2c:6d:9c:c0:80:1e:10:de:eb:45:93:a8:07:c9:
+         a3:2f:c5:5e
 -----BEGIN CERTIFICATE-----
 MIIDQTCCAimgAwIBAgIBAzANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
-IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMzMDYyNDIxMTgwMFowHzEdMBsGA1UEAwwU
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTM0MDEyNzE4NDMzMlowHzEdMBsGA1UEAwwU
 VGVzdCBDQSBTdWJhdXRob3JpdHkwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
-AoIBAQDAkfyY7DBr8FzWC+15q2mAwcpb1Uqj4xs+JfFHC3uf3BsKi9YKweiLyjho
-vpFY1/9BoQBIWaBiLh3nLXrFZE2+SDDrT+OePwak7+SVXIb/VCRJdRaEQXjFjaz/
-r5WRruHzkvCh3RjpfI7QhumEhPPLTJwS9qdU8JyHO/FQZ88SBBHAG+BG5ANznDzq
-7T4xL7zPvTj7Hfr1jWbn8gtf3w+Z7EXJquQQrVtkpdqvJ+FHrE+qqnSlDpwUxInv
-zvtQOLn5Cdb5ultJHIxwnA1OPJRtnmMkw+hJdHp5Ag20b/O54MBMdCQhVrVX5skp
-CBtjbS2c4mgzwc9gB1SI1NpsFUgbAgMBAAGjgZQwgZEwDAYDVR0TAQH/BAIwADAO
-BgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFDh+ZsR6ixbsigx2/MSmf3nl3Zr7MDEG
+AoIBAQCk8XTy2ySEOdomXHLILqY+V4iQq0EEenrzr/dDt5vYV5F+FdWqy43Upd5U
+SiK7428aA38nQorbRe55Dt3ACPzzSJ7qmfkIzTiGLcosm9AC8oEpcqGqo+r8X0qh
+FWhVqe19OiOEDArYEMcLjLOTmmFVEHM0FCHeKGW/atPd6D2eaXgecon9c35155tM
+8mU81e3U0VOWUrApweSdX9di0IR76NuFk7mPSgHEbm3iqW3sUddRSP70g0WhwbcA
+aJwCkqYg1ECgyO6rlkBTEPG1Laj5UP7rlpqcwTEsH3DVpzf/NRqs1/ydT+FnIOad
+SmbIrOAK9U/UQ1bW4W0E9OoC1a+pAgMBAAGjgZQwgZEwDAYDVR0TAQH/BAIwADAO
+BgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFOvqexXJTghbhycJ5EIQVEdy6TgpMDEG
 CWCGSAGG+EIBDQQkFiJQdXBwZXQgU2VydmVyIEludGVybmFsIENlcnRpZmljYXRl
-MB8GA1UdIwQYMBaAFINoJhZKw4gKpkhDmOctT19wjGKyMA0GCSqGSIb3DQEBCwUA
-A4IBAQCMS74OsK/QFH8ETZllPuxDbmJciU5gdMNyri3xnOZfxizT15uv8o1R03y8
-NE01SfV4bUGMww2/Sm/c8NeSnStxFsggQLgh+CproPVUQBMluf6/KQrTtXETnZL5
-28Hm+gQkthxhRi1sjhjF8jAAbvXTS8AuaD5utlzu5JgEcd+1WAs7BHLiHurPlKLU
-HmCkhwBagCiFhV6Y1rx6vs5ozT/ULbLjhGHVTdGGdDrhR+x9Dz+I4huGWgEDassd
-EFsNx8Vm5OR+Aq7TqT8KZnBIZfD6U7tlHN0DbP86bUd9saBo3/9ZBYTj+95ZpAB7
-a4reotVpYlevEV4SQGpYoYr1VTQw
+MB8GA1UdIwQYMBaAFFjTbjU2lwSRarbfRYCaU7PkNsg9MA0GCSqGSIb3DQEBCwUA
+A4IBAQCd6hpCtTiOZQ2lgyGKNyEFqDDq6RtRMSFyRI6wKnjMG/CVAcRs4XSTzMwu
+NroRMaFhBoTUA9U9s259QtpxkgH9LCIhykd4bMDOrLx5bfucKHdvV0Fn3A6mivOx
+HLlgGTZ9MwBkwLHqiobVO58fOTIzd8u/lVB5GIQtEiNjz3gCPh9EDKf1KmTkZHx5
+upmE8X1xeD1woiugBN/ym13uxwhJTqH6ObMIUaEiZKGOYUSqL9t7P+R3nAo1upvi
+tIeSUmD7uwG8SsTK3nBhxLvTmq0lR3PTz8uSPv8JttwiMvwAv8kcm/dJaon7kQm0
+8aKJLG2cwIAeEN7rRZOoB8mjL8Ve
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/ca.pem
+++ b/spec/fixtures/ssl/ca.pem
@@ -6,30 +6,30 @@ Certificate:
         Issuer: CN=Test CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Jun 24 21:18:00 2033 GMT
+            Not After : Jan 27 18:43:32 2034 GMT
         Subject: CN=Test CA
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                Public-Key: (2048 bit)
+                RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:f4:9a:3e:d9:2b:e1:1e:ea:3c:85:7d:27:87:f5:
-                    f7:50:c6:60:f0:79:3b:86:23:ce:c9:ba:42:22:1b:
-                    61:1a:bc:33:c7:cf:e2:56:8f:6c:84:3e:4e:d0:48:
-                    b5:27:7e:7b:49:de:2b:5d:b2:9c:e6:49:53:52:c8:
-                    89:92:cb:e1:6c:30:67:c6:74:25:e3:3f:7a:37:ef:
-                    54:b4:bd:80:07:a6:db:77:5c:8f:56:ed:1b:14:af:
-                    2a:12:f5:44:88:15:a3:63:f2:f9:44:fb:51:ed:9a:
-                    6d:9c:cf:48:69:f6:d0:c9:6c:57:ee:1b:be:04:91:
-                    b3:ad:16:ed:c8:d0:bf:b4:55:6b:e9:3c:2b:8c:57:
-                    19:bc:f1:76:6f:90:8d:e4:60:79:c7:03:e3:9d:83:
-                    42:ec:0e:79:78:3c:30:c4:d5:87:63:4d:2c:17:ad:
-                    c6:ea:3b:ff:e4:73:1a:12:bb:ed:d3:f6:9d:9d:d9:
-                    e7:05:7f:21:6c:27:0a:27:c5:6e:c8:53:6c:a3:bb:
-                    0e:11:fa:c4:ab:97:8f:a1:fd:bd:f3:5e:fb:80:1d:
-                    15:87:c7:b4:20:94:fc:cb:ac:06:a8:ae:b1:80:a0:
-                    5d:50:68:8d:49:63:1b:b2:77:a2:6b:81:21:b6:58:
-                    3a:f2:3d:21:ac:a5:91:bc:7d:36:46:f4:87:ea:ce:
-                    a3:0f
+                    00:bf:58:f9:d6:80:6e:15:94:3c:42:eb:4c:9a:74:
+                    a6:70:16:0e:31:aa:3b:94:06:d9:28:5e:21:5b:da:
+                    fc:b7:cc:3e:06:fb:f9:fe:4c:84:dd:d1:b0:a3:1a:
+                    68:20:99:2e:28:02:59:dc:03:12:5c:21:8b:2a:0b:
+                    92:8f:87:61:d0:2c:bd:4b:84:84:c2:e8:4b:cf:09:
+                    28:86:65:89:9d:f5:85:70:a0:58:29:aa:bd:f5:3d:
+                    b0:fe:98:5d:f2:50:f3:f1:1f:94:d5:f8:ff:25:92:
+                    14:a4:81:19:bc:1a:03:5b:b3:1b:ea:7b:9c:99:9a:
+                    f4:3f:2a:a5:96:b0:07:96:48:79:b0:52:d4:fc:f2:
+                    51:62:94:fa:b0:69:b8:86:11:ab:b8:02:4d:93:e5:
+                    2b:01:50:ef:fa:06:f6:91:4d:56:58:a3:11:f3:0f:
+                    16:87:de:42:0a:53:b0:07:73:07:6d:ed:cf:91:52:
+                    2b:b4:e8:93:7e:57:aa:39:a4:47:1f:f6:ff:7d:8f:
+                    73:16:b3:2e:cb:4c:5f:40:c0:0c:02:2c:c8:6c:1b:
+                    8c:ec:54:d9:e1:60:98:de:77:e7:ee:a9:95:80:83:
+                    39:de:44:c2:83:d6:46:a2:f7:ac:63:6e:f5:b8:30:
+                    c2:5c:63:8f:0a:47:3a:6f:be:ef:3e:21:0a:52:69:
+                    8f:35
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Basic Constraints: critical
@@ -37,45 +37,45 @@ Certificate:
             X509v3 Key Usage: critical
                 Certificate Sign, CRL Sign
             X509v3 Subject Key Identifier: 
-                83:68:26:16:4A:C3:88:0A:A6:48:43:98:E7:2D:4F:5F:70:8C:62:B2
+                58:D3:6E:35:36:97:04:91:6A:B6:DF:45:80:9A:53:B3:E4:36:C8:3D
             Netscape Comment: 
                 Puppet Server Internal Certificate
             X509v3 Authority Key Identifier: 
-                83:68:26:16:4A:C3:88:0A:A6:48:43:98:E7:2D:4F:5F:70:8C:62:B2
+                keyid:58:D3:6E:35:36:97:04:91:6A:B6:DF:45:80:9A:53:B3:E4:36:C8:3D
+
     Signature Algorithm: sha256WithRSAEncryption
-    Signature Value:
-        53:4c:5e:b5:86:73:e9:d0:ab:f1:87:8e:3c:3e:8c:5c:ce:c9:
-        aa:86:a5:ea:96:96:77:e5:31:98:04:e5:46:f8:75:7b:00:b7:
-        2a:b4:f6:a4:6c:e8:e8:7e:95:b0:c2:bb:a3:ae:87:49:9f:a2:
-        ea:49:5a:d8:ac:79:b4:f7:aa:0c:6c:57:fb:27:8c:c0:31:97:
-        b0:8f:b0:4e:53:96:99:3a:0e:4c:47:51:d1:93:88:48:a4:c4:
-        e7:7b:c2:d7:34:4c:22:88:1b:85:f2:3f:ff:88:39:c1:61:da:
-        52:ba:42:69:1a:9a:5b:1f:b5:f6:88:76:4e:21:f9:48:0a:4d:
-        6e:4c:f2:b4:8c:4d:3b:c1:95:6d:f1:09:26:68:63:83:f5:d2:
-        3e:d2:6d:c0:09:8e:93:36:c3:58:5e:c7:8b:79:1a:72:b6:af:
-        eb:2e:3b:1d:2b:19:55:49:09:df:55:49:2b:d4:93:bf:95:df:
-        ab:6d:aa:bc:57:e2:67:33:ec:6a:7a:33:e9:31:c8:01:01:53:
-        03:f5:43:fb:8f:18:7c:0b:69:0d:81:d9:af:4b:f2:b9:b0:cd:
-        5f:3d:24:a0:ad:ca:c5:b5:60:3c:fb:52:8f:48:1c:2d:ec:45:
-        01:03:79:40:4e:f9:1c:e4:e5:67:27:21:2c:f7:48:95:ff:22:
-        da:2b:2e:48
+         8b:75:55:6d:7c:61:c3:55:54:a8:d8:ed:47:e0:0a:e6:fb:ae:
+         93:b3:d4:e5:69:ec:c3:db:0c:6a:91:05:84:3b:44:3c:d9:ce:
+         36:50:ce:b1:f5:88:39:e1:a7:87:77:81:b3:67:4d:06:1a:87:
+         fd:50:6c:07:e5:24:32:0d:0e:95:c5:0d:c0:8f:af:1f:e7:9c:
+         65:5c:e1:c7:75:80:d5:6d:04:6a:2d:15:bc:d5:09:dc:9b:38:
+         bc:12:df:94:32:25:36:53:bc:a4:1a:a2:c7:11:1d:aa:c6:93:
+         48:ec:25:52:88:6b:04:94:c3:ac:6b:bc:17:c0:75:2e:c9:53:
+         83:63:1c:77:69:42:4a:cd:7c:d1:3b:a5:a4:fc:1c:71:66:1b:
+         b1:44:32:53:4d:3c:26:a8:7e:ea:99:de:3a:5a:a9:70:7b:49:
+         f5:27:c4:d2:10:de:51:87:e2:5b:c9:7c:08:58:de:13:68:07:
+         f1:69:05:65:e9:b3:6f:ad:cd:06:10:f7:1d:f8:bd:c3:26:e1:
+         e1:0c:8a:0b:f2:36:d8:ab:4f:fe:b2:b2:7e:b4:3a:f5:31:46:
+         3f:ce:36:1c:e6:30:f7:11:66:21:1c:48:e9:49:a0:90:b4:3f:
+         04:ae:f0:f8:00:65:9e:9c:c5:28:d5:c8:3a:ff:a0:eb:03:bf:
+         c0:2f:41:cd
 -----BEGIN CERTIFICATE-----
 MIIDNzCCAh+gAwIBAgIBAjANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
-IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMzMDYyNDIxMTgwMFowEjEQMA4GA1UEAwwH
-VGVzdCBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAPSaPtkr4R7q
-PIV9J4f191DGYPB5O4Yjzsm6QiIbYRq8M8fP4laPbIQ+TtBItSd+e0neK12ynOZJ
-U1LIiZLL4WwwZ8Z0JeM/ejfvVLS9gAem23dcj1btGxSvKhL1RIgVo2Py+UT7Ue2a
-bZzPSGn20MlsV+4bvgSRs60W7cjQv7RVa+k8K4xXGbzxdm+QjeRgeccD452DQuwO
-eXg8MMTVh2NNLBetxuo7/+RzGhK77dP2nZ3Z5wV/IWwnCifFbshTbKO7DhH6xKuX
-j6H9vfNe+4AdFYfHtCCU/MusBqiusYCgXVBojUljG7J3omuBIbZYOvI9Iaylkbx9
-Nkb0h+rOow8CAwEAAaOBlzCBlDAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQE
-AwIBBjAdBgNVHQ4EFgQUg2gmFkrDiAqmSEOY5y1PX3CMYrIwMQYJYIZIAYb4QgEN
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTM0MDEyNzE4NDMzMlowEjEQMA4GA1UEAwwH
+VGVzdCBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL9Y+daAbhWU
+PELrTJp0pnAWDjGqO5QG2SheIVva/LfMPgb7+f5MhN3RsKMaaCCZLigCWdwDElwh
+iyoLko+HYdAsvUuEhMLoS88JKIZliZ31hXCgWCmqvfU9sP6YXfJQ8/EflNX4/yWS
+FKSBGbwaA1uzG+p7nJma9D8qpZawB5ZIebBS1PzyUWKU+rBpuIYRq7gCTZPlKwFQ
+7/oG9pFNVlijEfMPFofeQgpTsAdzB23tz5FSK7Tok35XqjmkRx/2/32PcxazLstM
+X0DADAIsyGwbjOxU2eFgmN535+6plYCDOd5EwoPWRqL3rGNu9bgwwlxjjwpHOm++
+7z4hClJpjzUCAwEAAaOBlzCBlDAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQE
+AwIBBjAdBgNVHQ4EFgQUWNNuNTaXBJFqtt9FgJpTs+Q2yD0wMQYJYIZIAYb4QgEN
 BCQWIlB1cHBldCBTZXJ2ZXIgSW50ZXJuYWwgQ2VydGlmaWNhdGUwHwYDVR0jBBgw
-FoAUg2gmFkrDiAqmSEOY5y1PX3CMYrIwDQYJKoZIhvcNAQELBQADggEBAFNMXrWG
-c+nQq/GHjjw+jFzOyaqGpeqWlnflMZgE5Ub4dXsAtyq09qRs6Oh+lbDCu6Ouh0mf
-oupJWtisebT3qgxsV/snjMAxl7CPsE5Tlpk6DkxHUdGTiEikxOd7wtc0TCKIG4Xy
-P/+IOcFh2lK6QmkamlsftfaIdk4h+UgKTW5M8rSMTTvBlW3xCSZoY4P10j7SbcAJ
-jpM2w1hex4t5GnK2r+suOx0rGVVJCd9VSSvUk7+V36ttqrxX4mcz7Gp6M+kxyAEB
-UwP1Q/uPGHwLaQ2B2a9L8rmwzV89JKCtysW1YDz7Uo9IHC3sRQEDeUBO+Rzk5Wcn
-ISz3SJX/ItorLkg=
+FoAUWNNuNTaXBJFqtt9FgJpTs+Q2yD0wDQYJKoZIhvcNAQELBQADggEBAIt1VW18
+YcNVVKjY7UfgCub7rpOz1OVp7MPbDGqRBYQ7RDzZzjZQzrH1iDnhp4d3gbNnTQYa
+h/1QbAflJDINDpXFDcCPrx/nnGVc4cd1gNVtBGotFbzVCdybOLwS35QyJTZTvKQa
+oscRHarGk0jsJVKIawSUw6xrvBfAdS7JU4NjHHdpQkrNfNE7paT8HHFmG7FEMlNN
+PCaofuqZ3jpaqXB7SfUnxNIQ3lGH4lvJfAhY3hNoB/FpBWXps2+tzQYQ9x34vcMm
+4eEMigvyNtirT/6ysn60OvUxRj/ONhzmMPcRZiEcSOlJoJC0PwSu8PgAZZ6cxSjV
+yDr/oOsDv8AvQc0=
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/crl.pem
+++ b/spec/fixtures/ssl/crl.pem
@@ -3,38 +3,38 @@ Certificate Revocation List (CRL):
         Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA
         Last Update: Jan  1 00:00:00 1970 GMT
-        Next Update: Jun 24 21:18:00 2033 GMT
+        Next Update: Jan 27 18:43:32 2034 GMT
         CRL extensions:
             X509v3 Authority Key Identifier: 
-                83:68:26:16:4A:C3:88:0A:A6:48:43:98:E7:2D:4F:5F:70:8C:62:B2
+                keyid:58:D3:6E:35:36:97:04:91:6A:B6:DF:45:80:9A:53:B3:E4:36:C8:3D
+
             X509v3 CRL Number: 
                 0
 No Revoked Certificates.
     Signature Algorithm: sha256WithRSAEncryption
-    Signature Value:
-        8a:b8:7b:ae:cf:3e:a0:77:0b:35:2f:98:d9:35:29:97:56:2f:
-        7b:e4:74:1e:29:2c:46:1f:bb:da:1d:60:fb:83:8b:fe:dd:42:
-        f6:94:ab:c3:f1:a2:b9:1c:11:e8:85:be:5c:fd:ac:21:d9:e8:
-        d7:af:be:bd:5c:e9:df:c4:13:6f:a6:5b:2e:9e:c5:dd:49:16:
-        b5:ef:c8:21:c7:85:42:f0:b6:b5:d9:56:8d:d4:e8:0b:78:ba:
-        96:44:a7:14:60:47:af:a6:6d:ac:11:1c:7d:52:59:57:ec:03:
-        ea:de:ce:58:5d:0e:5a:71:c9:e5:0c:80:01:37:91:dc:14:b2:
-        0e:3e:20:7e:e2:2e:18:56:6b:9a:3d:2c:d8:76:68:12:83:1a:
-        b2:54:c8:82:30:12:52:b0:64:c8:b8:37:39:48:2a:5b:6b:0d:
-        f8:01:5f:e6:c9:bd:73:64:82:af:66:62:d5:22:b6:eb:05:14:
-        6b:cc:95:32:e6:bc:87:07:32:33:c1:2a:92:ef:16:48:be:40:
-        4a:0d:78:de:bd:46:9c:d6:22:b2:44:8b:47:3f:79:28:7e:f9:
-        16:23:74:d7:bc:19:64:b6:78:82:f1:4c:13:9f:12:c3:b8:57:
-        c5:ce:2d:56:81:36:88:9d:99:6b:61:f5:60:21:e5:26:39:77:
-        ce:60:08:2c
+         9c:a5:dd:b2:ab:44:59:89:72:dc:e3:70:5d:e0:cb:5c:4d:a2:
+         d3:35:61:15:2f:77:9c:d5:2c:82:82:b0:57:a6:f0:87:76:15:
+         4c:34:18:8b:6c:e9:df:36:e0:a2:60:68:0d:67:3c:e4:82:9a:
+         50:25:8d:fe:8c:be:57:f6:b1:ef:35:41:64:19:87:86:a5:39:
+         d4:1b:8e:3f:59:29:42:9b:74:dd:b8:b0:03:8d:62:cd:c6:f1:
+         84:ce:cb:8d:2f:dc:4c:5a:26:09:0d:e7:88:41:05:5f:27:80:
+         14:68:50:56:46:00:2c:15:63:8d:01:78:fe:48:b0:89:63:05:
+         38:5a:d5:b8:cf:14:0a:da:e0:ea:51:68:fe:5e:a6:d7:e9:30:
+         8f:99:6a:3b:bd:a3:79:e2:f7:b5:ae:11:79:b9:aa:a4:55:80:
+         74:95:ee:c9:f2:e6:fb:5b:71:ae:df:4f:ad:a1:8e:42:d2:c6:
+         2d:03:1a:46:d4:41:a8:6e:25:a4:1f:9d:b1:04:bc:8c:8e:c7:
+         b8:0d:77:ce:92:55:48:72:fb:5b:26:85:64:ff:ea:33:57:0c:
+         d0:38:d7:cb:3e:07:08:1e:be:e3:03:05:1e:e9:31:2f:86:0f:
+         8c:59:cd:20:30:5e:e7:e5:2b:a5:8e:11:0c:33:04:23:64:d0:
+         78:80:28:a7
 -----BEGIN X509 CRL-----
 MIIBizB1AgEBMA0GCSqGSIb3DQEBCwUAMBIxEDAOBgNVBAMMB1Rlc3QgQ0EXDTcw
-MDEwMTAwMDAwMFoXDTMzMDYyNDIxMTgwMFqgLzAtMB8GA1UdIwQYMBaAFINoJhZK
-w4gKpkhDmOctT19wjGKyMAoGA1UdFAQDAgEAMA0GCSqGSIb3DQEBCwUAA4IBAQCK
-uHuuzz6gdws1L5jZNSmXVi975HQeKSxGH7vaHWD7g4v+3UL2lKvD8aK5HBHohb5c
-/awh2ejXr769XOnfxBNvplsunsXdSRa178ghx4VC8La12VaN1OgLeLqWRKcUYEev
-pm2sERx9UllX7APq3s5YXQ5accnlDIABN5HcFLIOPiB+4i4YVmuaPSzYdmgSgxqy
-VMiCMBJSsGTIuDc5SCpbaw34AV/myb1zZIKvZmLVIrbrBRRrzJUy5ryHBzIzwSqS
-7xZIvkBKDXjevUac1iKyRItHP3kofvkWI3TXvBlktniC8UwTnxLDuFfFzi1WgTaI
-nZlrYfVgIeUmOXfOYAgs
+MDEwMTAwMDAwMFoXDTM0MDEyNzE4NDMzMlqgLzAtMB8GA1UdIwQYMBaAFFjTbjU2
+lwSRarbfRYCaU7PkNsg9MAoGA1UdFAQDAgEAMA0GCSqGSIb3DQEBCwUAA4IBAQCc
+pd2yq0RZiXLc43Bd4MtcTaLTNWEVL3ec1SyCgrBXpvCHdhVMNBiLbOnfNuCiYGgN
+ZzzkgppQJY3+jL5X9rHvNUFkGYeGpTnUG44/WSlCm3TduLADjWLNxvGEzsuNL9xM
+WiYJDeeIQQVfJ4AUaFBWRgAsFWONAXj+SLCJYwU4WtW4zxQK2uDqUWj+XqbX6TCP
+mWo7vaN54ve1rhF5uaqkVYB0le7J8ub7W3Gu30+toY5C0sYtAxpG1EGobiWkH52x
+BLyMjse4DXfOklVIcvtbJoVk/+ozVwzQONfLPgcIHr7jAwUe6TEvhg+MWc0gMF7n
+5SuljhEMMwQjZNB4gCin
 -----END X509 CRL-----

--- a/spec/fixtures/ssl/ec-key.pem
+++ b/spec/fixtures/ssl/ec-key.pem
@@ -1,18 +1,18 @@
 Private-Key: (256 bit)
 priv:
-    da:dd:0f:94:97:b5:3a:8d:cb:0c:1b:b1:55:85:e4:
-    71:e4:6c:f3:45:0c:55:07:3d:9c:1d:d0:86:06:1a:
-    f7:12
+    3c:a7:b7:fd:33:b3:ab:bf:09:82:0e:97:88:2f:1a:
+    7b:af:da:9d:c6:ad:e0:b1:06:ce:42:33:be:c9:97:
+    db:96
 pub:
-    04:d0:40:f7:c9:01:ec:97:dc:32:1c:19:85:59:29:
-    19:a9:40:21:ba:9e:f9:87:f6:49:d6:97:e4:1a:d3:
-    d6:ac:12:de:63:34:2b:62:16:19:0b:af:3c:fd:87:
-    a1:66:3e:36:39:65:83:fd:2f:36:bc:fd:58:14:ff:
-    a5:2b:fb:35:32
+    04:e7:c1:a2:97:cd:95:ad:fe:a5:05:43:41:2d:19:
+    55:21:11:f5:f6:46:9f:45:74:6a:8c:91:c2:2e:32:
+    aa:47:1e:9e:2e:49:99:7c:af:98:fa:d8:ae:b3:a1:
+    26:46:d3:22:d3:3c:b1:2d:8d:3b:e2:03:cf:25:93:
+    d5:b7:a8:e2:ab
 ASN1 OID: prime256v1
 NIST CURVE: P-256
 -----BEGIN EC PRIVATE KEY-----
-MHcCAQEEINrdD5SXtTqNywwbsVWF5HHkbPNFDFUHPZwd0IYGGvcSoAoGCCqGSM49
-AwEHoUQDQgAE0ED3yQHsl9wyHBmFWSkZqUAhup75h/ZJ1pfkGtPWrBLeYzQrYhYZ
-C688/YehZj42OWWD/S82vP1YFP+lK/s1Mg==
+MHcCAQEEIDynt/0zs6u/CYIOl4gvGnuv2p3GreCxBs5CM77Jl9uWoAoGCCqGSM49
+AwEHoUQDQgAE58Gil82Vrf6lBUNBLRlVIRH19kafRXRqjJHCLjKqRx6eLkmZfK+Y
++tius6EmRtMi0zyxLY074gPPJZPVt6jiqw==
 -----END EC PRIVATE KEY-----

--- a/spec/fixtures/ssl/ec.pem
+++ b/spec/fixtures/ssl/ec.pem
@@ -6,45 +6,44 @@ Certificate:
         Issuer: CN=Test CA Subauthority
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Jun 24 21:18:00 2033 GMT
+            Not After : Jan 27 18:43:32 2034 GMT
         Subject: CN=ec
         Subject Public Key Info:
             Public Key Algorithm: id-ecPublicKey
                 Public-Key: (256 bit)
                 pub:
-                    04:d0:40:f7:c9:01:ec:97:dc:32:1c:19:85:59:29:
-                    19:a9:40:21:ba:9e:f9:87:f6:49:d6:97:e4:1a:d3:
-                    d6:ac:12:de:63:34:2b:62:16:19:0b:af:3c:fd:87:
-                    a1:66:3e:36:39:65:83:fd:2f:36:bc:fd:58:14:ff:
-                    a5:2b:fb:35:32
+                    04:e7:c1:a2:97:cd:95:ad:fe:a5:05:43:41:2d:19:
+                    55:21:11:f5:f6:46:9f:45:74:6a:8c:91:c2:2e:32:
+                    aa:47:1e:9e:2e:49:99:7c:af:98:fa:d8:ae:b3:a1:
+                    26:46:d3:22:d3:3c:b1:2d:8d:3b:e2:03:cf:25:93:
+                    d5:b7:a8:e2:ab
                 ASN1 OID: prime256v1
                 NIST CURVE: P-256
     Signature Algorithm: sha256WithRSAEncryption
-    Signature Value:
-        97:13:55:70:9a:23:39:f8:08:f9:a6:9e:18:a0:08:23:a9:39:
-        1b:2f:88:b9:db:37:da:28:4c:49:a0:eb:e5:5d:ee:c5:60:f7:
-        6d:13:b1:cb:92:73:70:40:7e:d2:b8:7a:19:08:63:78:a3:0d:
-        ab:c5:f3:93:90:93:fa:25:e5:f6:18:f7:bf:57:68:97:51:9f:
-        04:69:f9:10:7d:63:2a:2c:d4:41:0d:65:19:6e:3a:cd:dd:fd:
-        17:64:9e:14:1c:ef:d7:64:09:3f:16:b6:23:c1:f5:97:a8:5a:
-        79:97:61:10:9e:f4:88:dc:78:ef:5e:2f:6d:05:a3:b1:8a:d7:
-        92:2f:0e:66:3e:b4:fd:00:5c:f9:7c:0a:7d:78:75:33:3c:8f:
-        59:0a:ca:0a:da:14:a7:36:00:5c:ec:df:26:e0:cb:90:0d:4a:
-        12:8b:f1:c2:a8:9f:a8:de:f2:a0:2c:33:28:38:c0:00:a6:09:
-        e8:80:7f:2a:aa:e5:9c:55:c7:ed:62:21:2b:33:0c:6e:a7:04:
-        b0:e1:63:19:75:26:76:80:2c:af:23:9d:d6:39:c8:b2:e3:78:
-        8d:fe:2c:a6:06:55:11:10:9d:23:12:e9:74:5b:75:73:19:32:
-        a1:83:d7:24:ba:61:b3:8b:81:2b:45:80:bf:f2:fa:6a:0b:7c:
-        8d:46:81:0f
+         7b:c4:a8:34:2e:98:20:62:b2:23:44:29:1b:b7:b4:00:01:ea:
+         94:59:ef:2a:76:73:4d:a4:5a:28:73:11:54:d5:00:19:89:90:
+         e9:00:1b:68:01:2e:ab:66:76:bb:0b:2f:08:48:86:7b:8f:02:
+         81:42:70:ec:fb:66:59:e7:40:f3:7b:13:c7:3a:29:79:60:5e:
+         b1:86:0e:ef:78:dd:1c:67:b6:60:02:e0:a1:6d:bc:66:99:6d:
+         46:ec:dd:a8:b6:36:38:1a:2e:29:5d:f7:aa:07:ef:d5:a7:48:
+         78:38:16:29:08:61:f7:ab:a3:03:05:e6:7c:60:46:50:f6:05:
+         03:a2:37:7a:67:0a:63:f5:bd:5d:12:82:06:0f:58:c9:58:33:
+         bf:a7:4c:c1:e5:3c:5e:d7:e4:91:f2:67:24:03:46:e8:94:84:
+         14:ae:be:c6:bc:2d:37:d8:5f:1d:ee:68:52:6c:9f:34:14:8d:
+         ba:e6:7d:b1:d3:47:76:13:ef:11:18:28:64:c3:84:6b:cf:5d:
+         68:4c:59:4f:09:55:e9:55:63:de:61:cf:98:2b:cf:f2:be:8d:
+         c8:7b:62:8d:8b:98:4d:16:81:ce:8a:83:5a:e8:3a:50:18:cb:
+         cc:92:54:07:d0:29:3c:96:70:86:b7:f3:a2:bb:8f:df:62:51:
+         3d:20:58:0d
 -----BEGIN CERTIFICATE-----
 MIIB2TCBwqADAgECAgEJMA0GCSqGSIb3DQEBCwUAMB8xHTAbBgNVBAMMFFRlc3Qg
-Q0EgU3ViYXV0aG9yaXR5MB4XDTcwMDEwMTAwMDAwMFoXDTMzMDYyNDIxMTgwMFow
-DTELMAkGA1UEAwwCZWMwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATQQPfJAeyX
-3DIcGYVZKRmpQCG6nvmH9knWl+Qa09asEt5jNCtiFhkLrzz9h6FmPjY5ZYP9Lza8
-/VgU/6Ur+zUyMA0GCSqGSIb3DQEBCwUAA4IBAQCXE1VwmiM5+Aj5pp4YoAgjqTkb
-L4i52zfaKExJoOvlXe7FYPdtE7HLknNwQH7SuHoZCGN4ow2rxfOTkJP6JeX2GPe/
-V2iXUZ8EafkQfWMqLNRBDWUZbjrN3f0XZJ4UHO/XZAk/FrYjwfWXqFp5l2EQnvSI
-3HjvXi9tBaOxiteSLw5mPrT9AFz5fAp9eHUzPI9ZCsoK2hSnNgBc7N8m4MuQDUoS
-i/HCqJ+o3vKgLDMoOMAApgnogH8qquWcVcftYiErMwxupwSw4WMZdSZ2gCyvI53W
-Ociy43iN/iymBlUREJ0jEul0W3VzGTKhg9ckumGzi4ErRYC/8vpqC3yNRoEP
+Q0EgU3ViYXV0aG9yaXR5MB4XDTcwMDEwMTAwMDAwMFoXDTM0MDEyNzE4NDMzMlow
+DTELMAkGA1UEAwwCZWMwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATnwaKXzZWt
+/qUFQ0EtGVUhEfX2Rp9FdGqMkcIuMqpHHp4uSZl8r5j62K6zoSZG0yLTPLEtjTvi
+A88lk9W3qOKrMA0GCSqGSIb3DQEBCwUAA4IBAQB7xKg0LpggYrIjRCkbt7QAAeqU
+We8qdnNNpFoocxFU1QAZiZDpABtoAS6rZna7Cy8ISIZ7jwKBQnDs+2ZZ50DzexPH
+Oil5YF6xhg7veN0cZ7ZgAuChbbxmmW1G7N2otjY4Gi4pXfeqB+/Vp0h4OBYpCGH3
+q6MDBeZ8YEZQ9gUDojd6Zwpj9b1dEoIGD1jJWDO/p0zB5Txe1+SR8mckA0bolIQU
+rr7GvC032F8d7mhSbJ80FI265n2x00d2E+8RGChkw4Rrz11oTFlPCVXpVWPeYc+Y
+K8/yvo3Ie2KNi5hNFoHOioNa6DpQGMvMklQH0Ck8lnCGt/Oiu4/fYlE9IFgN
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/encrypted-ec-key.pem
+++ b/spec/fixtures/ssl/encrypted-ec-key.pem
@@ -1,21 +1,21 @@
 Private-Key: (256 bit)
 priv:
-    da:dd:0f:94:97:b5:3a:8d:cb:0c:1b:b1:55:85:e4:
-    71:e4:6c:f3:45:0c:55:07:3d:9c:1d:d0:86:06:1a:
-    f7:12
+    3c:a7:b7:fd:33:b3:ab:bf:09:82:0e:97:88:2f:1a:
+    7b:af:da:9d:c6:ad:e0:b1:06:ce:42:33:be:c9:97:
+    db:96
 pub:
-    04:d0:40:f7:c9:01:ec:97:dc:32:1c:19:85:59:29:
-    19:a9:40:21:ba:9e:f9:87:f6:49:d6:97:e4:1a:d3:
-    d6:ac:12:de:63:34:2b:62:16:19:0b:af:3c:fd:87:
-    a1:66:3e:36:39:65:83:fd:2f:36:bc:fd:58:14:ff:
-    a5:2b:fb:35:32
+    04:e7:c1:a2:97:cd:95:ad:fe:a5:05:43:41:2d:19:
+    55:21:11:f5:f6:46:9f:45:74:6a:8c:91:c2:2e:32:
+    aa:47:1e:9e:2e:49:99:7c:af:98:fa:d8:ae:b3:a1:
+    26:46:d3:22:d3:3c:b1:2d:8d:3b:e2:03:cf:25:93:
+    d5:b7:a8:e2:ab
 ASN1 OID: prime256v1
 NIST CURVE: P-256
 -----BEGIN EC PRIVATE KEY-----
 Proc-Type: 4,ENCRYPTED
-DEK-Info: AES-128-CBC,F24798971C256A4FC58DE36E2AF14278
+DEK-Info: AES-128-CBC,1ADDF7360FB53F38DC3B58192DBBCC40
 
-AhRyG1cSvDiQGOj3S5BxWwB3udT0rEan5kKlXeXSqWFay3u2SM3jMqWvzc0cZtyo
-/OHDtRkyHohDtTJNqcJJSqrwAyjQ6w/XQVKd9dqfX3ATssUA9yvZKYIoS67uUrbW
-fQXzaBFNJoh7wtL3qK2f6of6LpQsyK6WQNDQvDbo2dc=
+acDyKuVWLOvDWANpKQrbR45nec2DS6RMmwi5f6n96+4Z+ejPVjKFswmabDyyOwnd
+UJgwDn+LZzLBNHuvF7OBc7eQ9cLsR2abGhLdW7HrmGspKL1ZItxnAuKPGGby1JT3
+4T/RxSVjlIROCpJ+oKW6dCMGWQNH2uoifGjHmsuLS8o=
 -----END EC PRIVATE KEY-----

--- a/spec/fixtures/ssl/encrypted-key.pem
+++ b/spec/fixtures/ssl/encrypted-key.pem
@@ -1,120 +1,120 @@
-Private-Key: (2048 bit, 2 primes)
+RSA Private-Key: (2048 bit, 2 primes)
 modulus:
-    00:c4:7f:b6:dd:ab:a8:58:7f:49:48:9d:bd:6f:91:
-    9a:ea:bc:8c:3c:20:5f:ec:3b:30:4e:c2:c5:98:8e:
-    52:27:74:d9:d1:28:7e:6a:09:b1:fc:ea:d2:28:a7:
-    48:30:b8:bc:93:11:e8:56:93:bf:02:86:1c:78:16:
-    0b:b8:c3:ce:aa:b1:27:de:c6:96:20:f8:d4:8e:63:
-    58:b3:05:c6:df:a7:eb:eb:85:14:98:04:0e:d7:99:
-    17:81:0c:15:0b:c7:f0:bf:14:a5:8e:e9:5b:88:65:
-    e9:b4:3e:9f:77:f4:77:60:dd:aa:75:e9:f2:75:07:
-    a8:47:17:a3:79:f1:e5:ea:01:80:25:5a:5a:1b:fb:
-    8d:6e:17:c7:b8:7d:bb:1d:ec:67:bf:c9:83:8f:28:
-    02:99:83:16:f4:2c:f0:94:25:1b:7f:f0:99:fb:ec:
-    75:63:88:97:2f:1d:f8:bf:14:92:3b:df:ed:a0:56:
-    0c:94:c6:92:b4:91:e2:85:88:de:99:93:00:17:b0:
-    f1:ed:45:03:8f:07:2e:5a:e5:82:6a:99:6f:45:00:
-    54:2a:37:93:77:23:06:c3:99:fa:c1:1f:4c:59:63:
-    e1:35:b9:f7:f6:ab:81:a5:11:ef:9c:a1:e6:64:ab:
-    2f:fc:f9:cd:b3:d0:b7:33:81:4c:36:13:03:3a:5e:
-    e6:e5
+    00:ac:0d:e2:e1:62:ee:7a:55:f6:46:0a:5f:ed:dc:
+    4a:a6:d4:d0:19:7f:a8:4d:cd:a0:c1:61:d4:e8:78:
+    50:d4:5d:40:1f:e0:c3:79:26:95:19:4c:cd:70:10:
+    53:38:b1:68:e4:7e:d4:44:65:68:94:8c:b6:ab:d2:
+    22:36:d8:b0:92:ba:ed:3f:00:ec:b0:b6:5f:26:ac:
+    f7:2b:71:e4:d7:8a:28:49:a8:fe:f9:a1:c8:b8:09:
+    73:8c:f7:d3:90:ab:ed:74:fb:25:29:bf:81:51:b3:
+    ac:02:81:ba:c1:7f:8a:ad:d7:18:6d:d0:73:1e:7f:
+    d9:54:ed:0b:a2:a6:d7:7e:22:e1:3f:a3:6d:77:4a:
+    9e:17:68:42:ef:99:63:e0:0f:5c:35:4e:3a:ef:5a:
+    84:3c:c6:c1:ac:78:c5:fe:60:56:f4:e5:86:7d:60:
+    1b:55:3c:bd:6a:c8:22:ea:b6:c3:f6:8a:67:e8:cb:
+    5d:23:61:44:4b:9e:24:f8:91:69:25:90:0b:d7:2e:
+    84:3f:c1:a2:8f:87:68:a8:36:b3:a7:b3:c8:0e:06:
+    bd:6b:f3:54:41:d2:47:49:a7:2f:9b:3c:2f:37:89:
+    46:12:90:95:fe:6a:6f:5e:29:c6:d9:ea:90:47:29:
+    1b:85:1e:d3:19:e9:80:40:f7:33:67:bb:e5:17:50:
+    5c:cd
 publicExponent: 65537 (0x10001)
 privateExponent:
-    02:ae:22:f2:7d:43:2a:53:da:ce:20:02:ae:63:d1:
-    75:b6:b5:2b:4e:73:68:7f:8f:d8:df:2c:be:a2:e0:
-    54:29:47:f2:f8:fc:57:c4:c2:95:ff:d0:f6:87:7e:
-    43:55:dd:bd:46:cf:01:11:4f:ac:c0:8e:0b:b0:47:
-    4a:d1:a1:94:6f:f3:ff:d9:fc:6b:13:8c:78:ab:0f:
-    bc:6a:0d:81:f8:4d:23:95:03:88:7a:f3:b0:8a:a6:
-    1e:01:ea:19:3d:f4:ac:1d:38:bb:37:e1:22:52:e6:
-    35:69:c3:97:3e:b1:25:d3:d8:32:f6:b4:dd:2b:9f:
-    26:bb:17:e5:29:00:c3:bd:e9:36:1a:19:b2:df:0c:
-    42:d0:9d:e0:c4:9a:6e:73:00:fc:57:c5:32:62:da:
-    0e:67:0e:bc:10:de:80:17:cd:bc:39:80:d2:d8:d9:
-    c1:11:c0:ac:6d:32:11:3a:e1:7d:64:c7:d9:5e:f0:
-    c8:e0:3f:ae:c2:8b:07:0a:da:a8:15:58:e0:2e:c1:
-    f5:f5:1a:4e:c5:bc:e8:c7:63:bf:28:84:0d:1d:e4:
-    8d:8c:9b:74:7b:9f:2b:f8:ba:9d:ee:d6:c4:9f:d6:
-    3d:90:d6:18:34:84:82:d2:12:4c:be:55:13:54:6b:
-    d1:9e:39:e9:62:6f:30:de:9d:c2:06:49:4d:78:04:
-    11
+    15:08:01:82:c1:80:1b:2e:24:d3:7c:f3:2a:f5:31:
+    9e:e1:06:ab:07:42:c0:77:f1:3d:92:42:df:43:cd:
+    c5:97:bc:7d:e9:10:9b:df:8e:7c:30:3a:30:87:9e:
+    54:a0:c3:0c:a3:40:39:38:18:27:88:67:cf:ea:f8:
+    c9:b1:85:2b:fa:73:83:af:0e:3f:af:9b:43:f4:02:
+    a6:a9:de:6a:46:76:14:42:f7:1f:f6:99:bd:7d:52:
+    45:9a:09:9f:76:94:a9:27:05:ec:eb:7e:d8:48:d9:
+    2e:d9:42:c5:e2:5c:46:51:b3:a7:c0:c2:41:a9:29:
+    1c:cb:79:0f:a1:cb:57:9c:a2:6a:35:d6:da:b2:21:
+    55:70:e2:8b:2d:e8:16:d3:37:41:fc:df:d4:b1:e0:
+    db:90:b8:e4:28:74:ad:8a:1d:92:b3:02:c3:68:65:
+    75:38:99:32:38:28:1f:64:91:3b:42:86:45:19:54:
+    2d:b0:26:48:88:25:32:5c:ab:f2:de:02:ec:77:fc:
+    cc:ea:6f:ce:e0:40:44:7e:80:c8:bf:99:25:5d:d5:
+    88:57:55:4b:07:64:d2:8b:a3:c2:86:56:d9:6f:16:
+    6c:c5:52:84:9b:e6:b4:4c:2e:ff:59:7b:d9:0e:fb:
+    95:4c:5a:56:58:e9:d1:9c:0f:84:ad:36:d3:c8:5b:
+    b5
 prime1:
-    00:db:85:36:5e:39:8e:46:b4:d2:ab:09:db:b1:c4:
-    d9:56:3c:c2:44:92:b7:60:74:e7:6d:07:75:ea:78:
-    bf:32:86:05:71:ab:e3:ad:22:b5:70:45:e7:26:49:
-    07:2a:92:1c:a0:31:c3:42:7e:7a:34:72:a0:c5:32:
-    92:65:17:bf:59:0a:59:41:d5:63:e8:ea:df:ae:1b:
-    e2:d8:b6:eb:bb:76:41:45:26:21:ac:de:4d:70:e1:
-    d4:bb:ce:30:c9:3b:a3:a9:96:95:7a:21:a3:6b:a1:
-    ea:e2:12:07:d9:0e:00:26:24:ee:91:2a:a5:69:ed:
-    d4:1c:03:c5:9d:80:35:5f:95
+    00:e3:17:e6:10:fa:80:d4:86:c4:59:bb:36:57:ad:
+    9a:12:8c:63:e0:84:b3:f3:ce:4b:d1:bf:a3:8c:0e:
+    a2:41:62:1a:46:74:eb:ce:01:55:33:8b:b1:1f:f2:
+    30:df:12:0f:69:0a:fb:e1:1e:32:80:5c:b0:85:5b:
+    ff:5a:93:9a:50:1b:7b:85:83:f0:8e:26:f9:e2:35:
+    5c:94:0c:ce:29:22:52:a0:a9:ac:64:d3:56:93:0d:
+    11:f7:16:07:10:0f:97:03:43:11:57:91:15:4d:04:
+    9c:6d:5e:26:b3:41:46:c8:7c:46:3c:2a:dd:40:e1:
+    9f:32:75:2b:82:49:dc:d8:73
 prime2:
-    00:e5:27:20:94:a0:f1:36:3f:97:ea:86:ed:4c:21:
-    8f:23:2b:09:49:7d:58:48:9f:c4:44:3f:8b:67:4b:
-    d4:1e:c2:87:fc:09:c6:06:d3:8b:82:e2:17:95:a6:
-    89:7c:df:43:2c:5b:fe:bb:ea:85:32:a7:59:eb:41:
-    31:81:e6:d2:8a:e8:1f:65:9e:dd:91:55:75:52:09:
-    e5:90:6a:44:22:99:47:e6:57:bb:f9:e6:df:f2:42:
-    b0:dd:1a:8f:6c:93:04:70:35:a9:3b:05:a9:04:78:
-    5a:97:39:53:d2:4c:3d:74:9a:d1:36:4c:98:9b:1a:
-    ba:1c:46:d0:46:5d:f9:d6:11
+    00:c1:f4:79:5b:51:e7:58:84:a6:57:11:48:e6:25:
+    60:dd:7b:67:e1:e4:61:6c:f2:37:6e:71:68:53:47:
+    1d:f2:e8:31:9f:60:64:6c:97:cf:2c:b9:b0:a5:39:
+    e2:11:40:c7:00:8a:4a:48:60:f3:33:3f:17:9f:56:
+    f9:74:f0:ad:ce:92:6a:30:c7:aa:32:b1:58:cb:08:
+    d4:44:40:29:56:cc:09:26:90:55:84:d8:b7:15:4a:
+    05:89:5d:29:d4:4a:4d:15:a9:40:f3:c7:a8:b0:73:
+    ba:4d:63:14:62:e6:cb:d6:b7:6c:8e:cb:68:a8:bf:
+    2f:10:5b:d5:f8:5b:64:e5:bf
 exponent1:
-    27:ad:ce:83:fd:97:50:04:83:47:d3:42:58:c1:a2:
-    1f:4a:60:3b:10:e2:00:97:60:f5:7e:31:bc:2e:13:
-    31:48:b4:57:35:a0:b3:bc:e0:5a:e8:e7:bd:2d:da:
-    13:c1:d1:56:cb:67:e5:ef:02:9b:d4:54:67:10:9b:
-    11:96:d7:49:7a:eb:63:50:f4:fc:36:e8:33:8a:6a:
-    d8:8d:47:d2:dc:af:33:96:8e:e3:b6:52:fd:22:74:
-    d7:75:8f:af:f0:0d:c7:2b:a6:dd:2a:93:65:73:21:
-    07:b8:06:9f:1f:3e:bb:a6:55:50:fc:0a:66:39:4c:
-    eb:bb:6a:ce:eb:4b:ba:79
+    4c:d9:6f:8f:db:55:f1:95:d1:a8:94:04:25:d3:a7:
+    ca:13:1c:51:84:56:e9:70:ac:93:c4:88:72:03:19:
+    c1:8a:93:5d:b8:7f:7b:ed:53:89:e8:01:fe:cf:94:
+    de:48:5c:52:ad:d6:e3:2d:b6:e5:5d:78:97:08:b4:
+    f7:4f:ef:ee:9f:fe:43:06:8d:47:6d:c5:2e:59:e4:
+    84:6d:78:ee:ce:a0:ab:a1:ff:a6:f7:25:db:09:97:
+    44:c8:7d:87:5f:df:38:c9:5f:7b:04:ab:f2:ae:56:
+    c9:64:0d:30:a8:2c:6d:f8:30:44:78:34:fb:99:de:
+    a7:d2:a2:f0:aa:52:44:25
 exponent2:
-    5f:ff:5f:3f:c4:98:a8:70:45:b5:23:67:3f:d0:83:
-    45:69:5f:0f:a1:6a:1d:aa:88:af:4a:ab:9c:cf:80:
-    82:8e:5e:27:70:f4:bb:a1:5d:bd:ab:f7:d3:62:9c:
-    10:6a:fb:9a:16:c4:05:77:3e:eb:b4:7e:0f:f7:14:
-    c5:65:ac:68:32:cc:0c:67:5c:4c:e9:2f:27:fa:2b:
-    68:af:8b:f1:ae:a3:17:55:43:d3:72:2b:f9:32:85:
-    23:6b:60:10:4d:1a:bb:e3:4f:0d:01:d7:07:9f:5f:
-    dc:20:51:04:35:9a:3d:42:2a:49:04:17:9e:4a:b9:
-    12:e5:7b:95:2f:03:5d:f1
+    7f:ef:5f:c1:51:d4:34:fa:42:b2:79:cf:49:27:ec:
+    ae:0b:81:a9:6a:38:ad:61:54:19:00:ab:5d:0b:33:
+    01:10:11:f3:5b:e4:c2:10:9c:f2:96:85:a3:66:fb:
+    ec:7f:7b:04:ab:33:76:6c:a4:de:ef:c6:08:2f:99:
+    9a:7e:4b:57:50:12:c5:9c:5e:72:d3:b2:8b:32:86:
+    b9:82:4d:02:58:d1:cc:63:36:55:cb:91:70:74:84:
+    14:68:a4:77:c8:8e:f2:33:d3:89:39:f0:d6:7b:6f:
+    af:2e:24:bb:5c:1b:a6:c5:14:d1:57:f0:f0:26:33:
+    c8:29:9b:89:17:d8:05:07
 coefficient:
-    56:b9:68:ee:96:8e:20:df:9c:e5:3c:29:41:a0:e9:
-    32:8f:a1:e9:de:1a:c5:e2:cd:c6:0c:b7:63:e6:9c:
-    f6:b4:0e:f4:fb:6a:7f:a7:7b:3f:fe:6c:0b:d6:da:
-    c4:9d:ef:59:72:da:0e:14:4f:e2:37:78:b0:34:00:
-    58:05:48:cb:0d:e8:c6:67:6f:2b:76:20:5f:93:36:
-    bc:6e:1b:b0:6d:67:fd:67:71:4c:18:08:73:52:95:
-    59:11:39:f3:4c:73:93:37:57:53:5d:30:32:75:99:
-    46:a1:b9:d8:84:86:32:5c:0d:93:95:46:f4:17:3f:
-    38:15:ac:eb:eb:51:79:68
+    00:bd:78:38:fa:43:8a:96:b9:4f:69:3f:2a:e0:82:
+    b6:be:76:43:91:b5:eb:ad:d6:db:a2:e3:51:01:39:
+    c8:54:18:87:06:03:e7:0e:2e:9c:82:5d:54:df:bb:
+    97:c8:d2:fa:be:12:8f:df:eb:03:b0:78:74:d0:cb:
+    cc:0c:ad:9a:f0:c7:16:3e:cf:84:d4:c7:b8:91:65:
+    7d:bd:29:cd:71:7a:f9:16:30:cb:4f:f0:f0:59:96:
+    24:19:d6:77:eb:36:1d:1c:3d:0d:89:08:9f:64:bb:
+    86:b9:be:3f:c1:67:e5:b7:fb:d4:65:cd:54:cc:3d:
+    3b:a1:5a:3f:61:91:20:c3:10
 -----BEGIN RSA PRIVATE KEY-----
 Proc-Type: 4,ENCRYPTED
-DEK-Info: AES-128-CBC,A4FAB87C746D77094021EC8C6EA63235
+DEK-Info: AES-128-CBC,0CF460F33E71D0E4C8E65D782B9359BA
 
-R7Ge2FyBxV2ElhGdTAbNR2J8M88roYKyiuXhhGuggLDHf66C7IigzFMvsxds37a+
-932ksUA011XvYjCRbCgTaDbfv02tmmClTNABnMUv/NQS6+OhY/KjCR99ZCzOWfwz
-0msj7k5UaEZyUPfX1JAgW0SV06j+WjoM+wEzKdRc4c+RXYJKlBF9UecdknE8Tkch
-MoVcMIlATkiJ0FCTXxlTyIicP9K0YdGAAzpa4wvKCflZuRiKbrGaelmI1nsMhEY6
-xMXMuhxxD39KyAHaWySrR4TVmgw2fRvdwuBUsGtSVgbnCop51znALtMzspmy2Nz3
-dvTYSa0GdJ6YwXaoWUEipWVCvT9hNADUe8MKtFQqO8/Hhazaceb//7Mn/kPIwnsD
-5vF/6xd5dALMSJ9zXSnJ8XpBMFszzgyN/FxzKu1p3GMU7QJNe24f4LfucQvGgiy3
-Ql/JrQdFDAHpMlLVgJj84H8L+xmMOZ80M1eQCk9/KiAGi69NARPScPrnnyOJtKbW
-uQXnKwKHHT7BQkdIJAb3Gyu1K29VMEZU15+xRJyvWIUPf8hWUohsn8eA0XdxQKBv
-OeAED0ptNHtaUL7uExQH3mn3qgYSw07/Ynlq0wg9Eugvdq3sU2xdbBDP/txuXUdF
-2evaA1YioV1NdYcAYsT5m2Sreeq2RW1o2MLX0IWGxV89TKX8SHoS/nIi4QhB9oLB
-q9Viv+8PW2G5OCKhxyJStSieER3dbAXOHoVzhFB7pS2HkpkL2dwh9eOHpKwFdcdu
-galMWHmb6+wGkFhVgFRTZ9F6mTCHcsEUoXt7a/ddydMB36tHQYUdxQuGlyGeF7C5
-cretPwuhUmIxlmPfoqYqNyDyTpVZaFI7823enscxu3fyqlF8AwO+REPVZt1yzqmf
-YZfnfYHWk3f7TvKBF9ZNjv7gWC4L+QyEOfQUcx0Vi4j0I4pgxo5Gk+7Eb0tw116w
-qALQ8qzwm1BUCPiP6WnwvM4oL4kZgMNgBAbxgxyeUeypm+tGQr2zya7h7RZJe4bw
-0XrBgerkj/Va78Wy//cJC2gwFzKJPtfcaQlzanNslMPAJ+Te6k8Tip+7HYD6F0f6
-FK+VDeuqBGAwNN9cPD8HBnjKltX4RggAaWasRukWWbCfjO0xuFFeLCZscf9vnvbz
-hq16xvoAHCA0O3WXUtdbTJNiRIjYpr9qymQynUN/eMSLEk1sduwBnGXRWuUvBCDS
-APFI9G5F7NM3GC+HqYyEsPe/mT8mqH0KU6881mudaZVu4QZzcIl1maRKMNBrUtep
-kmtFKWzC3YbMax05L4nA0HtWDZh28eCZyTOKqGzh0K/BDHM1FkyQmIt85UHT+MtJ
-SiXzL1514oY0+4uE0bSDv2seybS5KiKsEjvWeerPyYzgElmK8hQcWADDmrafDB9N
-2iybONLuPzKrDFmVmb20He3JKWGYcGyBqUVD203bdErlIbPLuoCnUmGhIxACqPdv
-dXs9U8eUAKpGwctHnnuYVb9aFt2QK+leNlYh4KNR7hVjqDpURBm84Va6gE/kvkIp
-wt23YK4OK4G1mDFXObmuk0a5zTrN1MC5J3tFvXh7R4N9e4+LnQ0Edgk5aE7Zfm06
+jR5jkDTTEatVYhvUFeDQD8GVek/IrzTLnAX3fQzhcLY25gEqdYO4wwuP6JrZmT18
+BmyNJNTmOgmRXmIv8dxpZrUe5Ah1F4dmrgu4VdnOpZ7HiMzFyPaIZ6IpWBFsJ/F+
+6NFpR9ii21Om1anhF/uJymny00h1tbzQ+QKsylzhxCL5PinHgJnz/V1KTvuefQaZ
+YTudmKzgPs4eu2urrtDGbhluVUlRoSyDINsjHuOPmd3RAa8PdU6YgcdusO5Zkv6r
+PFho9xdcocbeJQyYlARuZaQD+cmLFYwiZ/oIWfspQWEVa6CN+4MpxWYLfMp/JvKK
+3WwQ1A55m49IE97peUjs5nP6uCFyJQkVQklo7+07CdclNnMryoCBpelwvOCzv0Ya
+hnDRT4VWyRaRp8+bhU0kIh9NewBWB5e/YmlhyOqi4k3cKYDPxZJoVyFF6fx5Ze4T
+J0TTzMTYJltkPqxiBGS/5nQ6TvDgixDXSOJQ/KhSMu3oaSRsALiYaDHcW2ZtcXdV
+AsEMLgiPqXIfbLVBSTE0pf7MbWbjhRVgK19epjbt7W9qOAvlls9I2ebBQOXJKzD2
+4EkqIlIWkoITXlALYYuT5ub0V4XKxTp0OU3nnPtq6kG7jA6kK9iuVTPGkhgm0ZOX
+8sUEHBOeIGt9VR9BEgS/JbyOnOtalKQCSIeI+6MoJpQe1AU8f9jzUhMh0VxUWLtO
+a41zpy1NvuN921ytCT8Ew9EVXgE1IewOLoEIBOJ1iNXgxSYs7qgvGwPcfxD7EySY
+TNIw4byEpTAgjtMF9H+AM8Ty1AJUk71d2i/WDZI9uQ8JS7GSa528yyoE4jEj7FZ5
+fYdyKBJ7Eh1bBFk/Sbfox6nSptWJnC0vQwllq0XoBPHGZkxJnmRZIFipe2YVOHN4
+i1ixHNE4H9lcWBXd2YmQ8w1phVbZPaBIuH+YaY9TWdgo0qQHPr4C4sjQDx8oFriT
+0TFCxLaWRHMzKUGMoDu2hfjpuyP3IsQXgDrLaNvb6qA00mssdoQ6ZfbYJsTcHYb4
+FZnSm7e+CgMDyNZgM5xA2hU9B+Gx7/GUnpLBmV3YsHQzMaAHxzsvXV6IgVnS9pva
+DWJAZlecggMU4U7qC0ag/7nG493SBc0bviyrVbTPKqo+yD72KknsF+Bj7n2Pb201
+geuaF38HO4aU8fjtbl2gAoSGq2kaLGHwtiPRY+Iqq9fEydO9yN2w8WV3Vhso0kHr
+37FwgCmnWnsr/6HrEJkNJhZluSwoxnYXYFu7B2A4efgvDXtkdi/5iE8WgjLoazdJ
+udXY9Pfd0N/TFXugkWXNJ1K6bLluIMfnOn+D2Mt+Ha1hkgeguGazaB6lINBtwYJZ
+J4FIn8A1L+34A/s1sRYzNVdZrvx9U91tl6KLfuJGAjVJe81D593DEd288+zpn8V6
+RgTcsWW7YhQ8nwwdsq0mA0Is2GshraCyV6yofugh7rOPIuxydp53Rrev0/K5dmjq
+0ROjjWHMF7XJhUS72GfmIeT752EjGKUWOeB7Rwzbi+3wcJW36ZbbsxJFPxq7Ydj6
+XZQ9/Nb97N9yVoNfnw2dhLlTvLg0f9uWC0A25hW7aCL88w62dbRiF8CVBqdO52BQ
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/intermediate-agent-crl.pem
+++ b/spec/fixtures/ssl/intermediate-agent-crl.pem
@@ -3,38 +3,38 @@ Certificate Revocation List (CRL):
         Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA Agent Subauthority
         Last Update: Jan  1 00:00:00 1970 GMT
-        Next Update: Jun 24 21:18:00 2033 GMT
+        Next Update: Jan 27 18:43:32 2034 GMT
         CRL extensions:
             X509v3 Authority Key Identifier: 
-                92:84:BC:BD:F2:05:CC:1C:E3:00:5A:75:B1:A4:67:A9:31:08:9A:F2
+                keyid:48:07:33:D5:80:0C:18:AD:FD:7A:04:33:84:8F:A8:B2:D9:88:18:9A
+
             X509v3 CRL Number: 
                 0
 No Revoked Certificates.
     Signature Algorithm: sha256WithRSAEncryption
-    Signature Value:
-        78:e1:8b:90:01:c2:44:ae:09:0b:a0:d3:09:c7:3b:cc:10:bc:
-        87:4a:e2:85:76:45:8e:31:2c:96:3c:97:7b:ec:5a:4b:0d:ae:
-        30:e6:5f:53:18:ce:88:88:21:f9:4d:ff:00:07:14:37:d3:c1:
-        04:f7:03:55:29:59:60:95:ec:b7:d8:ad:0b:7f:b0:6a:7f:ec:
-        93:ac:52:ee:18:e3:85:d3:d1:82:c2:19:87:ae:2c:84:d1:e7:
-        59:dd:92:7b:84:bb:b9:ab:54:01:4f:84:71:80:53:36:b9:15:
-        43:a1:da:e3:ea:3b:d0:65:54:8d:4e:52:5f:6d:9b:28:47:20:
-        ce:be:bd:dd:e7:77:8c:43:f4:cd:83:d0:81:83:63:47:38:9f:
-        29:fd:fd:c5:ea:e2:28:1f:22:be:57:c5:82:6c:45:62:00:ea:
-        fc:4b:69:b9:d0:b2:02:7f:20:4e:d2:c4:ae:e1:96:7a:2e:bd:
-        85:d7:f7:47:e2:00:da:4c:0a:ca:c2:4f:05:be:49:92:7c:4b:
-        6d:39:48:1f:ab:83:de:a2:12:04:85:85:57:b0:78:7e:69:07:
-        ff:3b:bc:d8:53:74:94:e5:21:34:5b:30:09:08:9b:3e:f9:cd:
-        84:14:e0:51:46:5f:23:34:6c:47:d0:57:71:f9:b9:9c:94:c7:
-        df:4c:f5:2c
+         72:c6:aa:64:c7:1e:70:3a:93:ee:69:61:55:51:fb:95:3e:b1:
+         c7:e9:ac:60:4d:36:fb:94:26:53:c8:56:42:27:03:b9:f8:e2:
+         0c:fd:b7:75:21:58:27:08:69:93:19:34:71:ba:45:15:f5:34:
+         70:06:be:31:3a:63:83:1f:c2:ba:9f:08:0e:7f:10:97:41:32:
+         17:ac:71:69:ea:2b:44:b2:dd:27:c0:5f:da:7a:5a:26:ec:f6:
+         ba:b1:da:0b:c9:4d:f8:22:f4:78:7e:fe:4f:ae:86:55:11:74:
+         28:ba:c3:2f:c1:6c:09:a3:8a:60:ba:b3:8c:0e:de:cb:d4:3c:
+         a1:66:3e:a4:cd:f3:5d:4e:59:81:c1:b3:d4:6a:6c:ec:43:a1:
+         35:91:85:3c:ba:79:e4:4a:cc:a4:bd:ae:a8:cb:8f:0c:d4:b8:
+         26:5b:8d:2a:14:26:34:2b:84:d1:7e:6a:ae:ec:cf:14:cd:ca:
+         ad:1c:7e:f4:80:e3:32:c2:e8:b7:87:fa:5f:22:cf:08:bc:f4:
+         f5:a5:98:1f:d7:43:d9:29:eb:f3:65:c4:f4:d9:8e:90:3a:87:
+         27:ee:e7:7b:93:38:6b:5a:49:2e:4a:fa:e8:24:20:08:55:56:
+         4e:80:40:27:2f:d2:bf:52:31:19:d7:f1:b5:14:73:4c:cc:a0:
+         62:aa:50:0a
 -----BEGIN X509 CRL-----
 MIIBnzCBiAIBATANBgkqhkiG9w0BAQsFADAlMSMwIQYDVQQDDBpUZXN0IENBIEFn
-ZW50IFN1YmF1dGhvcml0eRcNNzAwMTAxMDAwMDAwWhcNMzMwNjI0MjExODAwWqAv
-MC0wHwYDVR0jBBgwFoAUkoS8vfIFzBzjAFp1saRnqTEImvIwCgYDVR0UBAMCAQAw
-DQYJKoZIhvcNAQELBQADggEBAHjhi5ABwkSuCQug0wnHO8wQvIdK4oV2RY4xLJY8
-l3vsWksNrjDmX1MYzoiIIflN/wAHFDfTwQT3A1UpWWCV7LfYrQt/sGp/7JOsUu4Y
-44XT0YLCGYeuLITR51ndknuEu7mrVAFPhHGAUza5FUOh2uPqO9BlVI1OUl9tmyhH
-IM6+vd3nd4xD9M2D0IGDY0c4nyn9/cXq4igfIr5XxYJsRWIA6vxLabnQsgJ/IE7S
-xK7hlnouvYXX90fiANpMCsrCTwW+SZJ8S205SB+rg96iEgSFhVeweH5pB/87vNhT
-dJTlITRbMAkImz75zYQU4FFGXyM0bEfQV3H5uZyUx99M9Sw=
+ZW50IFN1YmF1dGhvcml0eRcNNzAwMTAxMDAwMDAwWhcNMzQwMTI3MTg0MzMyWqAv
+MC0wHwYDVR0jBBgwFoAUSAcz1YAMGK39egQzhI+ostmIGJowCgYDVR0UBAMCAQAw
+DQYJKoZIhvcNAQELBQADggEBAHLGqmTHHnA6k+5pYVVR+5U+scfprGBNNvuUJlPI
+VkInA7n44gz9t3UhWCcIaZMZNHG6RRX1NHAGvjE6Y4MfwrqfCA5/EJdBMhescWnq
+K0Sy3SfAX9p6Wibs9rqx2gvJTfgi9Hh+/k+uhlURdCi6wy/BbAmjimC6s4wO3svU
+PKFmPqTN811OWYHBs9RqbOxDoTWRhTy6eeRKzKS9rqjLjwzUuCZbjSoUJjQrhNF+
+aq7szxTNyq0cfvSA4zLC6LeH+l8izwi89PWlmB/XQ9kp6/NlxPTZjpA6hyfu53uT
+OGtaSS5K+ugkIAhVVk6AQCcv0r9SMRnX8bUUc0zMoGKqUAo=
 -----END X509 CRL-----

--- a/spec/fixtures/ssl/intermediate-agent.pem
+++ b/spec/fixtures/ssl/intermediate-agent.pem
@@ -6,30 +6,30 @@ Certificate:
         Issuer: CN=Test CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Jun 24 21:18:00 2033 GMT
+            Not After : Jan 27 18:43:32 2034 GMT
         Subject: CN=Test CA Agent Subauthority
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                Public-Key: (2048 bit)
+                RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:ab:b8:fb:97:80:ff:7b:4a:ff:d9:6f:f6:8e:10:
-                    4c:d9:ea:0b:66:ed:3d:45:6f:06:cb:d8:ce:56:6c:
-                    3e:5a:c2:1b:fd:7a:ff:48:1c:0c:3e:a2:3a:f4:57:
-                    20:92:a5:35:98:4a:19:1b:8c:71:ce:0c:29:61:ca:
-                    58:9c:52:03:ef:73:3f:e4:66:8c:ac:00:d8:1e:4e:
-                    06:45:db:72:ac:59:63:05:30:6a:17:bd:f1:81:6c:
-                    e3:74:4d:90:a5:04:50:24:2a:c4:8e:9d:3f:45:c9:
-                    2e:47:03:f8:69:ad:49:b7:06:78:4a:dd:0d:e2:9b:
-                    f1:48:1b:81:4a:ef:5d:3e:28:44:49:4c:d8:53:25:
-                    f6:ca:1f:f6:76:86:97:b3:44:91:69:f2:c5:94:48:
-                    5d:3c:4a:21:e3:7e:a7:76:b6:14:bc:00:ac:58:92:
-                    b2:c6:83:cb:66:fd:8e:f8:89:23:c0:f2:5b:f9:74:
-                    6a:8d:0c:32:7e:dd:6e:75:38:c3:06:6c:ad:56:5d:
-                    3c:1f:40:80:c4:0b:2c:09:fc:c1:e2:d6:60:44:9f:
-                    8b:86:29:42:27:c0:67:d8:1e:2d:d8:8f:a8:55:94:
-                    7f:90:75:0c:27:52:ff:66:34:bd:74:49:54:f4:dd:
-                    32:b4:ce:b7:67:61:bb:45:8f:54:c0:27:ce:33:54:
-                    40:8f
+                    00:a5:a5:c5:33:81:1d:c3:9f:fc:10:26:db:e0:81:
+                    cd:2d:fe:0f:b0:74:16:51:2a:39:c1:3b:10:ca:27:
+                    ef:c6:ea:e7:95:a3:05:bd:24:dc:cb:2a:46:2e:87:
+                    cb:dc:b1:dc:d4:52:fd:86:a2:ec:f2:03:2b:97:aa:
+                    a5:38:35:45:02:5d:17:f1:0e:e8:45:57:d9:99:9e:
+                    d6:74:32:ce:f4:87:87:f7:d6:22:12:cd:a7:40:56:
+                    00:a5:d7:d2:8e:be:91:69:c2:6c:89:02:f7:b5:ef:
+                    56:66:49:32:fc:f8:a0:f1:f2:d0:56:1b:cc:bc:5c:
+                    33:4b:fd:c9:9e:0f:55:bd:4f:ef:46:57:26:72:61:
+                    94:ae:a7:85:5b:91:53:d2:1c:ba:b8:19:44:ee:b5:
+                    ca:34:dd:95:6b:8b:de:61:75:3d:6e:c9:79:f0:38:
+                    00:08:56:6b:b4:b0:4e:34:c2:45:ca:6a:25:33:65:
+                    0a:1f:95:2b:5b:71:a6:fe:af:ff:94:a5:14:6d:ca:
+                    1a:d3:6b:2d:44:e1:74:45:24:50:e1:cd:00:bb:0f:
+                    0d:fe:20:27:f8:14:c6:2b:ea:3a:b9:50:5c:a4:de:
+                    c3:90:ee:7b:b6:d3:82:d4:06:4f:af:d8:b0:d7:a7:
+                    d4:64:45:75:1f:ba:12:77:18:aa:de:6c:29:fe:e0:
+                    ea:bb
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Basic Constraints: critical
@@ -37,45 +37,45 @@ Certificate:
             X509v3 Key Usage: critical
                 Certificate Sign, CRL Sign
             X509v3 Subject Key Identifier: 
-                92:84:BC:BD:F2:05:CC:1C:E3:00:5A:75:B1:A4:67:A9:31:08:9A:F2
+                48:07:33:D5:80:0C:18:AD:FD:7A:04:33:84:8F:A8:B2:D9:88:18:9A
             Netscape Comment: 
                 Puppet Server Internal Certificate
             X509v3 Authority Key Identifier: 
-                83:68:26:16:4A:C3:88:0A:A6:48:43:98:E7:2D:4F:5F:70:8C:62:B2
+                keyid:58:D3:6E:35:36:97:04:91:6A:B6:DF:45:80:9A:53:B3:E4:36:C8:3D
+
     Signature Algorithm: sha256WithRSAEncryption
-    Signature Value:
-        89:7e:9c:5b:0f:48:35:ef:96:2c:4c:f9:c0:11:49:4c:5e:7a:
-        da:d3:e0:0a:11:f0:a3:55:1e:46:c1:d9:79:43:0c:00:2d:1f:
-        20:21:2a:0c:3b:a6:17:7b:6c:f2:74:8e:90:93:64:f9:0c:33:
-        0b:23:7d:a2:0c:0e:fd:82:ed:22:9b:d0:5f:bc:10:49:9d:ab:
-        2b:50:65:11:81:ee:3f:dc:48:49:2c:cf:41:e6:af:4f:34:8b:
-        da:47:b8:65:55:4f:85:bc:25:0e:e7:f5:ec:07:46:1c:19:03:
-        e2:6a:8a:95:7d:99:26:f1:66:46:35:7d:96:93:4d:e3:8f:1a:
-        c2:71:fe:3c:a9:45:c0:18:d8:43:d3:6c:68:56:b9:e4:04:15:
-        52:ea:4e:b3:d3:78:e9:87:51:18:f8:bd:b1:87:3a:59:ac:e4:
-        e1:ed:55:eb:de:27:85:a8:38:bc:ba:96:57:c3:9c:ec:64:65:
-        23:19:ec:f6:a6:c1:ce:83:08:13:a4:c5:fe:d0:e5:67:e3:70:
-        8b:96:84:b6:d4:4e:c4:43:60:d8:70:54:93:cd:24:44:ea:d5:
-        e9:f6:35:ee:a4:66:b4:2a:e0:5a:c1:7e:ad:e8:63:44:19:3e:
-        9d:49:61:50:91:d9:15:31:61:9c:59:68:d6:d3:5d:82:58:8c:
-        60:03:82:4e
+         b3:91:b4:7f:0b:b9:c3:7a:60:cf:e9:94:55:f1:12:7d:fb:f5:
+         1f:4b:0a:39:2d:70:9a:8d:ad:fa:98:b6:db:6a:80:a5:1b:23:
+         6f:7e:85:c1:62:11:44:8d:8a:bb:76:35:58:19:a2:e5:e2:43:
+         e7:17:75:b8:b7:74:fd:a2:b4:70:d8:76:b6:f0:e0:be:83:65:
+         85:ce:e9:92:5a:23:aa:f5:f5:ef:6b:d9:c3:ec:94:7d:ca:de:
+         18:75:91:23:90:14:c4:a7:0f:e6:e0:a7:b1:2c:af:9b:71:7f:
+         9e:f6:91:78:db:25:77:16:42:92:cc:d8:a8:b0:5e:d2:98:69:
+         56:0e:b8:6a:ef:c9:b8:e5:37:2c:12:47:a8:53:31:3e:0e:1a:
+         48:85:9e:46:39:e3:60:40:5e:db:28:21:fa:8a:af:83:d7:c6:
+         62:b6:16:36:2e:3d:58:0e:96:21:88:d1:1a:e7:d6:74:4c:ee:
+         c0:02:e0:51:c1:c6:1f:bd:c8:83:38:eb:86:e1:45:a4:f6:a0:
+         9e:bd:62:e5:75:c2:e4:9c:3a:b7:cb:28:03:5c:7c:ff:28:3f:
+         80:22:4b:ae:6c:8c:9c:9f:71:8b:0c:93:42:85:50:20:7d:ca:
+         a3:84:4f:e2:a0:ce:48:69:fd:8f:ef:3c:0c:55:a8:f0:5c:9f:
+         e8:37:48:65
 -----BEGIN CERTIFICATE-----
 MIIDSjCCAjKgAwIBAgIBCjANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
-IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMzMDYyNDIxMTgwMFowJTEjMCEGA1UEAwwa
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTM0MDEyNzE4NDMzMlowJTEjMCEGA1UEAwwa
 VGVzdCBDQSBBZ2VudCBTdWJhdXRob3JpdHkwggEiMA0GCSqGSIb3DQEBAQUAA4IB
-DwAwggEKAoIBAQCruPuXgP97Sv/Zb/aOEEzZ6gtm7T1FbwbL2M5WbD5awhv9ev9I
-HAw+ojr0VyCSpTWYShkbjHHODClhylicUgPvcz/kZoysANgeTgZF23KsWWMFMGoX
-vfGBbON0TZClBFAkKsSOnT9FyS5HA/hprUm3BnhK3Q3im/FIG4FK710+KERJTNhT
-JfbKH/Z2hpezRJFp8sWUSF08SiHjfqd2thS8AKxYkrLGg8tm/Y74iSPA8lv5dGqN
-DDJ+3W51OMMGbK1WXTwfQIDECywJ/MHi1mBEn4uGKUInwGfYHi3Yj6hVlH+QdQwn
-Uv9mNL10SVT03TK0zrdnYbtFj1TAJ84zVECPAgMBAAGjgZcwgZQwDwYDVR0TAQH/
-BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFJKEvL3yBcwc4wBadbGk
-Z6kxCJryMDEGCWCGSAGG+EIBDQQkFiJQdXBwZXQgU2VydmVyIEludGVybmFsIENl
-cnRpZmljYXRlMB8GA1UdIwQYMBaAFINoJhZKw4gKpkhDmOctT19wjGKyMA0GCSqG
-SIb3DQEBCwUAA4IBAQCJfpxbD0g175YsTPnAEUlMXnra0+AKEfCjVR5Gwdl5QwwA
-LR8gISoMO6YXe2zydI6Qk2T5DDMLI32iDA79gu0im9BfvBBJnasrUGURge4/3EhJ
-LM9B5q9PNIvaR7hlVU+FvCUO5/XsB0YcGQPiaoqVfZkm8WZGNX2Wk03jjxrCcf48
-qUXAGNhD02xoVrnkBBVS6k6z03jph1EY+L2xhzpZrOTh7VXr3ieFqDi8upZXw5zs
-ZGUjGez2psHOgwgTpMX+0OVn43CLloS21E7EQ2DYcFSTzSRE6tXp9jXupGa0KuBa
-wX6t6GNEGT6dSWFQkdkVMWGcWWjW012CWIxgA4JO
+DwAwggEKAoIBAQClpcUzgR3Dn/wQJtvggc0t/g+wdBZRKjnBOxDKJ+/G6ueVowW9
+JNzLKkYuh8vcsdzUUv2GouzyAyuXqqU4NUUCXRfxDuhFV9mZntZ0Ms70h4f31iIS
+zadAVgCl19KOvpFpwmyJAve171ZmSTL8+KDx8tBWG8y8XDNL/cmeD1W9T+9GVyZy
+YZSup4VbkVPSHLq4GUTutco03ZVri95hdT1uyXnwOAAIVmu0sE40wkXKaiUzZQof
+lStbcab+r/+UpRRtyhrTay1E4XRFJFDhzQC7Dw3+ICf4FMYr6jq5UFyk3sOQ7nu2
+04LUBk+v2LDXp9RkRXUfuhJ3GKrebCn+4Oq7AgMBAAGjgZcwgZQwDwYDVR0TAQH/
+BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFEgHM9WADBit/XoEM4SP
+qLLZiBiaMDEGCWCGSAGG+EIBDQQkFiJQdXBwZXQgU2VydmVyIEludGVybmFsIENl
+cnRpZmljYXRlMB8GA1UdIwQYMBaAFFjTbjU2lwSRarbfRYCaU7PkNsg9MA0GCSqG
+SIb3DQEBCwUAA4IBAQCzkbR/C7nDemDP6ZRV8RJ9+/UfSwo5LXCaja36mLbbaoCl
+GyNvfoXBYhFEjYq7djVYGaLl4kPnF3W4t3T9orRw2Ha28OC+g2WFzumSWiOq9fXv
+a9nD7JR9yt4YdZEjkBTEpw/m4KexLK+bcX+e9pF42yV3FkKSzNiosF7SmGlWDrhq
+78m45TcsEkeoUzE+DhpIhZ5GOeNgQF7bKCH6iq+D18ZithY2Lj1YDpYhiNEa59Z0
+TO7AAuBRwcYfvciDOOuG4UWk9qCevWLldcLknDq3yygDXHz/KD+AIkuubIycn3GL
+DJNChVAgfcqjhE/ioM5Iaf2P7zwMVajwXJ/oN0hl
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/intermediate-crl.pem
+++ b/spec/fixtures/ssl/intermediate-crl.pem
@@ -3,44 +3,44 @@ Certificate Revocation List (CRL):
         Signature Algorithm: sha256WithRSAEncryption
         Issuer: CN=Test CA Subauthority
         Last Update: Jan  1 00:00:00 1970 GMT
-        Next Update: Jun 24 21:18:00 2033 GMT
+        Next Update: Jan 27 18:43:32 2034 GMT
         CRL extensions:
             X509v3 Authority Key Identifier: 
-                38:7E:66:C4:7A:8B:16:EC:8A:0C:76:FC:C4:A6:7F:79:E5:DD:9A:FB
+                keyid:EB:EA:7B:15:C9:4E:08:5B:87:27:09:E4:42:10:54:47:72:E9:38:29
+
             X509v3 CRL Number: 
                 0
 Revoked Certificates:
     Serial Number: 08
-        Revocation Date: Jun 27 21:18:00 2023 GMT
+        Revocation Date: Jan 30 18:43:32 2024 GMT
         CRL entry extensions:
             X509v3 CRL Reason Code: 
                 Key Compromise
     Signature Algorithm: sha256WithRSAEncryption
-    Signature Value:
-        ab:a0:b0:99:81:11:c8:ed:1e:3d:af:3f:9e:96:c3:b8:e0:13:
-        15:0a:e4:23:15:e7:12:16:b9:4b:3e:37:e4:ba:80:c7:c5:b1:
-        e8:7d:1a:18:1c:5d:ef:10:00:5a:6a:e9:4e:99:6b:3a:fc:9c:
-        fc:55:70:eb:0d:64:60:38:ea:a7:81:9e:9a:46:2a:14:21:f7:
-        24:8a:db:49:77:47:9e:4e:ee:95:fc:3e:a1:04:cd:6e:db:80:
-        e2:cf:a2:bd:c1:6c:94:e2:43:3d:14:42:bf:a7:f3:b0:d9:9d:
-        a6:1d:d4:aa:b0:6c:87:d2:46:5e:b0:d5:26:ba:39:68:c3:34:
-        04:1f:c1:63:ac:1d:53:b4:47:ec:e5:e5:24:8f:ef:2d:75:c6:
-        a0:94:ef:5c:9c:d8:7e:52:7b:9e:5c:43:2d:7b:dc:94:40:6b:
-        99:65:ea:29:15:7c:25:7b:bd:6e:cd:b7:e2:3f:c7:fc:67:d0:
-        6e:b7:33:3b:57:64:29:f3:e1:88:b7:72:4e:4e:68:dd:7f:4a:
-        2b:3b:ae:30:45:a4:1f:a2:e5:43:af:b5:56:1f:63:da:42:20:
-        aa:20:82:0e:c3:68:06:c4:5f:33:bb:4b:a2:9c:a4:ea:44:b6:
-        3e:d5:df:c2:08:b4:6b:cf:6e:fb:a8:cf:80:0f:34:f2:d8:75:
-        1e:9e:28:1a
+         45:02:fb:e5:98:d2:db:b9:1d:00:55:6f:ca:2a:16:8f:62:5a:
+         2b:1f:34:75:1a:7e:84:70:35:92:e9:b9:76:79:88:dc:1c:77:
+         c3:2e:3d:e1:05:db:5f:23:ba:09:14:c8:39:4e:58:6d:19:2c:
+         c6:16:04:77:ae:5d:a6:09:1f:b2:c5:f5:76:f6:39:4f:7a:b7:
+         58:df:4b:ea:6f:6e:bb:54:88:dc:eb:f9:b9:f3:35:50:ed:66:
+         1a:53:58:3d:71:16:32:ab:1e:5f:85:90:96:70:72:10:77:90:
+         70:b5:5f:15:3e:ef:93:d4:c3:bb:92:cc:45:42:9e:d6:23:c4:
+         d2:20:75:08:d8:f4:09:82:56:85:92:83:32:87:0e:5e:85:e8:
+         2d:fd:8d:b8:57:9c:b8:3e:e3:83:4e:f0:65:87:ed:db:df:f8:
+         7a:ab:92:c7:dd:c4:88:b0:84:4a:dd:1b:14:97:7a:73:51:2b:
+         39:61:8a:0d:6d:9b:b4:4e:4e:9e:05:f2:4b:a0:b0:be:29:60:
+         12:99:d3:3b:d7:b6:5a:f7:fb:3d:79:01:c0:09:ea:79:32:38:
+         fa:4c:12:74:c8:73:39:62:b5:81:83:0e:0a:7c:d1:65:1f:b4:
+         ed:14:44:1c:95:5b:42:41:8b:49:f4:d4:0c:5c:82:7c:6d:29:
+         4a:c9:1d:a0
 -----BEGIN X509 CRL-----
 MIIBvTCBpgIBATANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0IENBIFN1
-YmF1dGhvcml0eRcNNzAwMTAxMDAwMDAwWhcNMzMwNjI0MjExODAwWjAiMCACAQgX
-DTIzMDYyNzIxMTgwMFowDDAKBgNVHRUEAwoBAaAvMC0wHwYDVR0jBBgwFoAUOH5m
-xHqLFuyKDHb8xKZ/eeXdmvswCgYDVR0UBAMCAQAwDQYJKoZIhvcNAQELBQADggEB
-AKugsJmBEcjtHj2vP56Ww7jgExUK5CMV5xIWuUs+N+S6gMfFseh9GhgcXe8QAFpq
-6U6Zazr8nPxVcOsNZGA46qeBnppGKhQh9ySK20l3R55O7pX8PqEEzW7bgOLPor3B
-bJTiQz0UQr+n87DZnaYd1KqwbIfSRl6w1Sa6OWjDNAQfwWOsHVO0R+zl5SSP7y11
-xqCU71yc2H5Se55cQy173JRAa5ll6ikVfCV7vW7Nt+I/x/xn0G63MztXZCnz4Yi3
-ck5OaN1/Sis7rjBFpB+i5UOvtVYfY9pCIKoggg7DaAbEXzO7S6KcpOpEtj7V38II
-tGvPbvuoz4APNPLYdR6eKBo=
+YmF1dGhvcml0eRcNNzAwMTAxMDAwMDAwWhcNMzQwMTI3MTg0MzMyWjAiMCACAQgX
+DTI0MDEzMDE4NDMzMlowDDAKBgNVHRUEAwoBAaAvMC0wHwYDVR0jBBgwFoAU6+p7
+FclOCFuHJwnkQhBUR3LpOCkwCgYDVR0UBAMCAQAwDQYJKoZIhvcNAQELBQADggEB
+AEUC++WY0tu5HQBVb8oqFo9iWisfNHUafoRwNZLpuXZ5iNwcd8MuPeEF218jugkU
+yDlOWG0ZLMYWBHeuXaYJH7LF9Xb2OU96t1jfS+pvbrtUiNzr+bnzNVDtZhpTWD1x
+FjKrHl+FkJZwchB3kHC1XxU+75PUw7uSzEVCntYjxNIgdQjY9AmCVoWSgzKHDl6F
+6C39jbhXnLg+44NO8GWH7dvf+HqrksfdxIiwhErdGxSXenNRKzlhig1tm7ROTp4F
+8kugsL4pYBKZ0zvXtlr3+z15AcAJ6nkyOPpMEnTIczlitYGDDgp80WUftO0URByV
+W0JBi0n01AxcgnxtKUrJHaA=
 -----END X509 CRL-----

--- a/spec/fixtures/ssl/intermediate-key.pem
+++ b/spec/fixtures/ssl/intermediate-key.pem
@@ -1,0 +1,117 @@
+RSA Private-Key: (2048 bit, 2 primes)
+modulus:
+    00:a4:f1:74:f2:db:24:84:39:da:26:5c:72:c8:2e:
+    a6:3e:57:88:90:ab:41:04:7a:7a:f3:af:f7:43:b7:
+    9b:d8:57:91:7e:15:d5:aa:cb:8d:d4:a5:de:54:4a:
+    22:bb:e3:6f:1a:03:7f:27:42:8a:db:45:ee:79:0e:
+    dd:c0:08:fc:f3:48:9e:ea:99:f9:08:cd:38:86:2d:
+    ca:2c:9b:d0:02:f2:81:29:72:a1:aa:a3:ea:fc:5f:
+    4a:a1:15:68:55:a9:ed:7d:3a:23:84:0c:0a:d8:10:
+    c7:0b:8c:b3:93:9a:61:55:10:73:34:14:21:de:28:
+    65:bf:6a:d3:dd:e8:3d:9e:69:78:1e:72:89:fd:73:
+    7e:75:e7:9b:4c:f2:65:3c:d5:ed:d4:d1:53:96:52:
+    b0:29:c1:e4:9d:5f:d7:62:d0:84:7b:e8:db:85:93:
+    b9:8f:4a:01:c4:6e:6d:e2:a9:6d:ec:51:d7:51:48:
+    fe:f4:83:45:a1:c1:b7:00:68:9c:02:92:a6:20:d4:
+    40:a0:c8:ee:ab:96:40:53:10:f1:b5:2d:a8:f9:50:
+    fe:eb:96:9a:9c:c1:31:2c:1f:70:d5:a7:37:ff:35:
+    1a:ac:d7:fc:9d:4f:e1:67:20:e6:9d:4a:66:c8:ac:
+    e0:0a:f5:4f:d4:43:56:d6:e1:6d:04:f4:ea:02:d5:
+    af:a9
+publicExponent: 65537 (0x10001)
+privateExponent:
+    26:98:fa:2c:fa:6b:09:26:20:8e:69:83:d2:a4:57:
+    f2:ae:b9:1e:61:74:cd:7f:7b:d6:1a:8f:5a:21:55:
+    2e:c3:0f:20:da:2b:2d:d4:84:54:06:9c:88:4c:f0:
+    e3:d6:cc:e0:e1:80:97:c7:52:87:0d:4e:48:b5:d9:
+    de:5e:3c:13:12:23:5d:f2:b9:fb:fd:4a:04:dc:22:
+    3b:5e:1a:c7:15:c8:73:d2:87:52:4f:19:66:05:46:
+    89:7b:60:f6:ea:d4:d0:41:12:9e:8b:d2:dd:cc:cf:
+    47:3c:9d:a9:24:af:32:20:af:54:b8:81:54:63:4f:
+    ac:03:6b:a0:b9:ff:f1:59:8c:b6:62:7a:1b:70:fb:
+    2b:16:22:d9:ef:d8:c0:57:1e:96:f4:fa:54:45:70:
+    b6:4b:61:31:b4:4e:02:62:ba:b8:f3:3e:ee:ba:e0:
+    49:5b:8a:13:a4:09:ed:5f:62:91:18:35:59:1c:6b:
+    36:c5:fe:b9:4a:27:85:34:f2:9d:33:2b:00:57:aa:
+    b6:fb:27:aa:34:85:50:18:dd:c9:36:ff:37:dd:08:
+    72:b8:2f:7d:29:9c:63:d4:1e:02:b6:e2:fd:51:c9:
+    7f:0b:6a:8e:29:4e:b6:01:54:16:c8:25:e1:3f:1e:
+    a8:34:3e:78:0b:0b:93:09:f1:53:b1:4e:39:db:18:
+    01
+prime1:
+    00:d2:bf:f7:f0:c3:89:a2:57:50:46:40:38:c2:bb:
+    13:2b:c6:da:de:f8:28:eb:ce:aa:46:24:65:71:a3:
+    e4:8e:54:53:e1:34:fb:50:e9:ec:31:49:fb:a5:3b:
+    60:c7:e8:57:25:28:69:0d:e2:04:72:38:95:9a:4c:
+    a4:af:b6:61:b9:3e:6e:2b:0b:ed:cd:b9:48:db:d4:
+    06:17:a1:7c:4f:c6:66:ce:e0:da:1e:f3:b9:67:c8:
+    0c:2a:3d:29:37:32:55:d1:98:95:58:00:fe:6e:6f:
+    fb:3c:35:29:2c:22:0a:35:3d:fd:22:7f:30:75:7a:
+    f2:ff:f2:a8:f9:e9:1e:5e:e1
+prime2:
+    00:c8:5b:b0:24:02:d7:b8:a9:b8:59:fd:52:a1:08:
+    e8:4d:1a:96:f3:98:6c:b8:cf:12:6b:5f:e9:f9:ff:
+    cf:90:bc:1d:53:7c:e6:ae:48:c2:0c:0d:3e:13:47:
+    a5:53:e1:14:18:4c:19:b1:73:f5:fc:af:ef:56:44:
+    fc:03:7f:82:1d:91:8f:b2:c8:70:51:55:2f:e3:48:
+    b8:a0:15:bf:e5:b4:3e:fb:4c:07:18:9d:cb:66:58:
+    72:dc:73:04:c9:0b:05:e6:1c:53:0a:be:70:c0:07:
+    d6:d7:46:68:0f:e4:ea:83:af:24:22:71:a0:5f:da:
+    f8:a2:cb:79:b5:f4:f8:51:c9
+exponent1:
+    4d:27:bc:a4:e7:61:67:0e:a2:33:e5:e5:21:dd:8d:
+    4a:34:96:02:95:45:9d:f6:de:3d:a9:ab:7d:ec:2b:
+    8b:b3:f1:b5:7c:49:19:b9:5a:20:3d:5e:a4:82:55:
+    8f:3a:4f:55:2a:33:33:c2:f0:2f:c4:e9:78:40:e0:
+    f5:f7:46:55:a4:36:7f:09:f1:f8:a4:01:b9:81:28:
+    ed:d3:d0:08:00:b1:b8:c1:76:f9:67:ef:13:c0:98:
+    3b:8a:82:a1:53:8b:39:9d:ab:e7:39:0d:ec:ee:90:
+    42:dd:8f:82:39:c0:14:f7:e9:c9:8c:58:f8:59:97:
+    c6:fe:56:c0:8f:88:ef:e1
+exponent2:
+    00:b8:09:f8:9e:eb:79:89:e7:64:2e:4d:12:24:57:
+    91:42:99:e5:04:b7:03:4f:32:ee:41:71:25:f3:fc:
+    f5:85:86:36:0d:e5:51:e3:cf:73:67:2c:96:d3:90:
+    e1:1d:4e:47:6e:16:21:17:ae:63:cb:0b:34:76:73:
+    01:66:99:2e:44:c8:db:4d:26:ee:7c:d7:1a:18:d5:
+    48:b9:cb:a0:ac:77:c7:ce:7f:44:99:69:00:57:ef:
+    70:fa:6c:30:7e:17:41:00:e1:0d:aa:75:ca:0d:aa:
+    65:be:f2:ae:4d:c3:41:63:5a:72:7f:ad:0d:da:5e:
+    c2:3a:8f:5b:2a:37:6e:0d:79
+coefficient:
+    4d:10:99:0a:78:4e:61:57:ee:44:a2:2c:b2:25:d2:
+    7a:8c:3d:a8:06:e2:a2:4b:ce:d5:bf:0b:6c:1f:1e:
+    60:c0:49:5f:a8:c5:93:80:0a:0f:b3:fe:58:38:2b:
+    4e:a6:3e:47:42:8b:9b:e7:e1:f5:b9:69:37:df:07:
+    70:b1:ec:0a:57:d2:f5:5d:b0:8e:3b:84:db:25:6c:
+    1c:32:73:d4:84:df:d8:73:30:33:79:1f:61:b3:6d:
+    eb:8c:80:cb:37:48:a0:54:45:f9:54:64:04:04:73:
+    42:6e:e1:18:c7:c9:41:6a:d1:34:c2:0e:14:ae:a7:
+    36:9b:05:9e:20:0e:a0:3f
+-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEApPF08tskhDnaJlxyyC6mPleIkKtBBHp686/3Q7eb2FeRfhXV
+qsuN1KXeVEoiu+NvGgN/J0KK20XueQ7dwAj880ie6pn5CM04hi3KLJvQAvKBKXKh
+qqPq/F9KoRVoVantfTojhAwK2BDHC4yzk5phVRBzNBQh3ihlv2rT3eg9nml4HnKJ
+/XN+deebTPJlPNXt1NFTllKwKcHknV/XYtCEe+jbhZO5j0oBxG5t4qlt7FHXUUj+
+9INFocG3AGicApKmINRAoMjuq5ZAUxDxtS2o+VD+65aanMExLB9w1ac3/zUarNf8
+nU/hZyDmnUpmyKzgCvVP1ENW1uFtBPTqAtWvqQIDAQABAoIBACaY+iz6awkmII5p
+g9KkV/KuuR5hdM1/e9Yaj1ohVS7DDyDaKy3UhFQGnIhM8OPWzODhgJfHUocNTki1
+2d5ePBMSI13yufv9SgTcIjteGscVyHPSh1JPGWYFRol7YPbq1NBBEp6L0t3Mz0c8
+nakkrzIgr1S4gVRjT6wDa6C5//FZjLZiehtw+ysWItnv2MBXHpb0+lRFcLZLYTG0
+TgJiurjzPu664ElbihOkCe1fYpEYNVkcazbF/rlKJ4U08p0zKwBXqrb7J6o0hVAY
+3ck2/zfdCHK4L30pnGPUHgK24v1RyX8Lao4pTrYBVBbIJeE/Hqg0PngLC5MJ8VOx
+TjnbGAECgYEA0r/38MOJoldQRkA4wrsTK8ba3vgo686qRiRlcaPkjlRT4TT7UOns
+MUn7pTtgx+hXJShpDeIEcjiVmkykr7ZhuT5uKwvtzblI29QGF6F8T8ZmzuDaHvO5
+Z8gMKj0pNzJV0ZiVWAD+bm/7PDUpLCIKNT39In8wdXry//Ko+ekeXuECgYEAyFuw
+JALXuKm4Wf1SoQjoTRqW85hsuM8Sa1/p+f/PkLwdU3zmrkjCDA0+E0elU+EUGEwZ
+sXP1/K/vVkT8A3+CHZGPsshwUVUv40i4oBW/5bQ++0wHGJ3LZlhy3HMEyQsF5hxT
+Cr5wwAfW10ZoD+Tqg68kInGgX9r4ost5tfT4UckCgYBNJ7yk52FnDqIz5eUh3Y1K
+NJYClUWd9t49qat97CuLs/G1fEkZuVogPV6kglWPOk9VKjMzwvAvxOl4QOD190ZV
+pDZ/CfH4pAG5gSjt09AIALG4wXb5Z+8TwJg7ioKhU4s5navnOQ3s7pBC3Y+COcAU
+9+nJjFj4WZfG/lbAj4jv4QKBgQC4Cfie63mJ52QuTRIkV5FCmeUEtwNPMu5BcSXz
+/PWFhjYN5VHjz3NnLJbTkOEdTkduFiEXrmPLCzR2cwFmmS5EyNtNJu581xoY1Ui5
+y6Csd8fOf0SZaQBX73D6bDB+F0EA4Q2qdcoNqmW+8q5Nw0FjWnJ/rQ3aXsI6j1sq
+N24NeQKBgE0QmQp4TmFX7kSiLLIl0nqMPagG4qJLztW/C2wfHmDASV+oxZOACg+z
+/lg4K06mPkdCi5vn4fW5aTffB3Cx7ApX0vVdsI47hNslbBwyc9SE39hzMDN5H2Gz
+beuMgMs3SKBURflUZAQEc0Ju4RjHyUFq0TTCDhSupzabBZ4gDqA/
+-----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/intermediate.pem
+++ b/spec/fixtures/ssl/intermediate.pem
@@ -6,30 +6,30 @@ Certificate:
         Issuer: CN=Test CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Jun 24 21:18:00 2033 GMT
+            Not After : Jan 27 18:43:32 2034 GMT
         Subject: CN=Test CA Subauthority
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                Public-Key: (2048 bit)
+                RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:c0:91:fc:98:ec:30:6b:f0:5c:d6:0b:ed:79:ab:
-                    69:80:c1:ca:5b:d5:4a:a3:e3:1b:3e:25:f1:47:0b:
-                    7b:9f:dc:1b:0a:8b:d6:0a:c1:e8:8b:ca:38:68:be:
-                    91:58:d7:ff:41:a1:00:48:59:a0:62:2e:1d:e7:2d:
-                    7a:c5:64:4d:be:48:30:eb:4f:e3:9e:3f:06:a4:ef:
-                    e4:95:5c:86:ff:54:24:49:75:16:84:41:78:c5:8d:
-                    ac:ff:af:95:91:ae:e1:f3:92:f0:a1:dd:18:e9:7c:
-                    8e:d0:86:e9:84:84:f3:cb:4c:9c:12:f6:a7:54:f0:
-                    9c:87:3b:f1:50:67:cf:12:04:11:c0:1b:e0:46:e4:
-                    03:73:9c:3c:ea:ed:3e:31:2f:bc:cf:bd:38:fb:1d:
-                    fa:f5:8d:66:e7:f2:0b:5f:df:0f:99:ec:45:c9:aa:
-                    e4:10:ad:5b:64:a5:da:af:27:e1:47:ac:4f:aa:aa:
-                    74:a5:0e:9c:14:c4:89:ef:ce:fb:50:38:b9:f9:09:
-                    d6:f9:ba:5b:49:1c:8c:70:9c:0d:4e:3c:94:6d:9e:
-                    63:24:c3:e8:49:74:7a:79:02:0d:b4:6f:f3:b9:e0:
-                    c0:4c:74:24:21:56:b5:57:e6:c9:29:08:1b:63:6d:
-                    2d:9c:e2:68:33:c1:cf:60:07:54:88:d4:da:6c:15:
-                    48:1b
+                    00:a4:f1:74:f2:db:24:84:39:da:26:5c:72:c8:2e:
+                    a6:3e:57:88:90:ab:41:04:7a:7a:f3:af:f7:43:b7:
+                    9b:d8:57:91:7e:15:d5:aa:cb:8d:d4:a5:de:54:4a:
+                    22:bb:e3:6f:1a:03:7f:27:42:8a:db:45:ee:79:0e:
+                    dd:c0:08:fc:f3:48:9e:ea:99:f9:08:cd:38:86:2d:
+                    ca:2c:9b:d0:02:f2:81:29:72:a1:aa:a3:ea:fc:5f:
+                    4a:a1:15:68:55:a9:ed:7d:3a:23:84:0c:0a:d8:10:
+                    c7:0b:8c:b3:93:9a:61:55:10:73:34:14:21:de:28:
+                    65:bf:6a:d3:dd:e8:3d:9e:69:78:1e:72:89:fd:73:
+                    7e:75:e7:9b:4c:f2:65:3c:d5:ed:d4:d1:53:96:52:
+                    b0:29:c1:e4:9d:5f:d7:62:d0:84:7b:e8:db:85:93:
+                    b9:8f:4a:01:c4:6e:6d:e2:a9:6d:ec:51:d7:51:48:
+                    fe:f4:83:45:a1:c1:b7:00:68:9c:02:92:a6:20:d4:
+                    40:a0:c8:ee:ab:96:40:53:10:f1:b5:2d:a8:f9:50:
+                    fe:eb:96:9a:9c:c1:31:2c:1f:70:d5:a7:37:ff:35:
+                    1a:ac:d7:fc:9d:4f:e1:67:20:e6:9d:4a:66:c8:ac:
+                    e0:0a:f5:4f:d4:43:56:d6:e1:6d:04:f4:ea:02:d5:
+                    af:a9
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Basic Constraints: critical
@@ -37,45 +37,45 @@ Certificate:
             X509v3 Key Usage: critical
                 Certificate Sign, CRL Sign
             X509v3 Subject Key Identifier: 
-                38:7E:66:C4:7A:8B:16:EC:8A:0C:76:FC:C4:A6:7F:79:E5:DD:9A:FB
+                EB:EA:7B:15:C9:4E:08:5B:87:27:09:E4:42:10:54:47:72:E9:38:29
             Netscape Comment: 
                 Puppet Server Internal Certificate
             X509v3 Authority Key Identifier: 
-                83:68:26:16:4A:C3:88:0A:A6:48:43:98:E7:2D:4F:5F:70:8C:62:B2
+                keyid:58:D3:6E:35:36:97:04:91:6A:B6:DF:45:80:9A:53:B3:E4:36:C8:3D
+
     Signature Algorithm: sha256WithRSAEncryption
-    Signature Value:
-        df:f7:e8:04:78:9d:61:be:69:3d:07:19:7f:d0:dd:53:b9:8a:
-        84:64:af:d2:17:07:77:83:9b:a4:cf:de:c1:a0:b6:88:1d:d7:
-        94:01:b7:7b:15:36:56:03:5d:70:97:cf:50:87:60:83:40:73:
-        a6:16:47:71:cd:74:32:3c:1f:36:be:cd:11:a7:2c:34:a4:3f:
-        1e:d8:e2:79:9f:7a:2e:20:41:ef:cf:7f:45:6a:3b:5c:fa:ff:
-        cb:f6:c2:0e:7d:ad:55:51:b8:23:bf:c1:77:74:7a:58:e3:a6:
-        db:2f:3b:09:16:26:98:0f:02:04:dd:aa:cd:b1:bc:16:ab:02:
-        50:97:68:4c:93:4c:1a:11:9e:b1:7e:88:b3:ce:cf:31:10:a7:
-        ba:3a:13:c0:5f:cf:74:4e:9f:a6:fc:90:26:3a:b1:cb:cb:45:
-        28:63:e6:2d:e1:cb:e3:93:1b:07:76:f2:6b:f6:00:87:94:1d:
-        91:5c:2e:84:e4:03:9c:32:23:fc:14:30:57:e5:e5:9c:b5:e8:
-        c3:0b:d2:82:a2:9b:1b:e7:66:68:78:92:3f:cd:0a:0c:ae:90:
-        66:50:d8:67:64:9a:48:3d:8f:a2:03:b1:7f:31:f2:b6:e5:46:
-        ac:16:53:c5:9f:2f:bd:44:85:e0:93:b7:3b:dc:b4:c6:b6:af:
-        a2:c3:ea:95
+         b1:df:5a:e5:7f:c9:d7:55:9f:a5:45:88:46:22:50:89:d2:0d:
+         b4:fb:ee:5c:93:d5:f4:3e:c4:da:af:63:c5:0f:1a:43:b6:7c:
+         6d:17:5e:ba:99:6b:ce:fe:e8:67:60:55:d4:fd:55:05:6c:fc:
+         d3:1f:9c:9f:45:e3:f6:43:52:0b:11:b0:fa:d7:58:a7:79:15:
+         a0:79:7b:e7:2b:59:49:5a:7f:84:73:34:98:d6:88:5a:e0:f3:
+         99:38:69:9b:eb:ea:4f:9e:43:91:c9:d9:c6:87:7f:a9:3e:96:
+         04:dd:75:04:30:ed:09:7e:da:bf:e9:a9:98:bf:a5:d1:71:c3:
+         de:cd:03:4f:0d:7d:18:ee:49:0f:d7:7b:b6:4d:da:3c:9e:e1:
+         d3:7b:d5:26:f7:b3:dc:af:c6:2c:5a:9f:f3:9f:ca:ef:23:7a:
+         ab:82:c3:b4:1a:2b:75:6a:9c:9f:5c:85:f8:18:a4:e0:b7:7d:
+         fd:12:a8:48:e6:b4:a9:5e:e9:12:06:56:47:24:7b:8a:30:62:
+         96:6d:27:f6:f3:0b:6c:1e:da:85:49:a3:2c:5b:45:8b:fe:17:
+         3b:bc:eb:54:57:23:15:b7:14:40:a0:72:4a:7f:f2:4c:f4:46:
+         96:93:d5:42:c5:e4:66:d8:99:9e:84:5a:03:ff:cd:6a:88:4a:
+         c8:40:b2:35
 -----BEGIN CERTIFICATE-----
 MIIDRDCCAiygAwIBAgIBAzANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdUZXN0
-IENBMB4XDTcwMDEwMTAwMDAwMFoXDTMzMDYyNDIxMTgwMFowHzEdMBsGA1UEAwwU
+IENBMB4XDTcwMDEwMTAwMDAwMFoXDTM0MDEyNzE4NDMzMlowHzEdMBsGA1UEAwwU
 VGVzdCBDQSBTdWJhdXRob3JpdHkwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
-AoIBAQDAkfyY7DBr8FzWC+15q2mAwcpb1Uqj4xs+JfFHC3uf3BsKi9YKweiLyjho
-vpFY1/9BoQBIWaBiLh3nLXrFZE2+SDDrT+OePwak7+SVXIb/VCRJdRaEQXjFjaz/
-r5WRruHzkvCh3RjpfI7QhumEhPPLTJwS9qdU8JyHO/FQZ88SBBHAG+BG5ANznDzq
-7T4xL7zPvTj7Hfr1jWbn8gtf3w+Z7EXJquQQrVtkpdqvJ+FHrE+qqnSlDpwUxInv
-zvtQOLn5Cdb5ultJHIxwnA1OPJRtnmMkw+hJdHp5Ag20b/O54MBMdCQhVrVX5skp
-CBtjbS2c4mgzwc9gB1SI1NpsFUgbAgMBAAGjgZcwgZQwDwYDVR0TAQH/BAUwAwEB
-/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFDh+ZsR6ixbsigx2/MSmf3nl3Zr7
+AoIBAQCk8XTy2ySEOdomXHLILqY+V4iQq0EEenrzr/dDt5vYV5F+FdWqy43Upd5U
+SiK7428aA38nQorbRe55Dt3ACPzzSJ7qmfkIzTiGLcosm9AC8oEpcqGqo+r8X0qh
+FWhVqe19OiOEDArYEMcLjLOTmmFVEHM0FCHeKGW/atPd6D2eaXgecon9c35155tM
+8mU81e3U0VOWUrApweSdX9di0IR76NuFk7mPSgHEbm3iqW3sUddRSP70g0WhwbcA
+aJwCkqYg1ECgyO6rlkBTEPG1Laj5UP7rlpqcwTEsH3DVpzf/NRqs1/ydT+FnIOad
+SmbIrOAK9U/UQ1bW4W0E9OoC1a+pAgMBAAGjgZcwgZQwDwYDVR0TAQH/BAUwAwEB
+/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFOvqexXJTghbhycJ5EIQVEdy6Tgp
 MDEGCWCGSAGG+EIBDQQkFiJQdXBwZXQgU2VydmVyIEludGVybmFsIENlcnRpZmlj
-YXRlMB8GA1UdIwQYMBaAFINoJhZKw4gKpkhDmOctT19wjGKyMA0GCSqGSIb3DQEB
-CwUAA4IBAQDf9+gEeJ1hvmk9Bxl/0N1TuYqEZK/SFwd3g5ukz97BoLaIHdeUAbd7
-FTZWA11wl89Qh2CDQHOmFkdxzXQyPB82vs0Rpyw0pD8e2OJ5n3ouIEHvz39Fajtc
-+v/L9sIOfa1VUbgjv8F3dHpY46bbLzsJFiaYDwIE3arNsbwWqwJQl2hMk0waEZ6x
-foizzs8xEKe6OhPAX890Tp+m/JAmOrHLy0UoY+Yt4cvjkxsHdvJr9gCHlB2RXC6E
-5AOcMiP8FDBX5eWctejDC9KCopsb52ZoeJI/zQoMrpBmUNhnZJpIPY+iA7F/MfK2
-5UasFlPFny+9RIXgk7c73LTGtq+iw+qV
+YXRlMB8GA1UdIwQYMBaAFFjTbjU2lwSRarbfRYCaU7PkNsg9MA0GCSqGSIb3DQEB
+CwUAA4IBAQCx31rlf8nXVZ+lRYhGIlCJ0g20++5ck9X0PsTar2PFDxpDtnxtF166
+mWvO/uhnYFXU/VUFbPzTH5yfReP2Q1ILEbD611ineRWgeXvnK1lJWn+EczSY1oha
+4POZOGmb6+pPnkORydnGh3+pPpYE3XUEMO0Jftq/6amYv6XRccPezQNPDX0Y7kkP
+13u2Tdo8nuHTe9Um97Pcr8YsWp/zn8rvI3qrgsO0Git1apyfXIX4GKTgt339EqhI
+5rSpXukSBlZHJHuKMGKWbSf28wtsHtqFSaMsW0WL/hc7vOtUVyMVtxRAoHJKf/JM
+9EaWk9VCxeRm2JmehFoD/81qiErIQLI1
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/oid-key.pem
+++ b/spec/fixtures/ssl/oid-key.pem
@@ -1,117 +1,117 @@
-Private-Key: (2048 bit, 2 primes)
+RSA Private-Key: (2048 bit, 2 primes)
 modulus:
-    00:e9:88:51:72:dc:84:5c:91:8c:bb:47:f5:d5:d5:
-    a0:d2:56:53:d7:5d:48:f1:bc:3a:fb:7f:68:37:31:
-    b5:2d:a7:3a:10:5b:fa:57:a4:b6:be:0b:73:ea:37:
-    95:66:6d:20:15:4e:cd:da:b7:d7:fe:55:b9:09:ed:
-    3e:c0:99:ad:85:1e:5c:b0:cd:91:76:2f:bb:a7:d0:
-    10:3e:58:81:29:80:c0:93:c9:e9:33:7c:05:08:f4:
-    b4:5f:fa:5b:e9:4b:4e:ff:61:25:00:00:c6:99:04:
-    45:81:c8:69:55:02:28:ff:07:c2:cc:1b:cb:c1:57:
-    17:31:15:2f:32:1f:0b:ac:76:7a:a5:0f:8e:c0:22:
-    ef:bb:b6:0b:3b:50:7b:b2:62:7b:86:83:19:43:74:
-    33:14:36:a1:95:38:85:80:72:4d:b8:65:b1:2c:29:
-    65:73:0f:9b:8f:f1:97:84:33:7d:ae:82:cd:0d:85:
-    b1:fe:09:8e:35:65:ae:02:83:2a:26:f3:63:68:73:
-    37:dd:b7:a1:3b:8e:18:ce:6a:2e:e4:fa:67:0c:2c:
-    b1:18:ae:bc:62:81:f2:0d:97:dc:c3:f1:eb:58:bf:
-    56:e8:7b:20:2d:91:1d:57:64:19:5b:93:4f:97:65:
-    bd:a4:6c:bd:eb:70:b6:1f:10:18:83:ee:61:d4:d5:
-    ba:59
+    00:d3:1e:8b:39:52:df:37:6e:2f:44:44:b9:55:2e:
+    1d:44:1f:dd:41:b3:ce:a4:fd:f3:5a:41:f6:9a:37:
+    05:a7:2c:34:ec:46:2f:89:9e:ff:9e:20:75:05:35:
+    68:68:45:d2:f5:15:0d:f7:9c:78:a7:69:a9:f6:3d:
+    4b:5d:ab:0d:a7:a7:75:a2:c8:d7:09:be:53:3c:8b:
+    75:95:0e:e3:f3:80:dc:26:6d:98:c5:48:fa:1b:68:
+    51:ec:47:44:72:5a:83:32:a9:65:8d:40:12:6d:46:
+    59:05:e7:cd:55:c1:67:7f:81:da:3d:43:04:d3:58:
+    09:c2:27:0a:52:84:01:a1:01:dd:ab:34:3b:a7:90:
+    a5:52:8d:d9:86:fc:d9:c1:9b:08:f0:67:c7:7e:a8:
+    61:de:fe:57:af:dc:58:8c:8e:eb:27:2a:b9:a2:34:
+    d4:31:33:87:c7:2e:69:e7:26:75:cd:bd:bb:61:00:
+    3b:d2:73:54:9f:b0:f6:78:5e:46:51:37:35:65:a1:
+    10:0e:97:7b:81:dc:9f:f2:1a:c7:9f:80:4d:e6:72:
+    e8:92:ee:3f:81:61:c5:a1:43:43:0b:1a:03:c4:0e:
+    bc:71:d0:30:8f:95:f7:9e:de:86:5e:4d:18:ab:5e:
+    8e:14:3e:f1:c5:98:78:11:65:4f:3c:7f:c3:d9:5e:
+    89:5b
 publicExponent: 65537 (0x10001)
 privateExponent:
-    01:53:0a:eb:34:d6:f1:fe:1d:51:de:94:45:54:83:
-    27:4e:38:06:d6:4f:98:97:5c:5a:45:71:b3:86:6e:
-    4e:f0:f8:d7:a8:e8:8a:e0:b3:41:f1:52:04:a2:5b:
-    65:8b:a4:37:f0:0c:ce:25:bc:18:2e:d2:45:7d:23:
-    f2:f7:01:7b:3f:73:2a:74:2f:fe:a9:ec:a2:d9:ff:
-    8d:95:a0:e8:8f:03:5d:e8:87:90:5e:d9:59:cb:51:
-    79:38:89:41:91:c7:6e:94:00:20:0c:e1:13:73:13:
-    c0:80:56:20:96:4a:37:3a:b5:b4:6f:4a:96:31:1b:
-    ea:3a:58:31:d7:92:90:60:24:dc:49:45:18:3f:bf:
-    89:d0:ea:89:a1:3b:06:c5:85:e3:b1:eb:ca:31:7a:
-    18:30:8e:ad:6a:5f:a0:d4:e3:41:65:51:4a:ac:86:
-    9d:f9:62:d4:76:31:0b:c0:9f:7e:b9:9e:26:e6:85:
-    10:81:3c:ad:72:af:7f:c4:58:90:65:d6:bb:a5:8f:
-    a4:fc:a0:ad:ab:51:5f:2b:0d:51:c5:cd:7a:22:2e:
-    2e:d9:66:9e:6c:47:d7:24:79:df:13:ae:c1:5d:3d:
-    b8:3a:52:88:32:2c:e8:71:4f:af:f8:d0:2c:5c:7b:
-    5a:2f:64:dc:b7:06:db:6d:c2:9c:2e:78:c2:c2:d0:
-    91
+    40:3c:c9:f5:fe:3e:47:1a:72:ad:5e:0f:da:58:36:
+    b5:74:d0:98:de:42:21:37:d8:24:fd:6f:30:8b:4f:
+    60:07:76:6e:f2:08:22:e2:cb:3a:6c:fb:ce:42:ea:
+    ea:d7:5c:12:10:7e:f8:79:96:c8:b1:c0:f2:58:c2:
+    26:d5:16:49:8e:0d:a0:23:66:32:e3:c3:65:e7:b5:
+    36:4e:9a:93:8c:00:f0:7c:66:80:98:ec:e9:0b:fb:
+    e9:5d:e1:f8:bd:8b:b0:0d:95:05:be:9a:1c:bf:cb:
+    f4:9d:0c:80:6c:61:b6:8d:67:3f:3e:b6:28:2c:60:
+    83:bf:e7:47:26:3d:6c:a4:9b:ac:89:50:42:c5:95:
+    53:b0:6f:ef:79:87:28:6c:12:c0:ea:1b:db:0a:5b:
+    1a:3e:24:e9:62:b3:c3:7b:9a:bd:3f:85:48:39:53:
+    c5:d1:21:33:55:39:85:70:21:30:52:5f:0d:69:d5:
+    9f:cf:9f:ca:f5:46:11:d4:84:92:62:d6:1d:8f:68:
+    3f:9a:27:d0:3d:82:c3:ff:06:84:6e:75:49:46:da:
+    60:61:eb:13:17:df:01:db:9a:a1:01:2b:82:2b:3d:
+    a5:bb:e9:01:8c:6f:0d:cc:82:67:71:e1:fe:4a:13:
+    6a:0e:f3:85:87:5a:05:e6:9d:0e:97:2d:7e:6d:7b:
+    89
 prime1:
-    00:fc:12:1d:13:e9:88:b0:51:1e:ae:c6:41:cf:27:
-    12:ce:27:f6:13:4b:5b:f9:79:28:24:d2:de:bd:f6:
-    b6:e1:90:a4:f1:ce:33:81:0a:bf:66:d7:d4:37:d5:
-    cf:24:60:f7:94:5f:4f:62:ac:ca:36:b1:4c:10:cf:
-    3d:8f:2a:a6:78:a5:57:11:dd:1b:c6:58:06:7f:2a:
-    4d:e5:94:64:da:4e:f9:38:d4:70:3b:32:e2:24:9d:
-    71:bc:fb:5e:52:84:0b:f1:8b:c9:9f:1e:46:9d:fe:
-    76:ba:2c:f6:c9:41:a6:05:96:af:cf:00:d8:8e:f7:
-    b9:0b:7b:c0:11:1c:b2:b5:75
+    00:fd:e9:b3:2e:6a:ce:87:8f:75:01:a1:a7:45:36:
+    42:83:99:f3:27:e5:86:83:ac:8d:5c:fd:5b:14:f8:
+    cf:02:c9:db:8e:a7:8e:c3:70:c4:cd:48:55:0f:21:
+    17:0e:3b:69:34:e0:5c:e6:dd:63:ae:ab:2c:a1:8a:
+    6b:a3:63:25:17:35:a4:67:d3:09:3f:0c:90:da:61:
+    96:3d:33:b2:f2:97:c0:62:2f:3b:f5:eb:cf:a2:1b:
+    7e:54:da:ab:36:d3:35:63:e6:6a:2c:4a:4a:71:b8:
+    df:3e:59:fd:d7:80:dd:31:ee:c6:16:7f:8d:a0:6b:
+    24:4b:c6:a2:e9:dc:d6:e0:dd
 prime2:
-    00:ed:2c:3a:4f:8b:dc:bf:5f:41:ef:f0:f8:2e:43:
-    c2:05:27:94:09:55:96:13:43:5c:69:7d:e5:58:0a:
-    de:7d:a3:91:e5:41:9d:c1:9f:a4:d5:15:16:22:e0:
-    71:43:f0:b5:8d:46:33:94:2d:e9:58:e1:86:7a:ad:
-    c0:e6:78:3c:10:ff:fa:e2:cf:f9:fd:95:3d:69:8c:
-    db:e4:a4:88:4a:6d:ff:22:25:c3:ce:ae:6e:42:02:
-    df:66:1e:4b:28:fc:31:9d:bf:d9:9e:8c:da:27:37:
-    41:50:85:be:2c:e6:dc:9d:a6:5d:63:79:f0:62:13:
-    66:2d:71:f7:f0:d1:39:c0:d5
+    00:d4:da:cb:7d:00:b4:67:75:f8:5b:02:99:44:27:
+    7a:1d:84:9c:06:9b:7a:99:fb:53:3e:aa:c1:7d:6c:
+    16:b6:ea:36:e2:79:5d:0e:76:f6:6f:fa:82:c3:d7:
+    d8:59:05:3f:63:b3:a8:3c:46:4b:c5:e9:f9:e6:8f:
+    9b:8a:06:95:fb:6a:da:ce:5f:b3:ad:cc:76:02:1d:
+    3f:c9:8d:48:9d:e0:0b:c3:f4:f4:02:ef:f3:3e:3d:
+    db:43:17:4f:ca:5e:6f:b1:4b:05:b2:8d:3e:e2:01:
+    d5:d6:8b:21:15:7d:48:74:16:58:29:f3:64:cd:98:
+    19:34:2d:70:f6:00:f5:93:97
 exponent1:
-    7e:47:94:c9:a4:f5:15:5f:8e:3f:80:92:f7:74:5b:
-    b7:6b:cd:9b:5c:e5:76:d5:7b:86:f7:1d:1f:8d:b9:
-    90:c7:25:da:fd:b2:4f:b3:52:af:f2:f0:1e:08:be:
-    fd:3a:96:cd:7d:f2:07:3d:09:10:dd:41:7e:2a:54:
-    6c:a4:b1:41:3f:93:9f:1f:66:0a:b7:8e:89:a6:67:
-    df:db:b7:aa:a6:65:b4:52:b8:e6:ef:56:db:81:04:
-    b9:e8:34:18:a2:8e:59:33:ee:8e:08:5c:d8:49:e2:
-    b0:e2:55:bf:fd:63:6e:e9:4e:aa:25:82:58:1d:42:
-    56:be:68:3a:2a:66:5d:01
+    00:fc:86:9f:c0:eb:52:aa:39:bf:b9:b6:a7:20:4b:
+    9d:8d:3a:e0:3c:ee:a6:80:70:6d:4b:6d:62:57:92:
+    38:77:e2:80:2c:f9:72:1f:e8:18:a2:bd:6c:73:16:
+    8a:d2:89:bd:d1:6b:ce:99:80:d7:71:d1:26:1b:27:
+    0a:74:3d:d7:96:a4:af:f4:de:4b:14:dc:8f:77:d1:
+    94:55:1c:04:be:06:b4:bc:31:93:e5:b9:f8:0f:96:
+    5e:67:4f:ee:f6:20:ca:b9:a7:60:32:da:53:fd:94:
+    4a:da:bd:2f:9b:53:bb:29:bc:fa:5f:47:ce:78:1b:
+    f6:c6:32:30:b6:7b:ff:6d:35
 exponent2:
-    28:70:fd:34:69:2d:e7:f7:ef:3f:61:c0:7f:eb:0f:
-    df:5f:23:50:00:27:09:fb:d7:7b:29:7b:7c:ea:c5:
-    8b:78:e3:bc:ca:d6:82:98:9d:3b:b4:4f:c4:fc:ae:
-    73:9e:4c:e6:dd:0c:98:7c:c7:a8:5f:34:56:20:e0:
-    9e:ab:eb:da:1e:3c:02:86:e2:22:ca:5a:e1:6f:a2:
-    63:37:67:02:02:05:9a:26:04:60:6e:bf:e0:43:ab:
-    22:37:92:2b:57:ed:81:ef:9f:c4:f8:51:8e:94:4e:
-    6f:d3:8e:5d:0b:b4:9c:b1:2c:85:74:da:77:6e:c5:
-    62:84:67:79:c9:c3:66:4d
+    7b:41:8f:5f:fd:4e:7a:32:c7:f3:fb:97:40:ee:13:
+    3a:90:95:c1:05:bb:82:fb:14:03:4f:e1:e7:7c:f5:
+    d2:49:e2:2a:56:d8:da:0d:6d:3a:fe:b7:46:2c:f1:
+    2c:eb:6a:ff:93:03:32:94:0a:40:ba:f2:68:de:73:
+    d5:03:67:4a:45:60:1a:ed:34:20:ca:2a:f3:a2:78:
+    53:80:2a:b2:b1:10:5f:12:b3:52:18:1c:a4:c8:30:
+    f5:b2:c4:13:8d:87:e4:04:6b:72:2f:74:60:6f:6b:
+    a2:66:c2:6b:ad:36:8d:72:7a:ef:1f:f0:19:55:a0:
+    12:a4:d5:aa:be:77:76:55
 coefficient:
-    00:b0:4e:a7:6e:f5:ba:26:52:c6:ec:07:82:e2:91:
-    ea:ac:08:05:dc:cd:c7:8b:00:01:7e:2a:c5:05:0b:
-    88:d1:74:1b:71:3b:9e:03:6d:df:cf:6e:cd:cd:47:
-    2d:73:3d:56:1a:ab:10:20:d5:67:1a:7e:87:ef:dc:
-    ac:71:5c:72:68:1c:15:20:87:82:a7:b9:0d:df:55:
-    92:f5:de:76:c6:e8:d2:06:78:b8:90:bc:43:1d:53:
-    49:99:b6:54:66:e5:ee:ca:5f:8e:ef:73:1a:55:71:
-    4e:1e:ec:95:4a:1d:f6:6c:51:09:2d:77:f4:17:49:
-    76:4c:3b:08:75:37:80:c3:f9
+    0f:15:97:5d:19:46:2b:fc:22:c8:5c:83:f2:57:5f:
+    33:d4:7d:57:88:dc:75:73:54:53:83:c9:a9:b9:ed:
+    9d:d0:f9:8a:2e:68:3b:ac:a3:b0:05:44:8d:8c:00:
+    3c:20:35:6c:93:ab:ed:22:05:8c:65:66:83:c1:a3:
+    56:94:34:85:ce:d8:79:05:5e:45:51:7f:74:8e:04:
+    45:23:bc:35:38:bc:cd:80:f1:1d:09:4e:e5:20:59:
+    44:59:b6:f5:b7:00:8a:79:6d:1b:c8:9b:93:a2:22:
+    2d:f4:79:f9:42:77:cd:db:a9:4b:c1:ff:89:9c:64:
+    7a:bd:73:66:86:11:70:d7
 -----BEGIN RSA PRIVATE KEY-----
-MIIEowIBAAKCAQEA6YhRctyEXJGMu0f11dWg0lZT111I8bw6+39oNzG1Lac6EFv6
-V6S2vgtz6jeVZm0gFU7N2rfX/lW5Ce0+wJmthR5csM2Rdi+7p9AQPliBKYDAk8np
-M3wFCPS0X/pb6UtO/2ElAADGmQRFgchpVQIo/wfCzBvLwVcXMRUvMh8LrHZ6pQ+O
-wCLvu7YLO1B7smJ7hoMZQ3QzFDahlTiFgHJNuGWxLCllcw+bj/GXhDN9roLNDYWx
-/gmONWWuAoMqJvNjaHM33behO44Yzmou5PpnDCyxGK68YoHyDZfcw/HrWL9W6Hsg
-LZEdV2QZW5NPl2W9pGy963C2HxAYg+5h1NW6WQIDAQABAoIBAAFTCus01vH+HVHe
-lEVUgydOOAbWT5iXXFpFcbOGbk7w+Neo6Irgs0HxUgSiW2WLpDfwDM4lvBgu0kV9
-I/L3AXs/cyp0L/6p7KLZ/42VoOiPA13oh5Be2VnLUXk4iUGRx26UACAM4RNzE8CA
-ViCWSjc6tbRvSpYxG+o6WDHXkpBgJNxJRRg/v4nQ6omhOwbFheOx68oxehgwjq1q
-X6DU40FlUUqshp35YtR2MQvAn365nibmhRCBPK1yr3/EWJBl1rulj6T8oK2rUV8r
-DVHFzXoiLi7ZZp5sR9cked8TrsFdPbg6UogyLOhxT6/40Cxce1ovZNy3Btttwpwu
-eMLC0JECgYEA/BIdE+mIsFEersZBzycSzif2E0tb+XkoJNLevfa24ZCk8c4zgQq/
-ZtfUN9XPJGD3lF9PYqzKNrFMEM89jyqmeKVXEd0bxlgGfypN5ZRk2k75ONRwOzLi
-JJ1xvPteUoQL8YvJnx5Gnf52uiz2yUGmBZavzwDYjve5C3vAERyytXUCgYEA7Sw6
-T4vcv19B7/D4LkPCBSeUCVWWE0NcaX3lWArefaOR5UGdwZ+k1RUWIuBxQ/C1jUYz
-lC3pWOGGeq3A5ng8EP/64s/5/ZU9aYzb5KSISm3/IiXDzq5uQgLfZh5LKPwxnb/Z
-nozaJzdBUIW+LObcnaZdY3nwYhNmLXH38NE5wNUCgYB+R5TJpPUVX44/gJL3dFu3
-a82bXOV21XuG9x0fjbmQxyXa/bJPs1Kv8vAeCL79OpbNffIHPQkQ3UF+KlRspLFB
-P5OfH2YKt46Jpmff27eqpmW0Urjm71bbgQS56DQYoo5ZM+6OCFzYSeKw4lW//WNu
-6U6qJYJYHUJWvmg6KmZdAQKBgChw/TRpLef37z9hwH/rD99fI1AAJwn713spe3zq
-xYt447zK1oKYnTu0T8T8rnOeTObdDJh8x6hfNFYg4J6r69oePAKG4iLKWuFvomM3
-ZwICBZomBGBuv+BDqyI3kitX7YHvn8T4UY6UTm/Tjl0LtJyxLIV02nduxWKEZ3nJ
-w2ZNAoGBALBOp271uiZSxuwHguKR6qwIBdzNx4sAAX4qxQULiNF0G3E7ngNt389u
-zc1HLXM9VhqrECDVZxp+h+/crHFccmgcFSCHgqe5Dd9VkvXedsbo0gZ4uJC8Qx1T
-SZm2VGbl7spfju9zGlVxTh7slUod9mxRCS139BdJdkw7CHU3gMP5
+MIIEowIBAAKCAQEA0x6LOVLfN24vRES5VS4dRB/dQbPOpP3zWkH2mjcFpyw07EYv
+iZ7/niB1BTVoaEXS9RUN95x4p2mp9j1LXasNp6d1osjXCb5TPIt1lQ7j84DcJm2Y
+xUj6G2hR7EdEclqDMqlljUASbUZZBefNVcFnf4HaPUME01gJwicKUoQBoQHdqzQ7
+p5ClUo3ZhvzZwZsI8GfHfqhh3v5Xr9xYjI7rJyq5ojTUMTOHxy5p5yZ1zb27YQA7
+0nNUn7D2eF5GUTc1ZaEQDpd7gdyf8hrHn4BN5nLoku4/gWHFoUNDCxoDxA68cdAw
+j5X3nt6GXk0Yq16OFD7xxZh4EWVPPH/D2V6JWwIDAQABAoIBAEA8yfX+Pkcacq1e
+D9pYNrV00JjeQiE32CT9bzCLT2AHdm7yCCLiyzps+85C6urXXBIQfvh5lsixwPJY
+wibVFkmODaAjZjLjw2XntTZOmpOMAPB8ZoCY7OkL++ld4fi9i7ANlQW+mhy/y/Sd
+DIBsYbaNZz8+tigsYIO/50cmPWykm6yJUELFlVOwb+95hyhsEsDqG9sKWxo+JOli
+s8N7mr0/hUg5U8XRITNVOYVwITBSXw1p1Z/Pn8r1RhHUhJJi1h2PaD+aJ9A9gsP/
+BoRudUlG2mBh6xMX3wHbmqEBK4IrPaW76QGMbw3Mgmdx4f5KE2oO84WHWgXmnQ6X
+LX5te4kCgYEA/emzLmrOh491AaGnRTZCg5nzJ+WGg6yNXP1bFPjPAsnbjqeOw3DE
+zUhVDyEXDjtpNOBc5t1jrqssoYpro2MlFzWkZ9MJPwyQ2mGWPTOy8pfAYi879evP
+oht+VNqrNtM1Y+ZqLEpKcbjfPln914DdMe7GFn+NoGskS8ai6dzW4N0CgYEA1NrL
+fQC0Z3X4WwKZRCd6HYScBpt6mftTPqrBfWwWtuo24nldDnb2b/qCw9fYWQU/Y7Oo
+PEZLxen55o+bigaV+2razl+zrcx2Ah0/yY1IneALw/T0Au/zPj3bQxdPyl5vsUsF
+so0+4gHV1oshFX1IdBZYKfNkzZgZNC1w9gD1k5cCgYEA/IafwOtSqjm/ubanIEud
+jTrgPO6mgHBtS21iV5I4d+KALPlyH+gYor1scxaK0om90WvOmYDXcdEmGycKdD3X
+lqSv9N5LFNyPd9GUVRwEvga0vDGT5bn4D5ZeZ0/u9iDKuadgMtpT/ZRK2r0vm1O7
+Kbz6X0fOeBv2xjIwtnv/bTUCgYB7QY9f/U56Msfz+5dA7hM6kJXBBbuC+xQDT+Hn
+fPXSSeIqVtjaDW06/rdGLPEs62r/kwMylApAuvJo3nPVA2dKRWAa7TQgyirzonhT
+gCqysRBfErNSGBykyDD1ssQTjYfkBGtyL3Rgb2uiZsJrrTaNcnrvH/AZVaASpNWq
+vnd2VQKBgA8Vl10ZRiv8Ishcg/JXXzPUfVeI3HVzVFODyam57Z3Q+YouaDuso7AF
+RI2MADwgNWyTq+0iBYxlZoPBo1aUNIXO2HkFXkVRf3SOBEUjvDU4vM2A8R0JTuUg
+WURZtvW3AIp5bRvIm5OiIi30eflCd83bqUvB/4mcZHq9c2aGEXDX
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/oid.pem
+++ b/spec/fixtures/ssl/oid.pem
@@ -6,65 +6,64 @@ Certificate:
         Issuer: CN=Test CA Subauthority
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Jun 24 21:18:00 2033 GMT
+            Not After : Jan 27 18:43:32 2034 GMT
         Subject: CN=oid
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                Public-Key: (2048 bit)
+                RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:e9:88:51:72:dc:84:5c:91:8c:bb:47:f5:d5:d5:
-                    a0:d2:56:53:d7:5d:48:f1:bc:3a:fb:7f:68:37:31:
-                    b5:2d:a7:3a:10:5b:fa:57:a4:b6:be:0b:73:ea:37:
-                    95:66:6d:20:15:4e:cd:da:b7:d7:fe:55:b9:09:ed:
-                    3e:c0:99:ad:85:1e:5c:b0:cd:91:76:2f:bb:a7:d0:
-                    10:3e:58:81:29:80:c0:93:c9:e9:33:7c:05:08:f4:
-                    b4:5f:fa:5b:e9:4b:4e:ff:61:25:00:00:c6:99:04:
-                    45:81:c8:69:55:02:28:ff:07:c2:cc:1b:cb:c1:57:
-                    17:31:15:2f:32:1f:0b:ac:76:7a:a5:0f:8e:c0:22:
-                    ef:bb:b6:0b:3b:50:7b:b2:62:7b:86:83:19:43:74:
-                    33:14:36:a1:95:38:85:80:72:4d:b8:65:b1:2c:29:
-                    65:73:0f:9b:8f:f1:97:84:33:7d:ae:82:cd:0d:85:
-                    b1:fe:09:8e:35:65:ae:02:83:2a:26:f3:63:68:73:
-                    37:dd:b7:a1:3b:8e:18:ce:6a:2e:e4:fa:67:0c:2c:
-                    b1:18:ae:bc:62:81:f2:0d:97:dc:c3:f1:eb:58:bf:
-                    56:e8:7b:20:2d:91:1d:57:64:19:5b:93:4f:97:65:
-                    bd:a4:6c:bd:eb:70:b6:1f:10:18:83:ee:61:d4:d5:
-                    ba:59
+                    00:d3:1e:8b:39:52:df:37:6e:2f:44:44:b9:55:2e:
+                    1d:44:1f:dd:41:b3:ce:a4:fd:f3:5a:41:f6:9a:37:
+                    05:a7:2c:34:ec:46:2f:89:9e:ff:9e:20:75:05:35:
+                    68:68:45:d2:f5:15:0d:f7:9c:78:a7:69:a9:f6:3d:
+                    4b:5d:ab:0d:a7:a7:75:a2:c8:d7:09:be:53:3c:8b:
+                    75:95:0e:e3:f3:80:dc:26:6d:98:c5:48:fa:1b:68:
+                    51:ec:47:44:72:5a:83:32:a9:65:8d:40:12:6d:46:
+                    59:05:e7:cd:55:c1:67:7f:81:da:3d:43:04:d3:58:
+                    09:c2:27:0a:52:84:01:a1:01:dd:ab:34:3b:a7:90:
+                    a5:52:8d:d9:86:fc:d9:c1:9b:08:f0:67:c7:7e:a8:
+                    61:de:fe:57:af:dc:58:8c:8e:eb:27:2a:b9:a2:34:
+                    d4:31:33:87:c7:2e:69:e7:26:75:cd:bd:bb:61:00:
+                    3b:d2:73:54:9f:b0:f6:78:5e:46:51:37:35:65:a1:
+                    10:0e:97:7b:81:dc:9f:f2:1a:c7:9f:80:4d:e6:72:
+                    e8:92:ee:3f:81:61:c5:a1:43:43:0b:1a:03:c4:0e:
+                    bc:71:d0:30:8f:95:f7:9e:de:86:5e:4d:18:ab:5e:
+                    8e:14:3e:f1:c5:98:78:11:65:4f:3c:7f:c3:d9:5e:
+                    89:5b
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             1.3.6.1.4.1.34380.1.2.1.1: 
                 ..somevalue
     Signature Algorithm: sha256WithRSAEncryption
-    Signature Value:
-        58:a5:3a:35:f2:ca:bc:9e:6f:a3:84:e4:2e:3a:1e:00:3d:34:
-        b2:23:f6:88:0b:e0:50:18:83:0f:16:6f:13:02:54:e7:30:16:
-        43:a0:aa:cf:f0:56:67:ac:c2:a5:38:e3:3b:f1:6a:59:e2:c2:
-        d6:56:49:52:9e:18:35:a2:58:5c:0a:ac:5f:dc:0d:65:60:23:
-        8d:a4:83:9e:05:c3:c5:a8:9e:6d:d0:97:26:f0:60:ca:b3:a4:
-        19:cc:ab:d1:82:3f:b5:00:85:96:aa:bf:2f:b7:12:83:8c:f0:
-        5e:95:f7:10:4d:5a:22:e7:f7:94:cc:48:44:47:5d:6f:68:23:
-        3a:f3:37:24:52:90:c9:70:e9:c2:15:2f:d1:fb:ad:88:ea:b9:
-        3e:58:57:1e:3d:96:af:32:5d:f8:1a:ec:f8:e2:1a:82:16:2f:
-        91:89:7e:7b:27:30:5e:df:4c:f9:b9:bd:87:0f:c2:6f:67:55:
-        06:a9:d1:9a:fa:3f:bf:4f:c8:66:d5:8d:c2:2f:2f:fb:72:1d:
-        b6:94:db:7c:94:1a:4d:09:0b:0b:7b:d0:db:f1:5b:0a:f0:1a:
-        71:a7:31:91:a0:43:0a:53:77:bf:ff:bd:9f:f7:3f:32:ba:4b:
-        d9:f3:af:9c:cb:00:aa:05:78:02:9d:6f:56:f9:f7:12:64:06:
-        f4:80:86:9f
+         68:29:84:a9:fc:d4:b9:72:ab:96:be:a9:e0:cc:4f:e1:f1:e6:
+         0e:46:69:e1:99:da:98:b7:ff:58:2f:45:5d:e7:de:79:39:42:
+         b0:ba:ab:6e:1f:9c:a8:a8:eb:3e:7b:78:c1:cc:2f:82:df:50:
+         73:01:85:5c:e6:e8:72:11:22:8a:8f:11:6c:23:e0:07:b2:e5:
+         a6:a3:99:e0:68:7e:01:3e:fc:4c:3e:cd:13:ec:56:00:74:29:
+         9f:23:ba:ba:98:b0:dd:4a:c6:26:6e:e0:58:8c:4b:b7:e0:a5:
+         bc:1c:b5:41:8b:c8:33:d4:1b:10:64:d9:2c:ba:57:d9:32:50:
+         ea:b7:1b:90:8a:b0:04:e4:2c:c5:f1:a1:2f:fc:22:d7:9f:b1:
+         5c:06:fb:b0:ee:34:53:03:a2:25:bc:57:86:1e:29:ef:4c:ca:
+         5b:08:3c:9c:6e:19:38:5e:4e:4c:fe:97:69:de:11:5a:28:37:
+         5d:1c:e9:b6:21:78:33:16:12:7e:72:f5:e4:22:da:6e:aa:bd:
+         4d:ca:e7:f7:13:f4:fc:e3:55:ae:e0:57:c8:ac:a7:2e:5e:dd:
+         81:70:68:1b:68:8e:47:a5:bf:84:59:ed:4a:85:8a:07:ce:cc:
+         a5:91:b7:59:64:d8:5c:26:19:bb:51:fe:87:d8:e6:36:9d:2c:
+         28:2a:df:c9
 -----BEGIN CERTIFICATE-----
 MIICxzCCAa+gAwIBAgIBBzANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0
-IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zMzA2MjQyMTE4MDBa
+IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zNDAxMjcxODQzMzJa
 MA4xDDAKBgNVBAMMA29pZDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
-AOmIUXLchFyRjLtH9dXVoNJWU9ddSPG8Ovt/aDcxtS2nOhBb+lektr4Lc+o3lWZt
-IBVOzdq31/5VuQntPsCZrYUeXLDNkXYvu6fQED5YgSmAwJPJ6TN8BQj0tF/6W+lL
-Tv9hJQAAxpkERYHIaVUCKP8Hwswby8FXFzEVLzIfC6x2eqUPjsAi77u2CztQe7Ji
-e4aDGUN0MxQ2oZU4hYByTbhlsSwpZXMPm4/xl4Qzfa6CzQ2Fsf4JjjVlrgKDKibz
-Y2hzN923oTuOGM5qLuT6ZwwssRiuvGKB8g2X3MPx61i/Vuh7IC2RHVdkGVuTT5dl
-vaRsvetwth8QGIPuYdTVulkCAwEAAaMfMB0wGwYMKwYBBAGCjEwBAgEBBAsMCXNv
-bWV2YWx1ZTANBgkqhkiG9w0BAQsFAAOCAQEAWKU6NfLKvJ5vo4TkLjoeAD00siP2
-iAvgUBiDDxZvEwJU5zAWQ6Cqz/BWZ6zCpTjjO/FqWeLC1lZJUp4YNaJYXAqsX9wN
-ZWAjjaSDngXDxaiebdCXJvBgyrOkGcyr0YI/tQCFlqq/L7cSg4zwXpX3EE1aIuf3
-lMxIREddb2gjOvM3JFKQyXDpwhUv0futiOq5PlhXHj2WrzJd+Brs+OIaghYvkYl+
-eycwXt9M+bm9hw/Cb2dVBqnRmvo/v0/IZtWNwi8v+3IdtpTbfJQaTQkLC3vQ2/Fb
-CvAacacxkaBDClN3v/+9n/c/MrpL2fOvnMsAqgV4Ap1vVvn3EmQG9ICGnw==
+ANMeizlS3zduL0REuVUuHUQf3UGzzqT981pB9po3BacsNOxGL4me/54gdQU1aGhF
+0vUVDfeceKdpqfY9S12rDaendaLI1wm+UzyLdZUO4/OA3CZtmMVI+htoUexHRHJa
+gzKpZY1AEm1GWQXnzVXBZ3+B2j1DBNNYCcInClKEAaEB3as0O6eQpVKN2Yb82cGb
+CPBnx36oYd7+V6/cWIyO6ycquaI01DEzh8cuaecmdc29u2EAO9JzVJ+w9nheRlE3
+NWWhEA6Xe4Hcn/Iax5+ATeZy6JLuP4FhxaFDQwsaA8QOvHHQMI+V957ehl5NGKte
+jhQ+8cWYeBFlTzx/w9leiVsCAwEAAaMfMB0wGwYMKwYBBAGCjEwBAgEBBAsMCXNv
+bWV2YWx1ZTANBgkqhkiG9w0BAQsFAAOCAQEAaCmEqfzUuXKrlr6p4MxP4fHmDkZp
+4ZnamLf/WC9FXefeeTlCsLqrbh+cqKjrPnt4wcwvgt9QcwGFXObochEiio8RbCPg
+B7LlpqOZ4Gh+AT78TD7NE+xWAHQpnyO6upiw3UrGJm7gWIxLt+ClvBy1QYvIM9Qb
+EGTZLLpX2TJQ6rcbkIqwBOQsxfGhL/wi15+xXAb7sO40UwOiJbxXhh4p70zKWwg8
+nG4ZOF5OTP6Xad4RWig3XRzptiF4MxYSfnL15CLabqq9Tcrn9xP0/ONVruBXyKyn
+Ll7dgXBoG2iOR6W/hFntSoWKB87MpZG3WWTYXCYZu1H+h9jmNp0sKCrfyQ==
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/pluto-key.pem
+++ b/spec/fixtures/ssl/pluto-key.pem
@@ -1,117 +1,117 @@
-Private-Key: (2048 bit, 2 primes)
+RSA Private-Key: (2048 bit, 2 primes)
 modulus:
-    00:a1:e2:44:51:1d:f3:95:9a:29:9d:d1:a5:3f:b5:
-    57:e4:2d:cb:45:94:b8:d8:80:9b:f1:e0:de:81:b9:
-    50:0a:37:24:34:91:b3:43:c7:ad:fb:eb:91:de:62:
-    15:39:70:6c:be:48:4d:98:2b:82:fb:74:6a:5e:26:
-    38:49:0a:5c:81:c0:1a:90:b8:15:70:60:a9:80:2f:
-    3b:b8:3e:f3:57:c8:75:bb:34:da:17:68:3f:00:04:
-    2d:fe:97:24:cc:2c:3c:d7:ca:81:53:46:f6:7c:ec:
-    9a:55:b2:b7:97:dd:3a:76:e3:c8:89:0c:19:40:dd:
-    17:63:36:66:5c:ad:17:e8:2b:02:98:54:e7:bf:0d:
-    5d:b0:5c:97:4b:23:99:ce:97:f9:59:e5:1e:ba:33:
-    6e:35:39:ef:7b:a0:62:4b:ac:91:05:8f:79:5b:7c:
-    82:88:41:e7:dc:51:1c:7d:80:3e:1c:aa:92:f0:7f:
-    67:5f:18:09:8a:35:02:82:4b:38:c0:03:8d:20:51:
-    d8:b2:18:63:96:9a:68:6e:e5:ae:5a:08:09:c2:01:
-    2f:2b:be:54:6b:c9:77:75:2e:71:30:b6:26:d9:5a:
-    12:0c:75:47:2e:c6:c2:b0:82:2f:64:5b:f0:b3:68:
-    af:83:8c:97:06:fc:99:5f:95:dc:ac:4e:99:95:b3:
-    47:cb
+    00:cb:df:c1:d7:96:85:2d:3b:83:ec:a0:78:6d:5e:
+    ed:d5:bc:c9:41:96:37:f4:c1:5d:da:c4:97:38:b9:
+    b8:c7:0f:69:2b:c7:8c:83:74:9a:44:1c:93:0d:2b:
+    7d:c6:09:f1:6d:87:ac:45:3a:88:bf:b1:f5:5a:07:
+    d1:e6:77:a2:d5:e1:4a:06:e3:2e:34:66:0d:ef:c5:
+    0a:2e:c9:a4:81:d5:2b:8a:07:d3:2b:4f:21:4c:16:
+    6d:bb:b7:ed:58:9f:0a:b5:5b:46:61:0d:e6:8e:f8:
+    91:be:6f:7f:c0:52:0c:48:a5:e7:93:5b:e1:be:8b:
+    83:c5:91:49:2d:b6:de:7c:dc:9d:08:b3:77:0c:84:
+    8e:d8:c4:20:c7:2c:f5:88:11:35:7a:1f:bd:f4:c0:
+    bb:37:e4:35:3a:aa:63:bf:b6:8d:20:6a:2c:c3:aa:
+    79:e5:02:76:d1:65:f7:43:0d:d4:34:74:2d:75:8e:
+    b4:d0:a3:51:e7:75:ee:a8:80:21:5f:7e:d8:fd:c8:
+    f6:a7:35:dd:cb:d5:9f:06:f1:3d:e2:60:8f:cb:04:
+    5b:73:a1:2f:a4:a0:b5:80:56:11:73:7d:ac:75:19:
+    50:e7:1f:08:bc:6f:30:37:d0:49:59:9f:a5:8d:9b:
+    59:85:f9:d8:99:fc:68:54:e5:7b:54:c9:b5:b1:88:
+    b3:b1
 publicExponent: 65537 (0x10001)
 privateExponent:
-    0a:41:9e:7d:70:83:30:72:6f:7a:39:c0:43:fc:8b:
-    cb:2a:4c:40:d0:ce:dd:f2:01:59:fe:45:6a:a7:a0:
-    81:67:d9:49:e1:59:f5:0c:8f:77:db:5c:1c:60:4f:
-    78:44:fe:06:c2:3d:9e:f5:fc:1a:f8:01:b8:8c:53:
-    05:96:fb:f7:16:82:38:5d:5e:b2:5b:80:1c:5d:cc:
-    65:51:cb:b3:69:eb:c2:46:c8:c8:87:33:72:9f:51:
-    2b:5a:4d:1b:b3:1e:79:b7:86:a1:0d:93:c1:4f:70:
-    e9:c6:b9:be:0b:e7:4f:da:ac:fd:0d:d6:03:17:89:
-    8b:4b:74:df:20:9d:02:a4:59:25:41:c3:3e:b9:93:
-    86:af:f0:bd:a0:f6:9b:2e:5d:b2:4b:19:ac:2c:98:
-    ab:db:b4:38:49:3f:68:3d:c9:97:f9:00:00:8b:66:
-    a8:bc:16:68:69:a9:5a:51:9e:fc:dd:e2:3d:8e:68:
-    cf:d4:2c:4c:63:14:9b:02:0c:52:2c:63:ca:9b:ac:
-    12:f7:4a:44:e7:45:2e:a3:9c:9a:5f:1c:2a:52:6f:
-    f7:6b:c4:0a:55:30:ff:99:19:d9:62:83:15:85:4b:
-    ae:17:c0:17:85:5c:f4:c1:d5:dc:99:1c:09:20:26:
-    60:47:24:3d:e7:98:bf:b7:b8:76:c5:7e:df:3c:cc:
-    d1
+    55:0d:93:63:ea:92:c2:cd:1a:7b:84:72:d9:46:0a:
+    38:ea:1a:98:37:20:3f:06:d0:ad:ec:e8:1d:ad:35:
+    8e:2e:3a:b5:1d:f9:db:f9:b0:46:0c:19:b9:1b:d4:
+    cb:e2:e8:0a:c6:d8:32:c5:79:b9:67:77:b1:48:a3:
+    e3:df:33:5a:c1:33:4d:ee:47:1f:6b:18:13:58:83:
+    a8:03:4d:93:30:a8:8a:5c:3b:57:cd:1a:5a:10:dd:
+    54:bc:25:d3:9b:fe:2e:ac:d6:8e:b4:ea:e3:e8:85:
+    7d:0a:2d:24:c1:d6:08:14:d6:a8:9e:63:6e:47:ec:
+    00:67:5d:3d:2a:16:65:c6:30:cb:66:4f:73:a3:15:
+    07:ec:bc:09:d0:0f:ad:b2:76:f7:b3:4b:7a:37:6e:
+    99:1e:09:de:a7:b8:54:b5:e4:90:17:67:5f:ad:b8:
+    07:98:7a:0f:b6:20:bb:09:28:67:b4:ad:16:df:b6:
+    b3:a9:6e:fc:8e:a4:7d:23:ae:cc:b9:3c:7e:18:f0:
+    eb:dd:55:51:85:0c:5f:51:bd:09:f2:9c:0e:47:d3:
+    48:53:46:42:90:d8:10:fe:76:81:5c:34:70:f6:b9:
+    ef:ac:83:6a:9c:b4:e2:4a:8a:3c:e1:4a:ee:5c:d8:
+    df:54:46:cd:bf:8d:de:48:1f:80:d9:5d:a3:40:39:
+    b1
 prime1:
-    00:c4:a4:4a:f9:ac:32:ef:e0:08:84:bb:c8:58:df:
-    7e:e7:85:5d:2d:46:12:2d:f1:fc:4e:5b:c7:a0:34:
-    9a:6c:fd:2c:95:70:54:df:68:76:b2:8d:23:73:ae:
-    de:96:9b:48:26:28:f8:f8:30:52:ca:f4:e9:ff:ff:
-    d9:e0:fa:b9:b3:a9:14:bc:66:fc:7a:23:69:88:4d:
-    80:98:3b:14:32:a4:55:7d:de:f4:3c:71:c9:25:a9:
-    36:b7:85:32:b3:86:e3:29:66:f6:f5:4b:4b:96:49:
-    fc:fe:c5:ac:64:09:3f:0c:1a:6b:14:17:7f:b8:29:
-    6c:29:d3:a4:82:a8:f7:d6:bb
+    00:f5:91:c5:e8:9c:ea:3f:3f:be:2a:9f:65:9d:93:
+    18:d8:53:a0:93:90:7a:79:92:78:fd:25:53:94:ed:
+    9e:bd:2f:07:1d:ee:77:8e:6b:3c:33:fa:47:9b:89:
+    97:43:38:7b:68:5e:ab:0a:e8:74:f1:e1:6c:4b:2b:
+    06:23:b4:c1:4f:66:5e:6c:4a:08:48:74:fc:5f:07:
+    3f:2f:02:3d:0c:e2:ce:96:ee:9c:38:42:a2:a7:ef:
+    f5:d3:9b:d5:98:73:26:cb:07:2c:e2:61:9e:bf:79:
+    a4:3f:46:81:53:4b:5d:80:11:d6:24:6b:36:ad:e7:
+    99:86:aa:bb:97:68:e7:36:f5
 prime2:
-    00:d2:c0:04:ad:cf:4f:b8:b7:d5:43:87:ad:9c:12:
-    30:fd:27:e3:e7:2e:76:d6:4a:a2:fe:b4:d3:a1:00:
-    ba:c9:52:a7:59:56:41:38:b8:79:f2:f2:cb:85:11:
-    bb:d9:50:11:99:76:4b:d9:9d:56:ae:02:82:e1:2b:
-    65:c8:6b:a1:37:55:c0:93:df:c9:7f:00:70:67:be:
-    c7:e4:b9:f2:fe:d3:5c:3e:40:42:5d:10:90:13:d8:
-    ce:66:40:92:69:f5:79:ed:80:e5:3d:a3:8e:f4:a8:
-    47:06:47:0e:4b:43:fa:b5:75:98:24:d6:67:84:69:
-    90:6a:08:65:d6:e1:d1:aa:31
+    00:d4:88:9a:d0:a0:06:3e:74:20:00:43:36:46:45:
+    a4:74:29:e4:a4:80:8a:f9:92:7f:c7:e5:62:6d:83:
+    94:8b:f0:1d:25:d1:9a:41:50:97:1a:0a:ff:9a:f6:
+    50:d8:dd:f6:3b:ff:4b:bb:07:5e:69:67:d7:0c:76:
+    9c:96:ad:50:9f:54:6b:10:8c:da:6d:44:19:9a:be:
+    67:9b:94:67:21:ee:e3:1a:93:5b:d0:6c:84:04:20:
+    9a:26:01:5a:8d:70:0e:ad:da:1e:25:93:90:47:67:
+    7b:b9:8e:6d:5b:ac:09:ed:9a:07:f3:32:6e:17:8e:
+    1d:69:c2:d4:db:8b:d4:fc:4d
 exponent1:
-    00:c1:01:54:c9:ac:57:ae:93:a1:28:ce:bb:3d:67:
-    d8:42:5b:e6:f1:99:f6:1b:fc:88:9d:4c:7e:2a:63:
-    97:32:e4:68:0f:21:5b:5c:90:46:f8:c7:89:05:71:
-    9c:ee:0b:e9:8b:f2:e9:33:89:12:aa:3c:2b:34:e6:
-    a5:ae:a9:c8:fd:6b:36:7c:19:45:34:88:6f:7b:a6:
-    3e:52:ac:a2:0d:76:b8:a6:bb:df:d3:38:07:ab:1c:
-    64:25:4a:ea:51:c5:52:4f:7f:cd:63:43:8d:24:2c:
-    e8:d2:13:a9:39:e2:cd:6c:0e:be:0c:d1:67:bd:95:
-    82:a1:a7:26:b0:4c:32:3e:23
+    74:69:b2:84:5f:3e:bc:d5:1e:f5:5d:b2:f2:4c:35:
+    4e:f7:f5:fb:7e:56:51:23:9a:af:86:ee:64:7f:70:
+    ed:06:4a:3d:6a:3a:cb:0d:12:f1:21:08:a9:37:44:
+    b9:dd:20:c3:8d:7d:50:22:7a:ad:df:cb:52:a7:06:
+    b6:0e:8e:45:71:a5:f9:77:ef:0d:4a:48:09:54:8a:
+    23:62:d0:46:37:8e:f0:06:15:90:a6:26:2d:ae:97:
+    be:c4:f5:30:dc:05:db:e1:7e:e9:a2:95:7a:f7:d3:
+    61:1b:af:5b:29:33:1d:ef:56:b0:d5:12:8a:c6:6c:
+    05:67:12:9e:e8:60:13:b1
 exponent2:
-    00:b2:f8:09:81:28:7a:04:dd:68:27:ce:c2:69:b5:
-    31:10:ea:9d:29:27:56:17:a8:8e:3e:4a:85:25:46:
-    9f:58:73:ee:55:79:60:2d:b0:cb:2e:bb:6c:85:76:
-    87:d5:85:9f:4c:79:1e:f4:90:1e:99:ea:dc:06:27:
-    7a:69:f6:ac:93:77:28:f0:ea:ac:0c:43:ed:30:cc:
-    dc:a7:aa:19:66:b9:4a:ae:3a:97:a0:bc:7d:fd:bc:
-    b1:9a:37:df:9e:47:ad:e1:39:02:73:93:bf:c4:98:
-    5a:a8:44:13:29:6b:73:2e:41:cc:90:0b:db:20:a1:
-    1c:d8:4e:85:5d:33:ab:7f:21
+    64:f9:d6:1c:22:bb:74:b6:b5:71:8a:7d:61:db:ba:
+    ab:9a:2f:d0:5c:66:2a:f7:08:90:cf:91:f9:18:17:
+    de:78:a1:50:93:8a:27:58:03:c2:52:d1:68:2d:78:
+    f1:e0:5b:19:dc:4c:7d:ba:9d:87:94:d7:5e:4b:88:
+    50:2a:5d:f0:a5:2a:0c:fd:ee:d5:15:12:d9:2b:77:
+    8c:3a:70:d9:75:67:1e:fc:3e:16:03:48:a1:b1:5f:
+    ab:88:df:1d:ed:cc:7b:9a:f2:d1:c5:8f:39:ed:97:
+    a1:ec:62:56:b8:a1:2a:eb:10:b5:e2:12:de:4c:1d:
+    fb:5e:9e:c5:04:65:97:cd
 coefficient:
-    2a:20:ea:12:bc:82:60:de:30:0d:2d:74:f1:94:0f:
-    66:4d:8a:34:92:ec:2f:da:ba:f4:b8:3e:b5:90:62:
-    35:89:2e:7c:5b:d0:8d:fc:7e:23:e5:02:cb:b7:69:
-    08:a1:7e:3c:93:8c:06:1d:9b:fd:69:a0:9d:13:95:
-    00:cc:bb:50:90:2d:6a:5e:fc:ab:4e:b1:9c:a4:f4:
-    fe:f4:8d:3e:73:21:67:48:53:3d:70:eb:c1:1d:ab:
-    ce:9a:9c:35:61:88:ba:96:9a:25:2b:f8:af:8d:f4:
-    a9:8a:8f:2a:21:73:8d:b9:3e:12:47:b6:ff:03:c7:
-    27:c6:59:5a:ac:3a:fc:1c
+    00:e3:fb:7e:20:c6:a0:93:15:c9:ec:d1:87:94:71:
+    ba:09:8d:11:60:49:65:0a:98:ac:a3:08:53:cc:6d:
+    b2:57:51:89:1c:96:7b:ba:d3:24:60:ee:d1:90:88:
+    53:b9:58:34:e4:3d:3c:0f:b7:0e:91:c8:6d:2e:61:
+    2c:c0:0b:35:cb:4b:a4:4a:d9:b2:b1:3d:5d:d4:86:
+    52:db:f7:1d:6a:cd:e9:65:81:bc:df:76:88:b2:96:
+    2c:24:0e:70:41:38:31:fc:46:66:9a:f6:75:0f:fc:
+    8d:c3:59:b3:76:6e:ee:ed:a6:d8:16:df:48:dd:5a:
+    26:8a:a7:6a:39:c6:dc:c8:5b
 -----BEGIN RSA PRIVATE KEY-----
-MIIEpAIBAAKCAQEAoeJEUR3zlZopndGlP7VX5C3LRZS42ICb8eDegblQCjckNJGz
-Q8et++uR3mIVOXBsvkhNmCuC+3RqXiY4SQpcgcAakLgVcGCpgC87uD7zV8h1uzTa
-F2g/AAQt/pckzCw818qBU0b2fOyaVbK3l906duPIiQwZQN0XYzZmXK0X6CsCmFTn
-vw1dsFyXSyOZzpf5WeUeujNuNTnve6BiS6yRBY95W3yCiEHn3FEcfYA+HKqS8H9n
-XxgJijUCgks4wAONIFHYshhjlppobuWuWggJwgEvK75Ua8l3dS5xMLYm2VoSDHVH
-LsbCsIIvZFvws2ivg4yXBvyZX5XcrE6ZlbNHywIDAQABAoIBAApBnn1wgzByb3o5
-wEP8i8sqTEDQzt3yAVn+RWqnoIFn2UnhWfUMj3fbXBxgT3hE/gbCPZ71/Br4AbiM
-UwWW+/cWgjhdXrJbgBxdzGVRy7Np68JGyMiHM3KfUStaTRuzHnm3hqENk8FPcOnG
-ub4L50/arP0N1gMXiYtLdN8gnQKkWSVBwz65k4av8L2g9psuXbJLGawsmKvbtDhJ
-P2g9yZf5AACLZqi8FmhpqVpRnvzd4j2OaM/ULExjFJsCDFIsY8qbrBL3SkTnRS6j
-nJpfHCpSb/drxApVMP+ZGdligxWFS64XwBeFXPTB1dyZHAkgJmBHJD3nmL+3uHbF
-ft88zNECgYEAxKRK+awy7+AIhLvIWN9+54VdLUYSLfH8TlvHoDSabP0slXBU32h2
-so0jc67elptIJij4+DBSyvTp///Z4Pq5s6kUvGb8eiNpiE2AmDsUMqRVfd70PHHJ
-Jak2t4Uys4bjKWb29UtLlkn8/sWsZAk/DBprFBd/uClsKdOkgqj31rsCgYEA0sAE
-rc9PuLfVQ4etnBIw/Sfj5y521kqi/rTToQC6yVKnWVZBOLh58vLLhRG72VARmXZL
-2Z1WrgKC4StlyGuhN1XAk9/JfwBwZ77H5Lny/tNcPkBCXRCQE9jOZkCSafV57YDl
-PaOO9KhHBkcOS0P6tXWYJNZnhGmQaghl1uHRqjECgYEAwQFUyaxXrpOhKM67PWfY
-Qlvm8Zn2G/yInUx+KmOXMuRoDyFbXJBG+MeJBXGc7gvpi/LpM4kSqjwrNOalrqnI
-/Ws2fBlFNIhve6Y+UqyiDXa4prvf0zgHqxxkJUrqUcVST3/NY0ONJCzo0hOpOeLN
-bA6+DNFnvZWCoacmsEwyPiMCgYEAsvgJgSh6BN1oJ87CabUxEOqdKSdWF6iOPkqF
-JUafWHPuVXlgLbDLLrtshXaH1YWfTHke9JAemercBid6afask3co8OqsDEPtMMzc
-p6oZZrlKrjqXoLx9/byxmjffnket4TkCc5O/xJhaqEQTKWtzLkHMkAvbIKEc2E6F
-XTOrfyECgYAqIOoSvIJg3jANLXTxlA9mTYo0kuwv2rr0uD61kGI1iS58W9CN/H4j
-5QLLt2kIoX48k4wGHZv9aaCdE5UAzLtQkC1qXvyrTrGcpPT+9I0+cyFnSFM9cOvB
-HavOmpw1YYi6lpolK/ivjfSpio8qIXONuT4SR7b/A8cnxllarDr8HA==
+MIIEowIBAAKCAQEAy9/B15aFLTuD7KB4bV7t1bzJQZY39MFd2sSXOLm4xw9pK8eM
+g3SaRByTDSt9xgnxbYesRTqIv7H1WgfR5nei1eFKBuMuNGYN78UKLsmkgdUrigfT
+K08hTBZtu7ftWJ8KtVtGYQ3mjviRvm9/wFIMSKXnk1vhvouDxZFJLbbefNydCLN3
+DISO2MQgxyz1iBE1eh+99MC7N+Q1Oqpjv7aNIGosw6p55QJ20WX3Qw3UNHQtdY60
+0KNR53XuqIAhX37Y/cj2pzXdy9WfBvE94mCPywRbc6EvpKC1gFYRc32sdRlQ5x8I
+vG8wN9BJWZ+ljZtZhfnYmfxoVOV7VMm1sYizsQIDAQABAoIBAFUNk2PqksLNGnuE
+ctlGCjjqGpg3ID8G0K3s6B2tNY4uOrUd+dv5sEYMGbkb1Mvi6ArG2DLFeblnd7FI
+o+PfM1rBM03uRx9rGBNYg6gDTZMwqIpcO1fNGloQ3VS8JdOb/i6s1o606uPohX0K
+LSTB1ggU1qieY25H7ABnXT0qFmXGMMtmT3OjFQfsvAnQD62ydvezS3o3bpkeCd6n
+uFS15JAXZ1+tuAeYeg+2ILsJKGe0rRbftrOpbvyOpH0jrsy5PH4Y8OvdVVGFDF9R
+vQnynA5H00hTRkKQ2BD+doFcNHD2ue+sg2qctOJKijzhSu5c2N9URs2/jd5IH4DZ
+XaNAObECgYEA9ZHF6JzqPz++Kp9lnZMY2FOgk5B6eZJ4/SVTlO2evS8HHe53jms8
+M/pHm4mXQzh7aF6rCuh08eFsSysGI7TBT2ZebEoISHT8Xwc/LwI9DOLOlu6cOEKi
+p+/105vVmHMmywcs4mGev3mkP0aBU0tdgBHWJGs2reeZhqq7l2jnNvUCgYEA1Iia
+0KAGPnQgAEM2RkWkdCnkpICK+ZJ/x+VibYOUi/AdJdGaQVCXGgr/mvZQ2N32O/9L
+uwdeaWfXDHaclq1Qn1RrEIzabUQZmr5nm5RnIe7jGpNb0GyEBCCaJgFajXAOrdoe
+JZOQR2d7uY5tW6wJ7ZoH8zJuF44dacLU24vU/E0CgYB0abKEXz681R71XbLyTDVO
+9/X7flZRI5qvhu5kf3DtBko9ajrLDRLxIQipN0S53SDDjX1QInqt38tSpwa2Do5F
+caX5d+8NSkgJVIojYtBGN47wBhWQpiYtrpe+xPUw3AXb4X7popV699NhG69bKTMd
+71aw1RKKxmwFZxKe6GATsQKBgGT51hwiu3S2tXGKfWHbuquaL9BcZir3CJDPkfkY
+F954oVCTiidYA8JS0WgtePHgWxncTH26nYeU115LiFAqXfClKgz97tUVEtkrd4w6
+cNl1Zx78PhYDSKGxX6uI3x3tzHua8tHFjzntl6HsYla4oSrrELXiEt5MHftensUE
+ZZfNAoGBAOP7fiDGoJMVyezRh5RxugmNEWBJZQqYrKMIU8xtsldRiRyWe7rTJGDu
+0ZCIU7lYNOQ9PA+3DpHIbS5hLMALNctLpErZsrE9XdSGUtv3HWrN6WWBvN92iLKW
+LCQOcEE4MfxGZpr2dQ/8jcNZs3Zu7u2m2BbfSN1aJoqnajnG3Mhb
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/pluto.pem
+++ b/spec/fixtures/ssl/pluto.pem
@@ -6,62 +6,61 @@ Certificate:
         Issuer: CN=Test CA Agent Subauthority
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Jun 24 21:18:00 2033 GMT
+            Not After : Jan 27 18:43:32 2034 GMT
         Subject: CN=pluto
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                Public-Key: (2048 bit)
+                RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:a1:e2:44:51:1d:f3:95:9a:29:9d:d1:a5:3f:b5:
-                    57:e4:2d:cb:45:94:b8:d8:80:9b:f1:e0:de:81:b9:
-                    50:0a:37:24:34:91:b3:43:c7:ad:fb:eb:91:de:62:
-                    15:39:70:6c:be:48:4d:98:2b:82:fb:74:6a:5e:26:
-                    38:49:0a:5c:81:c0:1a:90:b8:15:70:60:a9:80:2f:
-                    3b:b8:3e:f3:57:c8:75:bb:34:da:17:68:3f:00:04:
-                    2d:fe:97:24:cc:2c:3c:d7:ca:81:53:46:f6:7c:ec:
-                    9a:55:b2:b7:97:dd:3a:76:e3:c8:89:0c:19:40:dd:
-                    17:63:36:66:5c:ad:17:e8:2b:02:98:54:e7:bf:0d:
-                    5d:b0:5c:97:4b:23:99:ce:97:f9:59:e5:1e:ba:33:
-                    6e:35:39:ef:7b:a0:62:4b:ac:91:05:8f:79:5b:7c:
-                    82:88:41:e7:dc:51:1c:7d:80:3e:1c:aa:92:f0:7f:
-                    67:5f:18:09:8a:35:02:82:4b:38:c0:03:8d:20:51:
-                    d8:b2:18:63:96:9a:68:6e:e5:ae:5a:08:09:c2:01:
-                    2f:2b:be:54:6b:c9:77:75:2e:71:30:b6:26:d9:5a:
-                    12:0c:75:47:2e:c6:c2:b0:82:2f:64:5b:f0:b3:68:
-                    af:83:8c:97:06:fc:99:5f:95:dc:ac:4e:99:95:b3:
-                    47:cb
+                    00:cb:df:c1:d7:96:85:2d:3b:83:ec:a0:78:6d:5e:
+                    ed:d5:bc:c9:41:96:37:f4:c1:5d:da:c4:97:38:b9:
+                    b8:c7:0f:69:2b:c7:8c:83:74:9a:44:1c:93:0d:2b:
+                    7d:c6:09:f1:6d:87:ac:45:3a:88:bf:b1:f5:5a:07:
+                    d1:e6:77:a2:d5:e1:4a:06:e3:2e:34:66:0d:ef:c5:
+                    0a:2e:c9:a4:81:d5:2b:8a:07:d3:2b:4f:21:4c:16:
+                    6d:bb:b7:ed:58:9f:0a:b5:5b:46:61:0d:e6:8e:f8:
+                    91:be:6f:7f:c0:52:0c:48:a5:e7:93:5b:e1:be:8b:
+                    83:c5:91:49:2d:b6:de:7c:dc:9d:08:b3:77:0c:84:
+                    8e:d8:c4:20:c7:2c:f5:88:11:35:7a:1f:bd:f4:c0:
+                    bb:37:e4:35:3a:aa:63:bf:b6:8d:20:6a:2c:c3:aa:
+                    79:e5:02:76:d1:65:f7:43:0d:d4:34:74:2d:75:8e:
+                    b4:d0:a3:51:e7:75:ee:a8:80:21:5f:7e:d8:fd:c8:
+                    f6:a7:35:dd:cb:d5:9f:06:f1:3d:e2:60:8f:cb:04:
+                    5b:73:a1:2f:a4:a0:b5:80:56:11:73:7d:ac:75:19:
+                    50:e7:1f:08:bc:6f:30:37:d0:49:59:9f:a5:8d:9b:
+                    59:85:f9:d8:99:fc:68:54:e5:7b:54:c9:b5:b1:88:
+                    b3:b1
                 Exponent: 65537 (0x10001)
     Signature Algorithm: sha256WithRSAEncryption
-    Signature Value:
-        5c:74:cb:17:df:f2:1e:a8:de:4b:cd:c9:45:ee:d8:46:94:be:
-        19:e8:2f:66:28:01:29:18:4e:0e:b3:59:66:9d:d4:44:e2:44:
-        f0:34:e2:2c:08:d9:d3:ae:e0:70:77:79:32:4a:56:8c:11:84:
-        c2:8d:be:bc:c9:80:6f:f2:fb:fd:bc:96:7e:76:59:c7:46:12:
-        14:69:51:65:26:83:60:bf:f6:e9:f3:76:25:65:c2:12:4c:7f:
-        8b:3e:53:ba:8b:48:6e:e8:c2:a9:03:26:dc:af:58:3e:77:20:
-        a9:d6:0f:15:ea:7d:28:df:1d:88:7b:72:59:56:58:7a:46:b3:
-        2d:ca:3b:e8:fc:21:9b:fd:c2:c7:3d:24:78:7f:ad:23:b6:4b:
-        83:f0:d1:8a:40:8f:66:44:79:fb:ae:23:e5:5f:3e:3c:93:33:
-        34:cd:15:00:d7:d7:96:bb:61:42:8b:a2:07:0b:03:88:5f:b2:
-        47:a1:c3:66:eb:3a:b3:70:b1:44:61:10:c5:da:a6:34:9a:f6:
-        d3:c1:70:94:7c:6c:1f:ec:12:dc:c5:76:b6:58:92:a2:e7:3a:
-        7a:ea:8b:bf:96:57:f8:dc:ed:28:97:3f:b7:d9:96:ff:e9:42:
-        49:0a:02:9c:5e:44:84:9c:1f:c5:12:a0:3f:d5:14:0c:7f:e6:
-        3e:db:c0:3d
+         4d:d7:88:a0:d0:db:a1:00:ed:46:b8:dd:1d:a3:3d:3b:d4:c5:
+         46:df:01:0e:30:e5:2c:63:95:ca:90:68:50:3f:53:5c:df:e6:
+         0a:74:6b:88:20:3b:1e:19:4c:bd:08:70:44:f5:31:b3:23:b5:
+         4b:14:62:e2:0a:99:13:75:d0:db:63:01:49:3a:d2:c5:28:a5:
+         eb:cf:b5:92:38:5d:c8:3e:fc:8b:d1:b1:24:ca:60:de:9d:23:
+         14:10:e8:68:80:3c:a2:d3:89:ce:4b:2d:9a:42:42:00:06:9b:
+         92:76:a1:79:9d:e6:e6:1a:9f:10:06:0a:74:6d:8d:5f:2a:f3:
+         fb:49:16:7c:08:93:31:53:83:41:cc:62:c2:7c:2d:1a:57:cb:
+         2b:c1:6a:5f:7f:1e:a5:1d:2d:ff:3e:80:88:eb:55:53:a5:3f:
+         73:fc:5a:e7:ad:d9:00:77:a3:e4:a7:cd:12:c1:88:f6:93:7f:
+         46:9d:ca:20:9e:22:8a:1a:23:1e:20:78:cb:46:15:7e:73:40:
+         66:f5:16:b5:6d:5f:e2:9c:4c:4e:e1:23:f9:7b:45:7d:ee:7e:
+         b6:c9:96:16:52:dc:d8:8a:f6:4d:b0:d2:08:84:fb:4f:1f:af:
+         41:87:a3:39:d6:19:37:eb:ad:98:b2:6f:46:28:8b:26:43:f1:
+         c8:35:3c:81
 -----BEGIN CERTIFICATE-----
 MIICrjCCAZagAwIBAgIBCzANBgkqhkiG9w0BAQsFADAlMSMwIQYDVQQDDBpUZXN0
-IENBIEFnZW50IFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zMzA2MjQy
-MTE4MDBaMBAxDjAMBgNVBAMMBXBsdXRvMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
-MIIBCgKCAQEAoeJEUR3zlZopndGlP7VX5C3LRZS42ICb8eDegblQCjckNJGzQ8et
-++uR3mIVOXBsvkhNmCuC+3RqXiY4SQpcgcAakLgVcGCpgC87uD7zV8h1uzTaF2g/
-AAQt/pckzCw818qBU0b2fOyaVbK3l906duPIiQwZQN0XYzZmXK0X6CsCmFTnvw1d
-sFyXSyOZzpf5WeUeujNuNTnve6BiS6yRBY95W3yCiEHn3FEcfYA+HKqS8H9nXxgJ
-ijUCgks4wAONIFHYshhjlppobuWuWggJwgEvK75Ua8l3dS5xMLYm2VoSDHVHLsbC
-sIIvZFvws2ivg4yXBvyZX5XcrE6ZlbNHywIDAQABMA0GCSqGSIb3DQEBCwUAA4IB
-AQBcdMsX3/IeqN5LzclF7thGlL4Z6C9mKAEpGE4Os1lmndRE4kTwNOIsCNnTruBw
-d3kySlaMEYTCjb68yYBv8vv9vJZ+dlnHRhIUaVFlJoNgv/bp83YlZcISTH+LPlO6
-i0hu6MKpAybcr1g+dyCp1g8V6n0o3x2Ie3JZVlh6RrMtyjvo/CGb/cLHPSR4f60j
-tkuD8NGKQI9mRHn7riPlXz48kzM0zRUA19eWu2FCi6IHCwOIX7JHocNm6zqzcLFE
-YRDF2qY0mvbTwXCUfGwf7BLcxXa2WJKi5zp66ou/llf43O0olz+32Zb/6UJJCgKc
-XkSEnB/FEqA/1RQMf+Y+28A9
+IENBIEFnZW50IFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zNDAxMjcx
+ODQzMzJaMBAxDjAMBgNVBAMMBXBsdXRvMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+MIIBCgKCAQEAy9/B15aFLTuD7KB4bV7t1bzJQZY39MFd2sSXOLm4xw9pK8eMg3Sa
+RByTDSt9xgnxbYesRTqIv7H1WgfR5nei1eFKBuMuNGYN78UKLsmkgdUrigfTK08h
+TBZtu7ftWJ8KtVtGYQ3mjviRvm9/wFIMSKXnk1vhvouDxZFJLbbefNydCLN3DISO
+2MQgxyz1iBE1eh+99MC7N+Q1Oqpjv7aNIGosw6p55QJ20WX3Qw3UNHQtdY600KNR
+53XuqIAhX37Y/cj2pzXdy9WfBvE94mCPywRbc6EvpKC1gFYRc32sdRlQ5x8IvG8w
+N9BJWZ+ljZtZhfnYmfxoVOV7VMm1sYizsQIDAQABMA0GCSqGSIb3DQEBCwUAA4IB
+AQBN14ig0NuhAO1GuN0doz071MVG3wEOMOUsY5XKkGhQP1Nc3+YKdGuIIDseGUy9
+CHBE9TGzI7VLFGLiCpkTddDbYwFJOtLFKKXrz7WSOF3IPvyL0bEkymDenSMUEOho
+gDyi04nOSy2aQkIABpuSdqF5nebmGp8QBgp0bY1fKvP7SRZ8CJMxU4NBzGLCfC0a
+V8srwWpffx6lHS3/PoCI61VTpT9z/FrnrdkAd6Pkp80SwYj2k39GncogniKKGiMe
+IHjLRhV+c0Bm9Ra1bV/inExO4SP5e0V97n62yZYWUtzYivZNsNIIhPtPH69Bh6M5
+1hk3662Ysm9GKIsmQ/HINTyB
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/renewed.pem
+++ b/spec/fixtures/ssl/renewed.pem
@@ -6,62 +6,61 @@ Certificate:
         Issuer: CN=Test CA Subauthority
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Jun 24 21:18:00 2033 GMT
+            Not After : Jan 27 18:43:32 2034 GMT
         Subject: CN=renewed
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                Public-Key: (2048 bit)
+                RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:c4:7f:b6:dd:ab:a8:58:7f:49:48:9d:bd:6f:91:
-                    9a:ea:bc:8c:3c:20:5f:ec:3b:30:4e:c2:c5:98:8e:
-                    52:27:74:d9:d1:28:7e:6a:09:b1:fc:ea:d2:28:a7:
-                    48:30:b8:bc:93:11:e8:56:93:bf:02:86:1c:78:16:
-                    0b:b8:c3:ce:aa:b1:27:de:c6:96:20:f8:d4:8e:63:
-                    58:b3:05:c6:df:a7:eb:eb:85:14:98:04:0e:d7:99:
-                    17:81:0c:15:0b:c7:f0:bf:14:a5:8e:e9:5b:88:65:
-                    e9:b4:3e:9f:77:f4:77:60:dd:aa:75:e9:f2:75:07:
-                    a8:47:17:a3:79:f1:e5:ea:01:80:25:5a:5a:1b:fb:
-                    8d:6e:17:c7:b8:7d:bb:1d:ec:67:bf:c9:83:8f:28:
-                    02:99:83:16:f4:2c:f0:94:25:1b:7f:f0:99:fb:ec:
-                    75:63:88:97:2f:1d:f8:bf:14:92:3b:df:ed:a0:56:
-                    0c:94:c6:92:b4:91:e2:85:88:de:99:93:00:17:b0:
-                    f1:ed:45:03:8f:07:2e:5a:e5:82:6a:99:6f:45:00:
-                    54:2a:37:93:77:23:06:c3:99:fa:c1:1f:4c:59:63:
-                    e1:35:b9:f7:f6:ab:81:a5:11:ef:9c:a1:e6:64:ab:
-                    2f:fc:f9:cd:b3:d0:b7:33:81:4c:36:13:03:3a:5e:
-                    e6:e5
+                    00:ac:0d:e2:e1:62:ee:7a:55:f6:46:0a:5f:ed:dc:
+                    4a:a6:d4:d0:19:7f:a8:4d:cd:a0:c1:61:d4:e8:78:
+                    50:d4:5d:40:1f:e0:c3:79:26:95:19:4c:cd:70:10:
+                    53:38:b1:68:e4:7e:d4:44:65:68:94:8c:b6:ab:d2:
+                    22:36:d8:b0:92:ba:ed:3f:00:ec:b0:b6:5f:26:ac:
+                    f7:2b:71:e4:d7:8a:28:49:a8:fe:f9:a1:c8:b8:09:
+                    73:8c:f7:d3:90:ab:ed:74:fb:25:29:bf:81:51:b3:
+                    ac:02:81:ba:c1:7f:8a:ad:d7:18:6d:d0:73:1e:7f:
+                    d9:54:ed:0b:a2:a6:d7:7e:22:e1:3f:a3:6d:77:4a:
+                    9e:17:68:42:ef:99:63:e0:0f:5c:35:4e:3a:ef:5a:
+                    84:3c:c6:c1:ac:78:c5:fe:60:56:f4:e5:86:7d:60:
+                    1b:55:3c:bd:6a:c8:22:ea:b6:c3:f6:8a:67:e8:cb:
+                    5d:23:61:44:4b:9e:24:f8:91:69:25:90:0b:d7:2e:
+                    84:3f:c1:a2:8f:87:68:a8:36:b3:a7:b3:c8:0e:06:
+                    bd:6b:f3:54:41:d2:47:49:a7:2f:9b:3c:2f:37:89:
+                    46:12:90:95:fe:6a:6f:5e:29:c6:d9:ea:90:47:29:
+                    1b:85:1e:d3:19:e9:80:40:f7:33:67:bb:e5:17:50:
+                    5c:cd
                 Exponent: 65537 (0x10001)
     Signature Algorithm: sha256WithRSAEncryption
-    Signature Value:
-        be:f3:06:34:39:36:1e:41:38:64:bd:c8:01:05:b4:6d:f5:df:
-        44:2f:17:e5:86:b9:15:96:5e:94:38:2d:63:4a:54:90:21:cf:
-        d5:3e:e3:6e:0f:bf:0d:b9:9b:e9:a8:53:cb:38:c3:9b:88:af:
-        0c:c9:fa:2a:9b:0f:cc:be:d6:15:e8:fe:1d:6b:cb:30:3e:28:
-        c2:a5:87:69:be:8d:51:17:ed:c3:7f:e0:05:c2:3c:5c:d7:89:
-        d6:69:f2:44:25:1a:55:31:76:0f:83:4e:d7:30:d2:d5:82:eb:
-        e8:a3:75:15:01:b7:96:ca:4b:05:ca:81:6f:80:26:38:c5:5e:
-        a2:1c:24:0d:4a:bb:4a:41:51:9a:d1:ed:7e:bc:ad:1c:6a:cd:
-        fc:c4:53:11:14:a5:ff:a1:60:0b:3a:04:35:c4:03:a2:56:24:
-        92:a4:b6:e9:c0:c5:f5:2d:16:60:97:89:92:08:03:48:c2:ef:
-        9f:d1:7e:a7:56:ec:12:26:7f:36:0c:3b:7c:65:82:77:ba:0d:
-        28:fb:d2:e0:5c:19:5e:56:11:38:12:54:b6:b9:eb:55:3a:08:
-        81:e3:db:bc:6d:1a:c9:90:e2:1f:47:fa:55:23:c7:d0:e4:ba:
-        44:23:a8:39:52:fe:52:fc:6c:c8:4a:97:7d:4c:47:ab:21:79:
-        9f:25:bf:35
+         11:65:97:e8:a7:de:13:c9:de:80:c2:7b:06:71:f7:de:23:75:
+         6d:7a:fe:ad:cf:27:a6:29:c0:5c:c0:0e:4c:92:60:90:59:e0:
+         f6:ab:00:cd:9b:04:cb:36:f1:b3:02:b8:76:75:63:7f:fe:7c:
+         6d:7e:b9:c6:74:44:4d:73:da:02:90:05:de:8b:fa:83:b2:42:
+         a2:2d:50:7f:31:d3:c8:3c:90:8a:6d:f5:a1:d8:46:eb:5b:97:
+         89:bf:52:6f:7a:36:fd:dd:fc:fe:d0:2a:6b:3b:fb:5d:fc:e8:
+         ee:3f:03:75:d0:6a:f7:78:9f:f2:37:f9:24:a1:04:96:db:da:
+         0c:54:19:84:bb:a8:d8:88:61:aa:f9:08:a6:87:6b:cd:24:73:
+         e0:c3:03:1a:6b:66:a6:df:ab:f1:0f:fc:2d:77:fb:11:c2:2f:
+         a8:18:d9:26:a7:af:55:d1:1b:13:48:f1:6e:08:2b:83:90:8f:
+         37:ef:de:19:3c:34:97:d6:d8:b5:04:48:aa:83:8c:f9:73:a5:
+         02:93:2d:45:dd:05:77:80:4b:a3:13:88:e7:ce:24:58:33:b6:
+         42:5b:cf:91:9a:ab:6e:15:38:b1:a1:2c:01:b0:e0:9b:25:00:
+         7f:b0:30:6e:06:70:b3:ee:45:56:bb:04:b4:b6:7d:18:17:df:
+         bc:a3:89:87
 -----BEGIN CERTIFICATE-----
 MIICqjCCAZKgAwIBAgIBBTANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0
-IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zMzA2MjQyMTE4MDBa
+IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zNDAxMjcxODQzMzJa
 MBIxEDAOBgNVBAMMB3JlbmV3ZWQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
-AoIBAQDEf7bdq6hYf0lInb1vkZrqvIw8IF/sOzBOwsWYjlIndNnRKH5qCbH86tIo
-p0gwuLyTEehWk78Chhx4Fgu4w86qsSfexpYg+NSOY1izBcbfp+vrhRSYBA7XmReB
-DBULx/C/FKWO6VuIZem0Pp939Hdg3ap16fJ1B6hHF6N58eXqAYAlWlob+41uF8e4
-fbsd7Ge/yYOPKAKZgxb0LPCUJRt/8Jn77HVjiJcvHfi/FJI73+2gVgyUxpK0keKF
-iN6ZkwAXsPHtRQOPBy5a5YJqmW9FAFQqN5N3IwbDmfrBH0xZY+E1uff2q4GlEe+c
-oeZkqy/8+c2z0LczgUw2EwM6XublAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAL7z
-BjQ5Nh5BOGS9yAEFtG3130QvF+WGuRWWXpQ4LWNKVJAhz9U+424Pvw25m+moU8s4
-w5uIrwzJ+iqbD8y+1hXo/h1ryzA+KMKlh2m+jVEX7cN/4AXCPFzXidZp8kQlGlUx
-dg+DTtcw0tWC6+ijdRUBt5bKSwXKgW+AJjjFXqIcJA1Ku0pBUZrR7X68rRxqzfzE
-UxEUpf+hYAs6BDXEA6JWJJKktunAxfUtFmCXiZIIA0jC75/RfqdW7BImfzYMO3xl
-gne6DSj70uBcGV5WETgSVLa561U6CIHj27xtGsmQ4h9H+lUjx9DkukQjqDlS/lL8
-bMhKl31MR6sheZ8lvzU=
+AoIBAQCsDeLhYu56VfZGCl/t3Eqm1NAZf6hNzaDBYdToeFDUXUAf4MN5JpUZTM1w
+EFM4sWjkftREZWiUjLar0iI22LCSuu0/AOywtl8mrPcrceTXiihJqP75oci4CXOM
+99OQq+10+yUpv4FRs6wCgbrBf4qt1xht0HMef9lU7Quiptd+IuE/o213Sp4XaELv
+mWPgD1w1TjrvWoQ8xsGseMX+YFb05YZ9YBtVPL1qyCLqtsP2imfoy10jYURLniT4
+kWklkAvXLoQ/waKPh2ioNrOns8gOBr1r81RB0kdJpy+bPC83iUYSkJX+am9eKcbZ
+6pBHKRuFHtMZ6YBA9zNnu+UXUFzNAgMBAAEwDQYJKoZIhvcNAQELBQADggEBABFl
+l+in3hPJ3oDCewZx994jdW16/q3PJ6YpwFzADkySYJBZ4ParAM2bBMs28bMCuHZ1
+Y3/+fG1+ucZ0RE1z2gKQBd6L+oOyQqItUH8x08g8kIpt9aHYRutbl4m/Um96Nv3d
+/P7QKms7+1386O4/A3XQavd4n/I3+SShBJbb2gxUGYS7qNiIYar5CKaHa80kc+DD
+AxprZqbfq/EP/C13+xHCL6gY2Sanr1XRGxNI8W4IK4OQjzfv3hk8NJfW2LUESKqD
+jPlzpQKTLUXdBXeAS6MTiOfOJFgztkJbz5Gaq24VOLGhLAGw4JslAH+wMG4GcLPu
+RVa7BLS2fRgX37yjiYc=
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/request-key.pem
+++ b/spec/fixtures/ssl/request-key.pem
@@ -1,117 +1,117 @@
-Private-Key: (2048 bit, 2 primes)
+RSA Private-Key: (2048 bit, 2 primes)
 modulus:
-    00:c2:92:fa:28:25:5c:fe:d2:29:cb:70:b2:91:56:
-    cc:94:18:3d:f3:d6:e0:c9:fe:3e:92:c9:11:35:ac:
-    40:20:37:7e:1d:73:dc:45:67:50:29:8d:c4:40:be:
-    ae:53:4b:0e:58:22:b1:cc:fe:6c:da:3c:a7:ed:e4:
-    1c:ab:33:94:e6:40:85:44:c3:78:28:cb:c3:3d:c3:
-    fd:cc:91:d7:36:2c:f2:1f:01:f6:93:2c:00:cf:70:
-    d0:42:55:62:af:b3:93:5e:57:b7:03:0c:d9:22:b0:
-    d6:68:26:c6:d2:d7:32:7a:57:e6:96:bb:b0:69:71:
-    ad:77:48:64:ab:3b:4e:e5:ea:03:f4:d9:0f:5c:04:
-    4e:60:d3:b7:d7:89:c6:a2:50:b5:f4:da:f6:69:d5:
-    11:a8:50:67:a2:fd:ec:15:4f:13:22:8f:c7:74:ac:
-    84:31:c6:7f:1a:d1:9e:12:bf:dd:69:b6:79:46:ac:
-    e5:d2:d9:ae:59:51:77:e5:2a:6e:13:c4:a8:99:68:
-    d2:18:cd:3b:07:92:b7:7a:ad:a2:09:f6:ac:2d:2c:
-    47:4a:ce:2c:cc:fc:79:db:cf:71:41:1b:f0:0c:c5:
-    74:a8:2f:a4:18:7f:1f:45:35:b2:4d:d0:43:a2:62:
-    56:98:0f:6f:62:74:ad:8b:62:a8:8b:9b:5d:a8:23:
-    24:0d
+    00:ca:4a:fc:49:f0:75:de:db:71:88:87:f7:48:ec:
+    77:67:7c:38:a4:91:24:47:a4:85:1c:38:e4:ec:6d:
+    8a:aa:24:8d:fb:1c:41:ca:96:d7:92:70:14:9d:cc:
+    a7:26:d5:91:04:87:c3:9b:bc:7c:c2:7d:5f:8d:50:
+    75:d6:02:51:a3:38:94:b8:b8:63:4b:38:cf:08:0b:
+    c0:31:d9:a6:db:61:b7:11:32:95:ca:87:dc:54:21:
+    d1:bb:56:b9:2c:f2:c6:84:1f:54:df:09:d1:50:9d:
+    ae:97:45:f9:c0:66:58:d9:63:3e:fb:bf:af:e6:1a:
+    c8:ee:84:6b:cd:50:fe:dc:7a:52:74:17:3c:35:89:
+    4b:a7:48:3b:b8:84:ae:d1:0c:3c:5c:e0:e3:4c:20:
+    f8:aa:a4:70:4e:10:15:5e:a5:6e:6f:99:87:fd:79:
+    45:40:2b:6b:ec:e3:36:7a:ed:73:02:28:c7:cb:2e:
+    a0:ca:34:05:31:f5:98:c9:27:40:e6:e3:f3:26:2a:
+    25:cc:89:52:87:a0:33:a5:61:a2:c6:73:bd:a7:fc:
+    a6:0b:93:46:fe:3b:a7:6f:a3:3b:a4:6d:1e:1b:d1:
+    c4:28:09:ea:1d:b4:aa:f3:9a:fb:10:a2:b2:21:f2:
+    86:70:a4:b8:a8:df:4c:09:2c:fb:d2:48:a9:1c:3a:
+    4d:17
 publicExponent: 65537 (0x10001)
 privateExponent:
-    2c:db:4f:06:15:d5:0a:5f:1f:a9:09:d6:74:f8:be:
-    89:ae:cc:0b:8c:c0:7e:78:d9:6a:a4:25:8e:4a:e3:
-    6e:b9:f4:5e:6c:61:3d:f3:db:30:75:41:27:0e:fe:
-    a7:ef:b0:03:24:1e:7a:ec:b5:e2:1b:25:38:cc:03:
-    ca:f9:45:8c:ce:97:9a:ba:78:97:69:20:5d:fb:32:
-    e5:e8:42:65:f8:37:2a:6c:5c:b0:e1:ae:5f:24:7a:
-    32:ac:b6:27:5c:fe:2e:bc:08:92:50:b2:37:53:ee:
-    de:0c:80:7e:47:83:d8:de:2e:68:16:25:8d:ad:9a:
-    28:db:7c:ef:d7:e8:b0:ca:9a:fb:33:c8:f6:ab:cb:
-    44:25:4a:9a:a9:4d:06:83:0b:d3:c5:00:cb:dd:8a:
-    a8:b9:39:c7:af:f9:8e:8b:e5:7c:ea:a3:0c:9b:bf:
-    3d:2d:c2:79:2d:57:74:df:46:84:c1:d3:2c:54:0d:
-    c4:86:31:03:09:25:61:3e:30:b8:3e:8b:ff:c0:61:
-    38:31:f5:56:d5:c2:0b:4b:d1:50:30:bb:3a:00:59:
-    dd:63:16:1a:8d:83:b1:71:84:12:f2:7c:1b:6d:44:
-    e4:b9:38:36:07:0e:e7:a9:93:68:5e:83:7f:8d:30:
-    31:51:6e:15:68:04:62:7d:1c:1f:35:49:c6:1a:15:
-    21
+    47:98:90:80:2e:cd:d8:e9:3b:de:81:98:c0:c3:88:
+    63:24:f0:fb:35:af:6c:77:ca:f0:b9:26:34:93:74:
+    7f:51:5e:ba:e0:3e:5c:d0:54:4d:ac:c3:6f:32:0e:
+    7a:cd:1d:7d:47:fb:b0:33:de:c8:0b:0d:75:7b:63:
+    a9:31:ba:e9:14:ce:76:2e:34:5e:5c:25:d2:08:2e:
+    a6:b6:0c:bb:1a:73:6b:6f:c6:da:1e:89:99:71:3a:
+    c4:9e:25:fd:c5:93:03:11:ff:bc:cc:c1:bb:51:83:
+    88:60:a8:cb:32:ae:01:8a:81:b1:22:1f:c4:45:f8:
+    95:8a:62:89:11:40:92:91:4a:66:95:43:fc:f4:ef:
+    58:2f:6a:11:28:37:5d:8c:3a:f1:94:db:4e:36:79:
+    c4:0d:de:4f:5a:4e:f9:91:48:e9:a5:0c:2a:71:3f:
+    0f:18:e8:bc:f4:27:c7:3d:96:18:68:be:10:a5:5c:
+    44:30:f0:6f:6f:39:8a:8d:d8:a3:ee:55:c1:4a:c0:
+    d6:e2:b4:a2:a8:0d:3a:a5:f2:29:25:ff:b9:8c:aa:
+    fd:8f:80:7a:58:e6:29:fb:fc:40:10:f9:6a:90:e0:
+    0a:28:0d:78:08:18:da:44:ea:8d:13:5f:c8:d2:de:
+    ca:0e:81:af:d7:8f:37:ad:58:2a:bf:ca:9a:73:d5:
+    99
 prime1:
-    00:f1:a4:e8:bd:f8:07:5e:de:e4:e6:83:ba:83:78:
-    f4:a7:fb:c6:78:b3:ef:5e:09:67:88:7a:53:59:ec:
-    37:f6:07:ac:32:82:e7:c7:cc:93:8b:e4:e5:26:de:
-    7f:c3:c8:e2:6f:26:02:72:83:2c:7c:f7:36:10:04:
-    bb:a3:cc:68:60:dc:8b:98:6c:0d:2d:6e:9e:d0:d9:
-    be:cf:78:76:04:58:93:43:cf:2b:83:10:8a:fb:ea:
-    fd:d7:76:29:fa:dd:bd:c5:e8:f4:c7:c6:27:80:42:
-    8a:68:a7:ad:6b:cd:0f:af:06:f6:9d:62:2e:0b:fe:
-    67:93:08:b9:57:9c:32:5d:21
+    00:fe:54:28:81:30:a5:dc:18:13:ec:a6:30:5c:89:
+    a7:98:df:94:42:24:1a:28:ea:79:a7:f3:db:08:4d:
+    2b:27:29:f2:eb:10:7f:76:bb:d6:9d:de:09:af:6a:
+    0e:a2:fb:0b:6d:d1:a7:e5:cf:c5:7d:ba:5d:f6:a8:
+    06:51:7e:fb:17:70:3f:77:5a:16:f9:d3:af:44:d3:
+    d8:f7:75:47:ce:2b:83:f5:fe:c1:b8:40:dd:32:4f:
+    9b:66:42:be:da:42:03:17:ad:ec:d2:54:62:88:f2:
+    8f:0b:ca:fc:e6:4d:43:58:ae:36:ec:3e:90:55:f8:
+    42:7e:f3:83:8c:25:d7:68:1b
 prime2:
-    00:ce:22:31:c2:b9:6d:58:a0:c8:49:95:2e:35:48:
-    93:ce:85:7f:13:37:72:c1:1b:96:a7:ee:93:05:fa:
-    ca:c5:d0:49:96:a4:a2:9c:02:29:92:c3:62:f6:d8:
-    c6:75:40:5c:7c:30:da:0f:9a:9e:a8:a2:5e:39:a4:
-    a3:07:51:ea:8b:7f:e0:7d:e0:6d:04:f2:69:05:dc:
-    03:9d:6f:c7:84:1c:f8:d0:f5:fd:e7:da:a2:9d:cc:
-    cf:40:f4:f8:14:ff:4a:fa:61:4e:f2:da:4d:ad:1e:
-    f2:db:72:80:4a:60:6d:b2:6e:91:4e:26:b8:40:5c:
-    5f:90:32:33:c1:b6:cc:dd:6d
+    00:cb:9f:4a:62:a7:d0:bf:3e:84:39:58:41:7c:9b:
+    9b:dc:95:d0:7c:f7:39:59:7c:1e:2c:ac:cc:de:d8:
+    e6:5b:6a:45:86:18:96:c4:75:63:41:04:fb:e3:68:
+    2d:cf:8d:a2:3a:e3:ff:ed:58:2a:61:73:bb:b0:e6:
+    30:02:67:1d:7f:1a:bb:9b:96:cb:cb:64:da:bd:30:
+    64:cd:30:2b:6d:df:d2:28:56:9b:08:f9:81:32:27:
+    9c:7c:85:f2:03:d7:93:1c:b5:e3:65:76:81:48:98:
+    90:2e:29:01:ff:ec:2f:82:34:0c:d4:da:c8:49:eb:
+    ea:09:77:bd:c7:e0:68:36:b5
 exponent1:
-    10:38:40:83:17:d5:ee:d1:49:4e:0b:c3:86:35:a5:
-    3e:6d:50:fa:23:21:cb:0f:18:8a:f9:a3:04:a3:2d:
-    72:6f:3b:68:bc:8e:b0:43:94:17:cc:ca:70:dc:78:
-    78:fc:cf:ee:24:00:00:0d:bb:fb:bb:60:3e:9d:02:
-    b7:50:ee:24:aa:49:18:77:10:3f:5f:70:7b:96:52:
-    0f:7d:07:76:ed:37:1d:53:17:99:99:8f:aa:af:30:
-    50:b9:16:c2:47:06:08:f5:c5:10:6f:c5:90:ff:66:
-    68:f5:f0:57:0f:11:a1:6e:f7:38:c3:31:52:0e:c6:
-    87:01:0b:e7:cc:8d:38:e1
+    00:88:ab:8d:00:af:b5:d1:aa:96:ba:6b:2c:3d:ee:
+    33:44:31:91:a8:61:62:35:6e:9b:65:a7:e3:a2:78:
+    65:a2:2c:26:c0:2f:23:70:18:cc:e2:14:f9:bb:6c:
+    10:e5:80:66:c9:e3:0a:88:b2:b8:7c:31:f4:60:a2:
+    36:93:00:db:c9:e2:a6:18:6b:2f:41:9d:81:e8:48:
+    b7:a5:73:3e:dd:0a:01:65:e6:3b:0f:da:bb:83:57:
+    c8:38:91:d1:a1:d4:2b:79:44:1b:a9:83:73:58:08:
+    90:da:53:80:c7:f9:e9:20:f4:ad:cb:12:6b:d9:e7:
+    09:44:d3:73:73:92:ba:48:d5
 exponent2:
-    5a:16:73:ac:e8:a1:33:54:c1:73:f7:30:c4:b4:bd:
-    74:4a:bf:a8:c4:58:f0:b0:7f:fd:50:b5:0c:ad:f8:
-    a4:cf:4c:f9:fb:65:dd:cc:cc:22:8a:25:dc:40:0d:
-    2b:fd:3e:ee:3f:e3:6d:62:63:e8:cb:5d:66:cf:df:
-    38:39:c2:c9:c8:cf:71:f3:fd:71:66:08:24:39:6d:
-    93:06:e1:29:8a:07:ec:3b:36:06:78:75:0d:86:0f:
-    26:12:69:c1:b3:79:2f:48:0b:da:f3:31:73:71:cd:
-    2d:bf:32:f6:4e:82:62:b3:13:ea:15:dd:fc:b2:e2:
-    49:00:c7:c1:e7:84:4d:59
+    05:6a:5c:21:19:93:7c:b2:9d:f3:a4:7c:41:63:26:
+    17:0c:c8:f9:b9:dd:85:9a:be:76:b3:b5:d3:2b:73:
+    9c:f4:cb:9a:90:66:da:1c:c1:22:06:8e:e8:72:69:
+    dd:7e:47:d5:47:21:14:5f:e6:e8:a6:9a:54:4f:1a:
+    f1:c5:6a:4c:6a:1a:99:3d:be:77:cf:5b:dd:f2:3e:
+    8c:12:7e:e5:32:31:b5:ae:ef:fa:a2:20:24:84:57:
+    2e:1c:a5:de:22:4a:a0:55:da:11:65:c0:74:7c:d2:
+    40:d8:08:5c:95:1c:82:5a:fe:08:5f:35:3a:7a:12:
+    c4:63:b1:e1:71:ff:73:8d
 coefficient:
-    4e:75:e2:4f:d8:2f:70:8e:e1:88:8c:6c:12:e4:22:
-    05:ff:d9:3d:e1:c2:c4:ec:a9:7e:16:85:23:a5:55:
-    29:87:08:cb:ab:99:4d:c7:64:88:42:90:e7:f3:41:
-    4b:f8:cb:27:66:7d:20:63:33:82:bc:e4:d3:6a:26:
-    91:51:a0:96:b7:b6:22:d4:dc:ae:02:43:f8:f6:78:
-    34:54:16:c1:c8:9d:29:97:0a:c8:54:53:db:a9:73:
-    74:95:49:f2:cb:50:de:3e:45:c0:5c:b9:c8:e4:a2:
-    0f:32:a3:bc:2f:db:10:9b:01:80:c1:63:b0:6d:53:
-    71:a1:43:1e:9d:94:d0:1d
+    00:d4:26:27:a7:99:06:86:1c:e3:d0:79:d8:e0:7c:
+    9b:9b:b0:85:86:6f:67:c5:01:37:c0:b9:4a:92:32:
+    da:22:ec:e3:4a:98:a9:36:6d:01:a7:c1:11:3e:45:
+    2f:0f:01:ce:05:0c:de:27:af:c8:22:d9:de:64:83:
+    0a:fa:bb:0e:76:c1:a9:83:d0:55:62:36:93:bb:c0:
+    54:ed:03:bc:38:7a:94:68:0e:71:db:e0:0b:a2:fb:
+    4e:09:9a:bc:0f:6d:18:72:ab:76:aa:c9:4b:37:0e:
+    fa:0e:db:8b:0d:97:96:b5:59:ab:ac:7e:6f:d6:87:
+    da:45:25:78:a2:4c:ec:92:16
 -----BEGIN RSA PRIVATE KEY-----
-MIIEogIBAAKCAQEAwpL6KCVc/tIpy3CykVbMlBg989bgyf4+kskRNaxAIDd+HXPc
-RWdQKY3EQL6uU0sOWCKxzP5s2jyn7eQcqzOU5kCFRMN4KMvDPcP9zJHXNizyHwH2
-kywAz3DQQlVir7OTXle3AwzZIrDWaCbG0tcyelfmlruwaXGtd0hkqztO5eoD9NkP
-XAROYNO314nGolC19Nr2adURqFBnov3sFU8TIo/HdKyEMcZ/GtGeEr/dabZ5Rqzl
-0tmuWVF35SpuE8SomWjSGM07B5K3eq2iCfasLSxHSs4szPx5289xQRvwDMV0qC+k
-GH8fRTWyTdBDomJWmA9vYnSti2Koi5tdqCMkDQIDAQABAoIBACzbTwYV1QpfH6kJ
-1nT4vomuzAuMwH542WqkJY5K42659F5sYT3z2zB1QScO/qfvsAMkHnrsteIbJTjM
-A8r5RYzOl5q6eJdpIF37MuXoQmX4NypsXLDhrl8kejKstidc/i68CJJQsjdT7t4M
-gH5Hg9jeLmgWJY2tmijbfO/X6LDKmvszyPary0QlSpqpTQaDC9PFAMvdiqi5Ocev
-+Y6L5Xzqowybvz0twnktV3TfRoTB0yxUDcSGMQMJJWE+MLg+i//AYTgx9VbVwgtL
-0VAwuzoAWd1jFhqNg7FxhBLyfBttROS5ODYHDuepk2heg3+NMDFRbhVoBGJ9HB81
-ScYaFSECgYEA8aTovfgHXt7k5oO6g3j0p/vGeLPvXglniHpTWew39gesMoLnx8yT
-i+TlJt5/w8jibyYCcoMsfPc2EAS7o8xoYNyLmGwNLW6e0Nm+z3h2BFiTQ88rgxCK
-++r913Yp+t29xej0x8YngEKKaKeta80Prwb2nWIuC/5nkwi5V5wyXSECgYEAziIx
-wrltWKDISZUuNUiTzoV/EzdywRuWp+6TBfrKxdBJlqSinAIpksNi9tjGdUBcfDDa
-D5qeqKJeOaSjB1Hqi3/gfeBtBPJpBdwDnW/HhBz40PX959qinczPQPT4FP9K+mFO
-8tpNrR7y23KASmBtsm6RTia4QFxfkDIzwbbM3W0CgYAQOECDF9Xu0UlOC8OGNaU+
-bVD6IyHLDxiK+aMEoy1ybztovI6wQ5QXzMpw3Hh4/M/uJAAADbv7u2A+nQK3UO4k
-qkkYdxA/X3B7llIPfQd27TcdUxeZmY+qrzBQuRbCRwYI9cUQb8WQ/2Zo9fBXDxGh
-bvc4wzFSDsaHAQvnzI044QKBgFoWc6zooTNUwXP3MMS0vXRKv6jEWPCwf/1QtQyt
-+KTPTPn7Zd3MzCKKJdxADSv9Pu4/421iY+jLXWbP3zg5wsnIz3Hz/XFmCCQ5bZMG
-4SmKB+w7NgZ4dQ2GDyYSacGzeS9IC9rzMXNxzS2/MvZOgmKzE+oV3fyy4kkAx8Hn
-hE1ZAoGATnXiT9gvcI7hiIxsEuQiBf/ZPeHCxOypfhaFI6VVKYcIy6uZTcdkiEKQ
-5/NBS/jLJ2Z9IGMzgrzk02omkVGglre2ItTcrgJD+PZ4NFQWwcidKZcKyFRT26lz
-dJVJ8stQ3j5FwFy5yOSiDzKjvC/bEJsBgMFjsG1TcaFDHp2U0B0=
+MIIEpAIBAAKCAQEAykr8SfB13ttxiIf3SOx3Z3w4pJEkR6SFHDjk7G2KqiSN+xxB
+ypbXknAUncynJtWRBIfDm7x8wn1fjVB11gJRoziUuLhjSzjPCAvAMdmm22G3ETKV
+yofcVCHRu1a5LPLGhB9U3wnRUJ2ul0X5wGZY2WM++7+v5hrI7oRrzVD+3HpSdBc8
+NYlLp0g7uISu0Qw8XODjTCD4qqRwThAVXqVub5mH/XlFQCtr7OM2eu1zAijHyy6g
+yjQFMfWYySdA5uPzJiolzIlSh6AzpWGixnO9p/ymC5NG/junb6M7pG0eG9HEKAnq
+HbSq85r7EKKyIfKGcKS4qN9MCSz70kipHDpNFwIDAQABAoIBAEeYkIAuzdjpO96B
+mMDDiGMk8Ps1r2x3yvC5JjSTdH9RXrrgPlzQVE2sw28yDnrNHX1H+7Az3sgLDXV7
+Y6kxuukUznYuNF5cJdIILqa2DLsac2tvxtoeiZlxOsSeJf3FkwMR/7zMwbtRg4hg
+qMsyrgGKgbEiH8RF+JWKYokRQJKRSmaVQ/z071gvahEoN12MOvGU2042ecQN3k9a
+TvmRSOmlDCpxPw8Y6Lz0J8c9lhhovhClXEQw8G9vOYqN2KPuVcFKwNbitKKoDTql
+8ikl/7mMqv2PgHpY5in7/EAQ+WqQ4AooDXgIGNpE6o0TX8jS3soOga/XjzetWCq/
+yppz1ZkCgYEA/lQogTCl3BgT7KYwXImnmN+UQiQaKOp5p/PbCE0rJyny6xB/drvW
+nd4Jr2oOovsLbdGn5c/Ffbpd9qgGUX77F3A/d1oW+dOvRNPY93VHziuD9f7BuEDd
+Mk+bZkK+2kIDF63s0lRiiPKPC8r85k1DWK427D6QVfhCfvODjCXXaBsCgYEAy59K
+YqfQvz6EOVhBfJub3JXQfPc5WXweLKzM3tjmW2pFhhiWxHVjQQT742gtz42iOuP/
+7VgqYXO7sOYwAmcdfxq7m5bLy2TavTBkzTArbd/SKFabCPmBMiecfIXyA9eTHLXj
+ZXaBSJiQLikB/+wvgjQM1NrISevqCXe9x+BoNrUCgYEAiKuNAK+10aqWumssPe4z
+RDGRqGFiNW6bZafjonhloiwmwC8jcBjM4hT5u2wQ5YBmyeMKiLK4fDH0YKI2kwDb
+yeKmGGsvQZ2B6Ei3pXM+3QoBZeY7D9q7g1fIOJHRodQreUQbqYNzWAiQ2lOAx/np
+IPStyxJr2ecJRNNzc5K6SNUCgYAFalwhGZN8sp3zpHxBYyYXDMj5ud2Fmr52s7XT
+K3Oc9MuakGbaHMEiBo7ocmndfkfVRyEUX+bopppUTxrxxWpMahqZPb53z1vd8j6M
+En7lMjG1ru/6oiAkhFcuHKXeIkqgVdoRZcB0fNJA2AhclRyCWv4IXzU6ehLEY7Hh
+cf9zjQKBgQDUJienmQaGHOPQedjgfJubsIWGb2fFATfAuUqSMtoi7ONKmKk2bQGn
+wRE+RS8PAc4FDN4nr8gi2d5kgwr6uw52wamD0FViNpO7wFTtA7w4epRoDnHb4Aui
++04JmrwPbRhyq3aqyUs3DvoO24sNl5a1Wausfm/Wh9pFJXiiTOySFg==
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/request.pem
+++ b/spec/fixtures/ssl/request.pem
@@ -1,62 +1,60 @@
 Certificate Request:
     Data:
-        Version: Unknown (2)
+        Version: 3 (0x2)
         Subject: CN=pending
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                Public-Key: (2048 bit)
+                RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:c2:92:fa:28:25:5c:fe:d2:29:cb:70:b2:91:56:
-                    cc:94:18:3d:f3:d6:e0:c9:fe:3e:92:c9:11:35:ac:
-                    40:20:37:7e:1d:73:dc:45:67:50:29:8d:c4:40:be:
-                    ae:53:4b:0e:58:22:b1:cc:fe:6c:da:3c:a7:ed:e4:
-                    1c:ab:33:94:e6:40:85:44:c3:78:28:cb:c3:3d:c3:
-                    fd:cc:91:d7:36:2c:f2:1f:01:f6:93:2c:00:cf:70:
-                    d0:42:55:62:af:b3:93:5e:57:b7:03:0c:d9:22:b0:
-                    d6:68:26:c6:d2:d7:32:7a:57:e6:96:bb:b0:69:71:
-                    ad:77:48:64:ab:3b:4e:e5:ea:03:f4:d9:0f:5c:04:
-                    4e:60:d3:b7:d7:89:c6:a2:50:b5:f4:da:f6:69:d5:
-                    11:a8:50:67:a2:fd:ec:15:4f:13:22:8f:c7:74:ac:
-                    84:31:c6:7f:1a:d1:9e:12:bf:dd:69:b6:79:46:ac:
-                    e5:d2:d9:ae:59:51:77:e5:2a:6e:13:c4:a8:99:68:
-                    d2:18:cd:3b:07:92:b7:7a:ad:a2:09:f6:ac:2d:2c:
-                    47:4a:ce:2c:cc:fc:79:db:cf:71:41:1b:f0:0c:c5:
-                    74:a8:2f:a4:18:7f:1f:45:35:b2:4d:d0:43:a2:62:
-                    56:98:0f:6f:62:74:ad:8b:62:a8:8b:9b:5d:a8:23:
-                    24:0d
+                    00:ca:4a:fc:49:f0:75:de:db:71:88:87:f7:48:ec:
+                    77:67:7c:38:a4:91:24:47:a4:85:1c:38:e4:ec:6d:
+                    8a:aa:24:8d:fb:1c:41:ca:96:d7:92:70:14:9d:cc:
+                    a7:26:d5:91:04:87:c3:9b:bc:7c:c2:7d:5f:8d:50:
+                    75:d6:02:51:a3:38:94:b8:b8:63:4b:38:cf:08:0b:
+                    c0:31:d9:a6:db:61:b7:11:32:95:ca:87:dc:54:21:
+                    d1:bb:56:b9:2c:f2:c6:84:1f:54:df:09:d1:50:9d:
+                    ae:97:45:f9:c0:66:58:d9:63:3e:fb:bf:af:e6:1a:
+                    c8:ee:84:6b:cd:50:fe:dc:7a:52:74:17:3c:35:89:
+                    4b:a7:48:3b:b8:84:ae:d1:0c:3c:5c:e0:e3:4c:20:
+                    f8:aa:a4:70:4e:10:15:5e:a5:6e:6f:99:87:fd:79:
+                    45:40:2b:6b:ec:e3:36:7a:ed:73:02:28:c7:cb:2e:
+                    a0:ca:34:05:31:f5:98:c9:27:40:e6:e3:f3:26:2a:
+                    25:cc:89:52:87:a0:33:a5:61:a2:c6:73:bd:a7:fc:
+                    a6:0b:93:46:fe:3b:a7:6f:a3:3b:a4:6d:1e:1b:d1:
+                    c4:28:09:ea:1d:b4:aa:f3:9a:fb:10:a2:b2:21:f2:
+                    86:70:a4:b8:a8:df:4c:09:2c:fb:d2:48:a9:1c:3a:
+                    4d:17
                 Exponent: 65537 (0x10001)
         Attributes:
-            (none)
-            Requested Extensions:
+            a0:00
     Signature Algorithm: sha256WithRSAEncryption
-    Signature Value:
-        6c:33:bb:a7:17:97:ea:c8:e1:5c:d2:f6:43:bf:25:b7:5e:d6:
-        86:6b:d0:0b:2f:9e:1f:4b:24:98:e3:a7:6c:b3:3c:aa:a7:4d:
-        4c:9f:77:80:c8:2b:6a:d4:1e:90:bf:8b:31:2b:33:68:e9:55:
-        e5:41:82:10:f2:28:53:89:a8:97:00:05:d5:0f:48:22:38:0a:
-        69:ce:de:12:06:8c:f7:28:df:a9:d3:34:61:7e:31:a4:e9:13:
-        d3:de:e8:b9:81:bf:66:49:08:bd:3f:fd:63:6a:97:29:fa:42:
-        65:4a:b4:46:59:b9:63:12:f4:1e:f2:89:e6:17:6d:6f:28:fd:
-        10:d4:b8:9a:00:51:27:48:ef:65:41:76:c7:32:00:ac:d4:84:
-        2e:25:ee:b0:27:4d:f6:9f:75:b7:1a:92:ef:10:91:15:85:b9:
-        3c:8b:c9:c0:95:74:20:b6:46:d7:cb:5d:51:f8:b6:cf:52:0c:
-        70:9f:20:e0:63:21:d3:95:a9:e8:a5:7f:1d:71:32:22:a3:79:
-        bc:b8:e8:15:f9:a7:4e:26:b3:3e:3a:43:83:3c:23:05:98:18:
-        be:54:a7:ed:b3:cb:33:8d:22:0b:a0:1c:9b:fd:8b:d5:07:09:
-        bf:ad:31:06:02:a8:93:3a:ea:d6:75:a5:a1:72:1a:1b:f1:8c:
-        8c:47:0f:f7
+         4b:33:bf:da:81:1a:39:41:11:c4:1c:d0:e5:3c:c6:93:8d:df:
+         e5:91:c4:9f:d0:6b:07:61:94:25:d8:dc:9e:99:0d:9d:96:91:
+         b3:92:ff:eb:2e:f4:93:cd:05:26:6d:42:70:7b:73:08:59:2f:
+         4f:c8:7f:5a:ea:de:84:a8:62:b9:6b:6c:24:0a:89:6c:83:66:
+         43:d2:f5:84:d2:09:63:9e:21:44:9f:70:4a:90:9e:9d:4a:e2:
+         e6:b1:62:79:0f:12:cf:f7:91:39:31:e6:24:ee:96:bc:82:5f:
+         4e:0e:a4:f3:81:75:6f:e3:59:bd:e2:8e:24:9e:3f:fd:c4:52:
+         81:f6:0d:95:31:36:48:0b:29:4e:94:22:10:a6:25:1f:f9:a7:
+         9d:e9:fc:8d:c9:33:87:1e:00:c9:f8:81:0e:d7:02:31:74:f7:
+         57:ef:31:06:b8:fd:10:d3:43:a5:e9:ee:47:83:05:ac:8a:69:
+         22:19:03:52:66:df:ee:0a:3c:82:33:23:9c:ef:c6:f2:e3:88:
+         9e:03:aa:c1:ab:92:e5:ca:b7:ab:e9:ab:40:ab:8f:73:53:69:
+         ca:19:89:8c:a5:e2:2f:9a:0b:31:59:17:08:03:4b:d5:6e:74:
+         5a:d0:c8:b8:df:d7:39:88:45:cb:6a:02:d4:41:1c:f2:1e:b9:
+         77:3f:09:80
 -----BEGIN CERTIFICATE REQUEST-----
 MIICVzCCAT8CAQIwEjEQMA4GA1UEAwwHcGVuZGluZzCCASIwDQYJKoZIhvcNAQEB
-BQADggEPADCCAQoCggEBAMKS+iglXP7SKctwspFWzJQYPfPW4Mn+PpLJETWsQCA3
-fh1z3EVnUCmNxEC+rlNLDlgiscz+bNo8p+3kHKszlOZAhUTDeCjLwz3D/cyR1zYs
-8h8B9pMsAM9w0EJVYq+zk15XtwMM2SKw1mgmxtLXMnpX5pa7sGlxrXdIZKs7TuXq
-A/TZD1wETmDTt9eJxqJQtfTa9mnVEahQZ6L97BVPEyKPx3SshDHGfxrRnhK/3Wm2
-eUas5dLZrllRd+UqbhPEqJlo0hjNOweSt3qtogn2rC0sR0rOLMz8edvPcUEb8AzF
-dKgvpBh/H0U1sk3QQ6JiVpgPb2J0rYtiqIubXagjJA0CAwEAAaAAMA0GCSqGSIb3
-DQEBCwUAA4IBAQBsM7unF5fqyOFc0vZDvyW3XtaGa9ALL54fSySY46dsszyqp01M
-n3eAyCtq1B6Qv4sxKzNo6VXlQYIQ8ihTiaiXAAXVD0giOAppzt4SBoz3KN+p0zRh
-fjGk6RPT3ui5gb9mSQi9P/1japcp+kJlSrRGWbljEvQe8onmF21vKP0Q1LiaAFEn
-SO9lQXbHMgCs1IQuJe6wJ032n3W3GpLvEJEVhbk8i8nAlXQgtkbXy11R+LbPUgxw
-nyDgYyHTlanopX8dcTIio3m8uOgV+adOJrM+OkODPCMFmBi+VKfts8szjSILoByb
-/YvVBwm/rTEGAqiTOurWdaWhchob8YyMRw/3
+BQADggEPADCCAQoCggEBAMpK/Enwdd7bcYiH90jsd2d8OKSRJEekhRw45Oxtiqok
+jfscQcqW15JwFJ3MpybVkQSHw5u8fMJ9X41QddYCUaM4lLi4Y0s4zwgLwDHZptth
+txEylcqH3FQh0btWuSzyxoQfVN8J0VCdrpdF+cBmWNljPvu/r+YayO6Ea81Q/tx6
+UnQXPDWJS6dIO7iErtEMPFzg40wg+KqkcE4QFV6lbm+Zh/15RUAra+zjNnrtcwIo
+x8suoMo0BTH1mMknQObj8yYqJcyJUoegM6VhosZzvaf8pguTRv47p2+jO6RtHhvR
+xCgJ6h20qvOa+xCisiHyhnCkuKjfTAks+9JIqRw6TRcCAwEAAaAAMA0GCSqGSIb3
+DQEBCwUAA4IBAQBLM7/agRo5QRHEHNDlPMaTjd/lkcSf0GsHYZQl2NyemQ2dlpGz
+kv/rLvSTzQUmbUJwe3MIWS9PyH9a6t6EqGK5a2wkColsg2ZD0vWE0gljniFEn3BK
+kJ6dSuLmsWJ5DxLP95E5MeYk7pa8gl9ODqTzgXVv41m94o4knj/9xFKB9g2VMTZI
+CylOlCIQpiUf+aed6fyNyTOHHgDJ+IEO1wIxdPdX7zEGuP0Q00Ol6e5HgwWsimki
+GQNSZt/uCjyCMyOc78by44ieA6rBq5Llyrer6atAq49zU2nKGYmMpeIvmgsxWRcI
+A0vVbnRa0Mi439c5iEXLagLUQRzyHrl3PwmA
 -----END CERTIFICATE REQUEST-----

--- a/spec/fixtures/ssl/revoked-key.pem
+++ b/spec/fixtures/ssl/revoked-key.pem
@@ -1,117 +1,117 @@
-Private-Key: (2048 bit, 2 primes)
+RSA Private-Key: (2048 bit, 2 primes)
 modulus:
-    00:98:44:c4:15:34:87:c3:40:f4:b0:e6:2b:71:98:
-    b1:cc:de:56:ef:8c:51:49:35:17:0b:15:09:e9:ad:
-    45:2c:f0:c3:0e:20:99:6e:46:92:53:7f:cd:ec:fe:
-    62:60:1e:6f:7e:3e:f7:cf:cf:e0:de:ed:67:d9:f9:
-    0b:59:d8:c8:b5:8c:55:68:e3:2a:d4:bc:6b:73:38:
-    42:23:41:45:05:fa:ca:94:e7:98:d6:47:67:75:16:
-    6b:51:46:e5:66:f1:b4:e1:fe:18:07:ad:e6:3d:e0:
-    f0:6b:c9:0e:87:2e:12:27:7c:c1:35:cd:99:fa:8d:
-    dc:80:05:85:0a:2e:9f:9d:c0:87:76:7e:c8:aa:94:
-    2a:c3:91:07:67:25:7f:b2:b1:dc:e1:92:9b:db:20:
-    3e:75:05:36:a6:d0:a5:8f:54:4c:45:f6:c9:5c:15:
-    16:e9:fb:a4:a4:a7:47:a3:1b:9b:18:08:11:80:fd:
-    62:c3:6f:43:f7:a8:6c:f8:1a:9c:4b:8f:fe:64:2d:
-    27:9c:c5:11:e4:de:ea:7d:39:aa:62:d5:09:4d:c2:
-    fd:7a:d8:18:85:e9:07:de:4b:ac:b7:03:ff:6d:ca:
-    d7:96:2c:33:4d:cd:a9:0a:c1:7b:4a:d1:5c:07:90:
-    b2:ff:d6:48:54:2e:97:00:13:22:93:c5:6b:77:ab:
-    89:d5
+    00:c1:5b:fe:c1:98:52:de:3b:2b:71:ea:52:c9:4b:
+    07:f6:4e:d1:72:1f:5e:cc:cd:41:0b:2b:c7:aa:68:
+    05:56:0b:c3:42:66:ac:ee:d6:5a:3e:35:bb:b8:85:
+    27:ba:79:1b:97:b8:8c:b7:c7:64:96:de:7b:b8:78:
+    c1:56:5e:84:f8:9d:4a:a3:81:b4:d9:7d:ba:35:ee:
+    47:74:40:a4:47:a7:83:6c:af:9c:63:41:fa:8e:0e:
+    01:1d:92:b1:94:a9:ff:57:44:61:e9:3d:74:74:dd:
+    be:0b:73:f6:24:b7:92:f1:d3:35:34:a7:75:88:58:
+    7d:8b:5c:fb:39:f2:25:c4:fb:f2:39:8f:b6:85:a1:
+    38:7a:20:b8:8d:0d:68:c7:7f:48:1b:19:00:7a:f2:
+    71:ae:ef:b8:c7:6f:d5:0b:ff:ea:3b:7f:be:35:45:
+    ff:ae:3c:78:13:57:bf:ec:3c:cf:cc:26:9b:31:70:
+    8c:a9:c3:34:a0:49:99:d6:4c:db:30:8b:a0:b9:44:
+    15:49:3a:e6:51:f2:cd:26:c5:f1:b8:df:3f:70:20:
+    f5:52:ec:e2:f3:67:fc:86:f5:dd:31:a3:e9:70:ef:
+    35:0c:24:91:7d:20:06:d1:64:28:9e:80:23:c4:95:
+    06:b3:5b:25:3d:51:52:95:ad:29:c2:cd:34:40:b2:
+    96:b5
 publicExponent: 65537 (0x10001)
 privateExponent:
-    22:5f:07:6a:07:f9:0b:5c:9a:bf:61:bd:75:bf:73:
-    87:1c:bb:40:08:8b:02:bc:ee:ae:2c:3a:18:1a:ea:
-    2e:0a:4c:e5:5f:fb:72:56:90:ca:33:63:be:f6:ef:
-    2a:e6:43:e1:9a:02:23:51:37:df:ea:74:12:52:72:
-    ba:fd:c1:d4:a5:50:54:44:4f:13:45:52:f5:e7:c1:
-    9a:26:ae:17:7a:f4:86:a7:3e:ab:43:e3:f9:1c:ad:
-    ed:e3:54:7e:27:da:5e:57:16:82:89:41:1b:3f:ae:
-    d5:8d:c5:6f:43:39:8a:db:50:db:bd:c4:df:b7:6d:
-    0a:22:f4:d4:87:10:b5:b1:7a:40:c8:44:80:30:81:
-    e9:b2:33:3f:c6:3e:1a:a2:b4:c9:8c:6e:3d:c4:fa:
-    3e:e7:85:d4:c2:00:58:a0:1e:d9:01:ba:7b:42:51:
-    9b:65:37:fa:96:1c:57:1e:15:8e:c2:8c:27:60:55:
-    cf:cd:85:97:60:e9:ca:e5:e9:fc:cb:82:75:d8:24:
-    1f:6f:bb:66:15:5e:3e:a4:0e:32:58:36:ec:1a:f3:
-    3d:5c:7c:d4:f1:ad:39:f5:6c:ff:96:b2:c0:2f:58:
-    f0:0d:19:35:bb:67:e4:bd:f2:a8:9a:db:14:28:98:
-    9b:e3:74:a6:a7:c4:b1:a0:6c:09:3f:3b:87:a7:03:
-    33
+    00:93:a3:e3:e4:fc:a3:21:ce:fa:40:54:14:7c:60:
+    cf:26:92:4e:38:9e:9d:6b:31:ba:5d:86:43:41:e9:
+    85:51:8b:4f:bf:8e:d8:b2:d1:77:3c:93:18:d0:2e:
+    d4:03:fd:5f:45:3d:04:2d:7b:91:61:e5:65:80:98:
+    ab:bf:80:12:76:26:dc:0b:f7:09:19:1c:78:27:9f:
+    d6:6d:7c:c2:33:78:43:d0:a4:52:7c:33:af:d5:f1:
+    f9:86:14:31:85:fb:3b:dd:ed:77:f9:79:14:47:fb:
+    dc:95:b0:28:9d:26:92:8c:15:a2:45:9f:2c:0e:3c:
+    cb:37:b3:7a:9c:67:39:d1:aa:de:bb:2e:e9:17:56:
+    dd:0f:2f:3d:60:09:82:1d:74:cc:68:2a:b7:db:00:
+    28:32:1a:4c:d4:71:1d:b5:97:8c:fd:a5:d0:0a:41:
+    e1:b1:80:ae:1c:bd:01:b1:66:44:db:47:25:53:41:
+    d1:b2:c1:4e:74:b9:2c:8a:58:d9:22:37:5b:94:f0:
+    e0:32:58:1b:6a:6a:02:00:48:a8:97:e9:92:4b:2b:
+    8b:50:49:ce:a9:5d:e9:ea:9b:73:e1:28:0c:a6:09:
+    af:c6:da:c1:fc:8b:5a:c5:20:7e:6a:fd:da:1e:7d:
+    4a:12:fa:d7:75:a2:47:22:30:8e:0b:60:a2:33:f1:
+    37:6d
 prime1:
-    00:bb:5c:ab:7b:d1:66:04:73:ec:75:b1:59:79:33:
-    8b:be:82:c1:13:34:b0:88:48:53:60:1c:8f:b5:2e:
-    81:35:9a:60:c2:9d:b0:77:db:3e:3a:a7:0a:91:50:
-    54:ac:29:2a:34:c1:32:6d:e2:b5:fd:57:b8:f9:c0:
-    9e:c2:4e:04:a5:dd:9d:96:64:f1:29:b3:d9:e8:6d:
-    78:30:de:14:6e:18:8d:4e:30:f6:a2:b1:8c:ed:7a:
-    3f:d7:84:58:97:95:8f:e2:e9:5f:56:cb:3b:4a:f2:
-    be:23:9b:02:7c:4d:d3:6b:5b:6f:7b:45:51:89:b4:
-    cc:63:47:87:8d:3b:7e:18:03
+    00:e9:ee:32:cf:2e:3e:0b:94:a7:e6:b7:21:e8:ad:
+    61:53:14:dc:3f:18:89:1c:f4:bd:4b:66:4a:c3:4c:
+    03:b4:d4:7d:76:34:37:4c:24:ce:cf:20:b8:5e:fd:
+    b7:f1:d0:69:9e:9a:30:d9:ef:cb:3d:f1:c1:48:b0:
+    42:64:9e:07:20:13:dd:bd:61:0f:84:27:0e:57:05:
+    74:d5:ea:b9:1c:11:7e:17:43:fc:81:c3:da:2d:8d:
+    80:9c:9f:72:fc:04:4e:ca:90:a6:c5:8a:32:78:60:
+    6f:a5:81:6d:14:52:be:b9:40:a5:22:b5:10:a6:04:
+    8f:11:76:6b:3c:4e:4d:21:67
 prime2:
-    00:d0:0c:f1:08:a4:50:4c:91:97:00:ca:6c:af:a7:
-    76:c4:fa:3f:4f:a0:85:e1:01:99:d0:95:12:77:02:
-    14:b1:1f:77:8b:41:95:be:5b:c2:23:f3:d5:55:c8:
-    b6:15:7f:ee:89:7c:ed:47:0e:70:00:07:f8:e9:b2:
-    ae:b4:35:cf:ad:ad:49:94:02:f0:17:43:95:45:f7:
-    3f:30:5d:24:9b:4e:5f:8c:46:80:97:bf:91:5b:20:
-    47:11:76:44:8a:1a:0a:03:f0:8e:93:97:13:77:f4:
-    12:d2:cf:68:16:9b:97:59:fe:8a:aa:2b:62:23:4a:
-    57:02:d3:c7:12:e7:8e:4b:47
+    00:d3:99:f0:3a:2b:8a:42:12:08:c1:4e:17:3d:60:
+    73:15:b6:eb:d6:ae:d6:1e:18:25:6d:a8:34:1f:d7:
+    22:04:3b:bd:8d:51:5c:51:8d:46:06:50:6c:e4:c7:
+    7e:ef:c4:a9:55:73:46:13:e9:df:7b:bf:b2:aa:0d:
+    b2:a8:7c:a6:6e:7b:c3:d8:20:d9:dd:45:88:8b:2c:
+    d1:a3:83:b1:55:42:a4:b2:47:35:04:c5:e1:01:60:
+    b7:f9:a5:c5:09:3e:5e:28:30:63:7d:f4:fa:47:1e:
+    8c:63:2c:51:73:be:4f:aa:c0:fe:53:1d:2c:d0:d3:
+    46:d8:a1:ec:fb:82:77:29:83
 exponent1:
-    43:ca:23:c1:88:e2:00:7a:70:f3:a4:57:5b:22:eb:
-    4c:e2:c2:38:d0:b7:8e:97:9c:93:09:c2:75:2b:7e:
-    54:86:a6:bb:c3:92:35:cb:7d:98:7b:17:b7:bb:f8:
-    e6:d1:7e:13:d8:53:06:af:20:69:a9:73:a3:e9:ad:
-    87:5f:f3:0e:90:40:94:49:b1:78:05:3a:b2:7d:e9:
-    1e:c5:3b:5f:1a:43:06:27:71:15:2c:68:71:03:ea:
-    55:6f:ed:1d:eb:5f:44:1a:6c:04:5b:43:f8:ba:1b:
-    51:86:a4:3f:95:69:09:4e:eb:e7:0e:0d:92:65:78:
-    0d:f3:b3:77:c6:2e:b9:41
+    07:63:84:ab:52:94:97:1d:0c:e8:96:a4:35:8b:34:
+    65:c1:64:eb:81:44:e3:6b:3f:87:60:25:c0:61:68:
+    44:8f:e9:9e:90:2b:a6:f6:0a:aa:34:28:5e:a7:b8:
+    e5:a4:65:91:a2:e1:24:21:14:d4:52:0c:7e:d5:42:
+    63:97:32:36:6b:2a:37:cf:17:04:5f:8f:6e:64:37:
+    ba:81:fd:72:cb:82:a6:0d:79:ae:47:97:5e:94:f7:
+    98:fa:d8:50:e9:79:eb:a0:02:04:7f:46:f4:d2:66:
+    f4:5d:50:2a:b2:2a:60:03:90:b3:b5:f0:5e:ae:0a:
+    2e:cd:04:ba:14:e7:0e:c5
 exponent2:
-    30:5f:b1:f3:76:71:0d:3c:94:c5:a4:4b:5d:14:2c:
-    f3:63:d4:30:a9:7c:37:72:ed:d6:a7:b2:a1:65:24:
-    76:82:80:83:2a:7e:ac:c2:1d:03:cb:00:01:70:27:
-    96:1c:26:d4:64:ed:ae:a5:d6:b8:cb:21:bf:04:c2:
-    c6:37:f4:cf:c7:08:e2:97:44:47:c4:79:02:c9:98:
-    31:a0:96:90:5d:ca:ad:8c:fe:fd:49:97:7c:7e:a6:
-    c7:92:9e:21:16:28:d9:fd:a6:c8:fe:49:92:8c:77:
-    8b:f8:99:95:18:1c:3a:da:8a:57:42:bb:10:c5:8a:
-    31:a8:18:13:77:2f:88:a5
+    33:57:0d:47:3f:db:2a:ce:af:5b:1f:74:5a:0a:f5:
+    c1:56:01:80:b4:28:f5:62:4c:6a:7f:be:2d:df:87:
+    bc:59:36:53:7c:63:16:d2:5d:24:19:0d:62:b0:d8:
+    a6:9a:23:af:bc:e9:4a:d9:9a:c4:ae:ad:4d:bf:47:
+    12:c4:33:a9:68:d4:0a:b3:65:c8:df:1f:13:0d:8b:
+    cb:cd:9f:10:1d:bc:52:19:1e:cf:0a:a7:de:2a:b6:
+    58:97:14:e8:7a:3e:64:27:e1:6b:e5:2d:78:65:fc:
+    0f:ef:e7:cf:5a:64:7f:fc:95:78:5b:02:cd:a4:05:
+    73:78:4e:44:73:d2:2f:bb
 coefficient:
-    54:25:3a:4b:a8:8d:be:ea:99:b5:67:e9:31:32:aa:
-    73:1e:99:81:33:f6:6a:a9:37:70:3c:27:19:4f:d4:
-    18:80:1d:32:29:5b:2c:30:05:9e:b7:30:42:48:c8:
-    a7:cd:ca:12:dc:21:9d:f4:b0:db:e5:c0:8e:a6:51:
-    28:62:1c:7d:f5:f4:f1:7f:cc:45:86:9d:65:57:ee:
-    d5:3b:d0:5e:fd:06:98:7e:2b:d2:91:93:75:b8:25:
-    11:b9:cd:27:4d:7a:66:1a:f5:85:36:ac:cd:23:de:
-    c8:70:1c:e4:11:4f:f8:e3:dc:b5:39:85:b9:d8:00:
-    f1:4a:b1:c0:87:bb:bd:ca
+    60:ff:46:e7:ea:48:35:9e:b6:53:2c:0c:23:b4:f8:
+    a9:74:9a:d5:30:d5:65:b8:ad:44:d8:af:45:bc:37:
+    d3:15:bd:71:ab:58:4f:92:fe:d6:33:61:89:0d:db:
+    9d:1f:12:cf:64:b3:0d:51:71:9b:61:b4:a5:75:6e:
+    79:64:e0:ae:ca:29:f3:a3:02:b6:d6:99:d8:a9:9f:
+    d9:e6:cd:87:de:89:62:ab:f5:ef:be:1f:43:a3:d1:
+    97:62:1d:bf:ad:07:b9:b5:4e:a5:c3:2d:dd:55:d6:
+    15:9a:ff:57:b5:68:22:44:8f:33:8c:68:39:b0:bf:
+    14:18:52:91:24:8c:99:8e
 -----BEGIN RSA PRIVATE KEY-----
-MIIEogIBAAKCAQEAmETEFTSHw0D0sOYrcZixzN5W74xRSTUXCxUJ6a1FLPDDDiCZ
-bkaSU3/N7P5iYB5vfj73z8/g3u1n2fkLWdjItYxVaOMq1LxrczhCI0FFBfrKlOeY
-1kdndRZrUUblZvG04f4YB63mPeDwa8kOhy4SJ3zBNc2Z+o3cgAWFCi6fncCHdn7I
-qpQqw5EHZyV/srHc4ZKb2yA+dQU2ptClj1RMRfbJXBUW6fukpKdHoxubGAgRgP1i
-w29D96hs+BqcS4/+ZC0nnMUR5N7qfTmqYtUJTcL9etgYhekH3kustwP/bcrXliwz
-Tc2pCsF7StFcB5Cy/9ZIVC6XABMik8Vrd6uJ1QIDAQABAoIBACJfB2oH+Qtcmr9h
-vXW/c4ccu0AIiwK87q4sOhga6i4KTOVf+3JWkMozY7727yrmQ+GaAiNRN9/qdBJS
-crr9wdSlUFRETxNFUvXnwZomrhd69IanPqtD4/kcre3jVH4n2l5XFoKJQRs/rtWN
-xW9DOYrbUNu9xN+3bQoi9NSHELWxekDIRIAwgemyMz/GPhqitMmMbj3E+j7nhdTC
-AFigHtkBuntCUZtlN/qWHFceFY7CjCdgVc/NhZdg6crl6fzLgnXYJB9vu2YVXj6k
-DjJYNuwa8z1cfNTxrTn1bP+WssAvWPANGTW7Z+S98qia2xQomJvjdKanxLGgbAk/
-O4enAzMCgYEAu1yre9FmBHPsdbFZeTOLvoLBEzSwiEhTYByPtS6BNZpgwp2wd9s+
-OqcKkVBUrCkqNMEybeK1/Ve4+cCewk4Epd2dlmTxKbPZ6G14MN4UbhiNTjD2orGM
-7Xo/14RYl5WP4ulfVss7SvK+I5sCfE3Ta1tve0VRibTMY0eHjTt+GAMCgYEA0Azx
-CKRQTJGXAMpsr6d2xPo/T6CF4QGZ0JUSdwIUsR93i0GVvlvCI/PVVci2FX/uiXzt
-Rw5wAAf46bKutDXPra1JlALwF0OVRfc/MF0km05fjEaAl7+RWyBHEXZEihoKA/CO
-k5cTd/QS0s9oFpuXWf6KqitiI0pXAtPHEueOS0cCgYBDyiPBiOIAenDzpFdbIutM
-4sI40LeOl5yTCcJ1K35Uhqa7w5I1y32Yexe3u/jm0X4T2FMGryBpqXOj6a2HX/MO
-kECUSbF4BTqyfekexTtfGkMGJ3EVLGhxA+pVb+0d619EGmwEW0P4uhtRhqQ/lWkJ
-TuvnDg2SZXgN87N3xi65QQKBgDBfsfN2cQ08lMWkS10ULPNj1DCpfDdy7dansqFl
-JHaCgIMqfqzCHQPLAAFwJ5YcJtRk7a6l1rjLIb8EwsY39M/HCOKXREfEeQLJmDGg
-lpBdyq2M/v1Jl3x+pseSniEWKNn9psj+SZKMd4v4mZUYHDraildCuxDFijGoGBN3
-L4ilAoGAVCU6S6iNvuqZtWfpMTKqcx6ZgTP2aqk3cDwnGU/UGIAdMilbLDAFnrcw
-QkjIp83KEtwhnfSw2+XAjqZRKGIcffX08X/MRYadZVfu1TvQXv0GmH4r0pGTdbgl
-EbnNJ016Zhr1hTaszSPeyHAc5BFP+OPctTmFudgA8UqxwIe7vco=
+MIIEowIBAAKCAQEAwVv+wZhS3jsrcepSyUsH9k7Rch9ezM1BCyvHqmgFVgvDQmas
+7tZaPjW7uIUnunkbl7iMt8dklt57uHjBVl6E+J1Ko4G02X26Ne5HdECkR6eDbK+c
+Y0H6jg4BHZKxlKn/V0Rh6T10dN2+C3P2JLeS8dM1NKd1iFh9i1z7OfIlxPvyOY+2
+haE4eiC4jQ1ox39IGxkAevJxru+4x2/VC//qO3++NUX/rjx4E1e/7DzPzCabMXCM
+qcM0oEmZ1kzbMIuguUQVSTrmUfLNJsXxuN8/cCD1Uuzi82f8hvXdMaPpcO81DCSR
+fSAG0WQonoAjxJUGs1slPVFSla0pws00QLKWtQIDAQABAoIBAQCTo+Pk/KMhzvpA
+VBR8YM8mkk44np1rMbpdhkNB6YVRi0+/jtiy0Xc8kxjQLtQD/V9FPQQte5Fh5WWA
+mKu/gBJ2JtwL9wkZHHgnn9ZtfMIzeEPQpFJ8M6/V8fmGFDGF+zvd7Xf5eRRH+9yV
+sCidJpKMFaJFnywOPMs3s3qcZznRqt67LukXVt0PLz1gCYIddMxoKrfbACgyGkzU
+cR21l4z9pdAKQeGxgK4cvQGxZkTbRyVTQdGywU50uSyKWNkiN1uU8OAyWBtqagIA
+SKiX6ZJLK4tQSc6pXenqm3PhKAymCa/G2sH8i1rFIH5q/doefUoS+td1okciMI4L
+YKIz8TdtAoGBAOnuMs8uPguUp+a3IeitYVMU3D8YiRz0vUtmSsNMA7TUfXY0N0wk
+zs8guF79t/HQaZ6aMNnvyz3xwUiwQmSeByAT3b1hD4QnDlcFdNXquRwRfhdD/IHD
+2i2NgJyfcvwETsqQpsWKMnhgb6WBbRRSvrlApSK1EKYEjxF2azxOTSFnAoGBANOZ
+8DorikISCMFOFz1gcxW269au1h4YJW2oNB/XIgQ7vY1RXFGNRgZQbOTHfu/EqVVz
+RhPp33u/sqoNsqh8pm57w9gg2d1FiIss0aODsVVCpLJHNQTF4QFgt/mlxQk+Xigw
+Y330+kcejGMsUXO+T6rA/lMdLNDTRtih7PuCdymDAoGAB2OEq1KUlx0M6JakNYs0
+ZcFk64FE42s/h2AlwGFoRI/pnpArpvYKqjQoXqe45aRlkaLhJCEU1FIMftVCY5cy
+NmsqN88XBF+PbmQ3uoH9csuCpg15rkeXXpT3mPrYUOl566ACBH9G9NJm9F1QKrIq
+YAOQs7XwXq4KLs0EuhTnDsUCgYAzVw1HP9sqzq9bH3RaCvXBVgGAtCj1Ykxqf74t
+34e8WTZTfGMW0l0kGQ1isNimmiOvvOlK2ZrErq1Nv0cSxDOpaNQKs2XI3x8TDYvL
+zZ8QHbxSGR7PCqfeKrZYlxToej5kJ+Fr5S14ZfwP7+fPWmR//JV4WwLNpAVzeE5E
+c9IvuwKBgGD/RufqSDWetlMsDCO0+Kl0mtUw1WW4rUTYr0W8N9MVvXGrWE+S/tYz
+YYkN250fEs9ksw1RcZthtKV1bnlk4K7KKfOjArbWmdipn9nmzYfeiWKr9e++H0Oj
+0ZdiHb+tB7m1TqXDLd1V1hWa/1e1aCJEjzOMaDmwvxQYUpEkjJmO
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/revoked.pem
+++ b/spec/fixtures/ssl/revoked.pem
@@ -6,62 +6,61 @@ Certificate:
         Issuer: CN=Test CA Subauthority
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Jun 24 21:18:00 2033 GMT
+            Not After : Jan 27 18:43:32 2034 GMT
         Subject: CN=revoked
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                Public-Key: (2048 bit)
+                RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:98:44:c4:15:34:87:c3:40:f4:b0:e6:2b:71:98:
-                    b1:cc:de:56:ef:8c:51:49:35:17:0b:15:09:e9:ad:
-                    45:2c:f0:c3:0e:20:99:6e:46:92:53:7f:cd:ec:fe:
-                    62:60:1e:6f:7e:3e:f7:cf:cf:e0:de:ed:67:d9:f9:
-                    0b:59:d8:c8:b5:8c:55:68:e3:2a:d4:bc:6b:73:38:
-                    42:23:41:45:05:fa:ca:94:e7:98:d6:47:67:75:16:
-                    6b:51:46:e5:66:f1:b4:e1:fe:18:07:ad:e6:3d:e0:
-                    f0:6b:c9:0e:87:2e:12:27:7c:c1:35:cd:99:fa:8d:
-                    dc:80:05:85:0a:2e:9f:9d:c0:87:76:7e:c8:aa:94:
-                    2a:c3:91:07:67:25:7f:b2:b1:dc:e1:92:9b:db:20:
-                    3e:75:05:36:a6:d0:a5:8f:54:4c:45:f6:c9:5c:15:
-                    16:e9:fb:a4:a4:a7:47:a3:1b:9b:18:08:11:80:fd:
-                    62:c3:6f:43:f7:a8:6c:f8:1a:9c:4b:8f:fe:64:2d:
-                    27:9c:c5:11:e4:de:ea:7d:39:aa:62:d5:09:4d:c2:
-                    fd:7a:d8:18:85:e9:07:de:4b:ac:b7:03:ff:6d:ca:
-                    d7:96:2c:33:4d:cd:a9:0a:c1:7b:4a:d1:5c:07:90:
-                    b2:ff:d6:48:54:2e:97:00:13:22:93:c5:6b:77:ab:
-                    89:d5
+                    00:c1:5b:fe:c1:98:52:de:3b:2b:71:ea:52:c9:4b:
+                    07:f6:4e:d1:72:1f:5e:cc:cd:41:0b:2b:c7:aa:68:
+                    05:56:0b:c3:42:66:ac:ee:d6:5a:3e:35:bb:b8:85:
+                    27:ba:79:1b:97:b8:8c:b7:c7:64:96:de:7b:b8:78:
+                    c1:56:5e:84:f8:9d:4a:a3:81:b4:d9:7d:ba:35:ee:
+                    47:74:40:a4:47:a7:83:6c:af:9c:63:41:fa:8e:0e:
+                    01:1d:92:b1:94:a9:ff:57:44:61:e9:3d:74:74:dd:
+                    be:0b:73:f6:24:b7:92:f1:d3:35:34:a7:75:88:58:
+                    7d:8b:5c:fb:39:f2:25:c4:fb:f2:39:8f:b6:85:a1:
+                    38:7a:20:b8:8d:0d:68:c7:7f:48:1b:19:00:7a:f2:
+                    71:ae:ef:b8:c7:6f:d5:0b:ff:ea:3b:7f:be:35:45:
+                    ff:ae:3c:78:13:57:bf:ec:3c:cf:cc:26:9b:31:70:
+                    8c:a9:c3:34:a0:49:99:d6:4c:db:30:8b:a0:b9:44:
+                    15:49:3a:e6:51:f2:cd:26:c5:f1:b8:df:3f:70:20:
+                    f5:52:ec:e2:f3:67:fc:86:f5:dd:31:a3:e9:70:ef:
+                    35:0c:24:91:7d:20:06:d1:64:28:9e:80:23:c4:95:
+                    06:b3:5b:25:3d:51:52:95:ad:29:c2:cd:34:40:b2:
+                    96:b5
                 Exponent: 65537 (0x10001)
     Signature Algorithm: sha256WithRSAEncryption
-    Signature Value:
-        9b:26:09:f6:c7:a3:a7:35:2f:b2:55:db:8d:84:91:2a:5c:9b:
-        74:30:84:d3:36:a1:e0:2e:2f:e4:46:be:85:08:67:08:3c:6f:
-        63:06:e9:e3:60:2c:b6:26:86:37:81:56:6a:5c:d3:3a:79:f0:
-        d7:98:cb:07:e8:ef:14:35:e6:d2:42:ba:97:2d:76:38:3a:e1:
-        63:59:ee:c5:8e:f6:bf:57:88:9e:e9:03:c9:a2:cc:70:b9:1b:
-        ea:74:2d:5d:64:8d:63:3b:ed:26:ce:c6:7a:f9:37:8b:09:e2:
-        7a:e9:c2:17:c5:8d:7a:99:e4:19:4e:87:8f:62:ac:d8:e1:a7:
-        28:9d:1d:ec:e7:4b:26:97:a1:c2:82:d5:26:81:00:ee:34:26:
-        21:fe:58:8e:78:04:c6:a1:77:08:32:cc:f3:cf:5a:19:fe:6c:
-        5d:2d:92:b5:7c:fa:41:0e:73:23:9c:70:28:9d:d5:e6:7e:9b:
-        df:fe:bf:09:ac:86:81:ea:42:b0:12:a9:d8:a1:c7:65:74:7d:
-        d3:0e:bb:dd:5a:7e:84:6f:8e:24:6c:27:a7:c3:ad:ee:c5:c8:
-        cd:ef:df:29:01:4f:e0:75:af:e1:3c:0c:19:a6:5f:e3:7f:6f:
-        53:15:cc:ca:d9:11:6e:96:ee:97:0e:16:33:e9:a8:9d:db:c1:
-        d0:a3:d8:d6
+         6e:a8:0b:21:b3:f4:24:38:6e:9d:95:c5:cb:79:4e:7a:7a:43:
+         47:ab:d7:ff:b3:ff:2d:09:6f:b2:52:6c:c1:79:db:ab:78:06:
+         57:56:9b:57:a8:8d:1e:a4:18:6f:62:78:63:cd:f1:0a:40:2f:
+         46:bd:c1:2f:5e:cc:07:cc:52:70:f9:fa:45:d3:6a:7a:d3:59:
+         51:53:89:f1:cd:98:32:94:33:6b:e6:77:ac:f6:4f:e9:97:e0:
+         79:0e:7a:8e:45:86:8b:43:9f:04:3b:b1:ac:05:b1:da:2d:7b:
+         3f:f8:d6:44:a7:87:6b:17:36:d7:f4:f9:c6:ea:3b:cf:0c:30:
+         de:99:be:e4:8f:44:dd:06:29:28:bf:06:91:a4:94:8b:0a:97:
+         d4:70:1b:19:7e:c1:98:6d:b7:82:b5:55:da:01:7f:71:73:24:
+         05:5e:18:3b:48:38:44:53:99:06:c5:29:56:2c:ec:c5:62:ab:
+         2e:bc:16:a6:57:ee:e5:a2:04:74:2d:ee:64:75:8b:ce:8f:e2:
+         47:7b:78:4e:a6:fe:cd:5b:5c:ab:b3:c5:52:39:29:65:9b:49:
+         22:3f:4b:47:91:61:e9:34:c3:00:b8:bf:9c:b4:f4:66:d0:3c:
+         e5:91:3a:16:4f:e5:70:fe:d2:7a:f7:14:e4:f5:f1:34:32:e8:
+         b5:a4:e7:d9
 -----BEGIN CERTIFICATE-----
 MIICqjCCAZKgAwIBAgIBCDANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0
-IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zMzA2MjQyMTE4MDBa
+IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zNDAxMjcxODQzMzJa
 MBIxEDAOBgNVBAMMB3Jldm9rZWQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
-AoIBAQCYRMQVNIfDQPSw5itxmLHM3lbvjFFJNRcLFQnprUUs8MMOIJluRpJTf83s
-/mJgHm9+PvfPz+De7WfZ+QtZ2Mi1jFVo4yrUvGtzOEIjQUUF+sqU55jWR2d1FmtR
-RuVm8bTh/hgHreY94PBryQ6HLhInfME1zZn6jdyABYUKLp+dwId2fsiqlCrDkQdn
-JX+ysdzhkpvbID51BTam0KWPVExF9slcFRbp+6Skp0ejG5sYCBGA/WLDb0P3qGz4
-GpxLj/5kLSecxRHk3up9Oapi1QlNwv162BiF6QfeS6y3A/9tyteWLDNNzakKwXtK
-0VwHkLL/1khULpcAEyKTxWt3q4nVAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAJsm
-CfbHo6c1L7JV242EkSpcm3QwhNM2oeAuL+RGvoUIZwg8b2MG6eNgLLYmhjeBVmpc
-0zp58NeYywfo7xQ15tJCupctdjg64WNZ7sWO9r9XiJ7pA8mizHC5G+p0LV1kjWM7
-7SbOxnr5N4sJ4nrpwhfFjXqZ5BlOh49irNjhpyidHeznSyaXocKC1SaBAO40JiH+
-WI54BMahdwgyzPPPWhn+bF0tkrV8+kEOcyOccCid1eZ+m9/+vwmshoHqQrASqdih
-x2V0fdMOu91afoRvjiRsJ6fDre7FyM3v3ykBT+B1r+E8DBmmX+N/b1MVzMrZEW6W
-7pcOFjPpqJ3bwdCj2NY=
+AoIBAQDBW/7BmFLeOytx6lLJSwf2TtFyH17MzUELK8eqaAVWC8NCZqzu1lo+Nbu4
+hSe6eRuXuIy3x2SW3nu4eMFWXoT4nUqjgbTZfbo17kd0QKRHp4Nsr5xjQfqODgEd
+krGUqf9XRGHpPXR03b4Lc/Ykt5Lx0zU0p3WIWH2LXPs58iXE+/I5j7aFoTh6ILiN
+DWjHf0gbGQB68nGu77jHb9UL/+o7f741Rf+uPHgTV7/sPM/MJpsxcIypwzSgSZnW
+TNswi6C5RBVJOuZR8s0mxfG43z9wIPVS7OLzZ/yG9d0xo+lw7zUMJJF9IAbRZCie
+gCPElQazWyU9UVKVrSnCzTRAspa1AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAG6o
+CyGz9CQ4bp2Vxct5Tnp6Q0er1/+z/y0Jb7JSbMF526t4BldWm1eojR6kGG9ieGPN
+8QpAL0a9wS9ezAfMUnD5+kXTanrTWVFTifHNmDKUM2vmd6z2T+mX4HkOeo5FhotD
+nwQ7sawFsdotez/41kSnh2sXNtf0+cbqO88MMN6ZvuSPRN0GKSi/BpGklIsKl9Rw
+Gxl+wZhtt4K1VdoBf3FzJAVeGDtIOERTmQbFKVYs7MViqy68FqZX7uWiBHQt7mR1
+i86P4kd7eE6m/s1bXKuzxVI5KWWbSSI/S0eRYek0wwC4v5y09GbQPOWROhZP5XD+
+0nr3FOT18TQy6LWk59k=
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/signed-key.pem
+++ b/spec/fixtures/ssl/signed-key.pem
@@ -1,117 +1,117 @@
-Private-Key: (2048 bit, 2 primes)
+RSA Private-Key: (2048 bit, 2 primes)
 modulus:
-    00:c4:7f:b6:dd:ab:a8:58:7f:49:48:9d:bd:6f:91:
-    9a:ea:bc:8c:3c:20:5f:ec:3b:30:4e:c2:c5:98:8e:
-    52:27:74:d9:d1:28:7e:6a:09:b1:fc:ea:d2:28:a7:
-    48:30:b8:bc:93:11:e8:56:93:bf:02:86:1c:78:16:
-    0b:b8:c3:ce:aa:b1:27:de:c6:96:20:f8:d4:8e:63:
-    58:b3:05:c6:df:a7:eb:eb:85:14:98:04:0e:d7:99:
-    17:81:0c:15:0b:c7:f0:bf:14:a5:8e:e9:5b:88:65:
-    e9:b4:3e:9f:77:f4:77:60:dd:aa:75:e9:f2:75:07:
-    a8:47:17:a3:79:f1:e5:ea:01:80:25:5a:5a:1b:fb:
-    8d:6e:17:c7:b8:7d:bb:1d:ec:67:bf:c9:83:8f:28:
-    02:99:83:16:f4:2c:f0:94:25:1b:7f:f0:99:fb:ec:
-    75:63:88:97:2f:1d:f8:bf:14:92:3b:df:ed:a0:56:
-    0c:94:c6:92:b4:91:e2:85:88:de:99:93:00:17:b0:
-    f1:ed:45:03:8f:07:2e:5a:e5:82:6a:99:6f:45:00:
-    54:2a:37:93:77:23:06:c3:99:fa:c1:1f:4c:59:63:
-    e1:35:b9:f7:f6:ab:81:a5:11:ef:9c:a1:e6:64:ab:
-    2f:fc:f9:cd:b3:d0:b7:33:81:4c:36:13:03:3a:5e:
-    e6:e5
+    00:ac:0d:e2:e1:62:ee:7a:55:f6:46:0a:5f:ed:dc:
+    4a:a6:d4:d0:19:7f:a8:4d:cd:a0:c1:61:d4:e8:78:
+    50:d4:5d:40:1f:e0:c3:79:26:95:19:4c:cd:70:10:
+    53:38:b1:68:e4:7e:d4:44:65:68:94:8c:b6:ab:d2:
+    22:36:d8:b0:92:ba:ed:3f:00:ec:b0:b6:5f:26:ac:
+    f7:2b:71:e4:d7:8a:28:49:a8:fe:f9:a1:c8:b8:09:
+    73:8c:f7:d3:90:ab:ed:74:fb:25:29:bf:81:51:b3:
+    ac:02:81:ba:c1:7f:8a:ad:d7:18:6d:d0:73:1e:7f:
+    d9:54:ed:0b:a2:a6:d7:7e:22:e1:3f:a3:6d:77:4a:
+    9e:17:68:42:ef:99:63:e0:0f:5c:35:4e:3a:ef:5a:
+    84:3c:c6:c1:ac:78:c5:fe:60:56:f4:e5:86:7d:60:
+    1b:55:3c:bd:6a:c8:22:ea:b6:c3:f6:8a:67:e8:cb:
+    5d:23:61:44:4b:9e:24:f8:91:69:25:90:0b:d7:2e:
+    84:3f:c1:a2:8f:87:68:a8:36:b3:a7:b3:c8:0e:06:
+    bd:6b:f3:54:41:d2:47:49:a7:2f:9b:3c:2f:37:89:
+    46:12:90:95:fe:6a:6f:5e:29:c6:d9:ea:90:47:29:
+    1b:85:1e:d3:19:e9:80:40:f7:33:67:bb:e5:17:50:
+    5c:cd
 publicExponent: 65537 (0x10001)
 privateExponent:
-    02:ae:22:f2:7d:43:2a:53:da:ce:20:02:ae:63:d1:
-    75:b6:b5:2b:4e:73:68:7f:8f:d8:df:2c:be:a2:e0:
-    54:29:47:f2:f8:fc:57:c4:c2:95:ff:d0:f6:87:7e:
-    43:55:dd:bd:46:cf:01:11:4f:ac:c0:8e:0b:b0:47:
-    4a:d1:a1:94:6f:f3:ff:d9:fc:6b:13:8c:78:ab:0f:
-    bc:6a:0d:81:f8:4d:23:95:03:88:7a:f3:b0:8a:a6:
-    1e:01:ea:19:3d:f4:ac:1d:38:bb:37:e1:22:52:e6:
-    35:69:c3:97:3e:b1:25:d3:d8:32:f6:b4:dd:2b:9f:
-    26:bb:17:e5:29:00:c3:bd:e9:36:1a:19:b2:df:0c:
-    42:d0:9d:e0:c4:9a:6e:73:00:fc:57:c5:32:62:da:
-    0e:67:0e:bc:10:de:80:17:cd:bc:39:80:d2:d8:d9:
-    c1:11:c0:ac:6d:32:11:3a:e1:7d:64:c7:d9:5e:f0:
-    c8:e0:3f:ae:c2:8b:07:0a:da:a8:15:58:e0:2e:c1:
-    f5:f5:1a:4e:c5:bc:e8:c7:63:bf:28:84:0d:1d:e4:
-    8d:8c:9b:74:7b:9f:2b:f8:ba:9d:ee:d6:c4:9f:d6:
-    3d:90:d6:18:34:84:82:d2:12:4c:be:55:13:54:6b:
-    d1:9e:39:e9:62:6f:30:de:9d:c2:06:49:4d:78:04:
-    11
+    15:08:01:82:c1:80:1b:2e:24:d3:7c:f3:2a:f5:31:
+    9e:e1:06:ab:07:42:c0:77:f1:3d:92:42:df:43:cd:
+    c5:97:bc:7d:e9:10:9b:df:8e:7c:30:3a:30:87:9e:
+    54:a0:c3:0c:a3:40:39:38:18:27:88:67:cf:ea:f8:
+    c9:b1:85:2b:fa:73:83:af:0e:3f:af:9b:43:f4:02:
+    a6:a9:de:6a:46:76:14:42:f7:1f:f6:99:bd:7d:52:
+    45:9a:09:9f:76:94:a9:27:05:ec:eb:7e:d8:48:d9:
+    2e:d9:42:c5:e2:5c:46:51:b3:a7:c0:c2:41:a9:29:
+    1c:cb:79:0f:a1:cb:57:9c:a2:6a:35:d6:da:b2:21:
+    55:70:e2:8b:2d:e8:16:d3:37:41:fc:df:d4:b1:e0:
+    db:90:b8:e4:28:74:ad:8a:1d:92:b3:02:c3:68:65:
+    75:38:99:32:38:28:1f:64:91:3b:42:86:45:19:54:
+    2d:b0:26:48:88:25:32:5c:ab:f2:de:02:ec:77:fc:
+    cc:ea:6f:ce:e0:40:44:7e:80:c8:bf:99:25:5d:d5:
+    88:57:55:4b:07:64:d2:8b:a3:c2:86:56:d9:6f:16:
+    6c:c5:52:84:9b:e6:b4:4c:2e:ff:59:7b:d9:0e:fb:
+    95:4c:5a:56:58:e9:d1:9c:0f:84:ad:36:d3:c8:5b:
+    b5
 prime1:
-    00:db:85:36:5e:39:8e:46:b4:d2:ab:09:db:b1:c4:
-    d9:56:3c:c2:44:92:b7:60:74:e7:6d:07:75:ea:78:
-    bf:32:86:05:71:ab:e3:ad:22:b5:70:45:e7:26:49:
-    07:2a:92:1c:a0:31:c3:42:7e:7a:34:72:a0:c5:32:
-    92:65:17:bf:59:0a:59:41:d5:63:e8:ea:df:ae:1b:
-    e2:d8:b6:eb:bb:76:41:45:26:21:ac:de:4d:70:e1:
-    d4:bb:ce:30:c9:3b:a3:a9:96:95:7a:21:a3:6b:a1:
-    ea:e2:12:07:d9:0e:00:26:24:ee:91:2a:a5:69:ed:
-    d4:1c:03:c5:9d:80:35:5f:95
+    00:e3:17:e6:10:fa:80:d4:86:c4:59:bb:36:57:ad:
+    9a:12:8c:63:e0:84:b3:f3:ce:4b:d1:bf:a3:8c:0e:
+    a2:41:62:1a:46:74:eb:ce:01:55:33:8b:b1:1f:f2:
+    30:df:12:0f:69:0a:fb:e1:1e:32:80:5c:b0:85:5b:
+    ff:5a:93:9a:50:1b:7b:85:83:f0:8e:26:f9:e2:35:
+    5c:94:0c:ce:29:22:52:a0:a9:ac:64:d3:56:93:0d:
+    11:f7:16:07:10:0f:97:03:43:11:57:91:15:4d:04:
+    9c:6d:5e:26:b3:41:46:c8:7c:46:3c:2a:dd:40:e1:
+    9f:32:75:2b:82:49:dc:d8:73
 prime2:
-    00:e5:27:20:94:a0:f1:36:3f:97:ea:86:ed:4c:21:
-    8f:23:2b:09:49:7d:58:48:9f:c4:44:3f:8b:67:4b:
-    d4:1e:c2:87:fc:09:c6:06:d3:8b:82:e2:17:95:a6:
-    89:7c:df:43:2c:5b:fe:bb:ea:85:32:a7:59:eb:41:
-    31:81:e6:d2:8a:e8:1f:65:9e:dd:91:55:75:52:09:
-    e5:90:6a:44:22:99:47:e6:57:bb:f9:e6:df:f2:42:
-    b0:dd:1a:8f:6c:93:04:70:35:a9:3b:05:a9:04:78:
-    5a:97:39:53:d2:4c:3d:74:9a:d1:36:4c:98:9b:1a:
-    ba:1c:46:d0:46:5d:f9:d6:11
+    00:c1:f4:79:5b:51:e7:58:84:a6:57:11:48:e6:25:
+    60:dd:7b:67:e1:e4:61:6c:f2:37:6e:71:68:53:47:
+    1d:f2:e8:31:9f:60:64:6c:97:cf:2c:b9:b0:a5:39:
+    e2:11:40:c7:00:8a:4a:48:60:f3:33:3f:17:9f:56:
+    f9:74:f0:ad:ce:92:6a:30:c7:aa:32:b1:58:cb:08:
+    d4:44:40:29:56:cc:09:26:90:55:84:d8:b7:15:4a:
+    05:89:5d:29:d4:4a:4d:15:a9:40:f3:c7:a8:b0:73:
+    ba:4d:63:14:62:e6:cb:d6:b7:6c:8e:cb:68:a8:bf:
+    2f:10:5b:d5:f8:5b:64:e5:bf
 exponent1:
-    27:ad:ce:83:fd:97:50:04:83:47:d3:42:58:c1:a2:
-    1f:4a:60:3b:10:e2:00:97:60:f5:7e:31:bc:2e:13:
-    31:48:b4:57:35:a0:b3:bc:e0:5a:e8:e7:bd:2d:da:
-    13:c1:d1:56:cb:67:e5:ef:02:9b:d4:54:67:10:9b:
-    11:96:d7:49:7a:eb:63:50:f4:fc:36:e8:33:8a:6a:
-    d8:8d:47:d2:dc:af:33:96:8e:e3:b6:52:fd:22:74:
-    d7:75:8f:af:f0:0d:c7:2b:a6:dd:2a:93:65:73:21:
-    07:b8:06:9f:1f:3e:bb:a6:55:50:fc:0a:66:39:4c:
-    eb:bb:6a:ce:eb:4b:ba:79
+    4c:d9:6f:8f:db:55:f1:95:d1:a8:94:04:25:d3:a7:
+    ca:13:1c:51:84:56:e9:70:ac:93:c4:88:72:03:19:
+    c1:8a:93:5d:b8:7f:7b:ed:53:89:e8:01:fe:cf:94:
+    de:48:5c:52:ad:d6:e3:2d:b6:e5:5d:78:97:08:b4:
+    f7:4f:ef:ee:9f:fe:43:06:8d:47:6d:c5:2e:59:e4:
+    84:6d:78:ee:ce:a0:ab:a1:ff:a6:f7:25:db:09:97:
+    44:c8:7d:87:5f:df:38:c9:5f:7b:04:ab:f2:ae:56:
+    c9:64:0d:30:a8:2c:6d:f8:30:44:78:34:fb:99:de:
+    a7:d2:a2:f0:aa:52:44:25
 exponent2:
-    5f:ff:5f:3f:c4:98:a8:70:45:b5:23:67:3f:d0:83:
-    45:69:5f:0f:a1:6a:1d:aa:88:af:4a:ab:9c:cf:80:
-    82:8e:5e:27:70:f4:bb:a1:5d:bd:ab:f7:d3:62:9c:
-    10:6a:fb:9a:16:c4:05:77:3e:eb:b4:7e:0f:f7:14:
-    c5:65:ac:68:32:cc:0c:67:5c:4c:e9:2f:27:fa:2b:
-    68:af:8b:f1:ae:a3:17:55:43:d3:72:2b:f9:32:85:
-    23:6b:60:10:4d:1a:bb:e3:4f:0d:01:d7:07:9f:5f:
-    dc:20:51:04:35:9a:3d:42:2a:49:04:17:9e:4a:b9:
-    12:e5:7b:95:2f:03:5d:f1
+    7f:ef:5f:c1:51:d4:34:fa:42:b2:79:cf:49:27:ec:
+    ae:0b:81:a9:6a:38:ad:61:54:19:00:ab:5d:0b:33:
+    01:10:11:f3:5b:e4:c2:10:9c:f2:96:85:a3:66:fb:
+    ec:7f:7b:04:ab:33:76:6c:a4:de:ef:c6:08:2f:99:
+    9a:7e:4b:57:50:12:c5:9c:5e:72:d3:b2:8b:32:86:
+    b9:82:4d:02:58:d1:cc:63:36:55:cb:91:70:74:84:
+    14:68:a4:77:c8:8e:f2:33:d3:89:39:f0:d6:7b:6f:
+    af:2e:24:bb:5c:1b:a6:c5:14:d1:57:f0:f0:26:33:
+    c8:29:9b:89:17:d8:05:07
 coefficient:
-    56:b9:68:ee:96:8e:20:df:9c:e5:3c:29:41:a0:e9:
-    32:8f:a1:e9:de:1a:c5:e2:cd:c6:0c:b7:63:e6:9c:
-    f6:b4:0e:f4:fb:6a:7f:a7:7b:3f:fe:6c:0b:d6:da:
-    c4:9d:ef:59:72:da:0e:14:4f:e2:37:78:b0:34:00:
-    58:05:48:cb:0d:e8:c6:67:6f:2b:76:20:5f:93:36:
-    bc:6e:1b:b0:6d:67:fd:67:71:4c:18:08:73:52:95:
-    59:11:39:f3:4c:73:93:37:57:53:5d:30:32:75:99:
-    46:a1:b9:d8:84:86:32:5c:0d:93:95:46:f4:17:3f:
-    38:15:ac:eb:eb:51:79:68
+    00:bd:78:38:fa:43:8a:96:b9:4f:69:3f:2a:e0:82:
+    b6:be:76:43:91:b5:eb:ad:d6:db:a2:e3:51:01:39:
+    c8:54:18:87:06:03:e7:0e:2e:9c:82:5d:54:df:bb:
+    97:c8:d2:fa:be:12:8f:df:eb:03:b0:78:74:d0:cb:
+    cc:0c:ad:9a:f0:c7:16:3e:cf:84:d4:c7:b8:91:65:
+    7d:bd:29:cd:71:7a:f9:16:30:cb:4f:f0:f0:59:96:
+    24:19:d6:77:eb:36:1d:1c:3d:0d:89:08:9f:64:bb:
+    86:b9:be:3f:c1:67:e5:b7:fb:d4:65:cd:54:cc:3d:
+    3b:a1:5a:3f:61:91:20:c3:10
 -----BEGIN RSA PRIVATE KEY-----
-MIIEogIBAAKCAQEAxH+23auoWH9JSJ29b5Ga6ryMPCBf7DswTsLFmI5SJ3TZ0Sh+
-agmx/OrSKKdIMLi8kxHoVpO/AoYceBYLuMPOqrEn3saWIPjUjmNYswXG36fr64UU
-mAQO15kXgQwVC8fwvxSljulbiGXptD6fd/R3YN2qdenydQeoRxejefHl6gGAJVpa
-G/uNbhfHuH27Hexnv8mDjygCmYMW9CzwlCUbf/CZ++x1Y4iXLx34vxSSO9/toFYM
-lMaStJHihYjemZMAF7Dx7UUDjwcuWuWCaplvRQBUKjeTdyMGw5n6wR9MWWPhNbn3
-9quBpRHvnKHmZKsv/PnNs9C3M4FMNhMDOl7m5QIDAQABAoIBAAKuIvJ9QypT2s4g
-Aq5j0XW2tStOc2h/j9jfLL6i4FQpR/L4/FfEwpX/0PaHfkNV3b1GzwERT6zAjguw
-R0rRoZRv8//Z/GsTjHirD7xqDYH4TSOVA4h687CKph4B6hk99KwdOLs34SJS5jVp
-w5c+sSXT2DL2tN0rnya7F+UpAMO96TYaGbLfDELQneDEmm5zAPxXxTJi2g5nDrwQ
-3oAXzbw5gNLY2cERwKxtMhE64X1kx9le8MjgP67CiwcK2qgVWOAuwfX1Gk7FvOjH
-Y78ohA0d5I2Mm3R7nyv4up3u1sSf1j2Q1hg0hILSEky+VRNUa9GeOelibzDencIG
-SU14BBECgYEA24U2XjmORrTSqwnbscTZVjzCRJK3YHTnbQd16ni/MoYFcavjrSK1
-cEXnJkkHKpIcoDHDQn56NHKgxTKSZRe/WQpZQdVj6Orfrhvi2Lbru3ZBRSYhrN5N
-cOHUu84wyTujqZaVeiGja6Hq4hIH2Q4AJiTukSqlae3UHAPFnYA1X5UCgYEA5Scg
-lKDxNj+X6obtTCGPIysJSX1YSJ/ERD+LZ0vUHsKH/AnGBtOLguIXlaaJfN9DLFv+
-u+qFMqdZ60ExgebSiugfZZ7dkVV1UgnlkGpEIplH5le7+ebf8kKw3RqPbJMEcDWp
-OwWpBHhalzlT0kw9dJrRNkyYmxq6HEbQRl351hECgYAnrc6D/ZdQBINH00JYwaIf
-SmA7EOIAl2D1fjG8LhMxSLRXNaCzvOBa6Oe9LdoTwdFWy2fl7wKb1FRnEJsRltdJ
-eutjUPT8NugzimrYjUfS3K8zlo7jtlL9InTXdY+v8A3HK6bdKpNlcyEHuAafHz67
-plVQ/ApmOUzru2rO60u6eQKBgF//Xz/EmKhwRbUjZz/Qg0VpXw+hah2qiK9Kq5zP
-gIKOXidw9LuhXb2r99NinBBq+5oWxAV3Puu0fg/3FMVlrGgyzAxnXEzpLyf6K2iv
-i/GuoxdVQ9NyK/kyhSNrYBBNGrvjTw0B1wefX9wgUQQ1mj1CKkkEF55KuRLle5Uv
-A13xAoGAVrlo7paOIN+c5TwpQaDpMo+h6d4axeLNxgy3Y+ac9rQO9Ptqf6d7P/5s
-C9baxJ3vWXLaDhRP4jd4sDQAWAVIyw3oxmdvK3YgX5M2vG4bsG1n/WdxTBgIc1KV
-WRE580xzkzdXU10wMnWZRqG52ISGMlwNk5VG9Bc/OBWs6+tReWg=
+MIIEowIBAAKCAQEArA3i4WLuelX2Rgpf7dxKptTQGX+oTc2gwWHU6HhQ1F1AH+DD
+eSaVGUzNcBBTOLFo5H7URGVolIy2q9IiNtiwkrrtPwDssLZfJqz3K3Hk14ooSaj+
++aHIuAlzjPfTkKvtdPslKb+BUbOsAoG6wX+KrdcYbdBzHn/ZVO0LoqbXfiLhP6Nt
+d0qeF2hC75lj4A9cNU4671qEPMbBrHjF/mBW9OWGfWAbVTy9asgi6rbD9opn6Mtd
+I2FES54k+JFpJZAL1y6EP8Gij4doqDazp7PIDga9a/NUQdJHSacvmzwvN4lGEpCV
+/mpvXinG2eqQRykbhR7TGemAQPczZ7vlF1BczQIDAQABAoIBABUIAYLBgBsuJNN8
+8yr1MZ7hBqsHQsB38T2SQt9DzcWXvH3pEJvfjnwwOjCHnlSgwwyjQDk4GCeIZ8/q
++MmxhSv6c4OvDj+vm0P0Aqap3mpGdhRC9x/2mb19UkWaCZ92lKknBezrfthI2S7Z
+QsXiXEZRs6fAwkGpKRzLeQ+hy1ecomo11tqyIVVw4ost6BbTN0H839Sx4NuQuOQo
+dK2KHZKzAsNoZXU4mTI4KB9kkTtChkUZVC2wJkiIJTJcq/LeAux3/Mzqb87gQER+
+gMi/mSVd1YhXVUsHZNKLo8KGVtlvFmzFUoSb5rRMLv9Ze9kO+5VMWlZY6dGcD4St
+NtPIW7UCgYEA4xfmEPqA1IbEWbs2V62aEoxj4ISz885L0b+jjA6iQWIaRnTrzgFV
+M4uxH/Iw3xIPaQr74R4ygFywhVv/WpOaUBt7hYPwjib54jVclAzOKSJSoKmsZNNW
+kw0R9xYHEA+XA0MRV5EVTQScbV4ms0FGyHxGPCrdQOGfMnUrgknc2HMCgYEAwfR5
+W1HnWISmVxFI5iVg3Xtn4eRhbPI3bnFoU0cd8ugxn2BkbJfPLLmwpTniEUDHAIpK
+SGDzMz8Xn1b5dPCtzpJqMMeqMrFYywjUREApVswJJpBVhNi3FUoFiV0p1EpNFalA
+88eosHO6TWMUYubL1rdsjstoqL8vEFvV+Ftk5b8CgYBM2W+P21XxldGolAQl06fK
+ExxRhFbpcKyTxIhyAxnBipNduH977VOJ6AH+z5TeSFxSrdbjLbblXXiXCLT3T+/u
+n/5DBo1HbcUuWeSEbXjuzqCrof+m9yXbCZdEyH2HX984yV97BKvyrlbJZA0wqCxt
++DBEeDT7md6n0qLwqlJEJQKBgH/vX8FR1DT6QrJ5z0kn7K4LgalqOK1hVBkAq10L
+MwEQEfNb5MIQnPKWhaNm++x/ewSrM3ZspN7vxggvmZp+S1dQEsWcXnLTsosyhrmC
+TQJY0cxjNlXLkXB0hBRopHfIjvIz04k58NZ7b68uJLtcG6bFFNFX8PAmM8gpm4kX
+2AUHAoGBAL14OPpDipa5T2k/KuCCtr52Q5G1663W26LjUQE5yFQYhwYD5w4unIJd
+VN+7l8jS+r4Sj9/rA7B4dNDLzAytmvDHFj7PhNTHuJFlfb0pzXF6+RYwy0/w8FmW
+JBnWd+s2HRw9DYkIn2S7hrm+P8Fn5bf71GXNVMw9O6FaP2GRIMMQ
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/signed.pem
+++ b/spec/fixtures/ssl/signed.pem
@@ -6,62 +6,61 @@ Certificate:
         Issuer: CN=Test CA Subauthority
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Jun 24 21:18:00 2033 GMT
+            Not After : Jan 27 18:43:32 2034 GMT
         Subject: CN=signed
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                Public-Key: (2048 bit)
+                RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:c4:7f:b6:dd:ab:a8:58:7f:49:48:9d:bd:6f:91:
-                    9a:ea:bc:8c:3c:20:5f:ec:3b:30:4e:c2:c5:98:8e:
-                    52:27:74:d9:d1:28:7e:6a:09:b1:fc:ea:d2:28:a7:
-                    48:30:b8:bc:93:11:e8:56:93:bf:02:86:1c:78:16:
-                    0b:b8:c3:ce:aa:b1:27:de:c6:96:20:f8:d4:8e:63:
-                    58:b3:05:c6:df:a7:eb:eb:85:14:98:04:0e:d7:99:
-                    17:81:0c:15:0b:c7:f0:bf:14:a5:8e:e9:5b:88:65:
-                    e9:b4:3e:9f:77:f4:77:60:dd:aa:75:e9:f2:75:07:
-                    a8:47:17:a3:79:f1:e5:ea:01:80:25:5a:5a:1b:fb:
-                    8d:6e:17:c7:b8:7d:bb:1d:ec:67:bf:c9:83:8f:28:
-                    02:99:83:16:f4:2c:f0:94:25:1b:7f:f0:99:fb:ec:
-                    75:63:88:97:2f:1d:f8:bf:14:92:3b:df:ed:a0:56:
-                    0c:94:c6:92:b4:91:e2:85:88:de:99:93:00:17:b0:
-                    f1:ed:45:03:8f:07:2e:5a:e5:82:6a:99:6f:45:00:
-                    54:2a:37:93:77:23:06:c3:99:fa:c1:1f:4c:59:63:
-                    e1:35:b9:f7:f6:ab:81:a5:11:ef:9c:a1:e6:64:ab:
-                    2f:fc:f9:cd:b3:d0:b7:33:81:4c:36:13:03:3a:5e:
-                    e6:e5
+                    00:ac:0d:e2:e1:62:ee:7a:55:f6:46:0a:5f:ed:dc:
+                    4a:a6:d4:d0:19:7f:a8:4d:cd:a0:c1:61:d4:e8:78:
+                    50:d4:5d:40:1f:e0:c3:79:26:95:19:4c:cd:70:10:
+                    53:38:b1:68:e4:7e:d4:44:65:68:94:8c:b6:ab:d2:
+                    22:36:d8:b0:92:ba:ed:3f:00:ec:b0:b6:5f:26:ac:
+                    f7:2b:71:e4:d7:8a:28:49:a8:fe:f9:a1:c8:b8:09:
+                    73:8c:f7:d3:90:ab:ed:74:fb:25:29:bf:81:51:b3:
+                    ac:02:81:ba:c1:7f:8a:ad:d7:18:6d:d0:73:1e:7f:
+                    d9:54:ed:0b:a2:a6:d7:7e:22:e1:3f:a3:6d:77:4a:
+                    9e:17:68:42:ef:99:63:e0:0f:5c:35:4e:3a:ef:5a:
+                    84:3c:c6:c1:ac:78:c5:fe:60:56:f4:e5:86:7d:60:
+                    1b:55:3c:bd:6a:c8:22:ea:b6:c3:f6:8a:67:e8:cb:
+                    5d:23:61:44:4b:9e:24:f8:91:69:25:90:0b:d7:2e:
+                    84:3f:c1:a2:8f:87:68:a8:36:b3:a7:b3:c8:0e:06:
+                    bd:6b:f3:54:41:d2:47:49:a7:2f:9b:3c:2f:37:89:
+                    46:12:90:95:fe:6a:6f:5e:29:c6:d9:ea:90:47:29:
+                    1b:85:1e:d3:19:e9:80:40:f7:33:67:bb:e5:17:50:
+                    5c:cd
                 Exponent: 65537 (0x10001)
     Signature Algorithm: sha256WithRSAEncryption
-    Signature Value:
-        a5:35:e3:d1:e0:28:58:6d:a9:cb:9c:34:e8:1d:4a:a6:98:bd:
-        8c:25:07:56:93:bc:03:14:bd:5c:88:e7:dd:a8:84:64:6c:9f:
-        7e:78:7f:b2:cb:1c:a7:c5:6d:30:3e:9b:61:88:4a:94:80:6c:
-        35:09:23:0c:e2:1e:67:08:13:f6:a9:71:0c:b4:9b:38:b4:20:
-        83:18:83:3c:ae:ad:31:b1:9b:2e:29:30:60:e8:7a:bb:53:41:
-        cc:7c:f7:ed:e7:9f:3a:0a:18:5a:9f:01:c8:f7:27:18:11:28:
-        1c:40:a2:e1:58:74:0a:13:e9:f7:67:e8:df:07:44:cf:c8:71:
-        ad:90:ad:3d:7b:8a:1f:23:63:8d:c4:7f:be:d8:f1:ad:59:28:
-        ab:be:f9:84:dd:3b:77:97:29:63:56:99:60:1d:1f:5c:ac:d2:
-        a3:74:50:4b:04:46:ba:37:3c:a2:99:40:33:34:a4:b5:d6:a6:
-        02:47:bb:2d:cb:a9:4a:a4:53:85:bc:6c:d7:7e:54:d0:d4:96:
-        31:99:74:55:08:b3:15:62:c0:25:51:04:58:f9:33:24:80:fa:
-        80:5e:4a:3c:d1:b5:41:00:39:20:d1:e3:c7:14:a6:fb:fc:64:
-        17:be:97:aa:06:88:01:1e:0e:fd:b6:97:f8:6a:3a:0c:9c:bc:
-        8f:6d:a3:9b
+         8d:44:e0:60:b2:84:0b:75:3c:1b:b1:b9:a3:7b:1c:68:00:17:
+         c7:ff:7b:ea:49:cb:79:e8:33:7c:ce:bd:22:f7:91:6e:6f:ca:
+         1d:35:18:9c:fd:7a:3a:6d:8f:7a:f5:a0:ba:fa:db:08:be:52:
+         50:36:2b:6d:a0:a1:1e:8c:ab:07:34:28:0b:fd:4d:1a:64:5c:
+         bd:64:76:94:1d:1b:08:95:6d:3e:b7:15:3a:61:3d:2a:73:f9:
+         6b:38:c5:b8:17:a8:62:cc:43:6c:f7:0f:05:02:d5:fa:d5:81:
+         91:56:7c:9e:e2:1f:22:e8:e0:1d:68:02:10:08:fe:88:5f:03:
+         d2:38:0b:68:0e:b4:c3:2c:3e:09:f6:48:22:75:12:65:f5:78:
+         d0:6d:29:57:3c:75:f4:4b:cb:c0:c8:99:4f:82:df:2f:1f:97:
+         17:5a:3c:05:79:69:e3:3e:d6:71:6b:71:bd:55:92:49:e1:6f:
+         71:d5:73:96:89:e9:9c:63:b3:48:ee:f8:eb:1c:34:96:c1:98:
+         69:4d:4c:e9:09:0e:e1:4e:44:62:20:48:18:cf:6a:a2:0a:a8:
+         1d:29:3f:91:a7:e0:d6:14:6b:ba:fa:29:4f:df:eb:02:b2:59:
+         bf:c9:20:14:bb:e8:72:a8:26:a6:4c:fe:76:7d:66:28:44:64:
+         cf:65:91:38
 -----BEGIN CERTIFICATE-----
 MIICqTCCAZGgAwIBAgIBBDANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0
-IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zMzA2MjQyMTE4MDBa
+IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zNDAxMjcxODQzMzJa
 MBExDzANBgNVBAMMBnNpZ25lZDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC
-ggEBAMR/tt2rqFh/SUidvW+Rmuq8jDwgX+w7ME7CxZiOUid02dEofmoJsfzq0iin
-SDC4vJMR6FaTvwKGHHgWC7jDzqqxJ97GliD41I5jWLMFxt+n6+uFFJgEDteZF4EM
-FQvH8L8UpY7pW4hl6bQ+n3f0d2DdqnXp8nUHqEcXo3nx5eoBgCVaWhv7jW4Xx7h9
-ux3sZ7/Jg48oApmDFvQs8JQlG3/wmfvsdWOIly8d+L8Ukjvf7aBWDJTGkrSR4oWI
-3pmTABew8e1FA48HLlrlgmqZb0UAVCo3k3cjBsOZ+sEfTFlj4TW59/argaUR75yh
-5mSrL/z5zbPQtzOBTDYTAzpe5uUCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEApTXj
-0eAoWG2py5w06B1Kppi9jCUHVpO8AxS9XIjn3aiEZGyffnh/ssscp8VtMD6bYYhK
-lIBsNQkjDOIeZwgT9qlxDLSbOLQggxiDPK6tMbGbLikwYOh6u1NBzHz37eefOgoY
-Wp8ByPcnGBEoHECi4Vh0ChPp92fo3wdEz8hxrZCtPXuKHyNjjcR/vtjxrVkoq775
-hN07d5cpY1aZYB0fXKzSo3RQSwRGujc8oplAMzSktdamAke7LcupSqRThbxs135U
-0NSWMZl0VQizFWLAJVEEWPkzJID6gF5KPNG1QQA5INHjxxSm+/xkF76XqgaIAR4O
-/baX+Go6DJy8j22jmw==
+ggEBAKwN4uFi7npV9kYKX+3cSqbU0Bl/qE3NoMFh1Oh4UNRdQB/gw3kmlRlMzXAQ
+UzixaOR+1ERlaJSMtqvSIjbYsJK67T8A7LC2Xyas9ytx5NeKKEmo/vmhyLgJc4z3
+05Cr7XT7JSm/gVGzrAKBusF/iq3XGG3Qcx5/2VTtC6Km134i4T+jbXdKnhdoQu+Z
+Y+APXDVOOu9ahDzGwax4xf5gVvTlhn1gG1U8vWrIIuq2w/aKZ+jLXSNhREueJPiR
+aSWQC9cuhD/Boo+HaKg2s6ezyA4GvWvzVEHSR0mnL5s8LzeJRhKQlf5qb14pxtnq
+kEcpG4Ue0xnpgED3M2e75RdQXM0CAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAjUTg
+YLKEC3U8G7G5o3scaAAXx/976knLeegzfM69IveRbm/KHTUYnP16Om2PevWguvrb
+CL5SUDYrbaChHoyrBzQoC/1NGmRcvWR2lB0bCJVtPrcVOmE9KnP5azjFuBeoYsxD
+bPcPBQLV+tWBkVZ8nuIfIujgHWgCEAj+iF8D0jgLaA60wyw+CfZIInUSZfV40G0p
+Vzx19EvLwMiZT4LfLx+XF1o8BXlp4z7WcWtxvVWSSeFvcdVzlonpnGOzSO746xw0
+lsGYaU1M6QkO4U5EYiBIGM9qogqoHSk/kafg1hRruvopT9/rArJZv8kgFLvocqgm
+pkz+dn1mKERkz2WROA==
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/tampered-cert.pem
+++ b/spec/fixtures/ssl/tampered-cert.pem
@@ -6,62 +6,61 @@ Certificate:
         Issuer: CN=Test CA Subauthority
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Jun 24 21:18:00 2033 GMT
+            Not After : Jan 27 18:43:32 2034 GMT
         Subject: CN=signed
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                Public-Key: (2048 bit)
+                RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:8e:3c:2d:0d:df:a2:22:72:23:7b:71:32:48:34:
-                    e7:8e:09:7d:ef:da:b3:d6:b9:c7:7b:83:21:07:f0:
-                    1c:ec:a9:80:a1:28:cb:9d:7f:ff:95:d8:c0:06:27:
-                    ee:24:ce:85:3e:4d:3c:5a:d1:fe:42:b9:89:b2:a3:
-                    4c:ff:55:6a:8c:d4:1f:66:79:e4:b9:e2:a0:7b:16:
-                    09:57:98:46:76:c6:ef:5b:69:7c:99:39:ee:e7:39:
-                    cf:09:ca:c6:05:da:fe:9b:0f:c9:0c:27:a8:5a:bd:
-                    e7:71:e5:e1:16:1a:3e:ec:ea:78:82:4d:da:db:63:
-                    3b:96:6f:f6:21:25:7c:28:b8:a6:7a:de:19:a2:1d:
-                    1d:95:5f:f8:16:3d:11:3c:c6:59:88:dc:e5:52:70:
-                    e6:ae:f8:ba:9a:7b:7a:07:c4:d1:cb:7b:2e:4f:5b:
-                    28:40:ca:6f:88:62:e4:2b:2c:a2:65:01:f9:68:81:
-                    2b:bf:b0:41:90:8f:2f:09:24:51:9a:a7:77:cb:a4:
-                    6a:a6:52:12:0f:1d:35:10:c5:05:02:cf:7f:c6:08:
-                    39:bf:2c:a7:90:0b:1b:5e:04:30:95:21:3c:e4:2e:
-                    c5:98:a4:d3:b7:2d:9a:77:3b:8a:75:11:9c:a6:d8:
-                    f5:b7:6f:17:93:18:22:9b:50:fa:e5:b3:e7:be:94:
-                    14:c3
+                    00:bd:72:c2:5b:1a:e2:a2:27:e6:20:8c:5b:dd:b6:
+                    f2:49:66:5e:e0:a2:06:c0:83:01:c7:d3:ea:a5:28:
+                    89:1f:0d:11:e4:91:94:9a:23:39:06:b3:24:c3:92:
+                    6e:76:9d:f7:cb:76:d7:d2:df:3f:ce:6b:14:02:b8:
+                    01:15:5e:86:54:ae:b9:42:d7:4e:e1:ac:2e:65:83:
+                    1e:45:dc:93:b5:f1:de:55:97:5d:82:3a:f0:27:dc:
+                    1e:fe:4f:c6:c9:a6:4d:f6:5a:9d:dc:ae:1b:09:4c:
+                    b7:79:58:c2:e7:6f:81:2d:1a:63:f6:ef:a4:91:83:
+                    e0:dc:cb:ac:01:e6:5e:a6:fe:1b:78:7e:51:ad:ec:
+                    fd:68:c9:11:de:71:bf:e3:06:0d:fe:36:4b:8f:26:
+                    b8:d8:ff:68:41:f6:01:fc:40:a1:0e:30:06:c5:7e:
+                    de:f2:e7:99:69:92:88:07:1a:d0:93:ed:85:38:a1:
+                    82:8f:6b:3b:8c:a7:62:78:42:3a:54:83:01:45:56:
+                    4a:88:fe:1d:68:34:7b:29:6f:39:6b:08:90:f0:6d:
+                    50:6e:a8:44:b1:27:2d:c7:51:a3:90:d7:54:26:29:
+                    72:a7:c8:33:b7:42:08:1d:48:5f:61:41:aa:f0:b5:
+                    86:7c:94:ec:e0:97:d7:11:e2:80:35:35:ba:b0:3b:
+                    54:a7
                 Exponent: 65537 (0x10001)
     Signature Algorithm: sha256WithRSAEncryption
-    Signature Value:
-        54:ba:cd:b4:a4:c0:c8:be:3b:bc:f1:4b:ac:f4:25:50:0f:bb:
-        ed:95:f5:fa:c7:09:95:47:9a:26:40:36:31:99:a9:31:ed:30:
-        4c:58:64:66:77:03:3e:e8:9c:9a:af:98:26:41:c2:4c:0a:48:
-        36:f9:fb:95:68:d1:ce:3e:3d:1c:05:dd:9e:b5:91:3a:15:e5:
-        99:49:5a:16:94:37:10:6e:0d:c5:8e:86:ba:08:44:01:e6:5a:
-        a2:4a:46:2c:03:8a:65:86:b1:04:78:d7:0d:fc:94:a2:ba:96:
-        fa:a7:fa:9f:e7:02:91:40:01:54:b2:49:1c:80:33:9d:82:d7:
-        61:0c:b7:0b:50:f7:bf:46:89:de:c7:c8:c4:ae:c7:41:0d:2b:
-        c5:f7:77:b5:a0:b4:cc:79:87:1a:db:8a:a1:38:09:44:b7:9c:
-        cf:5e:4f:4e:0a:55:2d:55:2c:52:94:d7:08:c5:51:9d:1c:1d:
-        7a:8f:fe:2a:62:73:2d:9b:4d:96:66:fb:67:7a:dc:a1:ed:d3:
-        ce:b4:a1:99:f2:59:d8:2e:54:4b:83:6d:a8:47:10:57:ad:dc:
-        ea:ea:9e:db:03:71:46:8a:6a:43:16:31:6d:55:ff:70:0d:2c:
-        eb:48:fa:65:1b:69:d4:df:ad:70:2a:af:6f:d3:dd:96:87:0a:
-        1a:78:0a:ab
+         54:d4:70:cf:7c:14:90:0e:8c:ad:5b:3d:51:5e:2e:d3:88:f6:
+         ba:94:b8:ab:18:6b:7a:87:7c:d7:31:74:1e:0a:11:1b:72:88:
+         84:2b:3d:0b:52:38:cd:d8:44:30:e8:0a:e4:15:7a:80:20:9e:
+         fd:9c:5e:66:61:71:54:52:38:fd:64:7a:ae:10:93:21:90:94:
+         68:fa:13:33:1c:e4:d6:f5:79:81:c3:2c:ec:c2:d2:3f:d6:89:
+         40:50:6a:e8:7e:2d:c0:35:f2:77:b7:50:39:95:6c:72:02:d3:
+         78:46:de:72:87:29:ff:a7:4b:74:66:f2:15:ac:77:1a:09:46:
+         40:19:42:a9:4c:80:2e:d0:4d:d9:84:97:76:5e:dd:38:f1:e7:
+         d2:96:b4:89:bb:e4:f6:b2:0a:9f:7d:42:d2:04:3f:ce:8a:53:
+         f4:2f:a2:ca:a3:2f:b5:d7:08:d8:8d:32:1c:f9:e4:00:04:56:
+         a9:bb:ba:be:70:66:ef:ef:fc:bf:0a:13:b8:59:be:fc:a3:18:
+         97:e1:26:55:55:d2:6b:9e:17:4c:78:a1:73:db:bc:26:dd:a1:
+         29:94:a2:cc:56:8c:4e:00:2b:6c:66:2f:04:4d:44:37:35:86:
+         df:57:95:16:1b:97:bd:12:29:56:77:9f:d5:e1:f3:35:24:d2:
+         36:26:d0:3f
 -----BEGIN CERTIFICATE-----
 MIICqTCCAZGgAwIBAgIBDTANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRUZXN0
-IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zMzA2MjQyMTE4MDBa
+IENBIFN1YmF1dGhvcml0eTAeFw03MDAxMDEwMDAwMDBaFw0zNDAxMjcxODQzMzJa
 MBExDzANBgNVBAMMBnNpZ25lZDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC
-ggEBAI48LQ3foiJyI3txMkg0544Jfe/as9a5x3uDIQfwHOypgKEoy51//5XYwAYn
-7iTOhT5NPFrR/kK5ibKjTP9VaozUH2Z55LnioHsWCVeYRnbG71tpfJk57uc5zwnK
-xgXa/psPyQwnqFq953Hl4RYaPuzqeIJN2ttjO5Zv9iElfCi4pnreGaIdHZVf+BY9
-ETzGWYjc5VJw5q74upp7egfE0ct7Lk9bKEDKb4hi5CssomUB+WiBK7+wQZCPLwkk
-UZqnd8ukaqZSEg8dNRDFBQLPf8YIOb8sp5ALG14EMJUhPOQuxZik07ctmnc7inUR
-nKbY9bdvF5MYIptQ+uWz576UFMMCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAVLrN
-tKTAyL47vPFLrPQlUA+77ZX1+scJlUeaJkA2MZmpMe0wTFhkZncDPuicmq+YJkHC
-TApINvn7lWjRzj49HAXdnrWROhXlmUlaFpQ3EG4NxY6GughEAeZaokpGLAOKZYax
-BHjXDfyUorqW+qf6n+cCkUABVLJJHIAznYLXYQy3C1D3v0aJ3sfIxK7HQQ0rxfd3
-taC0zHmHGtuKoTgJRLecz15PTgpVLVUsUpTXCMVRnRwdeo/+KmJzLZtNlmb7Z3rc
-oe3TzrShmfJZ2C5US4NtqEcQV63c6uqe2wNxRopqQxYxbVX/cA0s60j6ZRtp1N+t
-cCqvb9PdlocKGngKqw==
+ggEBAL1ywlsa4qIn5iCMW9228klmXuCiBsCDAcfT6qUoiR8NEeSRlJojOQazJMOS
+bnad98t219LfP85rFAK4ARVehlSuuULXTuGsLmWDHkXck7Xx3lWXXYI68CfcHv5P
+xsmmTfZandyuGwlMt3lYwudvgS0aY/bvpJGD4NzLrAHmXqb+G3h+Ua3s/WjJEd5x
+v+MGDf42S48muNj/aEH2AfxAoQ4wBsV+3vLnmWmSiAca0JPthTihgo9rO4ynYnhC
+OlSDAUVWSoj+HWg0eylvOWsIkPBtUG6oRLEnLcdRo5DXVCYpcqfIM7dCCB1IX2FB
+qvC1hnyU7OCX1xHigDU1urA7VKcCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAVNRw
+z3wUkA6MrVs9UV4u04j2upS4qxhreod81zF0HgoRG3KIhCs9C1I4zdhEMOgK5BV6
+gCCe/ZxeZmFxVFI4/WR6rhCTIZCUaPoTMxzk1vV5gcMs7MLSP9aJQFBq6H4twDXy
+d7dQOZVscgLTeEbecocp/6dLdGbyFax3GglGQBlCqUyALtBN2YSXdl7dOPHn0pa0
+ibvk9rIKn31C0gQ/zopT9C+iyqMvtdcI2I0yHPnkAARWqbu6vnBm7+/8vwoTuFm+
+/KMYl+EmVVXSa54XTHihc9u8Jt2hKZSizFaMTgArbGYvBE1ENzWG31eVFhuXvRIp
+Vnef1eHzNSTSNibQPw==
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/tampered-csr.pem
+++ b/spec/fixtures/ssl/tampered-csr.pem
@@ -1,62 +1,60 @@
 Certificate Request:
     Data:
-        Version: Unknown (2)
+        Version: 3 (0x2)
         Subject: CN=signed
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                Public-Key: (2048 bit)
+                RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:95:70:64:7f:b5:26:4a:bc:50:e9:46:d1:d9:15:
-                    25:5f:9d:85:68:7b:16:eb:25:ac:84:f7:1d:96:a6:
-                    11:c3:cf:11:94:e4:5b:e5:b4:fe:d3:84:21:18:10:
-                    82:16:71:5d:1d:b8:7f:55:1b:99:65:57:9d:25:ea:
-                    e6:75:14:7e:92:ca:d9:2f:14:4b:89:b7:0a:fc:11:
-                    6e:76:5e:30:bc:da:f1:4d:a2:7b:53:aa:21:87:d2:
-                    25:f4:b4:08:d4:3d:a4:5e:f5:88:70:24:3f:ef:5d:
-                    9f:31:41:30:d0:71:5c:af:fc:be:3a:bc:d2:4f:a3:
-                    8d:5d:71:8c:46:67:51:6d:09:ad:3e:5b:86:4c:42:
-                    83:e4:45:35:37:3e:3e:39:52:8a:ea:f1:27:53:6a:
-                    ee:2a:a2:ed:de:e0:63:5b:1d:8c:a1:9c:7e:24:4f:
-                    fe:6e:1f:0d:d3:04:df:ff:42:d5:1a:9d:e1:89:50:
-                    ff:80:c5:1a:23:33:3c:34:8c:91:74:09:99:a1:dc:
-                    a2:16:4f:80:8a:cd:a7:38:ca:fc:ea:b2:af:b7:01:
-                    c6:1b:3a:c6:da:ef:86:72:f9:72:7b:0b:fb:58:e2:
-                    b7:61:9a:ae:20:f1:37:77:d5:f6:f1:ab:19:45:c1:
-                    6e:f4:63:4b:78:c1:71:02:59:0e:e6:4d:5e:1f:88:
-                    1a:69
+                    00:ca:3c:49:ca:69:e4:42:bc:a6:01:37:4e:c6:6c:
+                    1e:a9:d3:b1:7d:20:b6:7f:a9:74:c2:ce:33:f8:32:
+                    85:50:8a:c4:da:d6:47:2c:8e:3e:ef:9e:14:42:b3:
+                    43:b9:9f:59:ca:18:2c:32:f8:f8:5d:c6:74:1b:29:
+                    27:f8:d0:90:05:2e:03:46:b3:a2:c2:9d:38:de:06:
+                    f6:30:52:ff:e5:26:6e:88:fc:c4:23:32:f3:d3:09:
+                    67:1d:a6:52:f1:cc:06:28:2b:4e:af:7b:b2:50:a9:
+                    4f:7f:9b:62:6b:5a:cb:8c:f6:7e:ae:ed:a2:f2:4f:
+                    0d:d2:f5:42:2e:d8:50:b8:0f:fc:38:cd:80:7d:2a:
+                    d8:fc:76:e6:f7:28:91:f9:59:a7:d7:81:88:78:5c:
+                    74:0c:82:9b:14:65:35:2d:04:69:53:24:e4:c2:37:
+                    96:36:61:0b:e0:0f:2c:ac:50:85:84:ca:68:df:a4:
+                    15:2a:b0:a3:03:50:1f:11:45:d4:82:6a:02:eb:76:
+                    8b:82:1c:36:2b:8c:7e:3b:a6:12:c4:5a:8a:20:ab:
+                    2d:08:f8:49:1b:d6:f9:45:dc:d8:34:6c:8c:7b:2d:
+                    2a:8a:c6:87:d0:6a:45:20:9d:f0:43:d0:0f:0a:a2:
+                    69:d6:9b:a1:69:9c:57:e8:b2:f8:56:8f:f6:e4:24:
+                    af:c1
                 Exponent: 65537 (0x10001)
         Attributes:
-            (none)
-            Requested Extensions:
+            a0:00
     Signature Algorithm: sha256WithRSAEncryption
-    Signature Value:
-        ac:48:97:68:71:48:98:58:56:c7:4e:3e:28:10:66:09:67:28:
-        b5:e1:09:56:bf:20:76:ea:45:87:2f:48:36:0c:00:1b:4e:5a:
-        43:ca:25:a6:59:70:89:8a:19:7b:93:f9:19:9a:a0:29:57:b6:
-        eb:37:b5:1e:97:83:67:d8:a4:ee:e7:50:fc:5c:92:ff:0a:20:
-        85:f2:5c:82:e4:45:65:e5:9f:1a:e9:9f:24:ce:b6:6a:d4:6a:
-        77:da:65:10:e2:9d:03:d1:0e:9f:73:05:80:06:e4:37:99:70:
-        f7:a1:ee:8e:f2:6e:ac:ec:b2:0b:89:0c:c5:7d:d2:6b:3b:e4:
-        07:70:14:5c:90:3d:27:d6:3d:a6:9f:b4:b8:17:8c:ea:a5:3a:
-        ff:6e:6e:bc:98:02:5d:ae:f8:fe:6f:0c:97:62:36:24:bd:74:
-        7f:2f:61:8a:76:d2:b3:3e:ee:82:75:b8:c8:8f:41:e7:3a:3b:
-        f5:a6:6e:20:0c:f1:ea:2a:ba:17:ba:02:f5:5f:dd:63:06:f1:
-        86:ab:c8:8f:b4:85:e0:68:42:b8:86:32:4e:00:49:ca:a4:59:
-        b7:4a:87:98:39:d2:21:d1:41:7c:3c:25:ae:97:4d:06:82:93:
-        38:6b:9f:b2:d5:96:2f:6f:7b:f0:31:44:be:24:82:48:70:1a:
-        6b:5a:ec:e7
+         9f:1b:09:61:fd:59:7a:99:8d:c3:f3:44:44:10:af:ac:82:f6:
+         20:5e:5e:3d:e3:07:af:e7:f6:0e:31:1f:ae:7e:bc:fd:4c:db:
+         53:8c:6b:6b:ea:76:e7:96:2c:21:f7:e7:ac:ff:ce:47:ec:e3:
+         61:c2:40:3a:0a:58:ac:94:80:c2:24:25:c3:75:82:8a:60:aa:
+         c6:20:8a:b6:28:b6:97:56:7e:0c:92:d8:da:2f:e0:0e:59:6d:
+         e1:55:b0:01:a1:e7:a9:bc:57:a1:50:de:b3:47:8a:cc:2c:44:
+         cd:5a:9b:bf:64:d3:aa:f9:b1:b2:55:db:c6:6f:5a:6c:54:19:
+         8b:4d:b2:9c:54:e0:2b:6e:c7:8c:26:d4:8d:c7:6c:43:8d:3b:
+         d1:12:87:c2:ca:ba:49:1f:93:eb:e2:8a:a9:7c:7d:e6:32:f6:
+         78:83:ab:54:9b:47:d1:c1:c2:bb:b4:25:b0:9d:bb:29:40:db:
+         30:7f:9a:4d:7a:94:5b:a0:1d:33:99:0e:9a:02:f3:4f:a4:82:
+         dd:47:15:f6:76:03:14:9f:60:9e:89:1a:4f:04:fa:a8:23:49:
+         48:af:65:bd:8c:3a:0f:77:fa:c3:86:d4:87:1a:9c:94:61:28:
+         0b:72:2e:91:98:19:0b:fe:9a:93:45:2a:92:a7:93:83:89:d9:
+         93:6b:d5:ee
 -----BEGIN CERTIFICATE REQUEST-----
 MIICVjCCAT4CAQIwETEPMA0GA1UEAwwGc2lnbmVkMIIBIjANBgkqhkiG9w0BAQEF
-AAOCAQ8AMIIBCgKCAQEAlXBkf7UmSrxQ6UbR2RUlX52FaHsW6yWshPcdlqYRw88R
-lORb5bT+04QhGBCCFnFdHbh/VRuZZVedJermdRR+ksrZLxRLibcK/BFudl4wvNrx
-TaJ7U6ohh9Il9LQI1D2kXvWIcCQ/712fMUEw0HFcr/y+OrzST6ONXXGMRmdRbQmt
-PluGTEKD5EU1Nz4+OVKK6vEnU2ruKqLt3uBjWx2MoZx+JE/+bh8N0wTf/0LVGp3h
-iVD/gMUaIzM8NIyRdAmZodyiFk+Ais2nOMr86rKvtwHGGzrG2u+Gcvlyewv7WOK3
-YZquIPE3d9X28asZRcFu9GNLeMFxAlkO5k1eH4gaaQIDAQABoAAwDQYJKoZIhvcN
-AQELBQADggEBAKxIl2hxSJhYVsdOPigQZglnKLXhCVa/IHbqRYcvSDYMABtOWkPK
-JaZZcImKGXuT+RmaoClXtus3tR6Xg2fYpO7nUPxckv8KIIXyXILkRWXlnxrpnyTO
-tmrUanfaZRDinQPRDp9zBYAG5DeZcPeh7o7ybqzssguJDMV90ms75AdwFFyQPSfW
-PaaftLgXjOqlOv9ubryYAl2u+P5vDJdiNiS9dH8vYYp20rM+7oJ1uMiPQec6O/Wm
-biAM8eoquhe6AvVf3WMG8YaryI+0heBoQriGMk4AScqkWbdKh5g50iHRQXw8Ja6X
-TQaCkzhrn7LVli9ve/AxRL4kgkhwGmta7Oc=
+AAOCAQ8AMIIBCgKCAQEAyjxJymnkQrymATdOxmweqdOxfSC2f6l0ws4z+DKFUIrE
+2tZHLI4+754UQrNDuZ9ZyhgsMvj4XcZ0Gykn+NCQBS4DRrOiwp043gb2MFL/5SZu
+iPzEIzLz0wlnHaZS8cwGKCtOr3uyUKlPf5tia1rLjPZ+ru2i8k8N0vVCLthQuA/8
+OM2AfSrY/Hbm9yiR+Vmn14GIeFx0DIKbFGU1LQRpUyTkwjeWNmEL4A8srFCFhMpo
+36QVKrCjA1AfEUXUgmoC63aLghw2K4x+O6YSxFqKIKstCPhJG9b5RdzYNGyMey0q
+isaH0GpFIJ3wQ9APCqJp1puhaZxX6LL4Vo/25CSvwQIDAQABoAAwDQYJKoZIhvcN
+AQELBQADggEBAJ8bCWH9WXqZjcPzREQQr6yC9iBeXj3jB6/n9g4xH65+vP1M21OM
+a2vqdueWLCH356z/zkfs42HCQDoKWKyUgMIkJcN1gopgqsYgirYotpdWfgyS2Nov
+4A5ZbeFVsAGh56m8V6FQ3rNHiswsRM1am79k06r5sbJV28ZvWmxUGYtNspxU4Ctu
+x4wm1I3HbEONO9ESh8LKukkfk+viiql8feYy9niDq1SbR9HBwru0JbCduylA2zB/
+mk16lFugHTOZDpoC80+kgt1HFfZ2AxSfYJ6JGk8E+qgjSUivZb2MOg93+sOG1Ica
+nJRhKAtyLpGYGQv+mpNFKpKnk4OJ2ZNr1e4=
 -----END CERTIFICATE REQUEST-----

--- a/spec/fixtures/ssl/unknown-127.0.0.1-key.pem
+++ b/spec/fixtures/ssl/unknown-127.0.0.1-key.pem
@@ -1,117 +1,117 @@
-Private-Key: (2048 bit, 2 primes)
+RSA Private-Key: (2048 bit, 2 primes)
 modulus:
-    00:a1:6e:59:aa:03:84:68:6a:a4:1e:2f:6c:92:b4:
-    4c:2d:bc:7a:65:3a:77:0b:20:06:15:63:70:48:3b:
-    98:08:cb:03:7f:6f:18:be:19:28:e7:7d:e7:3f:f6:
-    c4:c3:02:71:0c:3b:0f:5b:a7:14:36:7b:aa:93:08:
-    16:ec:46:a8:d2:d2:35:78:2c:83:9d:dc:6b:53:27:
-    7d:c6:1d:5d:5a:1b:78:28:ae:c4:86:52:a0:b2:e1:
-    5e:3e:c6:d3:63:2d:a9:f7:cd:8c:1d:bd:d5:88:81:
-    0c:a1:93:9d:36:ca:d7:88:93:30:da:a3:40:40:0e:
-    0b:98:ce:05:4d:de:02:1d:9d:05:8d:c4:ac:8b:28:
-    08:6e:39:1c:66:de:8d:02:27:66:32:96:a5:03:58:
-    7e:d1:ab:bb:f6:42:c2:76:5a:59:ad:b1:4e:c5:fb:
-    93:51:ff:4e:87:c6:74:45:19:55:b9:02:dc:08:4d:
-    12:37:64:1a:e8:3f:14:1b:f7:bc:bf:57:99:b3:bd:
-    6d:87:b6:d9:45:a6:07:24:20:6d:7f:9b:fc:5d:8f:
-    43:9e:b7:fb:ff:8a:b4:d3:11:9e:95:c3:af:7c:a3:
-    09:2d:98:9e:0b:a1:c0:4b:ff:4c:03:41:c1:a2:fe:
-    57:26:6f:1c:39:4d:d9:38:61:02:02:8b:8d:fa:d2:
-    c4:31
+    00:ca:58:a4:83:cd:f9:ba:e2:42:9e:d4:ef:52:88:
+    2e:0a:65:74:54:0e:71:82:fe:62:e7:97:91:d1:51:
+    45:12:3f:a6:5c:ba:a3:37:0d:09:c5:d3:3f:7e:24:
+    13:36:ad:be:b6:83:3e:ca:53:ac:b5:e6:e5:0f:2b:
+    68:fb:a2:1e:55:09:79:51:ad:c1:a5:30:f2:fb:ad:
+    cf:59:c1:35:3e:08:f8:a8:20:49:3f:3e:37:e9:46:
+    1a:3f:af:a2:d7:c2:57:9c:6e:2d:ef:36:8b:fa:c8:
+    83:58:ed:bb:58:33:52:42:df:93:29:26:7a:92:70:
+    42:1e:f9:80:33:a2:08:f0:b3:2e:7b:7d:9a:07:e1:
+    41:9c:c1:3c:94:52:38:e2:3a:a3:72:f3:08:75:db:
+    38:ac:9f:f0:39:e7:e3:40:e5:22:34:0f:06:3a:d6:
+    33:40:7c:0a:41:27:ef:a9:06:95:c5:33:84:7b:96:
+    a9:9e:4b:3e:c4:a9:02:ce:a8:6b:61:e4:59:bb:f2:
+    2b:6f:2e:3d:41:75:74:5d:94:3a:8d:6b:28:3e:d9:
+    10:da:09:42:a0:35:84:66:63:57:8b:b6:3a:c1:fd:
+    1b:be:56:b1:16:a3:e4:18:60:e2:70:66:63:23:21:
+    13:25:87:5f:ab:6d:07:4c:8c:62:52:ac:c7:69:4d:
+    e7:bb
 publicExponent: 65537 (0x10001)
 privateExponent:
-    03:e9:0b:e3:f9:e4:d5:b0:ab:9c:0d:93:08:34:b4:
-    d9:b0:c4:98:3a:23:d3:11:aa:04:0f:9e:13:29:da:
-    63:70:23:7c:0d:41:60:ad:74:57:b3:2d:8c:57:9a:
-    69:8c:e0:17:27:41:16:7b:c4:1a:13:c1:cc:80:f8:
-    29:2e:06:fd:e0:58:aa:3a:0d:d0:1f:9c:3b:ed:eb:
-    76:86:94:91:cf:b3:87:ec:bf:d6:ef:1e:74:66:d0:
-    25:1e:24:d5:b4:af:f6:d0:34:52:2e:1c:83:8b:78:
-    b6:5b:40:86:28:c0:b2:ce:b9:f2:b9:dc:9f:10:98:
-    08:52:09:3f:db:1e:5b:00:3e:58:99:c9:14:c1:d2:
-    07:89:cc:ef:ae:00:f6:38:81:e7:38:22:a9:d2:1b:
-    5b:ce:ad:5a:6e:8a:ce:75:9a:77:c5:dd:77:9b:6c:
-    1f:fd:1c:7a:9d:b3:17:30:f5:5d:9f:30:ef:05:b2:
-    a7:4d:92:5c:c3:c2:ba:82:fb:84:b6:77:f5:ac:5c:
-    39:de:7f:8a:be:1a:0f:5c:4c:a9:44:ae:cc:20:6e:
-    db:e7:95:6b:25:50:89:72:27:4b:2d:68:7e:7d:29:
-    5d:81:8b:9f:f5:19:ff:ee:ef:16:58:1c:8a:db:7e:
-    35:05:b9:b1:6c:78:4a:33:d2:1d:0f:62:ff:7b:bc:
-    e1
+    3e:3f:50:b4:df:6b:80:cb:54:15:4a:8a:29:08:8d:
+    a9:53:16:9b:39:2a:40:53:03:98:1d:2f:95:85:fb:
+    ca:a6:5c:06:50:c0:1f:12:5a:bc:49:c5:51:87:c5:
+    85:5f:a3:b8:bf:dd:54:1e:b3:95:ed:e6:ef:68:ba:
+    4e:16:cc:5f:fa:9f:20:ba:64:44:ee:2f:01:af:b1:
+    86:fa:01:e8:08:98:7e:18:18:90:65:12:8c:27:ad:
+    b1:83:d5:83:ac:5c:89:59:f7:b5:8c:41:39:af:ef:
+    80:2e:fa:20:23:01:9e:62:eb:01:90:bd:ca:48:d0:
+    7e:78:e0:b0:81:9b:60:78:22:af:8b:88:0b:6b:85:
+    d0:8c:c9:f8:27:0e:1d:e8:22:58:08:f4:0c:01:34:
+    17:e6:33:05:39:f2:c3:03:98:89:a5:f2:7b:f6:2e:
+    09:b2:53:d1:1d:bd:dd:db:0f:03:48:d1:cb:c7:5c:
+    ad:5b:0a:01:4a:ec:a3:9b:6e:00:a2:c8:1c:86:fb:
+    96:3b:10:b7:b4:50:0a:76:e2:1e:e4:a7:41:ab:3d:
+    a6:12:4d:37:29:bd:d9:80:49:a2:e7:73:8f:09:12:
+    fd:18:9b:27:89:a9:f4:cc:da:c8:c5:bc:59:7e:94:
+    2b:7b:65:67:b7:0a:de:70:e1:be:de:55:97:4c:a9:
+    89
 prime1:
-    00:d9:99:ee:70:ef:a3:d8:c3:c4:5c:e0:eb:09:dc:
-    27:a7:c2:0c:41:cb:49:9f:cc:68:dc:7b:d2:fb:db:
-    aa:f7:56:cf:e8:68:37:b1:23:cc:8d:7b:49:12:be:
-    e6:11:d7:77:6d:8a:c5:6c:61:73:1d:da:24:61:75:
-    71:d0:d2:2c:d0:90:0f:b5:0a:b8:4c:ce:e3:46:f3:
-    4f:e4:a2:68:46:b9:80:b8:2e:0a:01:21:57:54:8c:
-    d1:f5:4d:ae:ce:eb:ce:d9:04:54:20:3d:c5:83:22:
-    2e:f2:65:2b:c6:e9:d9:7b:ab:a0:b5:c5:40:ee:8b:
-    d5:57:0d:f0:05:5c:40:69:79
+    00:ea:69:43:3a:cb:29:35:b5:d0:4f:e6:01:2f:f3:
+    ea:9a:74:cf:66:ae:30:dd:71:91:77:48:8d:05:2f:
+    9e:70:d9:23:7f:bd:8f:f5:c9:f5:70:26:ab:99:a3:
+    c2:2c:6c:05:82:c2:99:50:ba:05:1c:18:0a:98:b0:
+    85:77:d0:fa:5b:ed:21:d3:b6:26:c4:20:e9:1f:1c:
+    ef:cd:9e:ac:56:87:61:a0:92:83:45:7d:fa:31:5f:
+    71:a8:0e:67:94:3e:57:cf:17:4b:c6:ad:04:d6:3f:
+    a9:57:7e:e5:1f:cb:88:ac:96:59:67:0f:a4:84:c2:
+    70:59:81:0b:42:71:e3:fd:c7
 prime2:
-    00:bd:ea:f2:43:42:ad:95:71:8f:09:a0:15:c1:d7:
-    a1:b5:9d:48:b1:6f:e4:1b:bf:ab:fd:0d:47:d3:57:
-    f0:24:46:37:8d:f5:c5:37:80:52:72:65:e1:2a:df:
-    ee:f6:61:fa:9c:7e:e1:1e:60:96:a8:04:54:06:dd:
-    65:e8:1a:f7:8e:d2:30:d7:55:20:82:1a:bd:23:73:
-    c2:95:07:3c:3e:e7:58:7c:10:e6:87:b1:02:a5:69:
-    b1:f4:b2:a4:4a:49:c4:cf:b3:66:a8:4b:af:e6:3d:
-    18:59:69:52:63:b5:59:41:a2:a5:f8:49:ef:73:cc:
-    37:1d:df:52:3b:50:f7:ba:79
+    00:dc:fb:61:c7:48:8f:0a:d8:e7:03:7f:e4:a4:a8:
+    31:3a:24:c9:97:47:87:69:2b:ea:c4:6c:fb:20:56:
+    72:f9:c4:7b:b4:fd:62:f6:65:23:4c:7d:2d:af:a8:
+    ca:4c:71:a0:04:e3:b3:f6:01:44:40:68:85:80:99:
+    47:5c:65:ec:0d:3b:53:f0:e7:f6:f0:f8:c4:00:da:
+    69:d4:9c:e2:ba:04:bd:2b:b8:58:04:e9:5b:e1:9b:
+    81:a3:76:55:c4:9d:50:05:53:af:d4:cf:d3:fc:20:
+    93:7c:7f:7f:65:1a:47:54:5c:d3:5f:b6:8e:a3:82:
+    6e:36:4e:35:36:d4:36:56:6d
 exponent1:
-    5a:76:e2:68:55:58:7a:cf:b8:9d:1c:6c:da:a6:8a:
-    5d:f6:10:7e:71:f3:63:d9:e9:66:70:9c:20:55:0c:
-    d8:d3:60:90:30:73:a6:d3:49:41:30:96:0a:93:0e:
-    b7:30:2a:d8:81:ae:de:06:0d:83:c5:a3:06:59:7b:
-    3d:e3:82:fa:1a:4a:4d:6b:ed:7f:11:2b:ef:dd:4b:
-    c3:b3:b9:42:5d:f0:a3:a1:90:4b:33:ff:48:89:5a:
-    e8:6e:a9:54:21:38:d7:84:33:2d:4c:41:06:e9:79:
-    37:10:d4:88:57:c4:30:e4:03:66:4e:61:56:4b:10:
-    20:a7:0c:b8:4d:c8:01:91
+    00:a5:4d:e5:e3:28:31:bf:76:9f:98:38:92:cd:c6:
+    2c:c3:0f:6c:d2:f4:33:f1:75:8d:27:99:3a:19:56:
+    23:5d:61:42:ef:6a:36:83:16:10:c7:2d:fe:05:32:
+    be:53:a5:39:9d:a4:ad:89:88:24:e2:52:f1:e6:0b:
+    55:93:d1:03:3c:a0:55:22:7f:69:87:15:ce:4f:ea:
+    90:11:68:bc:0f:a9:18:e7:ab:6a:77:2f:07:a8:99:
+    ae:04:dd:63:9d:de:f8:fd:49:68:5e:8a:d4:c6:61:
+    ce:81:ad:32:d6:e1:29:58:cc:0d:ef:e7:d0:14:ef:
+    29:5b:74:ed:03:c6:5d:09:31
 exponent2:
-    4e:94:e1:4a:fd:52:ef:ab:fe:20:60:71:c0:34:25:
-    c0:0c:e5:60:2d:c8:f7:c6:56:36:ad:81:13:ac:a6:
-    3b:8c:26:3e:81:fb:e9:5c:1a:41:25:70:86:9a:03:
-    b9:44:8f:3a:a3:b1:28:2d:95:08:ce:49:aa:51:7f:
-    72:0b:7e:75:44:f9:5a:8f:e9:94:8b:d5:c8:ce:84:
-    2b:bf:c3:a8:cf:76:a8:57:21:db:f1:5d:03:ee:78:
-    e8:a3:e6:20:aa:e7:59:7d:84:b3:8c:25:ab:21:8a:
-    6a:ac:8e:9f:9d:10:e2:7c:97:29:e6:05:c3:27:33:
-    83:13:bd:65:b7:b9:d9:19
+    00:a3:cc:69:e3:cf:b2:c7:b5:93:37:12:db:a5:f9:
+    4d:d3:ed:64:c8:0f:ab:1d:98:02:02:eb:4d:11:e1:
+    42:84:44:d1:f5:8c:44:88:a2:db:11:5d:50:39:fe:
+    81:45:3c:8c:02:53:ce:17:31:45:28:00:d1:c4:4a:
+    d9:8c:71:b8:10:ee:c2:ff:b4:d1:64:38:e1:00:48:
+    e5:5d:45:95:01:91:75:af:2c:8b:81:c8:7f:e4:b0:
+    e1:dd:0a:5f:f4:c7:2e:83:64:4e:d7:0d:dd:f1:eb:
+    2b:a7:82:d2:29:5c:db:36:7b:3f:ea:98:65:0e:6a:
+    25:cb:77:19:16:b5:22:39:d9
 coefficient:
-    5a:93:09:c2:93:ac:b7:00:01:72:38:a9:d1:d7:6f:
-    28:48:bd:91:f3:72:af:5c:5a:6f:33:14:45:b4:61:
-    7b:26:ab:1a:2a:44:1c:46:00:1c:56:23:df:2b:38:
-    46:4d:fc:af:42:a7:f6:35:55:df:90:fd:26:33:0d:
-    5a:74:f1:37:20:0b:10:d4:63:5e:54:bd:58:4c:3c:
-    25:18:e3:f2:2d:69:c0:b6:d8:05:b4:4b:10:c0:4f:
-    03:61:9e:eb:4f:a1:c0:82:1c:35:82:fc:43:d9:1d:
-    1a:95:92:62:cd:70:1f:1f:94:6d:76:94:96:69:83:
-    50:89:24:6b:c3:00:c8:4a
+    0f:73:98:6f:8c:82:a4:80:95:b2:88:f5:52:34:ce:
+    da:16:a0:6b:6b:01:d5:d9:fb:d1:80:50:c2:7c:b2:
+    c7:f2:c2:51:2c:99:b2:18:cf:6b:29:b9:b5:14:9e:
+    ea:e0:4d:db:f1:c2:81:3e:88:3f:fc:3d:8f:c2:5e:
+    c7:eb:cc:68:f3:5e:48:ed:11:f8:65:01:b4:a7:6b:
+    75:54:6e:67:7a:4b:8c:ed:32:11:ec:d1:91:7e:e8:
+    7a:6d:24:b7:7e:51:ae:e1:1a:84:49:10:41:4d:9c:
+    63:25:5b:8d:50:f0:01:90:02:34:01:9d:3e:9b:ea:
+    8c:2b:5d:d6:51:06:39:71
 -----BEGIN RSA PRIVATE KEY-----
-MIIEogIBAAKCAQEAoW5ZqgOEaGqkHi9skrRMLbx6ZTp3CyAGFWNwSDuYCMsDf28Y
-vhko533nP/bEwwJxDDsPW6cUNnuqkwgW7Eao0tI1eCyDndxrUyd9xh1dWht4KK7E
-hlKgsuFePsbTYy2p982MHb3ViIEMoZOdNsrXiJMw2qNAQA4LmM4FTd4CHZ0FjcSs
-iygIbjkcZt6NAidmMpalA1h+0au79kLCdlpZrbFOxfuTUf9Oh8Z0RRlVuQLcCE0S
-N2Qa6D8UG/e8v1eZs71th7bZRaYHJCBtf5v8XY9Dnrf7/4q00xGelcOvfKMJLZie
-C6HAS/9MA0HBov5XJm8cOU3ZOGECAouN+tLEMQIDAQABAoIBAAPpC+P55NWwq5wN
-kwg0tNmwxJg6I9MRqgQPnhMp2mNwI3wNQWCtdFezLYxXmmmM4BcnQRZ7xBoTwcyA
-+CkuBv3gWKo6DdAfnDvt63aGlJHPs4fsv9bvHnRm0CUeJNW0r/bQNFIuHIOLeLZb
-QIYowLLOufK53J8QmAhSCT/bHlsAPliZyRTB0geJzO+uAPY4gec4IqnSG1vOrVpu
-is51mnfF3XebbB/9HHqdsxcw9V2fMO8FsqdNklzDwrqC+4S2d/WsXDnef4q+Gg9c
-TKlErswgbtvnlWslUIlyJ0staH59KV2Bi5/1Gf/u7xZYHIrbfjUFubFseEoz0h0P
-Yv97vOECgYEA2ZnucO+j2MPEXODrCdwnp8IMQctJn8xo3HvS+9uq91bP6Gg3sSPM
-jXtJEr7mEdd3bYrFbGFzHdokYXVx0NIs0JAPtQq4TM7jRvNP5KJoRrmAuC4KASFX
-VIzR9U2uzuvO2QRUID3FgyIu8mUrxunZe6ugtcVA7ovVVw3wBVxAaXkCgYEAvery
-Q0KtlXGPCaAVwdehtZ1IsW/kG7+r/Q1H01fwJEY3jfXFN4BScmXhKt/u9mH6nH7h
-HmCWqARUBt1l6Br3jtIw11Ugghq9I3PClQc8PudYfBDmh7ECpWmx9LKkSknEz7Nm
-qEuv5j0YWWlSY7VZQaKl+Envc8w3Hd9SO1D3unkCgYBaduJoVVh6z7idHGzapopd
-9hB+cfNj2elmcJwgVQzY02CQMHOm00lBMJYKkw63MCrYga7eBg2DxaMGWXs944L6
-GkpNa+1/ESvv3UvDs7lCXfCjoZBLM/9IiVrobqlUITjXhDMtTEEG6Xk3ENSIV8Qw
-5ANmTmFWSxAgpwy4TcgBkQKBgE6U4Ur9Uu+r/iBgccA0JcAM5WAtyPfGVjatgROs
-pjuMJj6B++lcGkElcIaaA7lEjzqjsSgtlQjOSapRf3ILfnVE+VqP6ZSL1cjOhCu/
-w6jPdqhXIdvxXQPueOij5iCq51l9hLOMJashimqsjp+dEOJ8lynmBcMnM4MTvWW3
-udkZAoGAWpMJwpOstwABcjip0ddvKEi9kfNyr1xabzMURbRheyarGipEHEYAHFYj
-3ys4Rk38r0Kn9jVV35D9JjMNWnTxNyALENRjXlS9WEw8JRjj8i1pwLbYBbRLEMBP
-A2Ge60+hwIIcNYL8Q9kdGpWSYs1wHx+UbXaUlmmDUIkka8MAyEo=
+MIIEpAIBAAKCAQEAylikg835uuJCntTvUoguCmV0VA5xgv5i55eR0VFFEj+mXLqj
+Nw0JxdM/fiQTNq2+toM+ylOsteblDyto+6IeVQl5Ua3BpTDy+63PWcE1Pgj4qCBJ
+Pz436UYaP6+i18JXnG4t7zaL+siDWO27WDNSQt+TKSZ6knBCHvmAM6II8LMue32a
+B+FBnME8lFI44jqjcvMIdds4rJ/wOefjQOUiNA8GOtYzQHwKQSfvqQaVxTOEe5ap
+nks+xKkCzqhrYeRZu/Irby49QXV0XZQ6jWsoPtkQ2glCoDWEZmNXi7Y6wf0bvlax
+FqPkGGDicGZjIyETJYdfq20HTIxiUqzHaU3nuwIDAQABAoIBAD4/ULTfa4DLVBVK
+iikIjalTFps5KkBTA5gdL5WF+8qmXAZQwB8SWrxJxVGHxYVfo7i/3VQes5Xt5u9o
+uk4WzF/6nyC6ZETuLwGvsYb6AegImH4YGJBlEownrbGD1YOsXIlZ97WMQTmv74Au
++iAjAZ5i6wGQvcpI0H544LCBm2B4Iq+LiAtrhdCMyfgnDh3oIlgI9AwBNBfmMwU5
+8sMDmIml8nv2LgmyU9Edvd3bDwNI0cvHXK1bCgFK7KObbgCiyByG+5Y7ELe0UAp2
+4h7kp0GrPaYSTTcpvdmASaLnc48JEv0YmyeJqfTM2sjFvFl+lCt7ZWe3Ct5w4b7e
+VZdMqYkCgYEA6mlDOsspNbXQT+YBL/PqmnTPZq4w3XGRd0iNBS+ecNkjf72P9cn1
+cCarmaPCLGwFgsKZULoFHBgKmLCFd9D6W+0h07YmxCDpHxzvzZ6sVodhoJKDRX36
+MV9xqA5nlD5XzxdLxq0E1j+pV37lH8uIrJZZZw+khMJwWYELQnHj/ccCgYEA3Pth
+x0iPCtjnA3/kpKgxOiTJl0eHaSvqxGz7IFZy+cR7tP1i9mUjTH0tr6jKTHGgBOOz
+9gFEQGiFgJlHXGXsDTtT8Of28PjEANpp1JziugS9K7hYBOlb4ZuBo3ZVxJ1QBVOv
+1M/T/CCTfH9/ZRpHVFzTX7aOo4JuNk41NtQ2Vm0CgYEApU3l4ygxv3afmDiSzcYs
+ww9s0vQz8XWNJ5k6GVYjXWFC72o2gxYQxy3+BTK+U6U5naStiYgk4lLx5gtVk9ED
+PKBVIn9phxXOT+qQEWi8D6kY56tqdy8HqJmuBN1jnd74/UloXorUxmHOga0y1uEp
+WMwN7+fQFO8pW3TtA8ZdCTECgYEAo8xp48+yx7WTNxLbpflN0+1kyA+rHZgCAutN
+EeFChETR9YxEiKLbEV1QOf6BRTyMAlPOFzFFKADRxErZjHG4EO7C/7TRZDjhAEjl
+XUWVAZF1ryyLgch/5LDh3Qpf9Mcug2RO1w3d8esrp4LSKVzbNns/6phlDmoly3cZ
+FrUiOdkCgYAPc5hvjIKkgJWyiPVSNM7aFqBrawHV2fvRgFDCfLLH8sJRLJmyGM9r
+Kbm1FJ7q4E3b8cKBPog//D2Pwl7H68xo815I7RH4ZQG0p2t1VG5nekuM7TIR7NGR
+fuh6bSS3flGu4RqESRBBTZxjJVuNUPABkAI0AZ0+m+qMK13WUQY5cQ==
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/unknown-127.0.0.1.pem
+++ b/spec/fixtures/ssl/unknown-127.0.0.1.pem
@@ -6,65 +6,64 @@ Certificate:
         Issuer: CN=Unknown CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Jun 24 21:18:00 2033 GMT
+            Not After : Jan 27 18:43:32 2034 GMT
         Subject: CN=127.0.0.1
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                Public-Key: (2048 bit)
+                RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:a1:6e:59:aa:03:84:68:6a:a4:1e:2f:6c:92:b4:
-                    4c:2d:bc:7a:65:3a:77:0b:20:06:15:63:70:48:3b:
-                    98:08:cb:03:7f:6f:18:be:19:28:e7:7d:e7:3f:f6:
-                    c4:c3:02:71:0c:3b:0f:5b:a7:14:36:7b:aa:93:08:
-                    16:ec:46:a8:d2:d2:35:78:2c:83:9d:dc:6b:53:27:
-                    7d:c6:1d:5d:5a:1b:78:28:ae:c4:86:52:a0:b2:e1:
-                    5e:3e:c6:d3:63:2d:a9:f7:cd:8c:1d:bd:d5:88:81:
-                    0c:a1:93:9d:36:ca:d7:88:93:30:da:a3:40:40:0e:
-                    0b:98:ce:05:4d:de:02:1d:9d:05:8d:c4:ac:8b:28:
-                    08:6e:39:1c:66:de:8d:02:27:66:32:96:a5:03:58:
-                    7e:d1:ab:bb:f6:42:c2:76:5a:59:ad:b1:4e:c5:fb:
-                    93:51:ff:4e:87:c6:74:45:19:55:b9:02:dc:08:4d:
-                    12:37:64:1a:e8:3f:14:1b:f7:bc:bf:57:99:b3:bd:
-                    6d:87:b6:d9:45:a6:07:24:20:6d:7f:9b:fc:5d:8f:
-                    43:9e:b7:fb:ff:8a:b4:d3:11:9e:95:c3:af:7c:a3:
-                    09:2d:98:9e:0b:a1:c0:4b:ff:4c:03:41:c1:a2:fe:
-                    57:26:6f:1c:39:4d:d9:38:61:02:02:8b:8d:fa:d2:
-                    c4:31
+                    00:ca:58:a4:83:cd:f9:ba:e2:42:9e:d4:ef:52:88:
+                    2e:0a:65:74:54:0e:71:82:fe:62:e7:97:91:d1:51:
+                    45:12:3f:a6:5c:ba:a3:37:0d:09:c5:d3:3f:7e:24:
+                    13:36:ad:be:b6:83:3e:ca:53:ac:b5:e6:e5:0f:2b:
+                    68:fb:a2:1e:55:09:79:51:ad:c1:a5:30:f2:fb:ad:
+                    cf:59:c1:35:3e:08:f8:a8:20:49:3f:3e:37:e9:46:
+                    1a:3f:af:a2:d7:c2:57:9c:6e:2d:ef:36:8b:fa:c8:
+                    83:58:ed:bb:58:33:52:42:df:93:29:26:7a:92:70:
+                    42:1e:f9:80:33:a2:08:f0:b3:2e:7b:7d:9a:07:e1:
+                    41:9c:c1:3c:94:52:38:e2:3a:a3:72:f3:08:75:db:
+                    38:ac:9f:f0:39:e7:e3:40:e5:22:34:0f:06:3a:d6:
+                    33:40:7c:0a:41:27:ef:a9:06:95:c5:33:84:7b:96:
+                    a9:9e:4b:3e:c4:a9:02:ce:a8:6b:61:e4:59:bb:f2:
+                    2b:6f:2e:3d:41:75:74:5d:94:3a:8d:6b:28:3e:d9:
+                    10:da:09:42:a0:35:84:66:63:57:8b:b6:3a:c1:fd:
+                    1b:be:56:b1:16:a3:e4:18:60:e2:70:66:63:23:21:
+                    13:25:87:5f:ab:6d:07:4c:8c:62:52:ac:c7:69:4d:
+                    e7:bb
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Subject Alternative Name: 
                 DNS:127.0.0.1, DNS:127.0.0.2
     Signature Algorithm: sha256WithRSAEncryption
-    Signature Value:
-        4e:fc:85:4d:87:e0:ae:d2:16:d0:1a:a9:cc:83:d5:46:e6:bc:
-        ea:41:ab:59:fb:72:93:f0:2a:71:44:ef:82:8c:4f:1b:67:33:
-        2f:f8:f7:47:10:fc:80:de:d8:4c:33:f6:f9:cc:c6:16:99:3e:
-        5b:d8:33:91:0c:dc:0f:59:45:b4:fe:ae:d0:b3:17:a3:e8:0a:
-        f8:17:0e:84:d6:32:59:ee:3f:57:21:f4:db:ca:79:01:ae:24:
-        56:50:c7:bd:00:12:8c:59:73:47:f3:3a:37:5f:2a:37:48:08:
-        6c:63:d8:e9:9d:8c:bb:18:e7:36:f1:9f:e6:43:47:50:d2:03:
-        30:b2:2e:7c:27:65:79:fe:84:20:da:69:78:fa:ec:8d:8d:ae:
-        a9:82:be:f8:3f:e5:84:8e:3a:37:a5:8b:ed:45:22:ba:d6:1e:
-        2e:6f:a1:ab:e7:aa:7b:1d:28:19:bc:0c:9a:89:9d:94:15:70:
-        70:2b:24:a6:24:4d:79:00:89:7d:51:e2:5f:fa:c6:25:01:dc:
-        8f:e0:72:90:e2:5f:1c:5d:1f:a5:a9:1e:d7:2a:e8:6f:03:69:
-        c8:e6:a9:b5:fe:c7:60:96:a1:e5:18:e7:9e:af:9f:68:6e:52:
-        60:c0:bc:a1:3e:74:51:16:12:3f:a4:53:fc:5d:a1:01:68:31:
-        82:8a:67:c9
+         94:63:d8:4e:ec:a1:98:49:08:5d:b1:14:e4:2e:db:1d:0f:f2:
+         88:0a:be:f4:2a:23:0f:80:f7:3a:93:c2:b1:7a:0e:c7:93:23:
+         82:24:87:f5:65:9c:18:63:51:b5:9e:0d:b2:cd:9d:13:01:83:
+         f6:f2:d4:94:c5:00:97:9e:72:6e:3b:29:7f:4e:73:72:52:2c:
+         e5:8f:ce:f3:18:08:8b:fc:dc:64:c1:f5:2f:5b:56:29:89:b4:
+         74:d6:66:3e:f7:f0:18:67:a8:c8:6e:fc:bc:ff:35:28:6f:85:
+         52:10:e2:fd:c4:87:f3:18:20:40:ea:e3:e6:11:6d:4c:c0:d4:
+         e7:05:d5:02:09:02:43:15:4a:d5:b6:db:97:ba:d5:31:00:68:
+         9f:20:34:59:77:33:e5:5d:c1:f3:4b:78:d7:d2:83:aa:a6:cc:
+         60:cf:79:27:b1:18:9b:09:64:61:41:0b:23:7a:c4:38:53:05:
+         e7:55:d7:26:2f:7b:f9:36:8d:82:2c:f1:bf:89:c6:cf:b9:30:
+         d9:42:05:83:43:91:cc:36:0c:e1:74:af:6d:1c:fb:38:77:c6:
+         cb:46:9d:63:df:9e:f8:4e:a5:40:ba:6c:14:01:0e:72:7c:87:
+         62:06:ba:1f:25:2b:ce:22:be:8d:8f:d2:45:d6:45:6f:d3:7e:
+         cd:fa:34:40
 -----BEGIN CERTIFICATE-----
 MIICxzCCAa+gAwIBAgIBATANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDDApVbmtu
-b3duIENBMB4XDTcwMDEwMTAwMDAwMFoXDTMzMDYyNDIxMTgwMFowFDESMBAGA1UE
-AwwJMTI3LjAuMC4xMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAoW5Z
-qgOEaGqkHi9skrRMLbx6ZTp3CyAGFWNwSDuYCMsDf28Yvhko533nP/bEwwJxDDsP
-W6cUNnuqkwgW7Eao0tI1eCyDndxrUyd9xh1dWht4KK7EhlKgsuFePsbTYy2p982M
-Hb3ViIEMoZOdNsrXiJMw2qNAQA4LmM4FTd4CHZ0FjcSsiygIbjkcZt6NAidmMpal
-A1h+0au79kLCdlpZrbFOxfuTUf9Oh8Z0RRlVuQLcCE0SN2Qa6D8UG/e8v1eZs71t
-h7bZRaYHJCBtf5v8XY9Dnrf7/4q00xGelcOvfKMJLZieC6HAS/9MA0HBov5XJm8c
-OU3ZOGECAouN+tLEMQIDAQABoyMwITAfBgNVHREEGDAWggkxMjcuMC4wLjGCCTEy
-Ny4wLjAuMjANBgkqhkiG9w0BAQsFAAOCAQEATvyFTYfgrtIW0BqpzIPVRua86kGr
-Wftyk/AqcUTvgoxPG2czL/j3RxD8gN7YTDP2+czGFpk+W9gzkQzcD1lFtP6u0LMX
-o+gK+BcOhNYyWe4/VyH028p5Aa4kVlDHvQASjFlzR/M6N18qN0gIbGPY6Z2Muxjn
-NvGf5kNHUNIDMLIufCdlef6EINppePrsjY2uqYK++D/lhI46N6WL7UUiutYeLm+h
-q+eqex0oGbwMmomdlBVwcCskpiRNeQCJfVHiX/rGJQHcj+BykOJfHF0fpake1yro
-bwNpyOaptf7HYJah5Rjnnq+faG5SYMC8oT50URYSP6RT/F2hAWgxgopnyQ==
+b3duIENBMB4XDTcwMDEwMTAwMDAwMFoXDTM0MDEyNzE4NDMzMlowFDESMBAGA1UE
+AwwJMTI3LjAuMC4xMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAylik
+g835uuJCntTvUoguCmV0VA5xgv5i55eR0VFFEj+mXLqjNw0JxdM/fiQTNq2+toM+
+ylOsteblDyto+6IeVQl5Ua3BpTDy+63PWcE1Pgj4qCBJPz436UYaP6+i18JXnG4t
+7zaL+siDWO27WDNSQt+TKSZ6knBCHvmAM6II8LMue32aB+FBnME8lFI44jqjcvMI
+dds4rJ/wOefjQOUiNA8GOtYzQHwKQSfvqQaVxTOEe5apnks+xKkCzqhrYeRZu/Ir
+by49QXV0XZQ6jWsoPtkQ2glCoDWEZmNXi7Y6wf0bvlaxFqPkGGDicGZjIyETJYdf
+q20HTIxiUqzHaU3nuwIDAQABoyMwITAfBgNVHREEGDAWggkxMjcuMC4wLjGCCTEy
+Ny4wLjAuMjANBgkqhkiG9w0BAQsFAAOCAQEAlGPYTuyhmEkIXbEU5C7bHQ/yiAq+
+9CojD4D3OpPCsXoOx5MjgiSH9WWcGGNRtZ4Nss2dEwGD9vLUlMUAl55ybjspf05z
+clIs5Y/O8xgIi/zcZMH1L1tWKYm0dNZmPvfwGGeoyG78vP81KG+FUhDi/cSH8xgg
+QOrj5hFtTMDU5wXVAgkCQxVK1bbbl7rVMQBonyA0WXcz5V3B80t419KDqqbMYM95
+J7EYmwlkYUELI3rEOFMF51XXJi97+TaNgizxv4nGz7kw2UIFg0ORzDYM4XSvbRz7
+OHfGy0adY9+e+E6lQLpsFAEOcnyHYga6HyUrziK+jY/SRdZFb9N+zfo0QA==
 -----END CERTIFICATE-----

--- a/spec/fixtures/ssl/unknown-ca-key.pem
+++ b/spec/fixtures/ssl/unknown-ca-key.pem
@@ -1,117 +1,117 @@
-Private-Key: (2048 bit, 2 primes)
+RSA Private-Key: (2048 bit, 2 primes)
 modulus:
-    00:a8:08:cd:22:aa:fa:a1:38:0e:d8:be:2f:57:b6:
-    fb:f5:e2:9b:04:72:49:56:15:71:42:1d:12:a8:8f:
-    29:03:63:e1:2a:1f:ec:4d:67:3d:7d:5e:27:a5:21:
-    fe:16:38:a0:f5:de:5c:76:ec:71:7d:6c:ae:ca:8a:
-    30:5d:fe:39:c5:4a:d0:14:13:76:b5:89:d8:58:7a:
-    11:76:54:3e:4d:e3:be:f9:fb:72:80:bc:19:07:0f:
-    e0:53:46:5b:f1:45:8c:d2:5c:af:e4:0f:ab:7d:bc:
-    22:3c:7a:b1:95:7d:6a:04:4b:fa:d2:e8:1e:c4:39:
-    4b:bd:dc:7e:69:ba:8e:a9:96:a5:17:e4:ae:4e:3e:
-    98:ad:2b:55:95:ac:6d:40:4b:20:55:51:31:98:9e:
-    4e:de:b4:37:31:5b:d9:3a:6c:e4:b1:0a:19:ce:5e:
-    a8:e2:29:97:de:3d:c7:50:54:fb:f2:8f:2a:a4:58:
-    a5:52:82:0b:52:c8:4e:6c:5d:78:10:c6:4b:05:36:
-    02:e4:df:bc:95:4a:47:b7:e8:e4:8b:6d:46:ab:fb:
-    fb:41:6b:bb:90:c4:1b:5a:7d:3b:2e:19:2d:0d:95:
-    70:d2:10:f9:7a:1a:ee:8f:20:cb:8d:8d:bf:23:75:
-    11:dd:02:ab:e3:fd:9e:b1:05:3b:63:2e:ab:87:93:
-    63:a3
+    00:ae:4c:42:b8:da:d0:6f:11:a4:ba:9c:ba:6b:dd:
+    7a:dd:8d:5f:8b:51:e9:b2:85:4d:9a:26:41:1d:8e:
+    52:2f:19:ed:79:6a:b7:04:f7:8e:9c:82:37:04:26:
+    71:10:3f:98:e6:a3:0c:58:fb:00:84:4f:d0:8d:fa:
+    50:2c:0c:59:1d:48:7d:de:af:5e:b4:27:09:f2:b8:
+    33:18:56:cb:40:9f:09:a7:61:08:88:ed:be:2d:96:
+    9c:03:a3:1a:ad:61:f6:e3:98:23:90:90:5c:66:90:
+    25:06:87:62:4b:f9:87:e6:dd:08:c3:e0:7a:67:3c:
+    1f:f9:cb:99:ad:53:dc:1d:9b:8f:85:0b:84:78:13:
+    95:71:a8:6a:b2:13:20:19:b6:b6:63:5e:3f:68:14:
+    1b:67:c1:75:cf:16:d1:26:c0:94:24:89:ce:3c:b3:
+    6d:05:4d:10:52:40:73:c4:7b:ac:f1:dd:64:6a:f0:
+    62:36:c6:08:17:03:64:d9:fb:1c:e2:99:25:2b:df:
+    47:fc:f8:c9:07:f3:84:96:da:19:27:25:1b:b6:ab:
+    be:0c:93:54:df:0d:2e:38:ab:da:e7:1c:56:86:0c:
+    4b:0a:96:46:30:8f:7c:ab:be:b0:22:6b:92:76:c6:
+    56:32:43:54:ab:18:25:5a:6c:09:05:ba:ca:74:d8:
+    86:1f
 publicExponent: 65537 (0x10001)
 privateExponent:
-    12:00:67:61:98:69:a3:4d:eb:21:43:36:b5:31:f0:
-    4a:46:4d:8f:2b:63:39:ea:b0:28:82:0e:d6:aa:07:
-    9d:ca:5c:7b:f3:d1:8f:f5:48:7c:1e:d3:26:78:be:
-    cc:c8:a2:4d:d4:d5:99:13:f9:90:93:4d:22:7b:ad:
-    74:d4:60:82:07:62:c5:53:d4:7a:dc:5a:a6:17:e5:
-    b9:04:8b:6c:32:c2:e9:eb:0b:38:49:6e:70:f8:3d:
-    73:0e:6d:99:2a:77:4c:ae:0b:55:e6:6b:db:db:84:
-    db:6f:d5:88:8b:58:09:3f:ce:8e:3b:b9:d8:11:bf:
-    50:86:c7:b0:32:01:48:9f:a3:5d:c2:dc:9a:67:2f:
-    94:70:99:08:31:bf:a3:e3:89:de:e2:f1:8c:4d:73:
-    5c:68:ac:76:36:4f:0d:ce:e8:62:5a:32:44:7a:13:
-    fa:9a:46:2e:30:aa:66:10:43:81:5d:57:65:99:3c:
-    82:0c:65:83:44:36:6a:e1:0d:44:16:74:e1:c6:a8:
-    9a:3d:a5:fa:a2:7e:cb:a1:76:c0:21:e0:4c:ea:a2:
-    f2:d9:a7:53:a8:41:39:db:51:c7:5d:31:b2:04:86:
-    4b:7d:cf:11:10:16:b3:b1:22:37:29:c4:20:7e:b0:
-    0c:7b:ac:89:78:6b:ef:3b:98:29:c2:23:29:9f:4e:
-    89
+    5e:f6:c7:e7:a5:b8:a8:bb:49:30:2f:92:56:90:be:
+    8f:95:a6:37:e7:32:58:04:cf:2a:2c:ab:8f:a9:ea:
+    57:25:5e:40:a8:06:fd:9a:cf:c5:b0:20:bf:8f:1e:
+    4d:07:09:8c:a7:cb:63:73:a6:6d:70:7b:25:cf:fa:
+    fc:74:e1:dc:d5:91:56:d1:df:dc:71:e4:b6:ac:eb:
+    91:d8:40:37:7e:2f:29:55:f1:eb:80:f4:fc:2b:b1:
+    e7:3d:67:9c:8d:e2:91:50:64:18:30:bf:57:56:34:
+    06:21:9f:49:db:b3:d2:f2:1d:03:73:fb:dc:e1:62:
+    5e:9c:32:a7:c0:28:0e:ac:bb:46:cf:cb:d2:27:2e:
+    af:6d:14:da:ab:41:49:f0:36:04:a6:4f:1a:a2:1f:
+    48:d1:1c:b5:fc:21:aa:85:9b:5b:42:9d:26:a4:89:
+    92:a5:dd:11:cf:06:61:16:56:3e:2f:1c:c3:d5:df:
+    43:41:2a:cf:ea:e1:bc:e3:47:b3:a1:68:61:d8:a5:
+    19:9a:68:dd:6c:89:2b:56:d0:d3:de:7c:dd:0f:e5:
+    53:da:eb:b1:3e:24:11:a4:60:c7:bb:f1:0e:46:b2:
+    32:62:65:ad:28:dd:0e:29:d9:14:e6:33:cb:8b:69:
+    64:89:c6:90:8f:e3:eb:b4:80:79:70:3f:fb:64:f2:
+    91
 prime1:
-    00:c0:6f:d4:87:c5:6a:30:aa:2a:5e:a1:f9:0c:0e:
-    c8:14:8e:56:8a:57:15:13:a9:10:31:a4:c9:62:21:
-    60:a0:98:a9:fa:82:8e:c6:c7:3a:1f:bb:2b:db:32:
-    e9:fc:9e:93:8e:d7:4c:1a:3a:87:11:76:a7:e9:7b:
-    1f:5c:2a:8f:22:d5:24:e1:5b:7d:fe:15:cd:af:43:
-    20:52:c8:2f:b1:a9:7c:11:5d:7a:61:71:d5:a8:e7:
-    22:66:4f:40:08:bf:75:b5:c4:7a:db:83:52:6c:88:
-    f9:27:6b:fd:8c:0d:05:f7:30:6f:0f:f7:7c:21:58:
-    aa:45:34:b1:73:12:63:45:af
+    00:e2:28:0b:9f:48:71:4e:64:49:0e:17:fa:84:95:
+    e8:c1:1c:65:f9:7f:55:65:45:90:3d:27:d4:38:aa:
+    8d:5d:ab:83:79:b9:75:96:86:88:c2:0f:a9:d8:2a:
+    0c:de:8b:d3:66:48:54:89:ee:02:3b:06:1c:22:1c:
+    c8:9a:6f:9b:b8:47:a7:be:86:e6:de:e7:b8:93:45:
+    c5:20:3a:59:eb:49:12:63:8a:73:91:18:70:8a:21:
+    c3:76:62:1c:7b:c6:93:ee:9c:5b:41:fd:58:2b:d8:
+    bd:53:1e:6a:e6:77:45:72:8c:95:b1:37:5c:a5:d0:
+    80:eb:20:76:c5:cb:64:0f:27
 prime2:
-    00:df:89:89:3a:49:8a:0f:91:87:04:b4:aa:73:d6:
-    b7:03:60:20:60:2e:b8:c0:eb:c4:70:ef:19:d6:ce:
-    72:ae:4c:b6:bb:c4:45:20:e7:8d:1a:44:4a:e4:1a:
-    67:67:42:28:93:32:b7:f2:90:04:53:88:46:1b:8a:
-    79:b8:18:fb:11:92:a3:fc:7e:b0:75:29:99:ee:89:
-    d9:5d:4e:fa:09:e0:cf:9f:e4:23:bc:72:97:32:99:
-    fc:14:78:ca:bc:b5:73:08:f8:cc:9b:81:ea:ae:71:
-    5b:f7:b0:f8:1b:16:0a:28:4e:01:11:40:e1:68:10:
-    5c:26:84:74:a7:a3:a8:f2:4d
+    00:c5:4c:58:2b:16:b4:a5:99:47:71:40:74:9e:e3:
+    ea:2d:6c:1a:f4:1b:23:33:01:28:e2:f8:6d:3f:d0:
+    d3:90:db:ef:52:04:0e:b9:cd:39:ee:10:07:51:4e:
+    28:b1:96:84:32:52:74:04:8e:04:ce:5b:1d:dd:a4:
+    e4:87:bf:80:6c:f9:c6:7b:6a:19:b9:d5:66:52:20:
+    7a:f1:43:59:2e:aa:eb:d2:32:74:8a:2b:03:a4:74:
+    e9:1b:48:5c:b3:55:f9:2a:0b:03:e7:80:fe:63:7e:
+    4a:a9:83:ff:3b:a5:b0:ac:96:08:86:67:fa:78:a6:
+    db:c7:ae:e6:d1:c1:0e:ac:49
 exponent1:
-    00:86:75:9d:2a:c0:e5:d1:db:14:7f:ca:ed:19:5f:
-    ba:ad:a2:47:15:a2:83:37:99:89:97:26:6d:10:04:
-    02:60:34:4b:90:9e:68:e4:bb:90:01:5b:e6:e8:e2:
-    4a:5c:18:f1:41:7d:6d:cf:65:d5:ba:7e:0e:15:35:
-    d2:53:b3:e9:0f:8d:9e:97:58:36:50:b3:2b:64:aa:
-    a2:8b:35:15:1e:2e:2e:62:73:ce:6f:07:fb:22:69:
-    5d:bf:de:df:ff:3c:c8:22:99:86:be:9a:a3:9c:f2:
-    98:24:d3:6f:f5:cb:a3:bf:74:38:26:0f:e6:cb:e6:
-    08:13:13:1e:6a:29:0e:f4:41
+    00:b8:4f:d0:a1:00:a6:2f:30:36:05:c1:6f:0e:cd:
+    29:c2:f0:44:ff:60:52:15:55:eb:26:9c:26:2e:04:
+    79:6f:a4:8f:63:0d:cd:92:5e:94:68:2b:e1:cc:e5:
+    00:56:02:f8:c7:bc:1d:01:c8:32:93:2d:f8:91:a8:
+    89:a8:ab:5a:ea:85:a3:64:f8:86:81:95:b1:ec:7c:
+    89:1a:29:d4:0c:98:21:df:73:ff:99:79:a4:86:3e:
+    dc:10:c8:06:d4:ad:52:f4:bd:02:f6:b5:e5:3c:de:
+    c7:f5:4c:ad:ec:a3:b9:ba:90:6e:92:de:3e:a8:78:
+    54:08:cc:0d:60:47:d1:85:33
 exponent2:
-    00:b3:dc:7a:6a:47:d9:aa:85:31:da:7b:73:db:19:
-    1c:d0:be:7b:ce:68:49:88:11:2c:52:a2:50:6c:22:
-    58:ec:1e:15:ba:27:46:68:1f:67:cd:86:bd:ab:a4:
-    03:27:76:78:27:58:5b:e1:f4:37:46:ef:13:59:fd:
-    a5:ca:97:6f:0c:c8:ac:e1:f1:1e:12:67:92:cf:f8:
-    62:c9:4d:4e:aa:bc:14:d3:56:41:da:d3:69:0c:f2:
-    11:7e:77:62:c9:4c:46:6f:25:a1:9c:4e:80:82:33:
-    fc:07:e4:80:fd:6a:52:69:f3:b9:b0:24:40:39:f7:
-    4f:ee:3e:0d:8f:05:84:5e:d1
+    6d:a8:2e:04:dc:dc:d0:81:6d:d4:c3:37:4e:2c:6c:
+    b6:8c:34:3a:e2:6e:60:e5:cf:1c:bf:68:b1:24:56:
+    c2:57:8b:1f:31:84:21:be:af:e8:e1:dd:bf:51:ca:
+    8a:51:96:ee:05:27:d8:74:3a:b5:9a:ac:f1:c8:b8:
+    ff:bd:ef:1a:22:85:2f:88:db:fd:8e:5f:0d:5c:62:
+    18:80:0f:2c:41:f1:49:e5:a3:22:3c:20:0d:22:b1:
+    80:e9:6a:24:7e:af:3a:af:de:9e:a7:f2:3b:c8:30:
+    a5:20:e9:15:f4:d4:4a:48:25:3a:d6:c5:be:93:36:
+    ea:38:0a:b0:20:36:10:89
 coefficient:
-    6d:a8:08:7a:ad:94:c8:0f:dc:07:57:71:1b:a7:3a:
-    4d:b9:a5:39:81:36:75:c3:ff:b5:ed:7c:6a:df:28:
-    f6:22:1e:33:a6:48:31:8f:dc:ba:03:72:e6:51:39:
-    d1:ce:c5:0a:7c:a3:dd:44:9b:1b:38:94:44:ce:1e:
-    c5:6b:f1:4d:c8:e8:6d:ed:ad:1e:8c:86:50:98:fb:
-    90:4a:25:d5:3d:2f:66:a7:b9:d6:5d:84:e7:77:25:
-    69:0b:89:4b:30:53:7c:74:01:72:37:91:31:2b:aa:
-    54:92:9e:41:18:a1:8c:0e:c6:74:c9:0b:1e:be:76:
-    06:54:29:52:c6:a1:26:01
+    5f:bb:2d:4b:b2:dc:11:ea:bf:76:aa:61:f0:8c:ba:
+    59:71:21:af:d8:36:7a:4f:eb:9f:ba:a3:cd:75:1c:
+    80:8d:1c:f8:d6:14:18:7e:dc:22:a2:8a:f5:f3:bf:
+    09:d0:5c:b6:a8:21:8a:eb:ce:f0:d1:10:46:ca:62:
+    8b:5d:39:cf:58:cf:cf:52:14:6d:43:ac:a4:3c:97:
+    2e:11:f0:d9:ff:8b:61:f4:06:f5:fc:b7:e2:eb:5f:
+    f0:5b:67:71:16:53:e7:32:f8:88:20:dd:e9:12:2f:
+    5d:a3:7f:2d:26:83:13:ff:67:95:4d:5f:60:62:95:
+    a2:85:f5:f4:e5:7c:57:f8
 -----BEGIN RSA PRIVATE KEY-----
-MIIEpAIBAAKCAQEAqAjNIqr6oTgO2L4vV7b79eKbBHJJVhVxQh0SqI8pA2PhKh/s
-TWc9fV4npSH+Fjig9d5cduxxfWyuyoowXf45xUrQFBN2tYnYWHoRdlQ+TeO++fty
-gLwZBw/gU0Zb8UWM0lyv5A+rfbwiPHqxlX1qBEv60ugexDlLvdx+abqOqZalF+Su
-Tj6YrStVlaxtQEsgVVExmJ5O3rQ3MVvZOmzksQoZzl6o4imX3j3HUFT78o8qpFil
-UoILUshObF14EMZLBTYC5N+8lUpHt+jki21Gq/v7QWu7kMQbWn07LhktDZVw0hD5
-ehrujyDLjY2/I3UR3QKr4/2esQU7Yy6rh5NjowIDAQABAoIBABIAZ2GYaaNN6yFD
-NrUx8EpGTY8rYznqsCiCDtaqB53KXHvz0Y/1SHwe0yZ4vszIok3U1ZkT+ZCTTSJ7
-rXTUYIIHYsVT1HrcWqYX5bkEi2wywunrCzhJbnD4PXMObZkqd0yuC1Xma9vbhNtv
-1YiLWAk/zo47udgRv1CGx7AyAUifo13C3JpnL5RwmQgxv6Pjid7i8YxNc1xorHY2
-Tw3O6GJaMkR6E/qaRi4wqmYQQ4FdV2WZPIIMZYNENmrhDUQWdOHGqJo9pfqifsuh
-dsAh4EzqovLZp1OoQTnbUcddMbIEhkt9zxEQFrOxIjcpxCB+sAx7rIl4a+87mCnC
-IymfTokCgYEAwG/Uh8VqMKoqXqH5DA7IFI5WilcVE6kQMaTJYiFgoJip+oKOxsc6
-H7sr2zLp/J6TjtdMGjqHEXan6XsfXCqPItUk4Vt9/hXNr0MgUsgvsal8EV16YXHV
-qOciZk9ACL91tcR624NSbIj5J2v9jA0F9zBvD/d8IViqRTSxcxJjRa8CgYEA34mJ
-OkmKD5GHBLSqc9a3A2AgYC64wOvEcO8Z1s5yrky2u8RFIOeNGkRK5BpnZ0IokzK3
-8pAEU4hGG4p5uBj7EZKj/H6wdSmZ7onZXU76CeDPn+QjvHKXMpn8FHjKvLVzCPjM
-m4HqrnFb97D4GxYKKE4BEUDhaBBcJoR0p6Oo8k0CgYEAhnWdKsDl0dsUf8rtGV+6
-raJHFaKDN5mJlyZtEAQCYDRLkJ5o5LuQAVvm6OJKXBjxQX1tz2XVun4OFTXSU7Pp
-D42el1g2ULMrZKqiizUVHi4uYnPObwf7Imldv97f/zzIIpmGvpqjnPKYJNNv9cuj
-v3Q4Jg/my+YIExMeaikO9EECgYEAs9x6akfZqoUx2ntz2xkc0L57zmhJiBEsUqJQ
-bCJY7B4VuidGaB9nzYa9q6QDJ3Z4J1hb4fQ3Ru8TWf2lypdvDMis4fEeEmeSz/hi
-yU1OqrwU01ZB2tNpDPIRfndiyUxGbyWhnE6AgjP8B+SA/WpSafO5sCRAOfdP7j4N
-jwWEXtECgYBtqAh6rZTID9wHV3EbpzpNuaU5gTZ1w/+17Xxq3yj2Ih4zpkgxj9y6
-A3LmUTnRzsUKfKPdRJsbOJREzh7Fa/FNyOht7a0ejIZQmPuQSiXVPS9mp7nWXYTn
-dyVpC4lLMFN8dAFyN5ExK6pUkp5BGKGMDsZ0yQsevnYGVClSxqEmAQ==
+MIIEowIBAAKCAQEArkxCuNrQbxGkupy6a9163Y1fi1HpsoVNmiZBHY5SLxnteWq3
+BPeOnII3BCZxED+Y5qMMWPsAhE/QjfpQLAxZHUh93q9etCcJ8rgzGFbLQJ8Jp2EI
+iO2+LZacA6MarWH245gjkJBcZpAlBodiS/mH5t0Iw+B6Zzwf+cuZrVPcHZuPhQuE
+eBOVcahqshMgGba2Y14/aBQbZ8F1zxbRJsCUJInOPLNtBU0QUkBzxHus8d1kavBi
+NsYIFwNk2fsc4pklK99H/PjJB/OEltoZJyUbtqu+DJNU3w0uOKva5xxWhgxLCpZG
+MI98q76wImuSdsZWMkNUqxglWmwJBbrKdNiGHwIDAQABAoIBAF72x+eluKi7STAv
+klaQvo+VpjfnMlgEzyosq4+p6lclXkCoBv2az8WwIL+PHk0HCYyny2Nzpm1weyXP
++vx04dzVkVbR39xx5Las65HYQDd+LylV8euA9Pwrsec9Z5yN4pFQZBgwv1dWNAYh
+n0nbs9LyHQNz+9zhYl6cMqfAKA6su0bPy9InLq9tFNqrQUnwNgSmTxqiH0jRHLX8
+IaqFm1tCnSakiZKl3RHPBmEWVj4vHMPV30NBKs/q4bzjR7OhaGHYpRmaaN1siStW
+0NPefN0P5VPa67E+JBGkYMe78Q5GsjJiZa0o3Q4p2RTmM8uLaWSJxpCP4+u0gHlw
+P/tk8pECgYEA4igLn0hxTmRJDhf6hJXowRxl+X9VZUWQPSfUOKqNXauDebl1loaI
+wg+p2CoM3ovTZkhUie4COwYcIhzImm+buEenvobm3ue4k0XFIDpZ60kSY4pzkRhw
+iiHDdmIce8aT7pxbQf1YK9i9Ux5q5ndFcoyVsTdcpdCA6yB2xctkDycCgYEAxUxY
+Kxa0pZlHcUB0nuPqLWwa9BsjMwEo4vhtP9DTkNvvUgQOuc057hAHUU4osZaEMlJ0
+BI4Ezlsd3aTkh7+AbPnGe2oZudVmUiB68UNZLqrr0jJ0iisDpHTpG0hcs1X5KgsD
+54D+Y35KqYP/O6WwrJYIhmf6eKbbx67m0cEOrEkCgYEAuE/QoQCmLzA2BcFvDs0p
+wvBE/2BSFVXrJpwmLgR5b6SPYw3Nkl6UaCvhzOUAVgL4x7wdAcgyky34kaiJqKta
+6oWjZPiGgZWx7HyJGinUDJgh33P/mXmkhj7cEMgG1K1S9L0C9rXlPN7H9Uyt7KO5
+upBukt4+qHhUCMwNYEfRhTMCgYBtqC4E3NzQgW3UwzdOLGy2jDQ64m5g5c8cv2ix
+JFbCV4sfMYQhvq/o4d2/UcqKUZbuBSfYdDq1mqzxyLj/ve8aIoUviNv9jl8NXGIY
+gA8sQfFJ5aMiPCANIrGA6Wokfq86r96ep/I7yDClIOkV9NRKSCU61sW+kzbqOAqw
+IDYQiQKBgF+7LUuy3BHqv3aqYfCMullxIa/YNnpP65+6o811HICNHPjWFBh+3CKi
+ivXzvwnQXLaoIYrrzvDREEbKYotdOc9Yz89SFG1DrKQ8ly4R8Nn/i2H0BvX8t+Lr
+X/BbZ3EWU+cy+Igg3ekSL12jfy0mgxP/Z5VNX2BilaKF9fTlfFf4
 -----END RSA PRIVATE KEY-----

--- a/spec/fixtures/ssl/unknown-ca.pem
+++ b/spec/fixtures/ssl/unknown-ca.pem
@@ -6,30 +6,30 @@ Certificate:
         Issuer: CN=Unknown CA
         Validity
             Not Before: Jan  1 00:00:00 1970 GMT
-            Not After : Jun 24 21:18:00 2033 GMT
+            Not After : Jan 27 18:43:32 2034 GMT
         Subject: CN=Unknown CA
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
-                Public-Key: (2048 bit)
+                RSA Public-Key: (2048 bit)
                 Modulus:
-                    00:a8:08:cd:22:aa:fa:a1:38:0e:d8:be:2f:57:b6:
-                    fb:f5:e2:9b:04:72:49:56:15:71:42:1d:12:a8:8f:
-                    29:03:63:e1:2a:1f:ec:4d:67:3d:7d:5e:27:a5:21:
-                    fe:16:38:a0:f5:de:5c:76:ec:71:7d:6c:ae:ca:8a:
-                    30:5d:fe:39:c5:4a:d0:14:13:76:b5:89:d8:58:7a:
-                    11:76:54:3e:4d:e3:be:f9:fb:72:80:bc:19:07:0f:
-                    e0:53:46:5b:f1:45:8c:d2:5c:af:e4:0f:ab:7d:bc:
-                    22:3c:7a:b1:95:7d:6a:04:4b:fa:d2:e8:1e:c4:39:
-                    4b:bd:dc:7e:69:ba:8e:a9:96:a5:17:e4:ae:4e:3e:
-                    98:ad:2b:55:95:ac:6d:40:4b:20:55:51:31:98:9e:
-                    4e:de:b4:37:31:5b:d9:3a:6c:e4:b1:0a:19:ce:5e:
-                    a8:e2:29:97:de:3d:c7:50:54:fb:f2:8f:2a:a4:58:
-                    a5:52:82:0b:52:c8:4e:6c:5d:78:10:c6:4b:05:36:
-                    02:e4:df:bc:95:4a:47:b7:e8:e4:8b:6d:46:ab:fb:
-                    fb:41:6b:bb:90:c4:1b:5a:7d:3b:2e:19:2d:0d:95:
-                    70:d2:10:f9:7a:1a:ee:8f:20:cb:8d:8d:bf:23:75:
-                    11:dd:02:ab:e3:fd:9e:b1:05:3b:63:2e:ab:87:93:
-                    63:a3
+                    00:ae:4c:42:b8:da:d0:6f:11:a4:ba:9c:ba:6b:dd:
+                    7a:dd:8d:5f:8b:51:e9:b2:85:4d:9a:26:41:1d:8e:
+                    52:2f:19:ed:79:6a:b7:04:f7:8e:9c:82:37:04:26:
+                    71:10:3f:98:e6:a3:0c:58:fb:00:84:4f:d0:8d:fa:
+                    50:2c:0c:59:1d:48:7d:de:af:5e:b4:27:09:f2:b8:
+                    33:18:56:cb:40:9f:09:a7:61:08:88:ed:be:2d:96:
+                    9c:03:a3:1a:ad:61:f6:e3:98:23:90:90:5c:66:90:
+                    25:06:87:62:4b:f9:87:e6:dd:08:c3:e0:7a:67:3c:
+                    1f:f9:cb:99:ad:53:dc:1d:9b:8f:85:0b:84:78:13:
+                    95:71:a8:6a:b2:13:20:19:b6:b6:63:5e:3f:68:14:
+                    1b:67:c1:75:cf:16:d1:26:c0:94:24:89:ce:3c:b3:
+                    6d:05:4d:10:52:40:73:c4:7b:ac:f1:dd:64:6a:f0:
+                    62:36:c6:08:17:03:64:d9:fb:1c:e2:99:25:2b:df:
+                    47:fc:f8:c9:07:f3:84:96:da:19:27:25:1b:b6:ab:
+                    be:0c:93:54:df:0d:2e:38:ab:da:e7:1c:56:86:0c:
+                    4b:0a:96:46:30:8f:7c:ab:be:b0:22:6b:92:76:c6:
+                    56:32:43:54:ab:18:25:5a:6c:09:05:ba:ca:74:d8:
+                    86:1f
                 Exponent: 65537 (0x10001)
         X509v3 extensions:
             X509v3 Basic Constraints: critical
@@ -37,45 +37,45 @@ Certificate:
             X509v3 Key Usage: critical
                 Certificate Sign, CRL Sign
             X509v3 Subject Key Identifier: 
-                EC:86:9A:24:5D:36:4B:28:24:DD:DF:75:52:D1:83:19:33:37:46:E9
+                62:4A:BC:91:9E:B7:40:6C:32:53:82:EC:19:CC:08:28:2D:6A:90:6F
             Netscape Comment: 
                 Puppet Server Internal Certificate
             X509v3 Authority Key Identifier: 
-                EC:86:9A:24:5D:36:4B:28:24:DD:DF:75:52:D1:83:19:33:37:46:E9
+                keyid:62:4A:BC:91:9E:B7:40:6C:32:53:82:EC:19:CC:08:28:2D:6A:90:6F
+
     Signature Algorithm: sha256WithRSAEncryption
-    Signature Value:
-        5a:5d:26:6a:dc:aa:0e:66:c5:9c:b8:15:09:20:25:0a:46:be:
-        6b:b9:b4:6d:a9:74:e3:cd:a4:40:4a:dc:71:d2:fa:50:3c:b9:
-        6e:0d:4b:c8:b9:d3:26:06:1b:3a:d7:e5:02:fd:ec:ad:e2:4b:
-        ad:19:49:57:11:a3:4c:0e:67:5c:46:63:7a:aa:8f:ca:f0:f5:
-        5e:ad:bf:85:3d:1b:88:b8:a8:21:da:25:9c:27:96:70:60:83:
-        0e:de:09:c3:a8:20:5f:9a:47:47:70:c8:94:aa:a5:2b:2d:bc:
-        c3:74:ee:ff:63:88:95:84:83:fe:66:99:e8:90:c0:ed:3b:1d:
-        00:84:1a:29:43:15:53:9d:71:13:71:bf:5b:9a:7d:4e:e1:e2:
-        28:1e:38:55:92:f8:16:28:8d:9b:1e:9a:fb:a7:7a:6e:b7:66:
-        56:ed:b6:36:ef:f8:f6:21:c9:20:f3:f4:13:9e:a6:21:2e:2c:
-        ca:55:b0:2b:6d:2d:4a:58:f5:30:d8:70:eb:66:ac:ea:a8:64:
-        23:0d:e8:39:28:34:f5:16:22:f0:84:c1:2a:9b:89:55:8f:72:
-        c2:6c:f0:62:bf:39:04:2c:fc:c1:f5:40:ad:fc:b0:c9:0f:ae:
-        8d:f4:ce:1b:24:27:06:21:8e:9a:9a:56:40:d8:fe:b2:46:46:
-        44:61:43:7c
+         47:5d:e0:f5:db:72:f1:c7:94:1b:3e:1c:8f:75:aa:8c:f0:53:
+         f0:2f:82:d6:8c:6f:67:3f:39:6d:9a:0c:73:18:87:8d:53:91:
+         18:0e:94:86:22:26:1c:81:f4:71:79:c4:38:9e:55:5e:26:e1:
+         69:05:43:3e:00:f8:c3:22:81:f9:a3:d4:43:13:8b:f2:76:b5:
+         c8:a7:f7:bb:0e:14:78:e7:29:8a:19:35:95:3a:99:c8:5b:6c:
+         ed:57:df:78:ea:0a:05:5d:2a:f3:c5:56:32:fa:2f:ec:1e:69:
+         30:ab:87:79:a8:89:f3:ca:f1:17:b2:94:d8:a5:03:92:07:55:
+         be:26:c7:2f:96:f8:e5:67:81:8e:63:d8:2b:4e:54:5e:b4:34:
+         e8:af:6b:ab:34:78:bc:1c:0b:71:60:23:0f:2e:b6:c8:83:a3:
+         ed:77:8d:76:66:8b:fd:07:d8:7b:3d:76:a6:2c:2d:71:66:86:
+         d1:cc:89:ed:95:fa:e7:dc:57:3f:14:20:08:4b:44:96:2f:c3:
+         f5:42:19:a4:06:5e:11:85:13:62:b8:6b:53:c0:e9:aa:56:41:
+         a4:eb:6b:00:4e:c6:85:77:9c:07:83:96:cb:a4:e6:89:3f:5e:
+         78:c2:f8:f3:dc:d4:0b:ef:5e:79:23:22:07:c1:fb:c4:7f:98:
+         8a:fe:10:cc
 -----BEGIN CERTIFICATE-----
 MIIDPTCCAiWgAwIBAgIBADANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDDApVbmtu
-b3duIENBMB4XDTcwMDEwMTAwMDAwMFoXDTMzMDYyNDIxMTgwMFowFTETMBEGA1UE
-AwwKVW5rbm93biBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKgI
-zSKq+qE4Dti+L1e2+/XimwRySVYVcUIdEqiPKQNj4Sof7E1nPX1eJ6Uh/hY4oPXe
-XHbscX1srsqKMF3+OcVK0BQTdrWJ2Fh6EXZUPk3jvvn7coC8GQcP4FNGW/FFjNJc
-r+QPq328Ijx6sZV9agRL+tLoHsQ5S73cfmm6jqmWpRfkrk4+mK0rVZWsbUBLIFVR
-MZieTt60NzFb2Tps5LEKGc5eqOIpl949x1BU+/KPKqRYpVKCC1LITmxdeBDGSwU2
-AuTfvJVKR7fo5IttRqv7+0Fru5DEG1p9Oy4ZLQ2VcNIQ+Xoa7o8gy42NvyN1Ed0C
-q+P9nrEFO2Muq4eTY6MCAwEAAaOBlzCBlDAPBgNVHRMBAf8EBTADAQH/MA4GA1Ud
-DwEB/wQEAwIBBjAdBgNVHQ4EFgQU7IaaJF02Sygk3d91UtGDGTM3RukwMQYJYIZI
+b3duIENBMB4XDTcwMDEwMTAwMDAwMFoXDTM0MDEyNzE4NDMzMlowFTETMBEGA1UE
+AwwKVW5rbm93biBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK5M
+Qrja0G8RpLqcumvdet2NX4tR6bKFTZomQR2OUi8Z7XlqtwT3jpyCNwQmcRA/mOaj
+DFj7AIRP0I36UCwMWR1Ifd6vXrQnCfK4MxhWy0CfCadhCIjtvi2WnAOjGq1h9uOY
+I5CQXGaQJQaHYkv5h+bdCMPgemc8H/nLma1T3B2bj4ULhHgTlXGoarITIBm2tmNe
+P2gUG2fBdc8W0SbAlCSJzjyzbQVNEFJAc8R7rPHdZGrwYjbGCBcDZNn7HOKZJSvf
+R/z4yQfzhJbaGSclG7arvgyTVN8NLjir2uccVoYMSwqWRjCPfKu+sCJrknbGVjJD
+VKsYJVpsCQW6ynTYhh8CAwEAAaOBlzCBlDAPBgNVHRMBAf8EBTADAQH/MA4GA1Ud
+DwEB/wQEAwIBBjAdBgNVHQ4EFgQUYkq8kZ63QGwyU4LsGcwIKC1qkG8wMQYJYIZI
 AYb4QgENBCQWIlB1cHBldCBTZXJ2ZXIgSW50ZXJuYWwgQ2VydGlmaWNhdGUwHwYD
-VR0jBBgwFoAU7IaaJF02Sygk3d91UtGDGTM3RukwDQYJKoZIhvcNAQELBQADggEB
-AFpdJmrcqg5mxZy4FQkgJQpGvmu5tG2pdOPNpEBK3HHS+lA8uW4NS8i50yYGGzrX
-5QL97K3iS60ZSVcRo0wOZ1xGY3qqj8rw9V6tv4U9G4i4qCHaJZwnlnBggw7eCcOo
-IF+aR0dwyJSqpSstvMN07v9jiJWEg/5mmeiQwO07HQCEGilDFVOdcRNxv1uafU7h
-4igeOFWS+BYojZsemvunem63Zlbttjbv+PYhySDz9BOepiEuLMpVsCttLUpY9TDY
-cOtmrOqoZCMN6DkoNPUWIvCEwSqbiVWPcsJs8GK/OQQs/MH1QK38sMkPro30zhsk
-JwYhjpqaVkDY/rJGRkRhQ3w=
+VR0jBBgwFoAUYkq8kZ63QGwyU4LsGcwIKC1qkG8wDQYJKoZIhvcNAQELBQADggEB
+AEdd4PXbcvHHlBs+HI91qozwU/AvgtaMb2c/OW2aDHMYh41TkRgOlIYiJhyB9HF5
+xDieVV4m4WkFQz4A+MMigfmj1EMTi/J2tcin97sOFHjnKYoZNZU6mchbbO1X33jq
+CgVdKvPFVjL6L+weaTCrh3moifPK8ReylNilA5IHVb4mxy+W+OVngY5j2CtOVF60
+NOiva6s0eLwcC3FgIw8utsiDo+13jXZmi/0H2Hs9dqYsLXFmhtHMie2V+ufcVz8U
+IAhLRJYvw/VCGaQGXhGFE2K4a1PA6apWQaTrawBOxoV3nAeDlsuk5ok/XnjC+PPc
+1AvvXnkjIgfB+8R/mIr+EMw=
 -----END CERTIFICATE-----

--- a/spec/unit/ssl/ssl_provider_spec.rb
+++ b/spec/unit/ssl/ssl_provider_spec.rb
@@ -391,6 +391,9 @@ describe Puppet::SSL::SSLProvider do
 
     it 'raises if cert is not valid yet', unless: Puppet::Util::Platform.jruby? do
       client_cert.not_before = Time.now + (5 * 60 * 60)
+      int_key = key_fixture('intermediate-key.pem')
+      client_cert.sign(int_key, OpenSSL::Digest::SHA256.new)
+
       expect {
         subject.create_context(**config.merge(client_cert: client_cert))
       }.to raise_error(Puppet::SSL::CertVerifyError,
@@ -399,6 +402,9 @@ describe Puppet::SSL::SSLProvider do
 
     it 'raises if cert is expired', unless: Puppet::Util::Platform.jruby? do
       client_cert.not_after = Time.at(0)
+      int_key = key_fixture('intermediate-key.pem')
+      client_cert.sign(int_key, OpenSSL::Digest::SHA256.new)
+
       expect {
         subject.create_context(**config.merge(client_cert: client_cert))
       }.to raise_error(Puppet::SSL::CertVerifyError,

--- a/tasks/generate_cert_fixtures.rake
+++ b/tasks/generate_cert_fixtures.rake
@@ -87,6 +87,7 @@ task(:gen_cert_fixtures) do
   # Create Intermediate CA & CRL "Test CA Subauthority" issued by "Test CA"
   inter = ca.create_intermediate_cert('Test CA Subauthority', ca.ca_cert, ca.key)
   save(dir, 'intermediate.pem', inter[:cert])
+  save(dir, 'intermediate-key.pem', inter[:private_key])
   inter_crl = ca.create_crl(inter[:cert], inter[:private_key])
 
   # Create a leaf/entity key and cert for host "signed" and issued by "Test CA Subauthority"


### PR DESCRIPTION
The intermediate CA private key fixture was missing so regenerate the key/cert fixtures using `bundle exec rake gen_cert_fixtures`

When modifying the not_before and not_after times on the client cert, resign it using the above private key, so that openssl 3.2.0 doesn't report that the signature is invalid.

Revert the pin to ruby 3.2.2
