### PR TITLE
(maint) Add workaround for AlmaLinux package testing failures

### DIFF
--- a/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
+++ b/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
@@ -6,6 +6,9 @@ test_name "ticket 1073: common package name in two different providers should be
     skip_test('Skipping EC2 Hosts') if fact_on(agent, 'ec2_metadata')
   end
 
+  # Upgrade the AlmaLinux release package for newer keys until our image is updated (RE-16096)
+  on(agent, 'dnf -y upgrade almalinux-release') if on(agent, facter('os.name')).stdout.strip == 'AlmaLinux'
+
   tag 'audit:high',
       'audit:acceptance' # Uses a provider that depends on AIO packaging
 

--- a/acceptance/tests/resource/package/yum.rb
+++ b/acceptance/tests/resource/package/yum.rb
@@ -6,6 +6,9 @@ test_name "test the yum package provider" do
     skip_test('Skipping EC2 Hosts') if fact_on(agent, 'ec2_metadata')
   end
 
+  # Upgrade the AlmaLinux release package for newer keys until our image is updated (RE-16096)
+  on(agent, 'dnf -y upgrade almalinux-release') if on(agent, facter('os.name')).stdout.strip == 'AlmaLinux'
+
   tag 'audit:high',
       'audit:acceptance' # Could be done at the integration (or unit) layer though
                          # actual changing of resources could irreparably damage a


### PR DESCRIPTION
Our AlmaLinux image is a bit out of date and needs to be updated. Until that is done we can update that as part of the tests that need it.