### PR TITLE
Update deprecated Beaker methods

### DIFF
--- a/acceptance/tests/agent/last_run_summary_report.rb
+++ b/acceptance/tests/agent/last_run_summary_report.rb
@@ -74,7 +74,7 @@ test_name "The 'last_run_summary.yaml' report has the right location and permiss
 
     step "Check that '#{statedir}' exists and has no 'last_run_summary.yaml' file" do
       on(agent, "ls #{statedir}",:acceptable_exit_codes => [0]) do |result|
-        assert_no_match(/last_run_summary.yaml/, result.stdout)
+        refute_match(/last_run_summary.yaml/, result.stdout)
       end
     end
     

--- a/acceptance/tests/aix/aix_package_provider.rb
+++ b/acceptance/tests/aix/aix_package_provider.rb
@@ -11,8 +11,8 @@ test_name "aix package provider should work correctly" do
     # The output of lslpp is a colon-delimited list like:
     # sudo:sudo.rte:1.8.6.4: : :C: :Configurable super-user privileges runtime: : : : : : :0:0:/:
     # We want the version, so grab the third field
-    on hosts, "lslpp -qLc #{package} | cut -f3 -d:" do
-      actual_version = stdout.chomp
+    on(hosts, "lslpp -qLc #{package} | cut -f3 -d:") do |result|
+      actual_version = result.stdout.chomp
       assert_equal(expected_version, actual_version, "Installed package version #{actual_version} does not match expected version #{expected_version}")
     end
   end

--- a/acceptance/tests/aix/nim_package_provider.rb
+++ b/acceptance/tests/aix/nim_package_provider.rb
@@ -20,8 +20,8 @@ def assert_package_version(package, expected_version)
   # The output of lslpp is a colon-delimited list like:
   # sudo:sudo.rte:1.8.6.4: : :C: :Configurable super-user privileges runtime: : : : : : :0:0:/:
   # We want the version, so grab the third field
-  on hosts, "lslpp -qLc #{package} | cut -f3 -d:" do
-    actual_version = stdout.chomp
+  on(hosts, "lslpp -qLc #{package} | cut -f3 -d:") do |result|
+    actual_version = result.stdout.chomp
     assert_equal(expected_version, actual_version, "Installed package version #{actual_version} does not match expected version #{expected_version}")
   end
 end
@@ -109,11 +109,11 @@ package_types.each do |package_type, details|
     version = details[:old_version]
 
     manifest = get_manifest(package_name, version)
-    on hosts, puppet_apply("--verbose", "--detailed-exitcodes"),
+    on(hosts, puppet_apply("--verbose", "--detailed-exitcodes"),
        { :stdin => manifest,
-         :acceptable_exit_codes => [4,6] } do
+         :acceptable_exit_codes => [4,6] }) do |result|
 
-        assert_match(/NIM package provider is unable to downgrade packages/, stderr, "Didn't get an error about downgrading packages")
+        assert_match(/NIM package provider is unable to downgrade packages/, result.stderr, "Didn't get an error about downgrading packages")
     end
   end
 

--- a/acceptance/tests/allow_arbitrary_node_name_fact_for_agent.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_fact_for_agent.rb
@@ -10,8 +10,8 @@ success_message = "node_name_fact setting was correctly used to determine the no
 testdir = master.tmpdir("nodenamefact")
 node_names = []
 
-on agents, facter('kernel') do
-  node_names << stdout.chomp
+on agents, facter('kernel') do |result|
+  node_names << result.stdout.chomp
 end
 
 node_names.uniq!
@@ -147,8 +147,8 @@ step "Ensure nodes are classified based on the node name fact" do
   }
 
   with_puppet_running_on(master, master_opts, testdir) do
-    on(agents, puppet('agent', "--no-daemonize --verbose --onetime --node_name_fact kernel")) do
-      assert_match(/defined 'message'.*#{success_message}/, stdout)
+    on(agents, puppet('agent', "--no-daemonize --verbose --onetime --node_name_fact kernel")) do |result|
+      assert_match(/defined 'message'.*#{success_message}/, result.stdout)
     end
   end
 end

--- a/acceptance/tests/allow_arbitrary_node_name_for_agent.rb
+++ b/acceptance/tests/allow_arbitrary_node_name_for_agent.rb
@@ -127,8 +127,8 @@ step "Ensure nodes are classified based on the node name fact" do
     },
   }
   with_puppet_running_on(master, master_opts, testdir) do
-    on(agents, puppet('agent', "-t --node_name_value specified_node_name"), :acceptable_exit_codes => [0,2]) do
-      assert_match(/defined 'message'.*#{success_message}/, stdout)
+    on(agents, puppet('agent', "-t --node_name_value specified_node_name"), :acceptable_exit_codes => [0,2]) do |result|
+      assert_match(/defined 'message'.*#{success_message}/, result.stdout)
     end
   end
 end

--- a/acceptance/tests/apply/classes/parameterized_classes.rb
+++ b/acceptance/tests/apply/classes/parameterized_classes.rb
@@ -12,8 +12,8 @@ class x($y, $z) {
 class {x: y => '1', z => '2'}
 }
 
-apply_manifest_on(agents, manifest) do
-    fail_test "inclusion after parameterization failed" unless stdout.include? "1-2"
+apply_manifest_on(agents, manifest) do |result|
+    fail_test "inclusion after parameterization failed" unless result.stdout.include? "1-2"
 end
 
 ########################################################################
@@ -28,8 +28,8 @@ class {x: y => '1', z => '2'}
 include x
 }
 
-apply_manifest_on(agents, manifest) do
-    fail_test "inclusion after parameterization failed" unless stdout.include? "1-2"
+apply_manifest_on(agents, manifest) do |result|
+    fail_test "inclusion after parameterization failed" unless result.stdout.include? "1-2"
 end
 
 ########################################################################
@@ -41,8 +41,8 @@ class x($y, $z='2') {
 class {x: y => '1'}
 }
 
-apply_manifest_on(agents, manifest) do
-    fail_test "the default didn't apply as expected" unless stdout.include? "1-2"
+apply_manifest_on(agents, manifest) do |result|
+    fail_test "the default didn't apply as expected" unless result.stdout.include? "1-2"
 end
 
 ########################################################################
@@ -54,6 +54,6 @@ class x($y, $z='2') {
 class {x: y => '1', z => '3'}
 }
 
-apply_manifest_on(agents, manifest) do
-    fail_test "the override didn't happen as we expected" unless stdout.include? "1-3"
+apply_manifest_on(agents, manifest) do |result|
+    fail_test "the override didn't happen as we expected" unless result.stdout.include? "1-3"
 end

--- a/acceptance/tests/apply/classes/should_allow_param_override.rb
+++ b/acceptance/tests/apply/classes/should_allow_param_override.rb
@@ -16,8 +16,8 @@ include parent
 include child
 }
 
-apply_manifest_on(agents, manifest) do
+apply_manifest_on(agents, manifest) do |result|
     fail_test "parameter override didn't work" unless
-        stdout.include? "defined 'message' as 'child'"
+        result.stdout.include? "defined 'message' as 'child'"
 end
 

--- a/acceptance/tests/apply/classes/should_allow_param_undef_override.rb
+++ b/acceptance/tests/apply/classes/should_allow_param_undef_override.rb
@@ -30,9 +30,9 @@ manifest = %Q{
   step "apply the manifest"
   apply_manifest_on(agent, manifest)
   step "verify the file content"
-  on(agent, "cat #{out}") do
-    fail_test "the file was not touched" if stdout.include? "hello world!"
-    fail_test "the file was not updated" unless stdout.include? "hello new world"
+  on(agent, "cat #{out}") do |result|
+    fail_test "the file was not touched" if result.stdout.include? "hello world!"
+    fail_test "the file was not updated" unless result.stdout.include? "hello new world"
   end
 
   on(agent, "rm -rf #{dir}")

--- a/acceptance/tests/apply/classes/should_include_resources_from_class.rb
+++ b/acceptance/tests/apply/classes/should_include_resources_from_class.rb
@@ -9,7 +9,6 @@ class x {
 }
 include x
 }
-apply_manifest_on(agents, manifest) do
-    fail_test "the resource did not apply" unless
-        stdout.include? "defined 'message' as 'a'"
+apply_manifest_on(agents, manifest) do |result|
+    fail_test "the resource did not apply" unless result.stdout.include?("defined 'message' as 'a'")
 end

--- a/acceptance/tests/apply/classes/should_not_auto_include_resources_from_class.rb
+++ b/acceptance/tests/apply/classes/should_not_auto_include_resources_from_class.rb
@@ -4,7 +4,7 @@ tag 'audit:high',
     'audit:unit'   # This should be covered at the unit layer.
 
 manifest = %q{ class x { notify { 'test': message => 'never invoked' } } }
-apply_manifest_on(agents, manifest) do
+apply_manifest_on(agents, manifest) do |result|
     fail_test "found the notify despite not including it" if
-        stdout.include? "never invoked"
+        result.stdout.include? "never invoked"
 end

--- a/acceptance/tests/direct_puppet/cached_catalog_remediate_local_drift.rb
+++ b/acceptance/tests/direct_puppet/cached_catalog_remediate_local_drift.rb
@@ -129,8 +129,8 @@ MANIFEST
 
       step "Run agent again using --use_cached_catalog and ensure content from the first code_id is used"
       on(agent, puppet("agent", "-t", "--use_cached_catalog"), :acceptable_exit_codes => [0,2])
-      on(agent, "cat #{agent_test_file_path}") do
-        assert_equal('code_version_1', stdout)
+      on(agent, "cat #{agent_test_file_path}") do |result|
+        assert_equal('code_version_1', result.stdout)
       end
     end
   end

--- a/acceptance/tests/direct_puppet/catalog_uuid_correlates_catalogs_with_reports.rb
+++ b/acceptance/tests/direct_puppet/catalog_uuid_correlates_catalogs_with_reports.rb
@@ -13,16 +13,16 @@ test_name "PUP-5872: catalog_uuid correlates catalogs with reports" do
 
   def get_catalog_uuid_from_cached_catalog(host, agent_vardir, agent_node_name)
     cache_catalog_uuid = nil
-    on(host, "cat #{agent_vardir}/client_data/catalog/#{agent_node_name}.json") do
-      cache_catalog_uuid = stdout.match(/"catalog_uuid":"([a-z0-9\-]*)",/)[1]
+    on(host, "cat #{agent_vardir}/client_data/catalog/#{agent_node_name}.json") do |result|
+      cache_catalog_uuid = result.stdout.match(/"catalog_uuid":"([a-z0-9\-]*)",/)[1]
     end
     cache_catalog_uuid
   end
 
   def get_catalog_uuid_from_report(master_reportdir, agent_node_name)
     report_catalog_uuid = nil
-    on(master, "cat #{master_reportdir}/#{agent_node_name}/*") do
-      report_catalog_uuid = stdout.match(/catalog_uuid: '?([a-z0-9\-]*)'?/)[1]
+    on(master, "cat #{master_reportdir}/#{agent_node_name}/*") do |result|
+      report_catalog_uuid = result.stdout.match(/catalog_uuid: '?([a-z0-9\-]*)'?/)[1]
     end
     report_catalog_uuid
   end

--- a/acceptance/tests/environment/broken_unassigned_environment_handled_gracefully.rb
+++ b/acceptance/tests/environment/broken_unassigned_environment_handled_gracefully.rb
@@ -59,9 +59,8 @@ with_puppet_running_on(master, master_opts, testdir) do
   agents.each do |agent|
     on(agent, puppet('agent',
                      "--test --environment #{environment}"),
-       :acceptable_exit_codes => (0..255)) do
-      assert_match(/you win/, stdout,
-                   'agent did not pickup newly classified environment.')
+       :acceptable_exit_codes => (0..255)) do |result|
+      assert_match(/you win/, result.stdout, 'agent did not pickup newly classified environment.')
     end
   end
 end

--- a/acceptance/tests/environment/can_enumerate_environments.rb
+++ b/acceptance/tests/environment/can_enumerate_environments.rb
@@ -59,8 +59,8 @@ end
 
 with_puppet_running_on(master, master_opts) do
   step "Ensure that an unauthenticated client cannot access the environments list" do
-    on master, "curl --tlsv1 -ksv https://#{master}:#{server_port(master)}/puppet/v3/environments", :acceptable_exit_codes => [0,7] do
-      assert_match(/< HTTP\/1\.\d 403/, stderr)
+    on(master, "curl --tlsv1 -ksv https://#{master}:#{server_port(master)}/puppet/v3/environments", :acceptable_exit_codes => [0,7]) do |result|
+      assert_match(/< HTTP\/1\.\d 403/, result.stderr)
     end
   end
 

--- a/acceptance/tests/environment/directory_environment_production_created_master.rb
+++ b/acceptance/tests/environment/directory_environment_production_created_master.rb
@@ -8,9 +8,6 @@ testdir = create_tmpdir_for_user master, 'prod-env-created'
 
 step 'make environmentpath'
 master_user = puppet_config(master, 'user', section: 'master')
-cert_path = puppet_config(master, 'hostcert', section: 'master')
-key_path = puppet_config(master, 'hostprivkey', section: 'master')
-cacert_path = puppet_config(master, 'localcacert', section: 'master')
 apply_manifest_on(master, <<-MANIFEST, :catch_failures => true)
 File {
   ensure => directory,
@@ -33,9 +30,6 @@ master_opts = {
 
 step 'run master; ensure production environment created'
 with_puppet_running_on(master, master_opts, testdir) do
-  if master.is_using_passenger?
-    on(master, "curl -k --cert #{cert_path} --key #{key_path} --cacert #{cacert_path} https://localhost:8140/puppet/v3/environments")
-  end
   on(master, "test -d '#{testdir}/environments/production'")
 
   step 'ensure catalog returned from production env with no changes'

--- a/acceptance/tests/environment/should_find_existing_production_environment.rb
+++ b/acceptance/tests/environment/should_find_existing_production_environment.rb
@@ -95,7 +95,7 @@ agents.each do |agent|
 
   step 'Expect no production environment folder changes' do
     on(agent, "ls #{custom_environment_path}") do |result|
-      assert_no_match(/production/, result.stdout)
+      refute_match(/production/, result.stdout)
     end
 
     on(agent, "ls #{default_environment_path}") do |result|
@@ -110,7 +110,7 @@ agents.each do |agent|
   step 'Expect production environment folder to be recreated in the custom path' do
     on(agent, puppet("agent -t"), :acceptable_exit_codes => [0, 2]) do |result|
       step 'Expect the module to be gone on the server node' do
-        assert_no_match(/Error:.*i18ndemo/, result.stderr)
+        refute_match(/Error:.*i18ndemo/, result.stderr)
       end if agent == master
 
       step 'Expect the production environment, along with the module, to be synced back on the agent node' do
@@ -123,7 +123,7 @@ agents.each do |agent|
     end
 
     on(agent, "ls #{default_environment_path}") do |result|
-      assert_no_match(/production/, result.stdout)
+      refute_match(/production/, result.stdout)
     end
   end
 
@@ -134,7 +134,7 @@ agents.each do |agent|
   step 'Expect production environment folder to be found in both paths but use the default one' do
     on(agent, puppet("agent -t"), :acceptable_exit_codes => [0, 2]) do |result|
       step 'Expect the module to be gone' do
-        assert_no_match(/Error:.*i18ndemo/, result.stderr)
+        refute_match(/Error:.*i18ndemo/, result.stderr)
       end if agent == master
     end
 

--- a/acceptance/tests/environment/use_environment_from_environmentpath.rb
+++ b/acceptance/tests/environment/use_environment_from_environmentpath.rb
@@ -180,7 +180,7 @@ file {
       end
 
       run_with_environment(agent, "production", :expected_exit_code => 2) do |tmpdir, catalog_result|
-        assert_no_match(/module-atmp/, catalog_result.stdout, "module-atmp was included despite the default environment being loaded")
+        refute_match(/module-atmp/, catalog_result.stdout, "module-atmp was included despite the default environment being loaded")
 
         assert_match(/environment fact from module-globalmod/, catalog_result.stdout)
 

--- a/acceptance/tests/face/4654_facts_face.rb
+++ b/acceptance/tests/face/4654_facts_face.rb
@@ -60,8 +60,8 @@ agents.each do |agent|
 MANIFEST
 
   step "Agent #{agent}: custom_fact and external_fact should be present in the output of `puppet facts`"
-  on agent, puppet('facts') do
-    assert_match(/"custom_fact": "foo"/, stdout, "custom_fact did not match expected output")
-    assert_match(/"external_fact": "bar"/, stdout, "external_fact did not match expected output")
+  on agent, puppet('facts') do |result|
+    assert_match(/"custom_fact": "foo"/, result.stdout, "custom_fact did not match expected output")
+    assert_match(/"external_fact": "bar"/, result.stdout, "external_fact did not match expected output")
   end
 end

--- a/acceptance/tests/face/loadable_from_modules.rb
+++ b/acceptance/tests/face/loadable_from_modules.rb
@@ -93,21 +93,21 @@ module Puppet::Helloworld
 end
 EOM
 
-  on(agent, puppet('help', '--config', puppetconf)) do
-    assert_match(/helloworld\s*Hello world face/, stdout, "Face missing from list of available subcommands")
+  on(agent, puppet('help', '--config', puppetconf)) do |result|
+    assert_match(/helloworld\s*Hello world face/, result.stdout, "Face missing from list of available subcommands")
   end
 
-  on(agent, puppet('help', 'helloworld', '--config', puppetconf)) do
-    assert_match(/This is the hello world face/, stdout, "Descripion help missing")
-    assert_match(/moduleprint\s*Prints hello world from a required module/, stdout, "help for moduleprint action missing")
-    assert_match(/actionprint\s*Prints hello world from an action/, stdout, "help for actionprint action missing")
+  on(agent, puppet('help', 'helloworld', '--config', puppetconf)) do |result|
+    assert_match(/This is the hello world face/, result.stdout, "Descripion help missing")
+    assert_match(/moduleprint\s*Prints hello world from a required module/, result.stdout, "help for moduleprint action missing")
+    assert_match(/actionprint\s*Prints hello world from an action/, result.stdout, "help for actionprint action missing")
   end
 
-  on(agent, puppet('helloworld', 'actionprint', '--config', puppetconf)) do
-    assert_match(/^Hello world from an action$/, stdout, "face did not print hello world")
+  on(agent, puppet('helloworld', 'actionprint', '--config', puppetconf)) do |result|
+    assert_match(/^Hello world from an action$/, result.stdout, "face did not print hello world")
   end
 
-  on(agent, puppet('helloworld', 'moduleprint', '--config', puppetconf)) do
-    assert_match(/^Hello world from a required module$/, stdout, "face did not load module to print hello world")
+  on(agent, puppet('helloworld', 'moduleprint', '--config', puppetconf)) do |result|
+    assert_match(/^Hello world from a required module$/, result.stdout, "face did not load module to print hello world")
   end
 end

--- a/acceptance/tests/language/pcore_resource_types_should_have_precedence_over_ruby.rb
+++ b/acceptance/tests/language/pcore_resource_types_should_have_precedence_over_ruby.rb
@@ -101,7 +101,7 @@ MANIFEST
 
     step 'compile catalog and make sure that ruby code is NOT executed' do
       on master, puppet('catalog', 'find', master.hostname) do |result|
-        assert_no_match(/running ruby code/, result.stderr)
+        refute_match(/running ruby code/, result.stderr)
         catalog_results[master.hostname]['pcore_cat'] = JSON.parse(result.stdout.sub(/^[^{]+/,''))
       end
     end

--- a/acceptance/tests/language/resource_refs_with_nested_arrays.rb
+++ b/acceptance/tests/language/resource_refs_with_nested_arrays.rb
@@ -24,7 +24,7 @@ exec { "third":
 }
 MANIFEST
 
-  apply_manifest_on agent, test_manifest do
-    assert_match(/Exec\[third\].*the final command/, stdout)
+  apply_manifest_on(agent, test_manifest) do |result|
+    assert_match(/Exec\[third\].*the final command/, result.stdout)
   end
 end

--- a/acceptance/tests/loader/func4x_loadable_from_modules.rb
+++ b/acceptance/tests/loader/func4x_loadable_from_modules.rb
@@ -70,11 +70,11 @@ class helloworld {
 SOURCE
 
   # Run apply to generate the file with the output
-  on agent, puppet('apply', '-e', "'include helloworld'", '--config', puppetconf)
+  on(agent, puppet('apply', '-e', "'include helloworld'", '--config', puppetconf))
 
   # Assert that the file was written with the generated content
-  on(agent, "cat #{File.join(target_path, 'result.txt')}") do
-    assert_match(/^Generated, 1 => 10, 2 => 20, 3 => 30$/, stdout, "Generated the wrong content")
+  on(agent, "cat #{File.join(target_path, 'result.txt')}") do |result|
+    assert_match(/^Generated, 1 => 10, 2 => 20, 3 => 30$/, result.stdout, "Generated the wrong content")
   end
 
 end

--- a/acceptance/tests/lookup/lookup.rb
+++ b/acceptance/tests/lookup/lookup.rb
@@ -306,26 +306,27 @@ PP
   with_puppet_running_on master, master_opts, testdir do
     step "Lookup string data, binding specified in metadata.json" do
       agents.each do |agent|
-        on(agent, puppet('agent', "-t"), :acceptable_exit_codes => [0, 2])
-        assert_match("#{env_data_implied_key} #{env_data_implied_value}", stdout)
-        assert_match("#{env_data_key} #{env_data_value}", stdout)
+        on(agent, puppet('agent', "-t"), :acceptable_exit_codes => [0, 2]) do |result|
+          assert_match("#{env_data_implied_key} #{env_data_implied_value}", result.stdout)
+          assert_match("#{env_data_key} #{env_data_value}", result.stdout)
 
-        assert_match("#{module_data_implied_key} #{module_data_implied_value}", stdout)
-        assert_match("#{module_data_key} #{module_data_value}", stdout)
+          assert_match("#{module_data_implied_key} #{module_data_implied_value}", result.stdout)
+          assert_match("#{module_data_key} #{module_data_value}", result.stdout)
 
-        assert_match("#{module_data_key} #{module_data_value_other}", stdout)
+          assert_match("#{module_data_key} #{module_data_value_other}", result.stdout)
 
-        assert_match("#{env_data_override_implied_key} #{env_data_override_implied_value}", stdout)
-        assert_match("#{env_data_override_key} #{env_data_override_value}", stdout)
+          assert_match("#{env_data_override_implied_key} #{env_data_override_implied_value}", result.stdout)
+          assert_match("#{env_data_override_key} #{env_data_override_value}", result.stdout)
 
-        assert_match("#{hiera_data_implied_key} #{hiera_data_implied_value}", stdout)
-        assert_match("#{hiera_data_key} #{hiera_data_value}", stdout)
+          assert_match("#{hiera_data_implied_key} #{hiera_data_implied_value}", result.stdout)
+          assert_match("#{hiera_data_key} #{hiera_data_value}", result.stdout)
 
-        assert_match("#{hash_name} {#{module_hash_key} => #{module_hash_value}, #{env_hash_key} => #{env_hash_value}, #{hiera_hash_key} => #{hiera_hash_value}}", stdout)
+          assert_match("#{hash_name} {#{module_hash_key} => #{module_hash_value}, #{env_hash_key} => #{env_hash_value}, #{hiera_hash_key} => #{hiera_hash_value}}", result.stdout)
 
-        assert_match("#{array_key} [#{hiera_array_value0}, #{hiera_array_value1}, #{env_array_value0}, #{env_array_value1}, #{module_array_value0}, #{module_array_value1}]", stdout)
+          assert_match("#{array_key} [#{hiera_array_value0}, #{hiera_array_value1}, #{env_array_value0}, #{env_array_value1}, #{module_array_value0}, #{module_array_value1}]", result.stdout)
 
-        assert_match("#{automatic_data_key} #{automatic_data_value}", stdout)
+          assert_match("#{automatic_data_key} #{automatic_data_value}", result.stdout)
+        end
       end
     end
   end

--- a/acceptance/tests/ordering/master_agent_application.rb
+++ b/acceptance/tests/ordering/master_agent_application.rb
@@ -42,9 +42,10 @@ master_opts = {
 
 with_puppet_running_on(master, master_opts) do
   agents.each do |agent|
-    on(agent, puppet('agent', "--no-daemonize --onetime --verbose"))
-    if stdout !~ /Notice: first.*Notice: second.*Notice: third.*Notice: fourth.*Notice: fifth.*Notice: sixth.*Notice: seventh.*Notice: eighth/m
-      fail_test "Output did not include the notify resources in the correct order"
+    on(agent, puppet('agent', "--no-daemonize --onetime --verbose")) do |result|
+      if result.stdout !~ /Notice: first.*Notice: second.*Notice: third.*Notice: fourth.*Notice: fifth.*Notice: sixth.*Notice: seventh.*Notice: eighth/m
+        fail_test "Output did not include the notify resources in the correct order"
+      end
     end
   end
 end

--- a/acceptance/tests/parser_functions/hiera/lookup_data.rb
+++ b/acceptance/tests/parser_functions/hiera/lookup_data.rb
@@ -88,8 +88,8 @@ master_opts = {
 
 with_puppet_running_on master, master_opts, testdir do
   agents.each do |agent|
-    on(agent, puppet('agent', "-t"), :acceptable_exit_codes => [2])
-
-    assert_match("apache server port: 8080", stdout)
+    on(agent, puppet('agent', "-t"), :acceptable_exit_codes => [2]) do |result|
+      assert_match('apache server port: 8080', result.stdout)
+    end
   end
 end

--- a/acceptance/tests/parser_functions/hiera_array/lookup_data.rb
+++ b/acceptance/tests/parser_functions/hiera_array/lookup_data.rb
@@ -100,9 +100,9 @@ master_opts = {
 
 with_puppet_running_on master, master_opts, testdir do
   agents.each do |agent|
-    on(agent, puppet('agent', "-t"), :acceptable_exit_codes => [2])
-
-    assert_match("ntpserver global.ntp.puppetlabs.com", stdout)
-    assert_match("ntpserver production.ntp.puppetlabs.com", stdout)
+    on(agent, puppet('agent', "-t"), :acceptable_exit_codes => [2]) do |result|
+      assert_match('ntpserver global.ntp.puppetlabs.com', result.stdout)
+      assert_match('ntpserver production.ntp.puppetlabs.com', result.stdout)
+    end
   end
 end

--- a/acceptance/tests/parser_functions/hiera_hash/lookup_data.rb
+++ b/acceptance/tests/parser_functions/hiera_hash/lookup_data.rb
@@ -98,8 +98,8 @@ master_opts = {
 
 with_puppet_running_on master, master_opts, testdir do
   agents.each do |agent|
-    on(agent, puppet('agent', "-t"), :acceptable_exit_codes => [2])
-
-    assert_match("name: postgres shell: /bin/bash", stdout)
+    on(agent, puppet('agent', "-t"), :acceptable_exit_codes => [2]) do |result|
+      assert_match("name: postgres shell: /bin/bash", result.stdout)
+    end
   end
 end

--- a/acceptance/tests/pluginsync/3935_pluginsync_should_follow_symlinks.rb
+++ b/acceptance/tests/pluginsync/3935_pluginsync_should_follow_symlinks.rb
@@ -42,7 +42,7 @@ master_opts = {
 with_puppet_running_on master, master_opts, basedir do
   agents.each do |agent|
     on(agent, puppet('agent', "-t"))
-      assert_no_match(/Could not retrieve information from environment production source\(s\) puppet:\/\/\/pluginfacts/, stderr)
-      assert_no_match(/Could not retrieve information from environment production source\(s\) puppet:\/\/\/plugins/, stderr)
+      refute_match(/Could not retrieve information from environment production source\(s\) puppet:\/\/\/pluginfacts/, stderr)
+      refute_match(/Could not retrieve information from environment production source\(s\) puppet:\/\/\/plugins/, stderr)
   end
 end

--- a/acceptance/tests/pluginsync/3935_pluginsync_should_follow_symlinks.rb
+++ b/acceptance/tests/pluginsync/3935_pluginsync_should_follow_symlinks.rb
@@ -41,8 +41,9 @@ master_opts = {
 
 with_puppet_running_on master, master_opts, basedir do
   agents.each do |agent|
-    on(agent, puppet('agent', "-t"))
-      refute_match(/Could not retrieve information from environment production source\(s\) puppet:\/\/\/pluginfacts/, stderr)
-      refute_match(/Could not retrieve information from environment production source\(s\) puppet:\/\/\/plugins/, stderr)
+    on(agent, puppet('agent', "-t")) do |result|
+      refute_match(/Could not retrieve information from environment production source\(s\) puppet:\/\/\/pluginfacts/, result.stderr)
+      refute_match(/Could not retrieve information from environment production source\(s\) puppet:\/\/\/plugins/, result.stderr)
+    end
   end
 end

--- a/acceptance/tests/pluginsync/7316_apps_should_be_available_via_pluginsync.rb
+++ b/acceptance/tests/pluginsync/7316_apps_should_be_available_via_pluginsync.rb
@@ -79,7 +79,7 @@ end
 
         step "run the agent" do
           on(agent, puppet("agent --libdir='#{agent_lib_dir}' --test --environment '#{tmp_environment}'")) do |result|
-            assert_no_match(
+            refute_match(
               /The \`source_permissions\` parameter is deprecated/,
               result.stderr,
               "pluginsync should not get a deprecation warning for source_permissions")

--- a/acceptance/tests/pluginsync/files_earlier_in_modulepath_take_precendence.rb
+++ b/acceptance/tests/pluginsync/files_earlier_in_modulepath_take_precendence.rb
@@ -62,8 +62,8 @@ master_opts = {
 with_puppet_running_on master, master_opts, basedir do
   agents.each do |agent|
     on(agent, puppet('agent', "-t"))
-    on agent, "cat \"#{agent.puppet['vardir']}/lib/foo.rb\"" do
-      assert_match(/from the first module/, stdout, "The synced plugin was not found or the wrong version was synced")
+    on(agent, "cat \"#{agent.puppet['vardir']}/lib/foo.rb\"") do |result|
+      assert_match(/from the first module/, result.stdout, "The synced plugin was not found or the wrong version was synced")
     end
   end
 end

--- a/acceptance/tests/provider/package/gem.rb
+++ b/acceptance/tests/provider/package/gem.rb
@@ -58,7 +58,7 @@ test_name "gem provider should install and uninstall" do
         package_manifest = resource_manifest('package', package, { ensure: 'absent', provider: 'gem' } )
         apply_manifest_on(agent, package_manifest, :catch_failures => true) do
           list = on(agent, "#{system_gem_command} list").stdout
-          assert_no_match(/#{package} \(/, list)
+          refute_match(/#{package} \(/, list)
         end
         on(agent, "#{system_gem_command} uninstall #{package}")
       end
@@ -106,7 +106,7 @@ test_name "gem provider should install and uninstall" do
       package_manifest = resource_manifest('package', package, { ensure: 'absent', provider: 'gem', command: puppet_gem_command } )
       apply_manifest_on(agent, package_manifest, :catch_failures => true) do
         list = on(agent, "#{puppet_gem_command} list").stdout
-        assert_no_match(/#{package} \(/, list)
+        refute_match(/#{package} \(/, list)
       end
       on(agent, "#{puppet_gem_command} uninstall #{package}")
     end

--- a/acceptance/tests/provider/package/pip.rb
+++ b/acceptance/tests/provider/package/pip.rb
@@ -74,7 +74,7 @@ test_name "pip provider should install, use install_options with latest, and uni
       package_manifest = resource_manifest('package', package, { ensure: 'absent', provider: 'pip' } )
       apply_manifest_on(agent, package_manifest, :catch_failures => true) do
         list = on(agent, "#{pip_command} list --disable-pip-version-check").stdout
-        assert_no_match(/#{package} \(/, list)
+        refute_match(/#{package} \(/, list)
       end
     end
   end

--- a/acceptance/tests/provider/package/puppetserver_gem.rb
+++ b/acceptance/tests/provider/package/puppetserver_gem.rb
@@ -31,7 +31,7 @@ test_name "puppetserver_gem provider should install and uninstall" do
     package_manifest = resource_manifest('package', package, { ensure: 'absent', provider: 'puppetserver_gem' } )
     apply_manifest_on(master, package_manifest, catch_failures: true) do
       list = on(master, "puppetserver gem list").stdout
-      assert_no_match(/#{package} \(/, list)
+      refute_match(/#{package} \(/, list)
     end
   end
 end

--- a/acceptance/tests/reports/cached_catalog_status_in_report.rb
+++ b/acceptance/tests/reports/cached_catalog_status_in_report.rb
@@ -22,8 +22,8 @@ test_name "PUP-5867: The report specifies whether a cached catalog was used, and
 
         step "Run again and ensure report indicates that the cached catalog was not used" do
           on(agent, puppet("agent", "--onetime", "--no-daemonize"), :acceptable_exit_codes => [0, 2])
-          on(master, "cat #{master_reportdir}/#{agent.node_name}/*") do
-            assert_match(/cached_catalog_status: not_used/, stdout, "expected to find 'cached_catalog_status: not_used' in the report")
+          on(master, "cat #{master_reportdir}/#{agent.node_name}/*") do |result|
+            assert_match(/cached_catalog_status: not_used/, result.stdout, "expected to find 'cached_catalog_status: not_used' in the report")
           end
           remove_reports_on_master(master_reportdir, agent.node_name)
         end
@@ -31,16 +31,16 @@ test_name "PUP-5867: The report specifies whether a cached catalog was used, and
 
       step "Run with --use_cached_catalog and ensure report indicates cached catalog was explicitly requested" do
         on(agent, puppet("agent", "--onetime", "--no-daemonize", "--use_cached_catalog"), :acceptable_exit_codes => [0, 2])
-        on(master, "cat #{master_reportdir}/#{agent.node_name}/*") do
-          assert_match(/cached_catalog_status: explicitly_requested/, stdout, "expected to find 'cached_catalog_status: explicitly_requested' in the report")
+        on(master, "cat #{master_reportdir}/#{agent.node_name}/*") do |result|
+          assert_match(/cached_catalog_status: explicitly_requested/, result.stdout, "expected to find 'cached_catalog_status: explicitly_requested' in the report")
         end
         remove_reports_on_master(master_reportdir, agent.node_name)
       end
 
       step "On a run which fails to retrieve a new catalog, ensure report indicates cached catalog was used on failure" do
         on(agent, puppet("agent", "--onetime", "--no-daemonize", "--report_server #{master}", "--server nonexist"), :acceptable_exit_codes => [0, 2])
-        on(master, "cat #{master_reportdir}/#{agent.node_name}/*") do
-          assert_match(/cached_catalog_status: on_failure/, stdout, "expected to find 'cached_catalog_status: on_failure' in the report")
+        on(master, "cat #{master_reportdir}/#{agent.node_name}/*") do |result|
+          assert_match(/cached_catalog_status: on_failure/, result.stdout, "expected to find 'cached_catalog_status: on_failure' in the report")
         end
       end
     end

--- a/acceptance/tests/resource/exec/accept_multi-line_commands.rb
+++ b/acceptance/tests/resource/exec/accept_multi-line_commands.rb
@@ -23,8 +23,8 @@ HERE
 
   apply_manifest_on agent, test_manifest
 
-  on(agent, "cat #{temp_file_name}") do
-    assert_equal(expected_results, stdout, "Unexpected result for host '#{agent}'")
+  on(agent, "cat #{temp_file_name}") do |result|
+    assert_equal(expected_results, result.stdout, "Unexpected result for host '#{agent}'")
   end
 
   on(agent, "rm -f #{temp_file_name}")

--- a/acceptance/tests/resource/exec/should_accept_large_output.rb
+++ b/acceptance/tests/resource/exec/should_accept_large_output.rb
@@ -15,15 +15,15 @@ occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim 
 EOF
   create_remote_file(agent, testfile, lorem_ipsum*1024)
 
-  apply_manifest_on(agent, "exec {'cat #{testfile}': path => ['/bin', '/usr/bin', 'C:/cygwin32/bin', 'C:/cygwin64/bin', 'C:/cygwin/bin'], logoutput => true}") do
+  apply_manifest_on(agent, "exec {'cat #{testfile}': path => ['/bin', '/usr/bin', 'C:/cygwin32/bin', 'C:/cygwin64/bin', 'C:/cygwin/bin'], logoutput => true}") do |result|
     fail_test "didn't seem to run the command" unless
-      stdout.include? 'executed successfully' unless agent['locale'] == 'ja'
+      result.stdout.include? 'executed successfully' unless agent['locale'] == 'ja'
     fail_test "didn't print output correctly" unless
-      stdout.lines.select {|line| line =~ /\/returns:/}.count == 4097
+      result.stdout.lines.select {|line| line =~ /\/returns:/}.count == 4097
   end
 
-  apply_manifest_on(agent, "exec {'echo': path => ['/bin', '/usr/bin', 'C:/cygwin32/bin', 'C:/cygwin64/bin', 'C:/cygwin/bin'], logoutput => true}") do
+  apply_manifest_on(agent, "exec {'echo': path => ['/bin', '/usr/bin', 'C:/cygwin32/bin', 'C:/cygwin64/bin', 'C:/cygwin/bin'], logoutput => true}") do |result|
     fail_test "didn't seem to run the command" unless
-      stdout.include? 'executed successfully' unless agent['locale'] == 'ja'
+      result.stdout.include? 'executed successfully' unless agent['locale'] == 'ja'
   end
 end

--- a/acceptance/tests/resource/exec/should_not_run_command_creates.rb
+++ b/acceptance/tests/resource/exec/should_not_run_command_creates.rb
@@ -15,9 +15,9 @@ manifest = %Q{
   on agent, "touch #{touch} && rm -f #{donottouch}"
 
   step "test using puppet apply"
-  apply_manifest_on(agent, manifest) do
+  apply_manifest_on(agent, manifest) do |result|
     fail_test "looks like the thing executed, which it shouldn't" if
-      stdout.include? 'executed successfully'
+      result.stdout.include? 'executed successfully'
   end
 
   step "verify the file didn't get created"
@@ -29,9 +29,9 @@ manifest = %Q{
   step "test using puppet resource"
   on(agent, puppet_resource('exec', "test#{Time.new.to_i}",
                    "command='#{agent.touch(donottouch)}'",
-                   "creates='#{touch}'")) do
+                   "creates='#{touch}'")) do |result|
     fail_test "looks like the thing executed, which it shouldn't" if
-      stdout.include? 'executed successfully'
+      result.stdout.include? 'executed successfully'
   end
 
   step "verify the file didn't get created the second time"

--- a/acceptance/tests/resource/exec/should_run_bad_command.rb
+++ b/acceptance/tests/resource/exec/should_run_bad_command.rb
@@ -62,9 +62,9 @@ agents.each do |agent|
   create_remote_file(agent, daemon, sleepy_daemon_script(agent))
   on(agent, "chmod +x #{daemon}")
 
-  apply_manifest_on(agent, "exec {'#{daemon}': logoutput => true}") do
+  apply_manifest_on(agent, "exec {'#{daemon}': logoutput => true}") do |result|
     fail_test "didn't seem to run the command" unless
-      stdout.include? 'executed successfully' unless agent['locale'] == 'ja'
+      result.stdout.include? 'executed successfully' unless agent['locale'] == 'ja'
   end
 end
 

--- a/acceptance/tests/resource/exec/should_run_command.rb
+++ b/acceptance/tests/resource/exec/should_run_command.rb
@@ -20,18 +20,16 @@ end
 
 agents.each do |agent|
   touched = before(agent)
-  apply_manifest_on(agent, "exec {'test': command=>'#{agent.touch(touched)}'}") do
+  apply_manifest_on(agent, "exec {'test': command=>'#{agent.touch(touched)}'}") do |result|
     fail_test "didn't seem to run the command" unless
-      stdout.include? 'executed successfully' unless agent['locale'] == 'ja'
+      result.stdout.include? 'executed successfully' unless agent['locale'] == 'ja'
   end
   after(agent, touched)
 
   touched = before(agent)
-  on(agent, puppet_resource('-d', 'exec', 'test', "command='#{agent.touch(touched)}'}")) do
+  on(agent, puppet_resource('-d', 'exec', 'test', "command='#{agent.touch(touched)}'}")) do |result|
     fail_test "didn't seem to run the command" unless
-      stdout.include? 'executed successfully' unless agent['locale'] == 'ja'
+      result.stdout.include? 'executed successfully' unless agent['locale'] == 'ja'
   end
   after(agent, touched)
 end
-
-

--- a/acceptance/tests/resource/file/ascii_diff_output_content_attribute.rb
+++ b/acceptance/tests/resource/file/ascii_diff_output_content_attribute.rb
@@ -23,18 +23,18 @@ test_name "ASCII Diff Output of Content Attribute" do
       step 'Create ASCII file using content' do
         manifest = "file { '#{target}': content => '#{initial_text}', ensure => present , checksum => 'sha256'}"
 
-        on(agent, puppet('apply'), :stdin => manifest) do
-          assert_match(/ensure: defined content as '{sha256}#{initial_text_sha_checksum}'/, stdout, "#{agent}: checksum of ASCII file not matched")
+        on(agent, puppet('apply'), :stdin => manifest) do |result|
+          assert_match(/ensure: defined content as '{sha256}#{initial_text_sha_checksum}'/, result.stdout, "#{agent}: checksum of ASCII file not matched")
         end
       end
 
       step 'Update existing ASCII file content' do
         manifest = "file { '#{target}': content => '#{updated_text}', ensure => present , checksum => 'sha256'}"
 
-        on(agent, puppet('apply','--show_diff'), :stdin => manifest) do
-          assert_match(/content: content changed '{sha256}#{initial_text_sha_checksum}' to '{sha256}#{updated_text_sha_checksum}'/, stdout, "#{agent}: checksum of ASCII file not matched after update")
-          assert_match(/^- ?#{initial_text}$/, stdout, "#{agent}: initial text not found in diff")
-          assert_match(/^\+ ?#{updated_text}$/, stdout, "#{agent}: updated text not found in diff")
+        on(agent, puppet('apply','--show_diff'), :stdin => manifest) do |result|
+          assert_match(/content: content changed '{sha256}#{initial_text_sha_checksum}' to '{sha256}#{updated_text_sha_checksum}'/, result.stdout, "#{agent}: checksum of ASCII file not matched after update")
+          assert_match(/^- ?#{initial_text}$/, result.stdout, "#{agent}: initial text not found in diff")
+          assert_match(/^\+ ?#{updated_text}$/, result.stdout, "#{agent}: updated text not found in diff")
         end
       end
     end

--- a/acceptance/tests/resource/file/bin_diff_output_content_attribute.rb
+++ b/acceptance/tests/resource/file/bin_diff_output_content_attribute.rb
@@ -54,7 +54,7 @@ test_name "Binary Diff Output of Content Attribute" do
 
         on(agent, puppet('apply','--show_diff'), :stdin => manifest) do
           assert_match(/content: content changed '{sha256}#{initial_sha_checksum}' to '{sha256}#{updated_sha_checksum}'/, stdout, "#{agent}: checksum of binary file not matched after update")
-          assert_no_match(/content: Received a Log attribute with invalid encoding:/, stdout, "#{agent}: Received a Log attribute with invalid encoding")
+          refute_match(/content: Received a Log attribute with invalid encoding:/, stdout, "#{agent}: Received a Log attribute with invalid encoding")
           if initial_bin_data.valid_encoding? && updated_bin_data.valid_encoding?
             assert_match(/^- ?#{initial_bin_data}$/, stdout, "#{agent}: initial utf-8 data not found in binary diff")
             assert_match(/^\+ ?#{updated_bin_data}$/, stdout, "#{agent}: updated utf-8 data not found in binary diff")

--- a/acceptance/tests/resource/file/bin_diff_output_content_attribute.rb
+++ b/acceptance/tests/resource/file/bin_diff_output_content_attribute.rb
@@ -11,17 +11,17 @@ test_name "Binary Diff Output of Content Attribute" do
   agents.each do |agent|
     step 'When handling binary files' do
       target = agent.tmpfile('content_binary_file_test')
-      initial_bin_data="\xc7\xd1\xfc\x84"
-      initial_base64_data=Base64.encode64(initial_bin_data).chomp
+      initial_bin_data = "\xc7\xd1\xfc\x84"
+      initial_base64_data = Base64.encode64(initial_bin_data).chomp
       initial_sha_checksum = sha256.hexdigest(initial_bin_data)
-      updated_bin_data="\xc7\xd1\xfc\x85"
-      updated_base64_data=Base64.encode64(updated_bin_data).chomp
+      updated_bin_data = "\xc7\xd1\xfc\x85"
+      updated_base64_data = Base64.encode64(updated_bin_data).chomp
       updated_sha_checksum = sha256.hexdigest(updated_bin_data)
-      on agent, puppet('config', 'set', 'diff', 'diff')
+      on(agent, puppet('config', 'set', 'diff', 'diff'))
 
       agent_default_external_encoding=nil
-      on(agent, "#{ruby_command(agent)} -e \"puts Encoding.default_external\"") do
-        agent_default_external_encoding=stdout.chomp
+      on(agent, "#{ruby_command(agent)} -e \"puts Encoding.default_external\"") do |result|
+        agent_default_external_encoding = result.stdout.chomp
       end
 
       if agent_default_external_encoding && agent_default_external_encoding != Encoding.default_external
@@ -44,22 +44,22 @@ test_name "Binary Diff Output of Content Attribute" do
       step 'Create binary file using content' do
         manifest = "file { '#{target}': content => Binary('#{initial_base64_data}'), ensure => present , checksum => 'sha256'}"
 
-        on(agent, puppet('apply'), :stdin => manifest) do
-          assert_match(/ensure: defined content as '{sha256}#{initial_sha_checksum}'/, stdout, "#{agent}: checksum of binary file not matched")
+        on(agent, puppet('apply'), :stdin => manifest) do |result|
+          assert_match(/ensure: defined content as '{sha256}#{initial_sha_checksum}'/, result.stdout, "#{agent}: checksum of binary file not matched")
         end
       end
 
       step 'Update existing binary file content' do
         manifest = "file { '#{target}': content => Binary('#{updated_base64_data}'), ensure => present , checksum => 'sha256'}"
 
-        on(agent, puppet('apply','--show_diff'), :stdin => manifest) do
-          assert_match(/content: content changed '{sha256}#{initial_sha_checksum}' to '{sha256}#{updated_sha_checksum}'/, stdout, "#{agent}: checksum of binary file not matched after update")
-          refute_match(/content: Received a Log attribute with invalid encoding:/, stdout, "#{agent}: Received a Log attribute with invalid encoding")
+        on(agent, puppet('apply','--show_diff'), :stdin => manifest) do |result|
+          assert_match(/content: content changed '{sha256}#{initial_sha_checksum}' to '{sha256}#{updated_sha_checksum}'/, result.stdout, "#{agent}: checksum of binary file not matched after update")
+          refute_match(/content: Received a Log attribute with invalid encoding:/, result.stdout, "#{agent}: Received a Log attribute with invalid encoding")
           if initial_bin_data.valid_encoding? && updated_bin_data.valid_encoding?
-            assert_match(/^- ?#{initial_bin_data}$/, stdout, "#{agent}: initial utf-8 data not found in binary diff")
-            assert_match(/^\+ ?#{updated_bin_data}$/, stdout, "#{agent}: updated utf-8 data not found in binary diff")
+            assert_match(/^- ?#{initial_bin_data}$/, result.stdout, "#{agent}: initial utf-8 data not found in binary diff")
+            assert_match(/^\+ ?#{updated_bin_data}$/, result.stdout, "#{agent}: updated utf-8 data not found in binary diff")
           else
-            assert_match(/Binary files #{target} and .* differ/, stdout, "#{agent}: Binary file diff notice not matched")
+            assert_match(/Binary files #{target} and .* differ/, result.stdout, "#{agent}: Binary file diff notice not matched")
           end
         end
       end

--- a/acceptance/tests/resource/file/content_attribute.rb
+++ b/acceptance/tests/resource/file/content_attribute.rb
@@ -24,35 +24,35 @@ agents.each do |agent|
   manifest += checksums.collect {|checksum_type|
     "file { '#{target+checksum_type}': content => 'This is the test file content', ensure => present, checksum => #{checksum_type} }"
   }.join("\n")
-  apply_manifest_on agent, manifest do
+  apply_manifest_on(agent, manifest) do |result|
     checksums.each do |checksum_type|
-      refute_match(/content changed/, stdout, "#{agent}: shouldn't have overwrote #{target+checksum_type}")
+      refute_match(/content changed/, result.stdout, "#{agent}: shouldn't have overwrote #{target+checksum_type}")
     end
   end
 
-  on agent, "cat #{target}" do
-    assert_match(/This is the test file content/, stdout, "File content not matched on #{agent}") unless agent['locale'] == 'ja'
+  on(agent, "cat #{target}") do |result|
+    assert_match(/This is the test file content/, result.stdout, "File content not matched on #{agent}") unless agent['locale'] == 'ja'
   end
 
   step "Content Attribute: illegal timesteps"
   ['mtime', 'ctime'].each do |checksum_type|
     manifest = "file { '#{target+checksum_type}': content => 'This is the test file content', ensure => present, checksum => #{checksum_type} }"
-    apply_manifest_on agent, manifest, :acceptable_exit_codes => [1] do
-      assert_match(/Error: Validation of File\[#{target+checksum_type}\] failed: You cannot specify content when using checksum '#{checksum_type}'/, stderr, "#{agent}: expected failure") unless agent['locale'] == 'ja'
+    apply_manifest_on(agent, manifest, :acceptable_exit_codes => [1]) do |result|
+      assert_match(/Error: Validation of File\[#{target+checksum_type}\] failed: You cannot specify content when using checksum '#{checksum_type}'/, result.stderr, "#{agent}: expected failure") unless agent['locale'] == 'ja'
     end
   end
 
   step "Ensure the test environment is clean"
-  on agent, "rm -f #{target}"
+  on(agent, "rm -f #{target}")
 
   step "Content Attribute: using a checksum from filebucket"
-  on agent, "echo 'This is the checksum file contents' > #{target}"
+  on(agent, "echo 'This is the checksum file contents' > #{target}")
 
   step "Backup file into the filebucket"
-  on agent, puppet_filebucket("backup --local #{target}")
+  on(agent, puppet_filebucket("backup --local #{target}"))
 
   step "Modify file to force apply to retrieve file from local clientbucket"
-  on agent, "echo 'This is the modified file contents' > #{target}"
+  on(agent, "echo 'This is the modified file contents' > #{target}")
 
   dir = on(agent, puppet_filebucket("--configprint clientbucketdir")).stdout.chomp
 
@@ -72,7 +72,7 @@ agents.each do |agent|
   apply_manifest_on agent, sha256_manifest
 
   step "Validate filebucket checksum file contents"
-  on agent, "cat #{target}" do
-    assert_match(/This is the checksum file content/, stdout, "File content not matched on #{agent}") unless agent['locale'] == 'ja'
+  on(agent, "cat #{target}") do |result|
+    assert_match(/This is the checksum file content/, result.stdout, "File content not matched on #{agent}") unless agent['locale'] == 'ja'
   end
 end

--- a/acceptance/tests/resource/file/content_attribute.rb
+++ b/acceptance/tests/resource/file/content_attribute.rb
@@ -26,7 +26,7 @@ agents.each do |agent|
   }.join("\n")
   apply_manifest_on agent, manifest do
     checksums.each do |checksum_type|
-      assert_no_match(/content changed/, stdout, "#{agent}: shouldn't have overwrote #{target+checksum_type}")
+      refute_match(/content changed/, stdout, "#{agent}: shouldn't have overwrote #{target+checksum_type}")
     end
   end
 

--- a/acceptance/tests/resource/file/handle_fifo_files.rb
+++ b/acceptance/tests/resource/file/handle_fifo_files.rb
@@ -31,8 +31,8 @@ agents.each do |agent|
   end
 
   step "puppet ensures given fifo is present" do
-    apply_manifest_on(agent, ensure_content_to_file_manifest(fifo_path, 'present'), :acceptable_exit_codes => [2]) do
-      assert_match(/Warning: .+ Ensure set to :present but file type is fifo so no content will be synced/, stderr)
+    apply_manifest_on(agent, ensure_content_to_file_manifest(fifo_path, 'present'), :acceptable_exit_codes => [2]) do |result|
+      assert_match(/Warning: .+ Ensure set to :present but file type is fifo so no content will be synced/, result.stderr)
     end
   end
 
@@ -43,9 +43,9 @@ agents.each do |agent|
   end
 
   step "puppet ensures given fifo is a regular file" do
-    apply_manifest_on(agent, ensure_content_to_file_manifest(fifo_path, 'file'), :acceptable_exit_codes => [0]) do
-      assert_match(/Notice: .+\/myfifo\]\/ensure: defined content as '{/, stdout)
-      refute_match(/Warning: .+ Ensure set to :present but file type is fifo so no content will be synced/, stderr)
+    apply_manifest_on(agent, ensure_content_to_file_manifest(fifo_path, 'file'), :acceptable_exit_codes => [0]) do |result|
+      assert_match(/Notice: .+\/myfifo\]\/ensure: defined content as '{/, result.stdout)
+      refute_match(/Warning: .+ Ensure set to :present but file type is fifo so no content will be synced/, result.stderr)
     end
   end
 

--- a/acceptance/tests/resource/file/handle_fifo_files.rb
+++ b/acceptance/tests/resource/file/handle_fifo_files.rb
@@ -45,7 +45,7 @@ agents.each do |agent|
   step "puppet ensures given fifo is a regular file" do
     apply_manifest_on(agent, ensure_content_to_file_manifest(fifo_path, 'file'), :acceptable_exit_codes => [0]) do
       assert_match(/Notice: .+\/myfifo\]\/ensure: defined content as '{/, stdout)
-      assert_no_match(/Warning: .+ Ensure set to :present but file type is fifo so no content will be synced/, stderr)
+      refute_match(/Warning: .+ Ensure set to :present but file type is fifo so no content will be synced/, stderr)
     end
   end
 

--- a/acceptance/tests/resource/file/handle_fifo_files_when_recursing.rb
+++ b/acceptance/tests/resource/file/handle_fifo_files_when_recursing.rb
@@ -43,7 +43,7 @@ agents.each do |agent|
   step "puppet ensures '#{random_user}' as owner of path" do
     apply_manifest_on(agent, ensure_owner_recursively_manifest(tmp_path, random_user), :acceptable_exit_codes => [0]) do
       assert_match(/#{tmp_path}\]\/owner: owner changed '#{initial_owner}' to '#{random_user}'/, stdout)
-      assert_no_match(/Error: .+ Failed to generate additional resources using ‘eval_generate’: Cannot manage files of type fifo/, stderr)
+      refute_match(/Error: .+ Failed to generate additional resources using ‘eval_generate’: Cannot manage files of type fifo/, stderr)
     end
   end
 

--- a/acceptance/tests/resource/file/handle_fifo_files_when_recursing.rb
+++ b/acceptance/tests/resource/file/handle_fifo_files_when_recursing.rb
@@ -41,9 +41,9 @@ agents.each do |agent|
   end
 
   step "puppet ensures '#{random_user}' as owner of path" do
-    apply_manifest_on(agent, ensure_owner_recursively_manifest(tmp_path, random_user), :acceptable_exit_codes => [0]) do
-      assert_match(/#{tmp_path}\]\/owner: owner changed '#{initial_owner}' to '#{random_user}'/, stdout)
-      refute_match(/Error: .+ Failed to generate additional resources using ‘eval_generate’: Cannot manage files of type fifo/, stderr)
+    apply_manifest_on(agent, ensure_owner_recursively_manifest(tmp_path, random_user), :acceptable_exit_codes => [0]) do |result|
+      assert_match(/#{tmp_path}\]\/owner: owner changed '#{initial_owner}' to '#{random_user}'/, result.stdout)
+      refute_match(/Error: .+ Failed to generate additional resources using ‘eval_generate’: Cannot manage files of type fifo/, result.stderr)
     end
   end
 

--- a/acceptance/tests/resource/file/should_create_symlink.rb
+++ b/acceptance/tests/resource/file/should_create_symlink.rb
@@ -15,24 +15,24 @@ end
 
 def verify_symlink(agent, link, target)
   step "verify the symlink was created"
-  on agent, "test -L #{link} && test -f #{link}"
+  on(agent, "test -L #{link} && test -f #{link}")
   step "verify the symlink points to a file"
-  on agent, "test -f #{target}"
+  on(agent, "test -f #{target}")
 
   step "verify the content is identical on both sides"
-  on(agent, "cat #{link}") do
-    fail_test "link missing content" unless stdout.include? message
+  on(agent, "cat #{link}") do |result|
+    fail_test "link missing content" unless result.stdout.include?(message)
   end
-  on(agent, "cat #{target}") do
-    fail_test "target missing content" unless stdout.include? message
+  on(agent, "cat #{target}") do |result|
+    fail_test "target missing content" unless result.stdout.include?(message)
   end
 end
 
 agents.each do |agent|
   if agent.platform.variant == 'windows'
     # symlinks are supported only on Vista+ (version 6.0 and higher)
-    on agent, facter('kernelmajversion') do
-      skip_test "Test not supported on this platform" if stdout.chomp.to_f < 6.0
+    on(agent, facter('kernelmajversion')) do |result|
+      skip_test "Test not supported on this platform" if result.stdout.chomp.to_f < 6.0
     end
   end
 

--- a/acceptance/tests/resource/file/should_default_mode.rb
+++ b/acceptance/tests/resource/file/should_default_mode.rb
@@ -13,8 +13,8 @@ agents.each do |agent|
   on(agent, "rm -rf #{parent}")
 
   step "puppet should set execute bit on readable directories"
-  on(agent, puppet_resource("file", parent, "ensure=directory", "mode=0644")) do
-    assert_match(regexp_mode(755), stdout)
+  on(agent, puppet_resource("file", parent, "ensure=directory", "mode=0644")) do |result|
+    assert_match(regexp_mode(755), result.stdout)
   end
 
   step "include execute bit on newly created directories"
@@ -24,20 +24,20 @@ agents.each do |agent|
   step "exclude execute bit from newly created files"
   file = "#{parent}/file.txt"
   on(agent, "echo foobar > #{file}")
-  on(agent, "#{file}", :acceptable_exit_codes => (1..255)) do
-    refute_match(/foobar/, stdout)
+  on(agent, "#{file}", :acceptable_exit_codes => (1..255)) do |result|
+    refute_match(/foobar/, result.stdout)
   end
 
   step "set execute bit on file if explicitly specified"
   file_750 = "#{parent}/file_750.txt"
-  on(agent, puppet_resource("file", file_750, "ensure=file", "mode=0750")) do
-    assert_match(regexp_mode(750), stdout)
+  on(agent, puppet_resource("file", file_750, "ensure=file", "mode=0750")) do |result|
+    assert_match(regexp_mode(750), result.stdout)
   end
 
   step "don't set execute bit if directory not readable"
   dir_600 = "#{parent}/dir_600"
-  on(agent, puppet_resource("file", dir_600, "ensure=directory", "mode=0600")) do
-    assert_match(regexp_mode(700), stdout) # readable by owner, but not group
+  on(agent, puppet_resource("file", dir_600, "ensure=directory", "mode=0600")) do |result|
+    assert_match(regexp_mode(700), result.stdout) # readable by owner, but not group
   end
 
   on(agent, "rm -rf #{parent}")

--- a/acceptance/tests/resource/file/should_default_mode.rb
+++ b/acceptance/tests/resource/file/should_default_mode.rb
@@ -25,7 +25,7 @@ agents.each do |agent|
   file = "#{parent}/file.txt"
   on(agent, "echo foobar > #{file}")
   on(agent, "#{file}", :acceptable_exit_codes => (1..255)) do
-    assert_no_match(/foobar/, stdout)
+    refute_match(/foobar/, stdout)
   end
 
   step "set execute bit on file if explicitly specified"

--- a/acceptance/tests/resource/file/should_remove_dir.rb
+++ b/acceptance/tests/resource/file/should_remove_dir.rb
@@ -7,20 +7,20 @@ agents.each do |agent|
   target = agent.tmpdir("delete-dir")
 
   step "clean up the system before we begin"
-  on agent, "rm -rf #{target} ; mkdir -p #{target}"
+  on(agent, "rm -rf #{target} ; mkdir -p #{target}")
 
   step "verify we can't remove a directory without 'force'"
-  on(agent, puppet_resource("file", target, 'ensure=absent')) do
+  on(agent, puppet_resource("file", target, 'ensure=absent')) do |result|
     fail_test "didn't tell us that force was required" unless
-      stdout.include? "Not removing directory; use 'force' to override" unless agent['locale'] == 'ja'
+      result.stdout.include? "Not removing directory; use 'force' to override" unless agent['locale'] == 'ja'
   end
 
   step "verify the directory still exists"
-  on agent, "test -d #{target}"
+  on(agent, "test -d #{target}")
 
   step "verify we can remove a directory with 'force'"
   on(agent, puppet_resource("file", target, 'ensure=absent', 'force=true'))
 
   step "verify that the directory is gone"
-  on agent, "test -d #{target}", :acceptable_exit_codes => [1]
+  on(agent, "test -d #{target}", :acceptable_exit_codes => [1])
 end

--- a/acceptance/tests/resource/file/source_attribute.rb
+++ b/acceptance/tests/resource/file/source_attribute.rb
@@ -167,19 +167,19 @@ test_name "The source attribute" do
         dir_to_check = agent['platform'] =~ /windows/ ? @target_dir_on_windows : @target_dir_on_nix
 
         checksums.each do |checksum_type|
-          on agent, "cat #{file_to_check}#{checksum_type}" do
-            assert_match(/the content is present/, stdout, "Result file not created #{checksum_type}")
+          on agent, "cat #{file_to_check}#{checksum_type}" do |result|
+            assert_match(/the content is present/, result.stdout, "Result file not created #{checksum_type}")
           end
 
-          on agent, "cat #{dir_to_check}#{checksum_type}/source_dir_file" do
-            assert_match(/the content is present/, stdout, "Result file not created #{checksum_type}")
+          on agent, "cat #{dir_to_check}#{checksum_type}/source_dir_file" do |result|
+            assert_match(/the content is present/, result.stdout, "Result file not created #{checksum_type}")
           end
         end
       end
 
       step "second run should not update file"
-      on(agent, puppet('agent', "--test"), :acceptable_exit_codes => [0,2]) do
-        refute_match(/content changed.*(md5|sha256)/, stdout, "Shouldn't have overwritten any files")
+      on(agent, puppet('agent', "--test"), :acceptable_exit_codes => [0,2]) do |result|
+        refute_match(/content changed.*(md5|sha256)/, result.stdout, "Shouldn't have overwritten any files")
 
         # When using ctime/mtime, the agent compares the values from its
         # local file with the values on the master to determine if the
@@ -190,11 +190,11 @@ test_name "The source attribute" do
         # again. This process will repeat until the agent updates the
         # file, and the resulting ctime/mtime are after the values on
         # the master, at which point it will have converged.
-        if stdout =~ /content changed.*ctime/
+        if result.stdout =~ /content changed.*ctime/
           Log.warn "Agent did not converge using ctime"
         end
 
-        if stdout =~ /content changed.*mtime/
+        if result.stdout =~ /content changed.*mtime/
           Log.warn "Agent did not converge using mtime"
         end
       end
@@ -248,14 +248,14 @@ test_name "The source attribute" do
 
     checksums.each do |checksum_type|
       step "Using a local file path. #{checksum_type}"
-      on agent, "cat #{target[checksum_type]}" do
-        assert_match(/Yay, this is the local file./, stdout, "FIRST: File contents not matched on #{agent}")
+      on(agent, "cat #{target[checksum_type]}") do |result|
+        assert_match(/Yay, this is the local file./, result.stdout, "FIRST: File contents not matched on #{agent}")
       end
     end
 
     step "second run should not update any files"
-    apply_manifest_on agent, local_apply_manifest do
-      refute_match(/content changed/, stdout, "Shouldn't have overwrote any files")
+    apply_manifest_on(agent, local_apply_manifest) do |result|
+      refute_match(/content changed/, result.stdout, "Shouldn't have overwrote any files")
     end
 
     # changes in source file producing updates is tested elsewhere
@@ -265,12 +265,12 @@ test_name "The source attribute" do
     create_remote_file agent, source, source_content
 
     if fips_host_present
-      apply_manifest_on agent, "file { '#{localsource_testdir}/targetsha256lite': source => '#{source}', ensure => present, checksum => sha256lite }" do
-        refute_match(/(content changed|defined content)/, stdout, "Shouldn't have overwrote any files")
+      apply_manifest_on(agent, "file { '#{localsource_testdir}/targetsha256lite': source => '#{source}', ensure => present, checksum => sha256lite }") do |result|
+        refute_match(/(content changed|defined content)/, result.stdout, "Shouldn't have overwrote any files")
       end
     else
-      apply_manifest_on agent, "file { '#{localsource_testdir}/targetmd5lite': source => '#{source}', ensure => present, checksum => md5lite } file { '#{localsource_testdir}/targetsha256lite': source => '#{source}', ensure => present, checksum => sha256lite }" do
-        refute_match(/(content changed|defined content)/, stdout, "Shouldn't have overwrote any files")
+      apply_manifest_on(agent, "file { '#{localsource_testdir}/targetmd5lite': source => '#{source}', ensure => present, checksum => md5lite } file { '#{localsource_testdir}/targetsha256lite': source => '#{source}', ensure => present, checksum => sha256lite }") do |result|
+        refute_match(/(content changed|defined content)/, result.stdout, "Shouldn't have overwrote any files")
       end
     end
 
@@ -287,14 +287,14 @@ test_name "The source attribute" do
 
     checksums.each do |checksum_type|
       step "Using a puppet:/// URI with checksum type: #{checksum_type}"
-      on agent, "cat #{target[checksum_type]}" do
-        assert_match(/Yay, this is the local file./, stdout, "FIRST: File contents not matched on #{agent}")
+      on(agent, "cat #{target[checksum_type]}") do |result|
+        assert_match(/Yay, this is the local file./, result.stdout, "FIRST: File contents not matched on #{agent}")
       end
     end
 
     step "second run should not update any files using apply with puppet:/// URI source"
-    on agent, puppet( %{apply --modulepath=#{localsource_testdir} #{localsource_test_manifest}} ) do
-      refute_match(/content changed/, stdout, "Shouldn't have overwrote any files")
+    on(agent, puppet( %{apply --modulepath=#{localsource_testdir} #{localsource_test_manifest}} )) do |result|
+      refute_match(/content changed/, result.stdout, "Shouldn't have overwrote any files")
     end
   end
 

--- a/acceptance/tests/resource/file/source_attribute.rb
+++ b/acceptance/tests/resource/file/source_attribute.rb
@@ -179,7 +179,7 @@ test_name "The source attribute" do
 
       step "second run should not update file"
       on(agent, puppet('agent', "--test"), :acceptable_exit_codes => [0,2]) do
-        assert_no_match(/content changed.*(md5|sha256)/, stdout, "Shouldn't have overwritten any files")
+        refute_match(/content changed.*(md5|sha256)/, stdout, "Shouldn't have overwritten any files")
 
         # When using ctime/mtime, the agent compares the values from its
         # local file with the values on the master to determine if the
@@ -255,7 +255,7 @@ test_name "The source attribute" do
 
     step "second run should not update any files"
     apply_manifest_on agent, local_apply_manifest do
-      assert_no_match(/content changed/, stdout, "Shouldn't have overwrote any files")
+      refute_match(/content changed/, stdout, "Shouldn't have overwrote any files")
     end
 
     # changes in source file producing updates is tested elsewhere
@@ -266,11 +266,11 @@ test_name "The source attribute" do
 
     if fips_host_present
       apply_manifest_on agent, "file { '#{localsource_testdir}/targetsha256lite': source => '#{source}', ensure => present, checksum => sha256lite }" do
-        assert_no_match(/(content changed|defined content)/, stdout, "Shouldn't have overwrote any files")
+        refute_match(/(content changed|defined content)/, stdout, "Shouldn't have overwrote any files")
       end
     else
       apply_manifest_on agent, "file { '#{localsource_testdir}/targetmd5lite': source => '#{source}', ensure => present, checksum => md5lite } file { '#{localsource_testdir}/targetsha256lite': source => '#{source}', ensure => present, checksum => sha256lite }" do
-        assert_no_match(/(content changed|defined content)/, stdout, "Shouldn't have overwrote any files")
+        refute_match(/(content changed|defined content)/, stdout, "Shouldn't have overwrote any files")
       end
     end
 
@@ -294,7 +294,7 @@ test_name "The source attribute" do
 
     step "second run should not update any files using apply with puppet:/// URI source"
     on agent, puppet( %{apply --modulepath=#{localsource_testdir} #{localsource_test_manifest}} ) do
-      assert_no_match(/content changed/, stdout, "Shouldn't have overwrote any files")
+      refute_match(/content changed/, stdout, "Shouldn't have overwrote any files")
     end
   end
 

--- a/acceptance/tests/resource/file/symbolic_modes.rb
+++ b/acceptance/tests/resource/file/symbolic_modes.rb
@@ -59,9 +59,9 @@ test_name 'file resource: symbolic modes' do
 
     def puppet_reapply
       @testcase.apply_manifest_on(@agent, manifest) do |apply_result|
-        assert_no_match(/mode changed/, apply_result.stdout, "reapplied the symbolic mode change")
+        refute_match(/mode changed/, apply_result.stdout, "reapplied the symbolic mode change")
         (@file_list + @directory_list).each do |file|
-          assert_no_match(/#{Regexp.escape(file.path)}/, apply_result.stdout, "Expected to not see '#{file.path}' in 'puppet apply' output")
+          refute_match(/#{Regexp.escape(file.path)}/, apply_result.stdout, "Expected to not see '#{file.path}' in 'puppet apply' output")
         end
       end
     end
@@ -119,7 +119,7 @@ test_name 'file resource: symbolic modes' do
           assert_match(/File\[#{Regexp.escape(file.path)}.* mode changed '#{'%04o' % file.start_mode}'.* to '#{'%04o' % file.mode}'/,
                        apply_result, "couldn't set mode to #{file.symbolic_mode}")
         else
-          assert_no_match(/#{Regexp.escape(file.path)}.*mode changed/, apply_result, "reapplied the symbolic mode change for file #{file.path}")
+          refute_match(/#{Regexp.escape(file.path)}.*mode changed/, apply_result, "reapplied the symbolic mode change for file #{file.path}")
         end
         assert_mode(@agent, file.path, file.mode)
       end

--- a/acceptance/tests/resource/file/ticket_7680-follow-symlinks.rb
+++ b/acceptance/tests/resource/file/ticket_7680-follow-symlinks.rb
@@ -31,8 +31,8 @@ agents.each do |agent|
   MANIFEST
   apply_manifest_on(agent, manifest, :trace => true)
 
-  on agent, "cat #{dest}" do
-    assert_match(/This is the real content/, stdout)
+  on(agent, "cat #{dest}") do |result|
+    assert_match(/This is the real content/, result.stdout)
   end
 
   step "Cleanup"

--- a/acceptance/tests/resource/file/ticket_8740_should_not_enumerate_root_directory.rb
+++ b/acceptance/tests/resource/file/ticket_8740_should_not_enumerate_root_directory.rb
@@ -20,14 +20,14 @@ agents.each do |agent|
   on(agent, "#{ruby_command(agent)} -e \"require 'socket'; UNIXServer::new('#{target}').close\"")
 
   step "query for all files, which should return nothing"
-  on(agent, puppet_resource('file'), :acceptable_exit_codes => [1]) do
-    assert_match(%r{Listing all file instances is not supported.  Please specify a file or directory, e.g. puppet resource file /etc}, stderr)
+  on(agent, puppet_resource('file'), :acceptable_exit_codes => [1]) do |result|
+    assert_match(%r{Listing all file instances is not supported.  Please specify a file or directory, e.g. puppet resource file /etc}, result.stderr)
   end
 
   ["/", "/etc"].each do |file|
     step "query '#{file}' directory, which should return single entry"
-    on(agent, puppet_resource('file', file)) do
-      files = stdout.scan(/^file \{ '([^']+)'/).flatten
+    on(agent, puppet_resource('file', file)) do |result|
+      files = result.stdout.scan(/^file \{ '([^']+)'/).flatten
 
       assert_equal(1, files.size, "puppet returned multiple files: #{files.join(', ')}")
       assert_match(file, files[0], "puppet did not return file")
@@ -35,8 +35,8 @@ agents.each do |agent|
   end
 
   step "query file that does not exist, which should report the file is absent"
-  on(agent, puppet_resource('file', '/this/does/notexist')) do
-    assert_match(/ensure\s+=>\s+'absent'/, stdout)
+  on(agent, puppet_resource('file', '/this/does/notexist')) do |result|
+    assert_match(/ensure\s+=>\s+'absent'/, result.stdout)
   end
 
   step "remove UNIX domain socket"

--- a/acceptance/tests/resource/group/should_modify_gid.rb
+++ b/acceptance/tests/resource/group/should_modify_gid.rb
@@ -14,13 +14,13 @@ gid2  = (rand(989999).to_i + 10000)
 agents.each do |agent|
   # AIX group provider returns quoted gids
   step "ensure that the group exists with gid #{gid1}"
-  on(agent, puppet_resource('group', name, 'ensure=present', "gid=#{gid1}")) do
-    fail_test "missing gid notice" unless stdout =~ /gid +=> +'?#{gid1}'?/
+  on(agent, puppet_resource('group', name, 'ensure=present', "gid=#{gid1}")) do |result|
+    fail_test "missing gid notice" unless result.stdout =~ /gid +=> +'?#{gid1}'?/
   end
 
   step "ensure that we can modify the GID of the group to #{gid2}"
-  on(agent, puppet_resource('group', name, 'ensure=present', "gid=#{gid2}")) do
-    fail_test "missing gid notice" unless stdout =~ /gid +=> +'?#{gid2}'?/
+  on(agent, puppet_resource('group', name, 'ensure=present', "gid=#{gid2}")) do |result|
+    fail_test "missing gid notice" unless result.stdout =~ /gid +=> +'?#{gid2}'?/
   end
 
   step "verify that the GID changed"

--- a/acceptance/tests/resource/group/should_not_create_existing.rb
+++ b/acceptance/tests/resource/group/should_not_create_existing.rb
@@ -13,9 +13,9 @@ agents.each do |agent|
   agent.group_present(name)
 
   step "verify that we don't try and create the existing group"
-  on(agent, puppet_resource('group', name, 'ensure=present')) do
+  on(agent, puppet_resource('group', name, 'ensure=present')) do |result|
     fail_test "looks like we created the group" if
-      stdout.include? "/Group[#{name}]/ensure: created"
+      result.stdout.include? "/Group[#{name}]/ensure: created"
   end
 
   step "clean up the system after the test run"

--- a/acceptance/tests/resource/group/should_not_destroy_unexisting.rb
+++ b/acceptance/tests/resource/group/should_not_destroy_unexisting.rb
@@ -14,8 +14,8 @@ agents.each do |agent|
 end
 
 step "verify that we don't remove the group when it doesn't exist"
-on(agents, puppet_resource('group', name, 'ensure=absent')) do
+on(agents, puppet_resource('group', name, 'ensure=absent')) do |result|
   fail_test "it looks like we tried to remove the group" if
-    stdout.include? "/Group[#{name}]/ensure: removed"
+    result.stdout.include? "/Group[#{name}]/ensure: removed"
 end
 

--- a/acceptance/tests/resource/group/should_query.rb
+++ b/acceptance/tests/resource/group/should_query.rb
@@ -15,8 +15,8 @@ agents.each do |agent|
   agent.group_present(name)
 
   step "query for the resource and verify it was found"
-  on(agent, puppet_resource('group', name)) do
-    fail_test "didn't find the group #{name}" unless stdout.include? 'present'
+  on(agent, puppet_resource('group', name)) do |result|
+    fail_test "didn't find the group #{name}" unless result.stdout.include? 'present'
   end
 
   step "clean up the group we added"

--- a/acceptance/tests/resource/group/should_query_all.rb
+++ b/acceptance/tests/resource/group/should_query_all.rb
@@ -13,8 +13,8 @@ agents.each do |agent|
   fail_test("No groups found") unless groups
 
   step "query with puppet"
-  on(agent, puppet_resource('group')) do
-    stdout.each_line do |line|
+  on(agent, puppet_resource('group')) do |result|
+    result.stdout.each_line do |line|
       name = ( line.match(/^group \{ '([^']+)'/) or next )[1]
 
       unless groups.delete(name)

--- a/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
+++ b/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
@@ -70,7 +70,7 @@ test_name "ticket 1073: common package name in two different providers should be
   end
 
   def verify_absent(hosts, pkg)
-    verify_state(hosts, pkg, '(?:purged|absent)', :assert_no_match)
+    verify_state(hosts, pkg, '(?:purged|absent)', :refute_match)
   end
 
   # Setup repo and package

--- a/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
+++ b/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
@@ -55,12 +55,12 @@ test_name "ticket 1073: common package name in two different providers should be
     hosts.each do |agent|
       cmd = rpm_provider(agent)
       # Note yum lists packages as <name>.<arch>
-      on agent, "#{cmd} list installed" do
-        method(match).call(/^#{pkg}\./, stdout)
+      on(agent, "#{cmd} list installed") do |result|
+        method(match).call(/^#{pkg}\./, result.stdout)
       end
 
-      on agent, "#{gem_command(agent, @options[:type])} list --local" do
-        method(match).call(/^#{pkg} /, stdout)
+      on(agent, "#{gem_command(agent, @options[:type])} list --local") do |result|
+        method(match).call(/^#{pkg} /, result.stdout)
       end
     end
   end

--- a/acceptance/tests/resource/package/does_not_exist.rb
+++ b/acceptance/tests/resource/package/does_not_exist.rb
@@ -9,8 +9,8 @@ test_name "Puppet returns only resource package declaration when querying an uni
   agents.each do |agent|
 
     step "test puppet resource package" do
-      on(agent, puppet('resource', 'package', 'not-installed-on-this-host')) do
-        assert_match(/package.*not-installed-on-this-host.*\n.*ensure.*(?:absent|purged).*\n.*provider/, stdout)
+      on(agent, puppet('resource', 'package', 'not-installed-on-this-host')) do |result|
+        assert_match(/package.*not-installed-on-this-host.*\n.*ensure.*(?:absent|purged).*\n.*provider/, result.stdout)
       end
     end
 
@@ -21,8 +21,8 @@ test_name "Puppet returns only resource package declaration when querying an uni
   confine_block(:to, :platform => /debian|ubuntu/) do
     agents.each do |agent|
       step "test puppet apply" do
-        on(agent, puppet('apply', '-e', %Q|"package {'not-installed-on-this-host': ensure => purged }"|)) do
-          refute_match(/warning/i, stdout)
+        on(agent, puppet('apply', '-e', %Q|"package {'not-installed-on-this-host': ensure => purged }"|)) do |result|
+          refute_match(/warning/i, result.stdout)
         end
       end
     end

--- a/acceptance/tests/resource/package/does_not_exist.rb
+++ b/acceptance/tests/resource/package/does_not_exist.rb
@@ -22,7 +22,7 @@ test_name "Puppet returns only resource package declaration when querying an uni
     agents.each do |agent|
       step "test puppet apply" do
         on(agent, puppet('apply', '-e', %Q|"package {'not-installed-on-this-host': ensure => purged }"|)) do
-          assert_no_match(/warning/i, stdout)
+          refute_match(/warning/i, stdout)
         end
       end
     end

--- a/acceptance/tests/resource/package/ips/basic_tests.rb
+++ b/acceptance/tests/resource/package/ips/basic_tests.rb
@@ -31,7 +31,7 @@ agents.each do |agent|
   step "IPS: basic ensure we are clean"
   apply_manifest_on(agent, 'package {mypkg : ensure=>absent}')
   on(agent, "pkg list -v mypkg", :acceptable_exit_codes => [1]) do
-    assert_no_match( /mypkg@0.0.1/, result.stdout, "err: #{agent}")
+    refute_match( /mypkg@0.0.1/, result.stdout, "err: #{agent}")
   end
 
   step "IPS: basic - it should create"
@@ -47,7 +47,7 @@ agents.each do |agent|
   step "IPS: do not upgrade until latest is mentioned"
   send_pkg agent,:pkg => 'mypkg@0.0.2'
   apply_manifest_on(agent, 'package {mypkg : ensure=>present}') do
-    assert_no_match( /ensure: created/, result.stdout, "err: #{agent}")
+    refute_match( /ensure: created/, result.stdout, "err: #{agent}")
   end
 
   step "IPS: verify it was not upgraded"
@@ -74,6 +74,6 @@ agents.each do |agent|
   step "IPS: ensure removed."
   apply_manifest_on(agent, 'package {mypkg : ensure=>absent}')
   on(agent, "pkg list -v mypkg", :acceptable_exit_codes => [1]) do
-    assert_no_match( /mypkg@0.0.1/, result.stdout, "err: #{agent}")
+    refute_match( /mypkg@0.0.1/, result.stdout, "err: #{agent}")
   end
 end

--- a/acceptance/tests/resource/package/ips/should_be_holdable.rb
+++ b/acceptance/tests/resource/package/ips/should_be_holdable.rb
@@ -62,7 +62,7 @@ agents.each do |agent|
   setup_fakeroot2 agent
   send_pkg2 agent, :pkg => 'mypkg2@0.0.3', :pkgdep => 'mypkg@0.0.3'
   apply_manifest_on(agent, 'package {mypkg2 : ensure=>"0.0.2"}') do
-    assert_no_match( /changed/, result.stdout, "err: #{agent}")
+    refute_match( /changed/, result.stdout, "err: #{agent}")
   end
   on agent, "pkg list -v mypkg" do
     assert_match( /mypkg@0.0.2/, result.stdout, "err: #{agent}")

--- a/acceptance/tests/resource/package/ips/should_be_idempotent.rb
+++ b/acceptance/tests/resource/package/ips/should_be_idempotent.rb
@@ -32,8 +32,8 @@ agents.each do |agent|
 
   step "IPS: should be idempotent (present)"
   apply_manifest_on(agent, 'package {mypkg : ensure=>present}') do
-    assert_no_match( /created/, result.stdout, "err: #{agent}")
-    assert_no_match( /changed/, result.stdout, "err: #{agent}")
+    refute_match( /created/, result.stdout, "err: #{agent}")
+    refute_match( /changed/, result.stdout, "err: #{agent}")
   end
   send_pkg agent, :pkg => 'mypkg@0.0.2'
 
@@ -42,7 +42,7 @@ agents.each do |agent|
 
   step "IPS: ask for latest version again: should be idempotent (latest)"
   apply_manifest_on(agent, 'package {mypkg : ensure=>latest}') do
-    assert_no_match( /created/, result.stdout, "err: #{agent}")
+    refute_match( /created/, result.stdout, "err: #{agent}")
   end
 
   step "IPS: ask for specific version"
@@ -53,14 +53,14 @@ agents.each do |agent|
 
   step "IPS: ask for specific version again: should be idempotent (version)"
   apply_manifest_on(agent, 'package {mypkg : ensure=>"0.0.3"}') do
-    assert_no_match( /created/, result.stdout, "err: #{agent}")
-    assert_no_match( /changed/, result.stdout, "err: #{agent}")
+    refute_match( /created/, result.stdout, "err: #{agent}")
+    refute_match( /changed/, result.stdout, "err: #{agent}")
   end
 
   step "IPS: ensure removed."
   apply_manifest_on(agent, 'package {mypkg : ensure=>absent}')
   on(agent, "pkg list -v mypkg", :acceptable_exit_codes => [1]) do
-    assert_no_match( /mypkg/, result.stdout, "err: #{agent}")
+    refute_match( /mypkg/, result.stdout, "err: #{agent}")
   end
 
 end

--- a/acceptance/tests/resource/package/ips/should_be_versionable.rb
+++ b/acceptance/tests/resource/package/ips/should_be_versionable.rb
@@ -38,7 +38,7 @@ agents.each do |agent|
     assert_match( /ensure changed/, result.stdout, "err: #{agent}")
   end
   on agent, "pkg list mypkg" do
-    assert_no_match( /0.0.1/, result.stdout, "err: #{agent}")
+    refute_match( /0.0.1/, result.stdout, "err: #{agent}")
     assert_match( /0.0.2/, result.stdout, "err: #{agent}")
   end
   step "IPS: it should downpgrade if asked for previous version"
@@ -46,7 +46,7 @@ agents.each do |agent|
     assert_match( /ensure changed/, result.stdout, "err: #{agent}")
   end
   on agent, "pkg list mypkg" do
-    assert_no_match( /0.0.2/, result.stdout, "err: #{agent}")
+    refute_match( /0.0.2/, result.stdout, "err: #{agent}")
     assert_match( /0.0.1/, result.stdout, "err: #{agent}")
   end
 end

--- a/acceptance/tests/resource/package/ips/should_remove.rb
+++ b/acceptance/tests/resource/package/ips/should_remove.rb
@@ -33,7 +33,7 @@ agents.each do |agent|
   apply_manifest_on(agent, 'package {mypkg : ensure=>absent}')
 
   on(agent, "pkg list -v mypkg", :acceptable_exit_codes => [1]) do
-    assert_no_match( /mypkg@0.0.1/, result.stdout, "err: #{agent}")
+    refute_match( /mypkg@0.0.1/, result.stdout, "err: #{agent}")
   end
 
 end

--- a/acceptance/tests/resource/package/yum.rb
+++ b/acceptance/tests/resource/package/yum.rb
@@ -45,7 +45,7 @@ test_name "test the yum package provider" do
   end
 
   def verify_absent(hosts, pkg)
-    verify_state(hosts, pkg, '(?:purged|absent)', :assert_no_match)
+    verify_state(hosts, pkg, '(?:purged|absent)', :refute_match)
   end
 
   step "Managing a package which does not include an epoch in its version" do
@@ -149,7 +149,7 @@ test_name "test the yum package provider" do
         end
 
         apply_manifest_on(agent, "package {'epoch': ensure => '1:1.1-1.noarch'}") do |result|
-          assert_no_match(/epoch/, result.stdout)
+          refute_match(/epoch/, result.stdout)
         end
       end
 
@@ -167,11 +167,11 @@ test_name "test the yum package provider" do
           end
 
           apply_manifest_on(agent, 'package {"epoch": ensure => "1:1.1-1"}') do |result|
-            assert_no_match(/epoch/, result.stdout)
+            refute_match(/epoch/, result.stdout)
           end
 
           apply_manifest_on(agent, "package {'epoch': ensure => '1:1.1-1.noarch'}") do |result|
-            assert_no_match(/epoch/, result.stdout)
+            refute_match(/epoch/, result.stdout)
           end
         end
       end
@@ -190,11 +190,11 @@ test_name "test the yum package provider" do
           end
 
           apply_manifest_on(agent, 'package {"epoch": ensure => "1.1-1"}') do |result|
-            assert_no_match(/epoch/, result.stdout)
+            refute_match(/epoch/, result.stdout)
           end
 
           apply_manifest_on(agent, "package {'epoch': ensure => '1:1.1-1.noarch'}") do |result|
-            assert_no_match(/epoch/, result.stdout)
+            refute_match(/epoch/, result.stdout)
           end
         end
       end

--- a/acceptance/tests/resource/package/yum.rb
+++ b/acceptance/tests/resource/package/yum.rb
@@ -34,8 +34,8 @@ test_name "test the yum package provider" do
     hosts.each do |agent|
       cmd = rpm_provider(agent)
       # Note yum and dnf list packages as <name>.<arch>
-      on agent, "#{cmd} list installed" do
-        method(match).call(/^#{pkg}\./, stdout)
+      on(agent, "#{cmd} list installed") do |result|
+        method(match).call(/^#{pkg}\./, result.stdout)
       end
     end
   end

--- a/acceptance/tests/resource/service/AIX_service_provider.rb
+++ b/acceptance/tests/resource/service/AIX_service_provider.rb
@@ -26,8 +26,8 @@ def lsitab_assert_enable(host, service, expected_status)
     raise "This test doesn't know what to do with an expected enable status of #{expected_status}"
   end
 
-  on host, "lsitab #{service} | cut -f 1 -d :" do
-    actual_output = stdout.chomp
+  on(host, "lsitab #{service} | cut -f 1 -d :") do |result|
+    actual_output = result.stdout.chomp
     assert_equal(expected_output, actual_output,
       "Service doesn't actually have enabled = #{expected_status}")
   end
@@ -45,8 +45,8 @@ def lssrc_assert_status(host, service, expected_status)
 
   # sometimes there's no group or PID which messes up the condense to a single
   # delimiter
-  on host, "lssrc -s #{service} | tr -s ' ' ':' | tail -1 | cut -f 3- -d :" do
-    actual_output = stdout.chomp
+  on(host, "lssrc -s #{service} | tr -s ' ' ':' | tail -1 | cut -f 3- -d :") do |result|
+    actual_output = result.stdout.chomp
     assert_match(/#{expected_output}\Z/, actual_output,
         "Service is not actually #{expected_status}")
   end
@@ -65,16 +65,16 @@ agents.each do |agent|
   step "Setup on #{agent}"
   sloth_daemon_path = agent.tmpfile("sloth_daemon.sh")
   create_remote_file(agent, sloth_daemon_path, sloth_daemon_script)
-  on agent, "chmod +x #{sloth_daemon_path}"
-  on agent, "mkssys -s sloth_daemon -p #{sloth_daemon_path} -u 0 -S -n 15 -f 9"
+  on(agent, "chmod +x #{sloth_daemon_path}")
+  on(agent, "mkssys -s sloth_daemon -p #{sloth_daemon_path} -u 0 -S -n 15 -f 9")
 
   # Creating the service may also start it. Stop service before beginning the test.
   on(agent, puppet_resource('service', 'sloth_daemon', 'ensure=stopped', 'enable=false'))
 
   ## Query
   step "Verify the service exists on #{agent}"
-  on(agent, puppet_resource('service', 'sloth_daemon')) do
-    assert_match(/sloth_daemon/, stdout, "Couldn't find service sloth_daemon")
+  on(agent, puppet_resource('service', 'sloth_daemon')) do |result|
+    assert_match(/sloth_daemon/, result.stdout, "Couldn't find service sloth_daemon")
   end
 
   ## Start the service

--- a/acceptance/tests/resource/service/init_on_systemd.rb
+++ b/acceptance/tests/resource/service/init_on_systemd.rb
@@ -1,8 +1,9 @@
 test_name 'SysV on default Systemd Service Provider Validation' do
 
   confine :to, :platform => /el-[6-8]|centos|fedora-(2[0-9])/ do |h|
-    on h, 'which systemctl', :acceptable_exit_codes => [0, 1]
-    stdout =~ /systemctl/
+    on(h, 'which systemctl', :acceptable_exit_codes => [0, 1]) do |result|
+      result.stdout =~ /systemctl/
+    end
   end
 
   tag 'audit:high',
@@ -80,12 +81,11 @@ INITD
   end
 
   def assert_service_status(agent, pidfile, expected_running)
-    on agent, "ps -p `cat #{pidfile}`", :acceptable_exit_codes => (expected_running ? [0] : [1])
+    on(agent, "ps -p `cat #{pidfile}`", :acceptable_exit_codes => (expected_running ? [0] : [1]))
   end
 
   agents.each do |agent|
-    on agent, 'which sleep'
-    sleep_bin = stdout.chomp
+    sleep_bin = on(agent, 'which sleep').stdout.chomp
 
     step "Create initd script with status command" do
       create_remote_file agent, initd_location, initd_file(svc, pidfile, initd_location, true)
@@ -93,9 +93,9 @@ INITD
 file {'/usr/bin/#{svc}': ensure => link, target => '#{sleep_bin}', }
 file {'#{initd_location}': ensure => file, mode   => '0755', }
 MANIFEST
-      on agent, "chkconfig --add #{svc}"
-      on agent, "chkconfig #{svc}", :acceptable_exit_codes => [0]
-      on agent, "service #{svc} status", :acceptable_exit_codes => [3]
+      on(agent, "chkconfig --add #{svc}")
+      on(agent, "chkconfig #{svc}", :acceptable_exit_codes => [0])
+      on(agent, "service #{svc} status", :acceptable_exit_codes => [3])
     end
 
     step "Verify the service exists on #{agent}" do
@@ -134,9 +134,9 @@ MANIFEST
 file {'/usr/bin/#{svc}': ensure => link, target => '#{sleep_bin}', }
 file {'#{initd_location}': ensure => file, mode   => '0755', }
 MANIFEST
-      on agent, "chkconfig --add #{svc}"
-      on agent, "chkconfig #{svc}", :acceptable_exit_codes => [0]
-      on agent, "service #{svc} status", :acceptable_exit_codes => [1]
+      on(agent, "chkconfig --add #{svc}")
+      on(agent, "chkconfig #{svc}", :acceptable_exit_codes => [0])
+      on(agent, "service #{svc} status", :acceptable_exit_codes => [1])
     end
 
     step "Verify the service exists on #{agent}" do
@@ -176,9 +176,9 @@ MANIFEST
     end
 
     teardown do
-      on agent, "service #{svc} stop", :accept_any_exit_code => true
-      on agent, "chkconfig --del #{svc}"
-      on agent, "rm /usr/bin/#{svc} #{initd_location}"
+      on(agent, "service #{svc} stop", :accept_any_exit_code => true)
+      on(agent, "chkconfig --del #{svc}")
+      on(agent, "rm /usr/bin/#{svc} #{initd_location}")
     end
   end
 end

--- a/acceptance/tests/resource/service/launchd_provider.rb
+++ b/acceptance/tests/resource/service/launchd_provider.rb
@@ -24,7 +24,7 @@ def launchctl_assert_status(host, service, expect_running)
     if expect_running
       assert_match(/#{service}/, stdout, 'Service was not found in launchctl list')
     else
-      assert_no_match(/#{service}/, stdout, 'Service was not expected in launchctl list')
+      refute_match(/#{service}/, stdout, 'Service was not expected in launchctl list')
     end
   end
 end

--- a/acceptance/tests/resource/service/launchd_provider.rb
+++ b/acceptance/tests/resource/service/launchd_provider.rb
@@ -20,11 +20,11 @@ svc = 'com.puppetlabs.sloth'
 launchd_script_path = "/Library/LaunchDaemons/#{svc}.plist"
 
 def launchctl_assert_status(host, service, expect_running)
-  on host, 'launchctl list' do
+  on(host, 'launchctl list') do |result|
     if expect_running
-      assert_match(/#{service}/, stdout, 'Service was not found in launchctl list')
+      assert_match(/#{service}/, result.stdout, 'Service was not found in launchctl list')
     else
-      refute_match(/#{service}/, stdout, 'Service was not expected in launchctl list')
+      refute_match(/#{service}/, result.stdout, 'Service was not expected in launchctl list')
     end
   end
 end

--- a/acceptance/tests/resource/service/should_not_change_the_system.rb
+++ b/acceptance/tests/resource/service/should_not_change_the_system.rb
@@ -24,10 +24,12 @@ agents.each do |agent|
                  end
 
   step "list running services and make sure ssh reports running"
-  on(agent, puppet('resource service'))
-  assert_match(/service { '#{service_name}':\n\s*ensure\s*=>\s*'(?:true|running)'/, stdout, "ssh is not running")
+  on(agent, puppet('resource service')) do |result|
+    assert_match(/service { '#{service_name}':\n\s*ensure\s*=>\s*'(?:true|running)'/, result.stdout, "ssh is not running")
+  end
 
   step "list running services again and make sure ssh is still running"
-  on(agent, puppet('resource service'))
-  assert_match(/service { '#{service_name}':\n\s*ensure\s*=>\s*'(?:true|running)'/, stdout, "ssh is no longer running")
+  on(agent, puppet('resource service')) do |result|
+    assert_match(/service { '#{service_name}':\n\s*ensure\s*=>\s*'(?:true|running)'/, result.stdout, "ssh is no longer running")
+  end
 end

--- a/acceptance/tests/resource/service/should_query_all.rb
+++ b/acceptance/tests/resource/service/should_query_all.rb
@@ -7,8 +7,8 @@ tag 'audit:high',
 
 agents.each do |agent|
   step "query with puppet"
-  on(agent, puppet_resource('service'), :accept_all_exit_codes => true) do
+  on(agent, puppet_resource('service'), :accept_all_exit_codes => true) do |result|
     assert_equal(exit_code, 0, "'puppet resource service' should have an exit code of 0")
-    assert(/^service/ =~ stdout, "'puppet resource service' should present service details")
+    assert(/^service/ =~ result.stdout, "'puppet resource service' should present service details")
   end
 end

--- a/acceptance/tests/resource/service/systemd_resource_shows_correct_output.rb
+++ b/acceptance/tests/resource/service/systemd_resource_shows_correct_output.rb
@@ -24,9 +24,9 @@ test_name 'systemd service shows correct output when queried with "puppet resour
     end
 
     step "Expect reported status to match system state" do
-      on(agent, puppet_resource('service', package_name, 'ensure=stopped', 'enable=true')) do
-        assert_match(/ensure\s*=>\s*'stopped'/, stdout, "Expected '#{package_name}' service to appear as stopped")
-        assert_match(/enable\s*=>\s*'true'/, stdout, "Expected '#{package_name}' service to appear as enabled")
+      on(agent, puppet_resource('service', package_name, 'ensure=stopped', 'enable=true')) do |result|
+        assert_match(/ensure\s*=>\s*'stopped'/, result.stdout, "Expected '#{package_name}' service to appear as stopped")
+        assert_match(/enable\s*=>\s*'true'/, result.stdout, "Expected '#{package_name}' service to appear as enabled")
       end
     end
   end

--- a/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
+++ b/acceptance/tests/resource/service/ticket_5024_systemd_enabling_masked_service.rb
@@ -71,21 +71,21 @@ agents.each do |agent|
 
   step "Masking the #{package_name[platform]} service"
   apply_manifest_on(agent, manifest_service_masked, :catch_failures => true)
-  on(agent, puppet_resource('service', package_name[platform])) do
-    assert_match(/ensure.+=> 'stopped'/, stdout, "Expected #{package_name[platform]} service to be stopped")
-    assert_match(/enable.+=> 'false'/, stdout, "Expected #{package_name[platform]} service to be masked")
-    on(agent, "readlink #{masked_symlink_systemd}") do
-      assert_equal('/dev/null', stdout.chomp, "Expected service symlink to point to /dev/null")
+  on(agent, puppet_resource('service', package_name[platform])) do |result|
+    assert_match(/ensure.+=> 'stopped'/, result.stdout, "Expected #{package_name[platform]} service to be stopped")
+    assert_match(/enable.+=> 'false'/, result.stdout, "Expected #{package_name[platform]} service to be masked")
+    on(agent, "readlink #{masked_symlink_systemd}") do |readlink_result|
+      assert_equal('/dev/null', readlink_result.stdout.chomp, "Expected service symlink to point to /dev/null")
     end
   end
 
   step "Enabling the #{package_name[platform]} service"
   apply_manifest_on(agent, manifest_service_enabled, :catch_failures => true)
-  on(agent, puppet_resource('service', package_name[platform])) do
-    assert_match(/ensure.+=> 'running'/, stdout, "Expected #{package_name[platform]} service to be running")
-    assert_match(/enable.+=> 'true'/, stdout, "Expected #{package_name[platform]} service to be enabled")
-    on(agent, "readlink #{symlink_systemd}") do
-      assert_equal(init_script_systemd, stdout.chomp, "Expected service symlink to point to systemd init script")
+  on(agent, puppet_resource('service', package_name[platform])) do |result|
+    assert_match(/ensure.+=> 'running'/, result.stdout, "Expected #{package_name[platform]} service to be running")
+    assert_match(/enable.+=> 'true'/, result.stdout, "Expected #{package_name[platform]} service to be enabled")
+    on(agent, "readlink #{symlink_systemd}") do |readlink_result|
+      assert_equal(init_script_systemd, readlink_result.stdout.chomp, "Expected service symlink to point to systemd init script")
     end
   end
 end

--- a/acceptance/tests/resource/service/windows.rb
+++ b/acceptance/tests/resource/service/windows.rb
@@ -120,9 +120,9 @@ MANIFEST
       assert_service_properties_on(agent, mock_service_nofail[:name], StartName: fresh_user)
       on(agent, puppet("resource service #{mock_service_nofail[:name]} logonaccount=S-1-5-19")) do |result|
         assert_match(/Service\[#{mock_service_nofail[:name]}\]\/logonaccount: logonaccount changed '.\\#{fresh_user}' to '#{Regexp.escape(local_service_locale_name)}'/, result.stdout)
-        assert_no_match(/Transitioning the #{mock_service_nofail[:name]} service from SERVICE_RUNNING to SERVICE_STOPPED/, result.stdout, 
+        refute_match(/Transitioning the #{mock_service_nofail[:name]} service from SERVICE_RUNNING to SERVICE_STOPPED/, result.stdout, 
           "Expected no service restarts since ensure isn't being managed as 'running'.")
-        assert_no_match(/Successfully started the #{mock_service_nofail[:name]} service/, result.stdout)
+        refute_match(/Successfully started the #{mock_service_nofail[:name]} service/, result.stdout)
       end
       assert_service_properties_on(agent, mock_service_nofail[:name], StartName: local_service_locale_name)
     end
@@ -152,10 +152,10 @@ MANIFEST
     step 'Verify that there are no restarts if logonaccount does not change, even though ensure is managed as running' do
       assert_service_properties_on(agent, mock_service_nofail[:name], StartName: 'LocalSystem')
       on(agent, puppet("resource service #{mock_service_nofail[:name]} logonaccount=LocalSystem ensure=running --debug")) do |result|
-        assert_no_match(/Service\[#{mock_service_nofail[:name]}\]\/logonaccount: logonaccount changed/, result.stdout)
-        assert_no_match(/Service\[#{mock_service_nofail[:name]}\]\/ensure: ensure changed/, result.stdout)
-        assert_no_match(/Transitioning the #{mock_service_nofail[:name]} service from SERVICE_RUNNING to SERVICE_STOPPED/, result.stdout)
-        assert_no_match(/Successfully started the #{mock_service_nofail[:name]} service/, result.stdout)
+        refute_match(/Service\[#{mock_service_nofail[:name]}\]\/logonaccount: logonaccount changed/, result.stdout)
+        refute_match(/Service\[#{mock_service_nofail[:name]}\]\/ensure: ensure changed/, result.stdout)
+        refute_match(/Transitioning the #{mock_service_nofail[:name]} service from SERVICE_RUNNING to SERVICE_STOPPED/, result.stdout)
+        refute_match(/Successfully started the #{mock_service_nofail[:name]} service/, result.stdout)
       end
       assert_service_properties_on(agent, mock_service_nofail[:name], StartName: 'LocalSystem')
     end

--- a/acceptance/tests/resource/tidy/resources_should_be_non_isomorphic.rb
+++ b/acceptance/tests/resource/tidy/resources_should_be_non_isomorphic.rb
@@ -31,7 +31,7 @@ MANIFEST
 
     step "Create multiple tidy resources with same path" do
       apply_manifest_on(agent, manifest) do |result|
-        assert_no_match(/Error:/, result.stderr, "Unexpected error was detected")
+        refute_match(/Error:/, result.stderr, "Unexpected error was detected")
       end
     end
 

--- a/acceptance/tests/resource/user/should_create_modify_with_password.rb
+++ b/acceptance/tests/resource/user/should_create_modify_with_password.rb
@@ -35,8 +35,8 @@ test_name 'should create a user with password and modify the password' do
     end
 
     step 'verify the password was set correctly' do
-      on(agent, puppet('resource', 'user', name), acceptable_exit_codes: 0) do
-        assert_match(/password\s*=>\s*'#{initial_password}'/, stdout, 'Password was not set correctly')
+      on(agent, puppet('resource', 'user', name), acceptable_exit_codes: 0) do |result|
+        assert_match(/password\s*=>\s*'#{initial_password}'/, result.stdout, 'Password was not set correctly')
       end
     end
 
@@ -50,8 +50,8 @@ test_name 'should create a user with password and modify the password' do
     end
 
     step 'verify the password was set correctly' do
-      on(agent, "puppet resource user #{name}", acceptable_exit_codes: 0) do
-        assert_match(/password\s*=>\s*'#{modified_password}'/, stdout, 'Password was not changed correctly')
+      on(agent, "puppet resource user #{name}", acceptable_exit_codes: 0) do |result|
+        assert_match(/password\s*=>\s*'#{modified_password}'/, result.stdout, 'Password was not changed correctly')
       end
     end
 

--- a/acceptance/tests/resource/user/should_create_with_expiry_absent.rb
+++ b/acceptance/tests/resource/user/should_create_with_expiry_absent.rb
@@ -26,7 +26,7 @@ test_name "verifies that puppet resource creates a user and assigns the correct 
     step "verify the user exists and expiry is not set (meaning never expire)"
     on(host, puppet_resource('user', user)) do |result|
       assert_match(/ensure.*=> 'present'/, result.stdout)
-      assert_no_match(/expiry.*=>/, result.stdout)
+      refute_match(/expiry.*=>/, result.stdout)
     end
   end
 end

--- a/acceptance/tests/resource/user/should_manage_purge_ssh_keys.rb
+++ b/acceptance/tests/resource/user/should_manage_purge_ssh_keys.rb
@@ -61,7 +61,7 @@ test_name 'should manage purge_ssh_keys' do
       end
 
       on(agent, "cat #{authorized_keys_path}") do |result|
-        assert_no_match(/ssh-rsa my-key #{name}@example.com/, result.stdout)
+        refute_match(/ssh-rsa my-key #{name}@example.com/, result.stdout)
       end
     end
 
@@ -91,7 +91,7 @@ test_name 'should manage purge_ssh_keys' do
       end
 
       on(agent, "cat #{authorized_keys_path}") do |result|
-        assert_no_match(/ssh-rsa my-key #{name}@example.com/, result.stdout)
+        refute_match(/ssh-rsa my-key #{name}@example.com/, result.stdout)
       end
     end
 
@@ -120,7 +120,7 @@ test_name 'should manage purge_ssh_keys' do
       end
 
       on(agent, "cat #{authorized_keys_path}") do |result|
-        assert_no_match(/ssh-rsa my-key #{name}@example.com/, result.stdout)
+        refute_match(/ssh-rsa my-key #{name}@example.com/, result.stdout)
       end
     end
   end

--- a/acceptance/tests/resource/user/should_manage_roles_on_windows.rb
+++ b/acceptance/tests/resource/user/should_manage_roles_on_windows.rb
@@ -39,7 +39,7 @@ MANIFEST
 
     step "Verify that a new user has no roles" do
       on(agent, puppet("resource user #{newUser}")) do |result|
-        assert_no_match(/roles\s+=>/, result.stdout)
+        refute_match(/roles\s+=>/, result.stdout)
       end
     end
 
@@ -81,13 +81,13 @@ MANIFEST
 
     step "Verify that :roles noops when #{newUser} already has given role while managing :role_membership as minimum" do
       apply_manifest_on(agent, user_manifest(newUser, roles: ['SeBackupPrivilege'], role_membership: :minimum), catch_changes: true) do |result|
-        assert_no_match(/User\[#{newUser}\]\/roles: roles changed/, result.stdout)
+        refute_match(/User\[#{newUser}\]\/roles: roles changed/, result.stdout)
       end
     end
 
     step "Verify that while not managing :role_membership, the behaviour remains the same, with noop from :roles when #{newUser} already has the given role" do
       apply_manifest_on(agent, user_manifest(newUser, roles: ['SeBackupPrivilege']), catch_changes: true) do |result|
-        assert_no_match(/User\[#{newUser}\]\/roles: roles changed/, result.stdout)
+        refute_match(/User\[#{newUser}\]\/roles: roles changed/, result.stdout)
       end
     end
 

--- a/acceptance/tests/resource/user/should_not_create_existing.rb
+++ b/acceptance/tests/resource/user/should_not_create_existing.rb
@@ -25,8 +25,8 @@ test_name "tests that user resource will not add users that already exist." do
 
   step "verify that we don't try to create a user account that already exists" do
     agents.each do |agent|
-      on(agent, puppet_resource('user', user, 'ensure=present')) do
-        fail_test "tried to create '#{user}' user" if stdout.include? 'created'
+      on(agent, puppet_resource('user', user, 'ensure=present')) do |result|
+        fail_test "tried to create '#{user}' user" if result.stdout.include? 'created'
       end
     end
   end

--- a/acceptance/tests/resource/user/should_not_destroy_unexisting.rb
+++ b/acceptance/tests/resource/user/should_not_destroy_unexisting.rb
@@ -15,6 +15,6 @@ agents.each do |agent|
 end
 
 step "ensure absent doesn't try and do anything"
-on(agents, puppet_resource('user', name, 'ensure=absent')) do
-  fail_test "tried to remove the user, apparently" if stdout.include? 'removed'
+on(agents, puppet_resource('user', name, 'ensure=absent')) do |result|
+  fail_test "tried to remove the user, apparently" if result.stdout.include? 'removed'
 end

--- a/acceptance/tests/resource/user/should_query.rb
+++ b/acceptance/tests/resource/user/should_query.rb
@@ -14,8 +14,8 @@ agents.each do |agent|
   agent.user_present(name)
 
   step "query for the resource and verify it was found"
-  on(agent, puppet_resource('user', name)) do
-    fail_test "didn't find the user #{name}" unless stdout.include? 'present'
+  on(agent, puppet_resource('user', name)) do |result|
+    fail_test "didn't find the user #{name}" unless result.stdout.include? 'present'
   end
 
   step "clean up the user and group we added"

--- a/acceptance/tests/resource/user/should_query_all.rb
+++ b/acceptance/tests/resource/user/should_query_all.rb
@@ -14,8 +14,8 @@ agents.each do |agent|
   fail_test("No users found") unless users
 
   step "query with puppet"
-  on(agent, puppet_resource('user')) do
-    stdout.each_line do |line|
+  on(agent, puppet_resource('user')) do |result|
+    result.stdout.each_line do |line|
       name = ( line.match(/^user \{ '([^']+)'/) or next )[1]
 
       unless users.delete(name)

--- a/acceptance/tests/security/cve-2013-1640_facter_string.rb
+++ b/acceptance/tests/security/cve-2013-1640_facter_string.rb
@@ -13,6 +13,6 @@ test_name "CVE 2013-1640 Remote Code Execution" do
              %q[ 'notice(inline_template("<%= \"I am Safe\" %>"))' ] do |test|
 
     assert_match(/I am Safe/, test.stdout)
-    assert_no_match(/hax0rd/, test.stdout)
+    refute_match(/hax0rd/, test.stdout)
   end
 end

--- a/acceptance/tests/security/cve-2013-2275_report_acl.rb
+++ b/acceptance/tests/security/cve-2013-2275_report_acl.rb
@@ -28,8 +28,8 @@ with_puppet_running_on(master, {}) do
     "\"https://#{master}:8140/puppet/v3/report/mccune?environment=production\"",
   ].join(" ")
 
-  on master, submit_fake_report_cmd, :acceptable_exit_codes => [0] do
+  on(master, submit_fake_report_cmd, :acceptable_exit_codes => [0]) do |result|
     msg = "(#19531) (CVE-2013-2275) Puppet Server accepted a report for a node that does not match the certname"
-    assert_match(/Forbidden request/, stdout, msg)
+    assert_match(/Forbidden request/, result.stdout, msg)
   end
 end

--- a/acceptance/tests/ticket_2280_refresh_fail_should_fail_run.rb
+++ b/acceptance/tests/ticket_2280_refresh_fail_should_fail_run.rb
@@ -27,7 +27,7 @@ EOS
   agents.each do |agent|
     step 'Apply manifest with fail on refresh. Ensure that this results in a failed dependency' do
       apply_manifest_on(agent, manifest, :expect_failures => true) do |res|
-        assert_no_match(/require_echo.*returns: executed successfully/, res.stdout)
+        refute_match(/require_echo.*returns: executed successfully/, res.stdout)
         assert_match(/require_echo.*Skipping because of failed dependencies/, res.stderr) unless agent['locale'] == 'ja'
       end
     end

--- a/acceptance/tests/ticket_2455_on_solaris_init_provider_should_start_service_in_own_smf_contract.rb
+++ b/acceptance/tests/ticket_2455_on_solaris_init_provider_should_start_service_in_own_smf_contract.rb
@@ -115,9 +115,9 @@ SCRIPT
 
     step "Start the fixture service on #{agent} "
     on(agent, puppet("resource service #{fixture_service} provider=init ensure=stopped"))
-    on(agent, puppet("resource service #{fixture_service} provider=init ensure=running"))
-
-    assert_match(/ensure changed 'stopped' to 'running'/, stdout, "The fixture service #{fixture_service} is not in a testable state on #{agent}.")
+    on(agent, puppet("resource service #{fixture_service} provider=init ensure=running")) do |result|
+      assert_match(/ensure changed 'stopped' to 'running'/, stdout, "The fixture service #{fixture_service} is not in a testable state on #{agent}.")
+    end
 
     step "Verify whether the fixture process is alone in its SMF contract on #{agent}"
     service_ctid = on(agent, "sleep 10;ps -eo ctid,args | grep #{fixture_service} | grep -v grep | awk '{print $1}'").stdout.chomp.to_i

--- a/acceptance/tests/ticket_5477_master_not_dectect_sitepp.rb
+++ b/acceptance/tests/ticket_5477_master_not_dectect_sitepp.rb
@@ -53,8 +53,8 @@ with_puppet_running_on master, master_opts, testdir do
   step "Agent: puppet agent --test"
 
   agents.each do |host|
-    on(host, puppet('agent', "-t"), :acceptable_exit_codes => [2]) do
-      assert_match(/ticket_5477_notify/, stdout, "#{host}: Site.pp not detected on Puppet Master")
+    on(host, puppet('agent', "-t"), :acceptable_exit_codes => [2]) do |result|
+      assert_match(/ticket_5477_notify/, result.stdout, "#{host}: Site.pp not detected on Puppet Master")
     end
   end
 end

--- a/acceptance/tests/ticket_5592_hiera_lookup_when_param_undef.rb
+++ b/acceptance/tests/ticket_5592_hiera_lookup_when_param_undef.rb
@@ -65,8 +65,9 @@ PP
     end
 
     step 'Invoke class with undef param and verify hiera value was applied' do
-      on(agent, puppet('apply', "-e 'class {\"test\": my_param => undef }'", "--modulepath=#{testdir}/environments/production/modules", "--hiera_config=#{testdir}/hiera.yaml" ), :acceptable_exit_codes => [0,2])
-      assert_match("hiera lookup value", stdout)
+      on(agent, puppet('apply', "-e 'class {\"test\": my_param => undef }'", "--modulepath=#{testdir}/environments/production/modules", "--hiera_config=#{testdir}/hiera.yaml" ), :acceptable_exit_codes => [0,2]) do |result|
+        assert_match('hiera lookup value', result.stdout)
+      end
     end
 
   end

--- a/acceptance/tests/ticket_6541_invalid_filebucket_files.rb
+++ b/acceptance/tests/ticket_6541_invalid_filebucket_files.rb
@@ -23,13 +23,13 @@ agents.each do |agent|
   manifest = "file { '#{target}': content => '{sha256}notahash' }"
 
   apply_manifest_on(agent, manifest) do
-    assert_no_match(/content changed/, stdout, "#{agent}: shouldn't have overwrote the file")
+    refute_match(/content changed/, stdout, "#{agent}: shouldn't have overwrote the file")
   end
 
   test_name "verify valid but unbucketed hashes should not change the file"
   manifest = "file { '#{target}': content => '{md5}13ad7345d56b566a4408ffdcd877bc78' }"
   apply_manifest_on(agent, manifest) do
-    assert_no_match(/content changed/, stdout, "#{agent}: shouldn't have overwrote the file")
+    refute_match(/content changed/, stdout, "#{agent}: shouldn't have overwrote the file")
   end
 
   test_name "verify that an empty file can be retrieved from the filebucket"

--- a/acceptance/tests/ticket_6541_invalid_filebucket_files.rb
+++ b/acceptance/tests/ticket_6541_invalid_filebucket_files.rb
@@ -8,7 +8,7 @@ tag 'audit:high',
 agents.each do |agent|
   target=agent.tmpfile('6541-target')
 
-  on agent, "rm -rf \"#{agent.puppet['vardir']}/*bucket\""
+  on(agent, "rm -rf \"#{agent.puppet['vardir']}/*bucket\"")
 
   step "write zero length file"
   manifest = "file { '#{target}': content => '' }"
@@ -22,20 +22,20 @@ agents.each do |agent|
 
   manifest = "file { '#{target}': content => '{sha256}notahash' }"
 
-  apply_manifest_on(agent, manifest) do
-    refute_match(/content changed/, stdout, "#{agent}: shouldn't have overwrote the file")
+  apply_manifest_on(agent, manifest) do |result|
+    refute_match(/content changed/, result.stdout, "#{agent}: shouldn't have overwrote the file")
   end
 
   test_name "verify valid but unbucketed hashes should not change the file"
   manifest = "file { '#{target}': content => '{md5}13ad7345d56b566a4408ffdcd877bc78' }"
-  apply_manifest_on(agent, manifest) do
-    refute_match(/content changed/, stdout, "#{agent}: shouldn't have overwrote the file")
+  apply_manifest_on(agent, manifest) do |result|
+    refute_match(/content changed/, result.stdout, "#{agent}: shouldn't have overwrote the file")
   end
 
   test_name "verify that an empty file can be retrieved from the filebucket"
   manifest = "file { '#{target}': content => '{sha256}e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855', backup => 'puppet' }"
 
-  apply_manifest_on(agent, manifest) do
-    assert_match(/content changed '\{sha256\}b94f6f125c79e3a5ffaa826f584c10d52ada669e6762051b826b55776d05aed2' to '\{sha256\}e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'/, stdout, "#{agent}: shouldn't have overwrote the file")
+  apply_manifest_on(agent, manifest) do |result|
+    assert_match(/content changed '\{sha256\}b94f6f125c79e3a5ffaa826f584c10d52ada669e6762051b826b55776d05aed2' to '\{sha256\}e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'/, result.stdout, "#{agent}: shouldn't have overwrote the file")
   end
 end

--- a/acceptance/tests/ticket_9862_puppet_runs_without_service_user_or_group_present.rb
+++ b/acceptance/tests/ticket_9862_puppet_runs_without_service_user_or_group_present.rb
@@ -21,19 +21,19 @@ end
 
 def missing_directory_for(agent, dir)
   agent_dir = get_test_file_path(agent, dir)
-  on agent, "rm -rf #{agent_dir}"
+  on(agent, "rm -rf #{agent_dir}")
   agent_dir
 end
 
 teardown do
   agents.each do |agent|
     step "ensure puppet resets it's user/group settings"
-    on agent, puppet('apply', '-e', '"notify { puppet_run: }"')
-    on agent, "find \"#{agent.puppet['vardir']}\" -user exist_u", {:acceptable_exit_codes => [0, 1]} do
-      assert_equal('',stdout)
+    on(agent, puppet('apply', '-e', '"notify { puppet_run: }"'))
+    on(agent, "find \"#{agent.puppet['vardir']}\" -user exist_u", {:acceptable_exit_codes => [0, 1]}) do |result|
+      assert_equal('', result.stdout)
     end
-    on agent, puppet('resource', 'user', 'exist_u', 'ensure=absent')
-    on agent, puppet('resource', 'group', 'exist_g', 'ensure=absent')
+    on(agent, puppet('resource', 'user', 'exist_u', 'ensure=absent'))
+    on(agent, puppet('resource', 'group', 'exist_g', 'ensure=absent'))
   end
 end
 
@@ -41,13 +41,13 @@ step "when the user and group are missing"
 agents.each do |agent|
   logdir = missing_directory_for(agent, 'log')
 
-  on agent, puppet('apply',
+  on(agent, puppet('apply',
                    '-e', '"notify { puppet_run: }"',
                    '--logdir', logdir,
                    '--user', 'missinguser',
-                   '--group', 'missinggroup') do
+                   '--group', 'missinggroup')) do |result|
 
-    assert_match(/puppet_run/, stdout)
+    assert_match(/puppet_run/, result.stdout)
     assert_ownership(agent, logdir, root_user(agent), root_group(agent))
   end
 end
@@ -56,16 +56,16 @@ step "when the user and group exist"
 agents.each do |agent|
   logdir = missing_directory_for(agent, 'log')
 
-  on agent, puppet('resource', 'user', 'exist_u', 'ensure=present')
-  on agent, puppet('resource', 'group', 'exist_g', 'ensure=present')
+  on(agent, puppet('resource', 'user', 'exist_u', 'ensure=present'))
+  on(agent, puppet('resource', 'group', 'exist_g', 'ensure=present'))
 
-  on agent, puppet('apply',
+  on(agent, puppet('apply',
                    '-e', '"notify { puppet_run: }"',
                    '--logdir', logdir,
                    '--user', 'exist_u',
-                   '--group', 'exist_g') do
+                   '--group', 'exist_g')) do |result|
 
-    assert_match(/puppet_run/, stdout)
+    assert_match(/puppet_run/, result.stdout)
     assert_ownership(agent, logdir, 'exist_u', 'exist_g')
   end
 end

--- a/acceptance/tests/utf8/utf8-in-file-resource.rb
+++ b/acceptance/tests/utf8/utf8-in-file-resource.rb
@@ -42,14 +42,8 @@ PP
           :environment => {:LANG => "en_US.UTF-8"}
         }
       )
-      on(
-        agent, "cat #{agent_file}", :environment => {:LANG => "en_US.UTF-8"}
-      ) do
-        assert_match(
-          /#{utf8chars}/,
-          stdout,
-          "result stdout did not contain \"#{utf8chars}\"",
-        )
+      on(agent, "cat #{agent_file}", :environment => {:LANG => "en_US.UTF-8"}) do |result|
+        assert_match(/#{utf8chars}/, result.stdout, "result stdout did not contain \"#{utf8chars}\"")
       end
     end
 
@@ -68,16 +62,8 @@ PP
           :environment => {:LANG => "en_US.UTF-8"}
         }
       )
-      on(
-        agent,
-        "cat #{agent_file}",
-        :environment => {:LANG => "en_US.UTF-8"}
-      ) do
-        assert_match(
-          /#{utf8chars}/,
-          stdout,
-          "result stdout did not contain \"#{utf8chars}\""
-        )
+      on(agent, "cat #{agent_file}", :environment => {:LANG => "en_US.UTF-8"}) do |result|
+        assert_match(/#{utf8chars}/, result.stdout, "result stdout did not contain \"#{utf8chars}\"")
       end
     end
   end


### PR DESCRIPTION
This PR updates several deprecated Beaker methods that were removed entirely in Beaker 5. This is in preparation for moving Puppet to using Beaker 5 for tests.
