### PR TITLE
Add options for failing resource check on command line

### DIFF
--- a/lib/puppet/application/resource.rb
+++ b/lib/puppet/application/resource.rb
@@ -236,8 +236,11 @@ class Puppet::Application::Resource < Puppet::Application
           resource = Puppet::Resource.new(type, name, :parameters => params)
 
           # save returns [resource that was saved, transaction log from applying the resource]
-          save_result = Puppet::Resource.indirection.save(resource, key)
-          [save_result.first]
+          save_result, report = Puppet::Resource.indirection.save(resource, key)
+          status = report.resource_statuses[resource.ref]
+          raise "Failed to manage resource #{resource.ref}" if status&.failed?
+
+          [save_result]
         end
       else
         if type == "file"

--- a/lib/puppet/application/resource.rb
+++ b/lib/puppet/application/resource.rb
@@ -15,6 +15,7 @@ class Puppet::Application::Resource < Puppet::Application
   option("--verbose", "-v")
   option("--edit", "-e")
   option("--to_yaml", "-y")
+  option('--fail', '-f')
 
   option("--types", "-t") do |_arg|
     env = Puppet.lookup(:environments).get(Puppet[:environment]) || create_default_environment
@@ -108,6 +109,9 @@ class Puppet::Application::Resource < Puppet::Application
       * --to_yaml:
         Output found resources in yaml format, suitable to use with Hiera and
         create_resources.
+
+      * --fail:
+        Fails and returns an exit code of 1 if the resource is not found.
 
       EXAMPLE
       -------
@@ -238,7 +242,7 @@ class Puppet::Application::Resource < Puppet::Application
           # save returns [resource that was saved, transaction log from applying the resource]
           save_result, report = Puppet::Resource.indirection.save(resource, key)
           status = report.resource_statuses[resource.ref]
-          raise "Failed to manage resource #{resource.ref}" if status&.failed?
+          raise "Failed to manage resource #{resource.ref}" if status&.failed? && !options[:fail].nil? && options[:fail]
 
           [save_result]
         end

--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -165,6 +165,20 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
     end
   end
 
+  # override base#status
+  def status
+    if exist?
+      status = service_command(:status, false)
+      if status.exitstatus == 0
+        return :running
+      else
+        return :stopped
+      end
+    else
+      return :absent
+    end
+  end
+
   def enable
     self.unmask
     systemctl_change_enable(:enable)

--- a/lib/puppet/provider/service/windows.rb
+++ b/lib/puppet/provider/service/windows.rb
@@ -90,7 +90,7 @@ Puppet::Type.type(:service).provide :windows, :parent => :service do
   end
 
   def status
-    return :stopped unless Puppet::Util::Windows::Service.exists?(@resource[:name])
+    return :absent unless Puppet::Util::Windows::Service.exists?(@resource[:name])
 
     current_state = Puppet::Util::Windows::Service.service_state(@resource[:name])
     state = case current_state

--- a/lib/puppet/type/service.rb
+++ b/lib/puppet/type/service.rb
@@ -110,6 +110,12 @@ module Puppet
         provider.start
       end
 
+      newvalue(:absent)
+
+      validate do |val|
+        fail "Managing absent on a service is not supported" if val.to_s == 'absent'
+      end
+
       aliasvalue(:false, :stopped)
       aliasvalue(:true, :running)
 

--- a/spec/unit/application/resource_spec.rb
+++ b/spec/unit/application/resource_spec.rb
@@ -118,12 +118,19 @@ describe Puppet::Application::Resource do
       @resource_app.main
     end
 
+    before :each do
+      allow(@res).to receive(:ref).and_return("type/name")
+    end
+
     it "should add given parameters to the object" do
       allow(@resource_app.command_line).to receive(:args).and_return(['type','name','param=temp'])
 
       expect(Puppet::Resource.indirection).to receive(:save).with(@res, 'type/name').and_return([@res, @report])
       expect(Puppet::Resource).to receive(:new).with('type', 'name', {:parameters => {'param' => 'temp'}}).and_return(@res)
 
+      resource_status = instance_double('Puppet::Resource::Status')
+      allow(@report).to receive(:resource_statuses).and_return({'type/name' => resource_status})
+      allow(resource_status).to receive(:failed?).and_return(false)
       @resource_app.main
     end
   end
@@ -140,11 +147,13 @@ describe Puppet::Application::Resource do
         true
       end
 
+      def string=(value)
+      end
+
       def string
         Puppet::Util::Execution::ProcessOutput.new('test', 0)
       end
     end
-    
     it "should not emit puppet class tags when printing yaml when strict mode is off" do
       Puppet[:strict] = :warning
 

--- a/spec/unit/provider/service/windows_spec.rb
+++ b/spec/unit/provider/service/windows_spec.rb
@@ -81,10 +81,10 @@ describe 'Puppet::Type::Service::Provider::Windows',
   end
 
   describe "#status" do
-    it "should report a nonexistent service as stopped" do
+    it "should report a nonexistent service as absent" do
       allow(service_util).to receive(:exists?).with(resource[:name]).and_return(false)
 
-      expect(provider.status).to eql(:stopped)
+      expect(provider.status).to eql(:absent)
     end
 
     it "should report service as stopped when status cannot be retrieved" do

--- a/spec/unit/type/service_spec.rb
+++ b/spec/unit/type/service_spec.rb
@@ -67,6 +67,12 @@ describe test_title, "when validating attribute values" do
     expect(svc.should(:ensure)).to eq(:stopped)
   end
 
+  describe 'the absent property' do
+    it 'should fail validate if it is a service' do
+      expect { Puppet::Type.type(:service).new(:name => "service_name", :ensure => :absent) }.to raise_error(Puppet::Error, /Managing absent on a service is not supported/)
+    end
+  end
+
   describe "the enable property" do
     before :each do
       allow(@provider.class).to receive(:supports_parameter?).and_return(true)


### PR DESCRIPTION
When running `puppet resource service`, and the service does not exist, the application will return a 0 exit code and display that the service is not running.
This PR introduces a new option for the `puppet resource service` application, `--fail`, if the service is not found and the option is used, the application will return with a non-zero exit code, and display an error message.
Example of use:

```
[root@potent-image ~]# puppet resource service made_up_service ensure=running --fail
Error: Systemd start for made_up_service failed!
journalctl log for made_up_service:
-- No entries --

Error: /Service[made_up_service]/ensure: change from 'absent' to 'running' failed: Systemd start for made_up_service failed!
journalctl log for made_up_service:
-- No entries --

Error: Could not run: Failed to manage resource Service[made_up_service]
[root@potent-image ~]# echo $?
1
```

Here is an example without the flag:
```
[root@potent-image ~]# puppet resource service made_up_service ensure=running
Error: Systemd start for made_up_service failed!
journalctl log for made_up_service:
-- No entries --

Error: /Service[made_up_service]/ensure: change from 'absent' to 'running' failed: Systemd start for made_up_service failed!
journalctl log for made_up_service:
-- No entries --
[root@potent-image ~]# echo $?
0
```