### PR TITLE
(packaging) Bump to version '8.6.0' [no-promote]

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -16,7 +16,7 @@
 
 Gem::Specification.new do |s|
   s.name = "puppet"
-  version = "8.5.0x"
+  version = "8.6.0"
   mdata = version.match(/(\d+\.\d+\.\d+)/)
   s.version = mdata ? mdata[1] : version
 

--- a/lib/puppet/version.rb
+++ b/lib/puppet/version.rb
@@ -8,7 +8,7 @@
 # Raketasks and such to set the version based on the output of `git describe`
 
 module Puppet
-  PUPPETVERSION = '8.5.0x'
+  PUPPETVERSION = '8.6.0'
 
   ##
   # version is a public API method intended to always provide a fast and


### PR DESCRIPTION
db7c196 accidentally bumped Puppet's version to "8.5.0x" instead of "8.6.0". This commit updates Puppet's version, both in the version file and gemspec, to 8.6.0.