### PR TITLE
(PUP-12020) Skip tests on debian-12-amd64

### DIFF
--- a/acceptance/tests/resource/exec/should_run_command_in_cwd.rb
+++ b/acceptance/tests/resource/exec/should_run_command_in_cwd.rb
@@ -1,6 +1,7 @@
 test_name "The Exec resource should run commands in the specified cwd" do
   tag 'audit:high',
       'audit:acceptance'
+  confine :except, :platform => /debian-12-amd64/ # PUP-12020
 
   require 'puppet/acceptance/windows_utils'
   extend Puppet::Acceptance::WindowsUtils

--- a/acceptance/tests/utf8/utf8-in-function-args.rb
+++ b/acceptance/tests/utf8/utf8-in-function-args.rb
@@ -1,4 +1,5 @@
 test_name 'utf-8 characters in function parameters' do
+  confine :except, :platform => /debian-12-amd64/ # PUP-12020
 
   tag 'audit:high',
       'audit:integration', # not package dependent but may want to vary platform by LOCALE/encoding


### PR DESCRIPTION
en_US.UTF-8 support is not setup on the test image and session linger support is enabled by default

revert when the test images are rebuilt

needs backport