### PR TITLE
Drop specs when building gem

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -7,10 +7,10 @@ summary: 'Puppet, an automated configuration management tool'
 description: 'Puppet, an automated configuration management tool'
 version_file: 'lib/puppet/version.rb'
 # files and gem_files are space separated lists
-files: '[A-Z]* install.rb bin lib conf man examples ext tasks spec locales'
-# Make sure these gem requirements are in sync with the gempspec and Gemfile
-gem_files: '[A-Z]* install.rb bin lib conf man examples ext tasks spec locales'
-gem_test_files: 'spec/**/*'
+files: '[A-Z]* install.rb bin lib conf man examples ext tasks locales'
+# Make sure these gem requirements are in sync with the gemspec and Gemfile
+gem_files: '[A-Z]* install.rb bin lib conf man examples ext tasks locales'
+gem_test_files:
 gem_executables: 'puppet'
 gem_default_executables: 'puppet'
 gem_license: 'Apache-2.0'


### PR DESCRIPTION
Previously our key and cert test fixtures were shipped in the gem, which
triggered security scanners. This deletes the `spec` directory from each
platform specific gem and reduces the size of each gem by about 1MB when
using the `bundle exec rake package:gem` task:

Before:

```
$ ls -la pkg/puppet-8.4.0.178.gem
-rw-rw-r-- 1 josh 1.5M Feb  9 11:21 pkg/puppet-8.4.0.178.gem
```

After:

```
$ ls -la pkg/puppet-8.4.0.177.gem
-rw-rw-r-- 1 josh 2.8M Feb  9 11:21 pkg/puppet-8.4.0.177.gem
```

For reasons described in PA-5400 we don't currently use `gem build .gemspec`
to build puppet gems.

No changes are needed to the .gemspec or Gemfile, because they both
include the content from project_data.yaml.