### PR TITLE
(PUP-11655) Use run_mode for better platform independence

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -47,29 +47,15 @@ module Puppet
   end
 
   def self.default_basemodulepath
-    if Puppet::Util::Platform.windows?
-      path = ['$codedir/modules']
-      installdir = ENV.fetch("FACTER_env_windows_installdir", nil)
-      if installdir
-        path << "#{installdir}/puppet/modules"
-      end
-      path.join(File::PATH_SEPARATOR)
-    else
-      '$codedir/modules:/opt/puppetlabs/puppet/modules'
+    path = ['$codedir/modules']
+    if (run_mode_dir = Puppet.run_mode.common_module_dir)
+      path << run_mode_dir
     end
+    path.join(File::PATH_SEPARATOR)
   end
 
   def self.default_vendormoduledir
-    if Puppet::Util::Platform.windows?
-      installdir = ENV.fetch("FACTER_env_windows_installdir", nil)
-      if installdir
-        "#{installdir}\\puppet\\vendor_modules"
-      else
-        nil
-      end
-    else
-      '/opt/puppetlabs/puppet/vendor_modules'
-    end
+    Puppet.run_mode.vendor_module_dir
   end
 
   ############################################################################################

--- a/lib/puppet/provider/package/gem.rb
+++ b/lib/puppet/provider/package/gem.rb
@@ -83,6 +83,7 @@ Puppet::Type.type(:package).provide :gem, :parent => Puppet::Provider::Package::
       custom_environment[:PATH] = windows_path_without_puppet_bin
     end
 
+    # This uses an unusual form of passing the command and args as [<cmd>, [<arg1>, <arg2>, ...]]
     execute(cmd, { :failonfail => true, :combine => true, :custom_environment => custom_environment })
   end
 

--- a/lib/puppet/provider/package/puppet_gem.rb
+++ b/lib/puppet/provider/package/puppet_gem.rb
@@ -8,20 +8,7 @@ Puppet::Type.type(:package).provide :puppet_gem, :parent => :gem do
 
   confine :true => Puppet.runtime[:facter].value(:aio_agent_version)
 
-  def self.windows_gemcmd
-    puppet_dir = ENV.fetch('PUPPET_DIR', nil)
-    if puppet_dir
-      File.join(puppet_dir.to_s, 'bin', 'gem.bat')
-    else
-      File.join(Gem.default_bindir, 'gem.bat')
-    end
-  end
-
-  if Puppet::Util::Platform.windows?
-    commands :gemcmd => windows_gemcmd
-  else
-    commands :gemcmd => "/opt/puppetlabs/puppet/bin/gem"
-  end
+  commands :gemcmd => Puppet.run_mode.gem_cmd
 
   def uninstall
     super
@@ -30,7 +17,9 @@ Puppet::Type.type(:package).provide :puppet_gem, :parent => :gem do
   end
 
   def self.execute_gem_command(command, command_options, custom_environment = {})
-    custom_environment['PKG_CONFIG_PATH'] = '/opt/puppetlabs/puppet/lib/pkgconfig' unless Puppet::Util::Platform.windows?
+    if (pkg_config_path = Puppet.run_mode.pkg_config_path)
+      custom_environment['PKG_CONFIG_PATH'] = pkg_config_path
+    end
     super(command, command_options, custom_environment)
   end
 end

--- a/lib/puppet/util/run_mode.rb
+++ b/lib/puppet/util/run_mode.rb
@@ -87,6 +87,22 @@ module Puppet
       def log_dir
         which_dir("/var/log/puppetlabs/puppet", "~/.puppetlabs/var/log")
       end
+
+      def pkg_config_path
+        '/opt/puppetlabs/puppet/lib/pkgconfig'
+      end
+
+      def gem_cmd
+        '/opt/puppetlabs/puppet/bin/gem'
+      end
+
+      def common_module_dir
+        '/opt/puppetlabs/puppet/modules'
+      end
+
+      def vendor_module_dir
+        '/opt/puppetlabs/puppet/vendor_modules'
+      end
     end
 
     class WindowsRunMode < RunMode
@@ -114,7 +130,31 @@ module Puppet
         which_dir(File.join(windows_common_base("puppet/var/log")), "~/.puppetlabs/var/log")
       end
 
+      def pkg_config_path
+        nil
+      end
+
+      def gem_cmd
+        if (puppet_dir = ENV.fetch('PUPPET_DIR', nil))
+          File.join(puppet_dir.to_s, 'bin', 'gem.bat')
+        else
+          File.join(Gem.default_bindir, 'gem.bat')
+        end
+      end
+
+      def common_module_dir
+        "#{installdir}/puppet/modules" if installdir
+      end
+
+      def vendor_module_dir
+        "#{installdir}\\puppet\\vendor_modules" if installdir
+      end
+
       private
+
+      def installdir
+        ENV.fetch('FACTER_env_windows_installdir', nil)
+      end
 
       def windows_common_base(*extra)
         [ENV.fetch('ALLUSERSPROFILE', nil), "PuppetLabs"] + extra

--- a/spec/unit/provider/package/puppet_gem_spec.rb
+++ b/spec/unit/provider/package/puppet_gem_spec.rb
@@ -42,32 +42,6 @@ describe Puppet::Type.type(:package).provider(:puppet_gem) do
     allow(File).to receive(:file?).with(provider_gem_cmd).and_return(true)
   end
 
-  describe '.windows_gemcmd' do
-    context 'when PUPPET_DIR is not set' do
-      before do
-        # allow(ENV).to receive(:fetch, anything).and_call_original
-        allow(ENV).to receive(:fetch).with('PUPPET_DIR', anything).and_return(nil)
-        allow(Gem).to receive(:default_bindir).and_return('default_gem_bin')
-      end
-
-      it 'uses Gem.default_bindir' do
-        expected_path = File.join('default_gem_bin', 'gem.bat')
-        expect(described_class.windows_gemcmd).to eql(expected_path)
-      end
-    end
-
-    context 'when PUPPET_DIR is set' do
-      before do
-        allow(ENV).to receive(:fetch).with('PUPPET_DIR', anything).and_return('puppet_dir')
-      end
-
-      it 'uses Gem.default_bindir' do
-        expected_path = File.join('puppet_dir', 'bin', 'gem.bat')
-        expect(described_class.windows_gemcmd).to eql(expected_path)
-      end
-    end
-  end
-
   context "when installing" do
     before :each do
       allow(provider).to receive(:rubygem_version).and_return('1.9.9')
@@ -133,5 +107,4 @@ describe Puppet::Type.type(:package).provider(:puppet_gem) do
       it { is_expected.to be > 100 }
     end
   end
-
 end

--- a/spec/unit/provider/package/puppet_gem_spec.rb
+++ b/spec/unit/provider/package/puppet_gem_spec.rb
@@ -20,17 +20,27 @@ describe Puppet::Type.type(:package).provider(:puppet_gem) do
     let(:provider_gem_cmd) { '/opt/puppetlabs/puppet/bin/gem' }
   end
 
-  custom_environment = {"HOME"=>ENV["HOME"]}
-  custom_environment['PKG_CONFIG_PATH'] = '/opt/puppetlabs/puppet/lib/pkgconfig'
-
-  let(:execute_options) { {:failonfail => true, :combine => true, :custom_environment => custom_environment} }
+  let(:execute_options) do
+    {
+      failonfail: true,
+      combine: true,
+      custom_environment: {
+        'HOME'=>ENV['HOME'],
+        'PKG_CONFIG_PATH' => '/opt/puppetlabs/puppet/lib/pkgconfig'
+      }
+    }
+  end
 
   before :each do
     resource.provider = provider
-    allow(described_class).to receive(:command).with(:gemcmd).and_return(provider_gem_cmd)
-    allow(Puppet::Util::Platform).to receive(:windows?).and_return(false)
+    if Puppet::Util::Platform.windows?
+      # provider is loaded before we can stub, so stub the class we're testing
+      allow(provider.class).to receive(:command).with(:gemcmd).and_return(provider_gem_cmd)
+    else
+      allow(provider.class).to receive(:which).with(provider_gem_cmd).and_return(provider_gem_cmd)
+    end
+    allow(File).to receive(:file?).with(provider_gem_cmd).and_return(true)
   end
-
 
   describe '.windows_gemcmd' do
     context 'when PUPPET_DIR is not set' do
@@ -64,45 +74,43 @@ describe Puppet::Type.type(:package).provider(:puppet_gem) do
     end
 
     it "should use the path to the gem command" do
-      allow(described_class).to receive(:validate_command).with(provider_gem_cmd)
-      expect(described_class).to receive(:execute).with(be_a(Array), execute_options) { |args| expect(args[0]).to eq(provider_gem_cmd) }.and_return('')
+      expect(described_class).to receive(:execute).with([provider_gem_cmd, be_an(Array)], be_a(Hash)).and_return('')
       provider.install
     end
 
     it "should not append install_options by default" do
-      expect(described_class).to receive(:execute_gem_command).with(provider_gem_cmd, %w{install --no-rdoc --no-ri myresource}).and_return('')
+      expect(described_class).to receive(:execute).with([provider_gem_cmd, %w{install --no-rdoc --no-ri myresource}], anything).and_return('')
       provider.install
     end
 
     it "should allow setting an install_options parameter" do
       resource[:install_options] = [ '--force', {'--bindir' => '/usr/bin' } ]
-      expect(described_class).to receive(:execute_gem_command).with(provider_gem_cmd, %w{install --force --bindir=/usr/bin --no-rdoc --no-ri myresource}).and_return('')
+      expect(described_class).to receive(:execute).with([provider_gem_cmd, %w{install --force --bindir=/usr/bin --no-rdoc --no-ri myresource}], anything).and_return('')
       provider.install
     end
   end
 
   context "when uninstalling" do
     it "should use the path to the gem command" do
-      allow(described_class).to receive(:validate_command).with(provider_gem_cmd)
-      expect(described_class).to receive(:execute).with(be_a(Array), execute_options) { |args| expect(args[0]).to eq(provider_gem_cmd) }.and_return('')
+      expect(described_class).to receive(:execute).with([provider_gem_cmd, be_an(Array)], be_a(Hash)).and_return('')
       provider.uninstall
     end
 
     it "should not append uninstall_options by default" do
-      expect(described_class).to receive(:execute_gem_command).with(provider_gem_cmd, %w{uninstall --executables --all myresource}).and_return('')
+      expect(described_class).to receive(:execute).with([provider_gem_cmd, %w{uninstall --executables --all myresource}], anything).and_return('')
       provider.uninstall
     end
 
     it "should allow setting an uninstall_options parameter" do
       resource[:uninstall_options] = [ '--force', {'--bindir' => '/usr/bin' } ]
-      expect(described_class).to receive(:execute_gem_command).with(provider_gem_cmd, %w{uninstall --executables --all myresource --force --bindir=/usr/bin}).and_return('')
+      expect(described_class).to receive(:execute).with([provider_gem_cmd, %w{uninstall --executables --all myresource --force --bindir=/usr/bin}], anything).and_return('')
       provider.uninstall
     end
 
     it 'should invalidate the rubygems cache' do
       gem_source = double('gem_source')
       allow(Puppet::Util::Autoload).to receive(:gem_source).and_return(gem_source)
-      expect(described_class).to receive(:execute_gem_command).with(provider_gem_cmd, %w{uninstall --executables --all myresource}).and_return('')
+      expect(described_class).to receive(:execute).with([provider_gem_cmd, %w{uninstall --executables --all myresource}], anything).and_return('')
       expect(gem_source).to receive(:clear_paths)
       provider.uninstall
     end


### PR DESCRIPTION
The run mode already determines the platform. Moving all platform specific paths into RunMode makes it easier to get a complete overview and change things where needed.

@ekohl originally filed this #8938. I've retargeted his commit for `main` and updated some spec failures.