### PR TITLE
Bump CFPropertyList to >= 3.0.6

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -36,7 +36,7 @@ gem_rdoc_options:
 gem_platform_dependencies:
   universal-darwin:
     gem_runtime_dependencies:
-      CFPropertyList: '~> 2.2'
+      CFPropertyList: ['>= 3.0.6', '< 4']
   x86-mingw32:
     gem_runtime_dependencies:
       ffi: '1.15.5'


### PR DESCRIPTION
CFPropertyList up until 3.0.6 used the File.exists? method, which was deprecated in Ruby 2.7 and removed entirely in Ruby 3.2.

Because puppet-agent 8 vendors Ruby 3.2, this commit bumps CFPropertyList's dependency from ~> 2.2 to >= 3.0.6.

See also: https://github.com/puppetlabs/puppet-runtime/commit/0977603530285ce5af113a5378d7a75fb4c8d624