### PR TITLE
Return boolean instead of Beaker::Result

### DIFF
--- a/acceptance/tests/resource/service/init_on_systemd.rb
+++ b/acceptance/tests/resource/service/init_on_systemd.rb
@@ -1,9 +1,8 @@
 test_name 'SysV on default Systemd Service Provider Validation' do
 
   confine :to, :platform => /el-[6-8]|centos|fedora-(2[0-9])/ do |h|
-    on(h, 'which systemctl', :acceptable_exit_codes => [0, 1]) do |result|
-      result.stdout =~ /systemctl/
-    end
+    result = on(h, 'which systemctl', :acceptable_exit_codes => [0, 1])
+    result.stdout =~ /systemctl/
   end
 
   tag 'audit:high',


### PR DESCRIPTION
Commit 9f5f8e5a eliminated the global `stdout`, but changed the block to return whatever the `on` method returned (which was a Beaker::Result object). Since the object is truthy, RHEL6 wasn't excluded.

This needs to be backported to 7.x