### PR TITLE
Use agents beaker DSL method

### DIFF
--- a/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
+++ b/acceptance/tests/resource/package/common_package_name_in_different_providers.rb
@@ -7,7 +7,9 @@ test_name "ticket 1073: common package name in two different providers should be
   end
 
   # Upgrade the AlmaLinux release package for newer keys until our image is updated (RE-16096)
-  on(agent, 'dnf -y upgrade almalinux-release') if on(agent, facter('os.name')).stdout.strip == 'AlmaLinux'
+  agents.each do |agent|
+    on(agent, 'dnf -y upgrade almalinux-release') if fact_on(agent, 'os.name') == 'AlmaLinux'
+  end
 
   tag 'audit:high',
       'audit:acceptance' # Uses a provider that depends on AIO packaging

--- a/acceptance/tests/resource/package/yum.rb
+++ b/acceptance/tests/resource/package/yum.rb
@@ -7,7 +7,9 @@ test_name "test the yum package provider" do
   end
 
   # Upgrade the AlmaLinux release package for newer keys until our image is updated (RE-16096)
-  on(agent, 'dnf -y upgrade almalinux-release') if on(agent, facter('os.name')).stdout.strip == 'AlmaLinux'
+  agents.each do |agent|
+    on(agent, 'dnf -y upgrade almalinux-release') if fact_on(agent, 'os.name') == 'AlmaLinux'
+  end
 
   tag 'audit:high',
       'audit:acceptance' # Could be done at the integration (or unit) layer though


### PR DESCRIPTION
Beaker's singular `agent` method can either return a single host or an array of hosts, depending on how many hosts have the agent role in your beaker config. For example, when running with `redhat7-64m-ubuntu2004-64a`, then it will return a single host. If running with `redhat7-64ma-ubuntu2004-64a`, then it will return an array of hosts[1].

The beaker `agent` method should never be used as it can cause tests to pass in agent CI, but fail in puppetserver CI, since they test the agent running on the server host.

Instead reference the `agents` method, which is guaranteed to exist and return an array, possible empty.

Also use the `fact_on` helper which parses the facter output as JSON and avoids having to chomp newlines in the output.

[1] https://github.com/voxpupuli/beaker/blob/abd5b30e93061b44e45f2211bc6a73cb6e20b353/lib/beaker/dsl/roles.rb#L181-L187