### PR TITLE
Stop installing i18n module from the forge during beaker tests

### DIFF
--- a/acceptance/tests/environment/should_find_existing_production_environment.rb
+++ b/acceptance/tests/environment/should_find_existing_production_environment.rb
@@ -1,5 +1,5 @@
 test_name "should find existing production environment"
-tag 'audit:high'
+tag 'audit:medium'
 
 require 'puppet/acceptance/i18ndemo_utils'
 extend Puppet::Acceptance::I18nDemoUtils

--- a/acceptance/tests/i18n/modules/puppet_agent.rb
+++ b/acceptance/tests/i18n/modules/puppet_agent.rb
@@ -1,7 +1,7 @@
 test_name 'C100565: puppet agent with module should translate messages' do
   confine :except, :platform => /^solaris/ # translation not supported
 
-  tag 'audit:high',
+  tag 'audit:medium',
       'audit:acceptance'
 
   skip_test('i18n test module uses deprecated function; update module to resume testing.')


### PR DESCRIPTION
The 'should_find_existing_production_environment' test is useful and will be re-enabled later using a module fixture.

```
❯ git grep -zl audit:high acceptance/tests | xargs -0 grep -l install_i18n
❯ 
```

This should be backported to 7.x