### PR TITLE
Update Beaker result proxies on host object

### DIFF
--- a/acceptance/lib/puppet/acceptance/environment_utils.rb
+++ b/acceptance/lib/puppet/acceptance/environment_utils.rb
@@ -241,7 +241,7 @@ module Puppet
               # Test agents configured to use directory environments (affects environment
               # loading on the agent, especially with regards to requests/node environment)
               args << "--environmentpath='$confdir/environments'" if directory_environments && agent != master
-              on(agent, puppet("agent", *args), :acceptable_exit_codes => (0..255)) do
+              on(agent, puppet("agent", *args), :acceptable_exit_codes => (0..255)) do |result|
                 agent_results[:puppet_agent] = result
               end
 
@@ -249,12 +249,12 @@ module Puppet
               args << ["--environment", environment] if environment
 
               step "print puppet config for #{description} environment"
-              on(master, puppet(*(["config", "print", "basemodulepath", "modulepath", "manifest", "config_version", config_print] + args)), :acceptable_exit_codes => (0..255)) do
+              on(master, puppet(*(["config", "print", "basemodulepath", "modulepath", "manifest", "config_version", config_print] + args)), :acceptable_exit_codes => (0..255)) do |result|
                 agent_results[:puppet_config] = result
               end
 
               step "puppet apply using #{description} environment"
-              on(master, puppet(*(["apply", '-e', '"include testing_mod"'] + args)), :acceptable_exit_codes => (0..255)) do
+              on(master, puppet(*(["apply", '-e', '"include testing_mod"'] + args)), :acceptable_exit_codes => (0..255)) do |result|
                 agent_results[:puppet_apply] = result
               end
             end

--- a/acceptance/lib/puppet/acceptance/module_utils.rb
+++ b/acceptance/lib/puppet/acceptance/module_utils.rb
@@ -44,11 +44,12 @@ module Puppet
       # @param host [String] hostname
       # @return [Array] paths for found modules
       def get_installed_modules_for_host(host)
-        on host, puppet("module list --render-as json")
-        str  = stdout.lines.to_a.last
-        pat = /\(([^()]+)\)/
-        mods =  str.scan(pat).flatten
-        return mods
+        on(host, puppet('module list --render-as json')) do |result|
+          str  = result.stdout.lines.to_a.last
+          pat = /\(([^()]+)\)/
+          mods =  str.scan(pat).flatten
+          return mods
+        end
       end
 
       # Return a hash of array of paths to installed modules for a hosts.

--- a/acceptance/lib/puppet/acceptance/service_utils.rb
+++ b/acceptance/lib/puppet/acceptance/service_utils.rb
@@ -42,9 +42,9 @@ module Puppet
         # that the exit code is either
         #   2 => something changed, or
         #   0 => no change needed
-        apply_manifest_on host, service_manifest(service, status), :acceptable_exit_codes => [0, 2] do
-          assert_match(/Service\[#{service}\]\/ensure: ensure changed '\w+' to '#{status[:ensure]}'/, stdout, 'Service status change failed') if status[:ensure]
-          assert_match(/Service\[#{service}\]\/enable: enable changed '\w+' to '#{status[:enable]}'/, stdout, 'Service enable change failed') if status[:enable]
+        apply_manifest_on(host, service_manifest(service, status), :acceptable_exit_codes => [0, 2]) do |result|
+          assert_match(/Service\[#{service}\]\/ensure: ensure changed '\w+' to '#{status[:ensure]}'/, result.stdout, 'Service status change failed') if status[:ensure]
+          assert_match(/Service\[#{service}\]\/enable: enable changed '\w+' to '#{status[:enable]}'/, result.stdout, 'Service enable change failed') if status[:enable]
         end
       end
 
@@ -56,9 +56,9 @@ module Puppet
       # @return None
       def ensure_service_idempotent_on_host(host, service, status)
         # ensure idempotency
-        apply_manifest_on host, service_manifest(service, status) do
-          assert_no_match(/Service\[#{service}\]\/ensure/, stdout, 'Service status not idempotent') if status[:ensure]
-          assert_no_match(/Service\[#{service}\]\/enable/, stdout, 'Service enable not idempotent') if status[:enable]
+        apply_manifest_on(host, service_manifest(service, status)) do |result|
+          assert_no_match(/Service\[#{service}\]\/ensure/, result.stdout, 'Service status not idempotent') if status[:ensure]
+          assert_no_match(/Service\[#{service}\]\/enable/, result.stdout, 'Service enable not idempotent') if status[:enable]
         end
       end
 
@@ -86,8 +86,8 @@ module Puppet
         ensure_status = "ensure.+=> '#{status[:ensure]}'" if status[:ensure]
         enable_status = "enable.+=> '#{status[:enable]}'" if status[:enable]
 
-        on host, puppet_resource('service', service) do
-          assert_match(/'#{service}'.+#{ensure_status}.+#{enable_status}/m, stdout, "Service status does not match expectation #{status}")
+        on(host, puppet_resource('service', service)) do |result|
+          assert_match(/'#{service}'.+#{ensure_status}.+#{enable_status}/m, result.stdout, "Service status does not match expectation #{status}")
         end
 
         # Verify service state on the system using a custom block

--- a/acceptance/lib/puppet/acceptance/service_utils.rb
+++ b/acceptance/lib/puppet/acceptance/service_utils.rb
@@ -57,8 +57,8 @@ module Puppet
       def ensure_service_idempotent_on_host(host, service, status)
         # ensure idempotency
         apply_manifest_on(host, service_manifest(service, status)) do |result|
-          assert_no_match(/Service\[#{service}\]\/ensure/, result.stdout, 'Service status not idempotent') if status[:ensure]
-          assert_no_match(/Service\[#{service}\]\/enable/, result.stdout, 'Service enable not idempotent') if status[:enable]
+          refute_match(/Service\[#{service}\]\/ensure/, result.stdout, 'Service status not idempotent') if status[:ensure]
+          refute_match(/Service\[#{service}\]\/enable/, result.stdout, 'Service enable not idempotent') if status[:enable]
         end
       end
 
@@ -121,7 +121,7 @@ module Puppet
             { enable: false, ensure: :stopped }.each do |property, value|
               assert_match(/#{property}.*#{value}.*$/, result.stdout, "Puppet does not report #{property}=#{value} for a non-existent service")
             end
-            assert_no_match(/logonaccount\s+=>/, result.stdout, "Puppet reports logonaccount for a non-existent service")
+            refute_match(/logonaccount\s+=>/, result.stdout, "Puppet reports logonaccount for a non-existent service")
           end
         end
       

--- a/acceptance/tests/agent/agent_disable_lockfile.rb
+++ b/acceptance/tests/agent/agent_disable_lockfile.rb
@@ -66,8 +66,7 @@ with_puppet_running_on(master, {}) do
 
     step "attempt to run the agent (message: '#{expected_message}')" do
       agents.each do |agent|
-        on(agent, puppet('agent', "--test"),
-                     :acceptable_exit_codes => [1]) do
+        on(agent, puppet('agent', "--test"), :acceptable_exit_codes => [1]) do |result|
           disabled_regex = /administratively disabled.*'#{expected_message}'/
           unless result.stdout =~ disabled_regex
             fail_test("Unexpected output from attempt to run agent disabled; expecting to match '#{disabled_regex}', got '#{result.stdout}' on agent '#{agent}'") unless agent['locale'] == 'ja'

--- a/acceptance/tests/environment/can_enumerate_environments.rb
+++ b/acceptance/tests/environment/can_enumerate_environments.rb
@@ -65,8 +65,8 @@ with_puppet_running_on(master, master_opts) do
   end
 
   step "Ensure that an authenticated client can retrieve the list of environments" do
-    curl_master_from(master, '/puppet/v3/environments') do
-      data = JSON.parse(stdout)
+    curl_master_from(master, '/puppet/v3/environments') do |result|
+      data = JSON.parse(result.stdout)
       assert_equal(["env1", "env2", "production"], data["environments"].keys.sort)
     end
   end

--- a/acceptance/tests/environment/directory_environment_production_created_master.rb
+++ b/acceptance/tests/environment/directory_environment_production_created_master.rb
@@ -34,9 +34,9 @@ with_puppet_running_on(master, master_opts, testdir) do
 
   step 'ensure catalog returned from production env with no changes'
   agents.each do |agent|
-    on(agent, puppet("agent -t --environment production --detailed-exitcodes")) do
+    on(agent, puppet("agent -t --environment production --detailed-exitcodes")) do |result|
       # detailed-exitcodes produces a 0 when no changes are made.
-      assert_equal(0, exit_code)
+      assert_equal(0, result.exit_code)
     end
   end
 end

--- a/acceptance/tests/pluginsync/7316_faces_with_app_stubs_should_be_available_via_pluginsync.rb
+++ b/acceptance/tests/pluginsync/7316_faces_with_app_stubs_should_be_available_via_pluginsync.rb
@@ -133,7 +133,7 @@ begin
 
   step "verify that the application shows up in help" do
     agents.each do |agent|
-      on(agent, PuppetCommand.new(:help, "--libdir=\"#{get_test_file_path(agent, agent_lib_dir)}\"")) do
+      on(agent, PuppetCommand.new(:help, "--libdir=\"#{get_test_file_path(agent, agent_lib_dir)}\"")) do |result|
         assert_match(/^\s+#{app_name}\s+#{app_desc % "face"}/, result.stdout)
       end
     end
@@ -141,7 +141,7 @@ begin
 
   step "verify that we can run the application" do
     agents.each do |agent|
-      on(agent, PuppetCommand.new(:"#{app_name}", "--libdir=\"#{get_test_file_path(agent, agent_lib_dir)}\"")) do
+      on(agent, PuppetCommand.new(:"#{app_name}", "--libdir=\"#{get_test_file_path(agent, agent_lib_dir)}\"")) do |result|
         assert_match(/^#{app_output % "face"}/, result.stdout)
       end
     end

--- a/acceptance/tests/resource/service/should_query_all.rb
+++ b/acceptance/tests/resource/service/should_query_all.rb
@@ -8,7 +8,7 @@ tag 'audit:high',
 agents.each do |agent|
   step "query with puppet"
   on(agent, puppet_resource('service'), :accept_all_exit_codes => true) do |result|
-    assert_equal(exit_code, 0, "'puppet resource service' should have an exit code of 0")
+    assert_equal(result.exit_code, 0, "'puppet resource service' should have an exit code of 0")
     assert(/^service/ =~ result.stdout, "'puppet resource service' should present service details")
   end
 end

--- a/acceptance/tests/ticket_13948_lib_dir_hook_should_be_called_on_initialization.rb
+++ b/acceptance/tests/ticket_13948_lib_dir_hook_should_be_called_on_initialization.rb
@@ -137,7 +137,7 @@ begin
 
   step "verify that the application shows up in help" do
     agents.each do |agent|
-      on(agent, PuppetCommand.new(:help, "--vardir=\"#{get_test_file_path(agent, agent_var_dir)}\"")) do
+      on(agent, PuppetCommand.new(:help, "--vardir=\"#{get_test_file_path(agent, agent_var_dir)}\"")) do |result|
         assert_match(/^\s+#{app_name}\s+#{app_desc % "face"}/, result.stdout)
       end
     end
@@ -145,7 +145,7 @@ begin
 
   step "verify that we can run the application" do
     agents.each do |agent|
-      on(agent, PuppetCommand.new(:"#{app_name}", "--vardir=\"#{get_test_file_path(agent, agent_var_dir)}\"")) do
+      on(agent, PuppetCommand.new(:"#{app_name}", "--vardir=\"#{get_test_file_path(agent, agent_var_dir)}\"")) do |result|
         assert_match(/^#{app_output % "face"}/, result.stdout)
       end
     end


### PR DESCRIPTION
Previously in Beaker, you could use standalone stdout and stderr methods to access output from remote machines.

These methods were deprecated in 2013 with voxpupuli/beaker@28b2510 and dropped entirely in voxpupuli/beaker@73a31c7.

This commit updates any methods that were initially missed in the first pass of this work in commit 9f5f8e5.