### PR TITLE
(#9292) New command line flag for puppet resource, fail

### DIFF
--- a/lib/puppet/application/resource.rb
+++ b/lib/puppet/application/resource.rb
@@ -15,6 +15,7 @@ class Puppet::Application::Resource < Puppet::Application
   option("--verbose", "-v")
   option("--edit", "-e")
   option("--to_yaml", "-y")
+  option('--fail', '-f')
 
   option("--types", "-t") do |_arg|
     env = Puppet.lookup(:environments).get(Puppet[:environment]) || create_default_environment
@@ -108,6 +109,9 @@ class Puppet::Application::Resource < Puppet::Application
       * --to_yaml:
         Output found resources in yaml format, suitable to use with Hiera and
         create_resources.
+
+      * --fail:
+        Fails and returns an exit code of 1 if the resource could not be modified.
 
       EXAMPLE
       -------
@@ -236,8 +240,11 @@ class Puppet::Application::Resource < Puppet::Application
           resource = Puppet::Resource.new(type, name, :parameters => params)
 
           # save returns [resource that was saved, transaction log from applying the resource]
-          save_result = Puppet::Resource.indirection.save(resource, key)
-          [save_result.first]
+          save_result, report = Puppet::Resource.indirection.save(resource, key)
+          status = report.resource_statuses[resource.ref]
+          raise "Failed to manage resource #{resource.ref}" if status&.failed? && options[:fail]
+
+          [save_result]
         end
       else
         if type == "file"

--- a/spec/unit/application/resource_spec.rb
+++ b/spec/unit/application/resource_spec.rb
@@ -118,12 +118,19 @@ describe Puppet::Application::Resource do
       @resource_app.main
     end
 
+    before :each do
+      allow(@res).to receive(:ref).and_return("type/name")
+    end
+
     it "should add given parameters to the object" do
       allow(@resource_app.command_line).to receive(:args).and_return(['type','name','param=temp'])
 
       expect(Puppet::Resource.indirection).to receive(:save).with(@res, 'type/name').and_return([@res, @report])
       expect(Puppet::Resource).to receive(:new).with('type', 'name', {:parameters => {'param' => 'temp'}}).and_return(@res)
 
+      resource_status = instance_double('Puppet::Resource::Status')
+      allow(@report).to receive(:resource_statuses).and_return({'type/name' => resource_status})
+      allow(resource_status).to receive(:failed?).and_return(false)
       @resource_app.main
     end
   end
@@ -138,6 +145,9 @@ describe Puppet::Application::Resource do
     Puppet::Type.type(:stringify).provide(:stringify) do
       def exists?
         true
+      end
+
+      def string=(value)
       end
 
       def string


### PR DESCRIPTION
See discussion in issue #9292.
What this PR adds is the ability for on the command line if --fail is passed then the `puppet resource` command will exit with a non zero return code.