### PR TITLE
Dup frozen strings

### DIFF
--- a/lib/puppet/reference/indirection.rb
+++ b/lib/puppet/reference/indirection.rb
@@ -15,6 +15,9 @@ reference = Puppet::Util::Reference.newreference :indirection, :doc => "Indirect
     text << Puppet::Util::Docs.scrub(ind.doc) + "\n\n"
 
     Puppet::Indirector::Terminus.terminus_classes(ind.name).sort_by(&:to_s).each do |terminus|
+      # this is an "abstract" terminus, ignore it
+      next if ind.name == :resource && terminus == :validator
+
       terminus_name = terminus.to_s
       term_class = Puppet::Indirector::Terminus.terminus_class(ind.name, terminus)
       if term_class

--- a/lib/puppet/reference/metaparameter.rb
+++ b/lib/puppet/reference/metaparameter.rb
@@ -14,7 +14,7 @@ etc.), prevent Puppet from making changes (`noop`), and change logging verbosity
 
 ## Available Metaparameters
 
-}
+  }.dup
   begin
     params = []
     Puppet::Type.eachmetaparam { |param|

--- a/lib/puppet/reference/providers.rb
+++ b/lib/puppet/reference/providers.rb
@@ -13,7 +13,7 @@ providers = Puppet::Util::Reference.newreference :providers, :title => "Provider
   command_line = Puppet::Util::CommandLine.new
   types.reject! { |type| !command_line.args.include?(type.name.to_s) } unless command_line.args.empty?
 
-  ret = "Details about this host:\n\n"
+  ret = "Details about this host:\n\n".dup
 
   # Throw some facts in there, so we know where the report is from.
   ret << option('Ruby Version', Facter.value('ruby.version'))

--- a/lib/puppet/reference/type.rb
+++ b/lib/puppet/reference/type.rb
@@ -50,7 +50,7 @@ Puppet::Util::Reference.newreference :type, :doc => "All Puppet resource types a
   Resource types define features they can use, and providers can be tested to see
   which features they provide.
 
-  }
+  }.dup
 
   types.sort_by(&:to_s).each { |name, type|
     str << "

--- a/spec/integration/application/doc_spec.rb
+++ b/spec/integration/application/doc_spec.rb
@@ -14,11 +14,21 @@ describe Puppet::Application::Doc do
      .and output(/configuration - A reference for all settings/).to_stdout
   end
 
-  it 'generates markdown' do
-    app.command_line.args = ['-r', 'report']
-    expect {
-      app.run
-    }.to exit_with(0)
-     .and output(/# Report Reference/).to_stdout
+  {
+    'configuration' => /# Configuration Reference/,
+    'function'      => /# Function Reference/,
+    'indirection'   => /# Indirection Reference/,
+    'metaparameter' => /# Metaparameter Reference/,
+    'providers'     => /# Provider Suitability Report/,
+    'report'        => /# Report Reference/,
+    'type'          => /# Type Reference/
+  }.each_pair do |type, expected|
+    it "generates #{type} reference" do
+      app.command_line.args = ['-r', type]
+      expect {
+        app.run
+      }.to exit_with(0)
+       .and output(expected).to_stdout
+    end
   end
 end


### PR DESCRIPTION
Some of the `puppet doc --reference <name>` commands failed after the switch to frozen literal strings. This dups strings in the same way we did in fb20023e1e2 and adds missing tests.

Also ignore the validator terminus for the resource model when generating docs.