### PR TITLE
package: pacman provider: Add purgeable feature

### DIFF
--- a/lib/puppet/provider/package/pacman.rb
+++ b/lib/puppet/provider/package/pacman.rb
@@ -25,6 +25,7 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
   has_feature :uninstall_options
   has_feature :upgradeable
   has_feature :virtual_packages
+  has_feature :purgeable
 
   # Checks if a given name is a group
   def self.group?(name)
@@ -191,6 +192,16 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
 
   # Removes a package from the system.
   def uninstall
+    remove_package(false)
+  end
+
+  def purge
+    remove_package(true)
+  end
+
+  private
+
+  def remove_package(purge_configs = false)
     resource_name = @resource[:name]
 
     is_group = self.class.group?(resource_name)
@@ -201,6 +212,7 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
     cmd += uninstall_options if @resource[:uninstall_options]
     cmd << "-R"
     cmd << '-s' if is_group
+    cmd << '--nosave' if purge_configs
     cmd << resource_name
 
     if self.class.yaourt?
@@ -209,8 +221,6 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
       pacman(*cmd)
     end
   end
-
-  private
 
   def install_options
     join_options(@resource[:install_options])

--- a/spec/unit/provider/package/pacman_spec.rb
+++ b/spec/unit/provider/package/pacman_spec.rb
@@ -168,6 +168,14 @@ describe Puppet::Type.type(:package).provider(:pacman) do
     end
   end
 
+  describe "when purging" do
+    it "should call pacman to remove the right package and configs quietly" do
+      args = ["/usr/bin/pacman", "--noconfirm", "--noprogressbar", "-R", "--nosave", resource[:name]]
+      expect(executor).to receive(:execute).with(args, no_extra_options).and_return("")
+      provider.purge
+    end
+  end
+
   describe "when uninstalling" do
     it "should call pacman to remove the right package quietly" do
       args = ["/usr/bin/pacman", "--noconfirm", "--noprogressbar", "-R", resource[:name]]


### PR DESCRIPTION
This small patch adds an option to the pacman provider to purge config files.

From the manpage:

```console
$ pacman -R -h | head -n6
usage:  pacman {-R --remove} [options] <package(s)>
options:
  -b, --dbpath <path>  set an alternate database location
  -c, --cascade        remove packages and all packages that depend on them
  -d, --nodeps         skip dependency version checks (-dd to skip all checks)
  -n, --nosave         remove configuration files
```