### PR TITLE
(PUP-12023) Add option for disabling catalog messages

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -172,6 +172,12 @@ module Puppet
         end
       end
     },
+    :skip_logging_catalog_request_destination => {
+      :default => false,
+      :type    => :boolean,
+      :desc    => "If you wish to suppress the notice of which compiler supplied the
+        catalog",
+    },
     :merge_dependency_warnings => {
       :default => false,
       :type    => :boolean,

--- a/lib/puppet/indirector/catalog/rest.rb
+++ b/lib/puppet/indirector/catalog/rest.rb
@@ -16,12 +16,14 @@ class Puppet::Resource::Catalog::Rest < Puppet::Indirector::REST
     session = Puppet.lookup(:http_session)
     api = session.route_to(:puppet)
 
-    ip_address = begin
-      " (#{Resolv.getaddress(api.url.host)})"
-    rescue Resolv::ResolvError
-      nil
+    unless Puppet.settings[:skip_logging_catalog_request_destination]
+      ip_address = begin
+        " (#{Resolv.getaddress(api.url.host)})"
+      rescue Resolv::ResolvError
+        nil
+      end
+      Puppet.notice("Requesting catalog from #{api.url.host}:#{api.url.port}#{ip_address}")
     end
-    Puppet.notice("Requesting catalog from #{api.url.host}:#{api.url.port}#{ip_address}")
 
     _, catalog = api.post_catalog(
       request.key,


### PR DESCRIPTION
Add's a new Puppet setting, skip_logging_catalog_request_destination, which defaults to false and if set to true when the catalog is compiled Puppet will not output which server supplied the used catalog.