### PR TITLE
Add tests for -noarch

### DIFF
--- a/lib/puppet/util/rpm_compare.rb
+++ b/lib/puppet/util/rpm_compare.rb
@@ -7,7 +7,7 @@ module Puppet::Util::RpmCompare
     armv5tejl armv6l armv7l m68kmint s390 s390x ia64 x86_64 sh3 sh4
   ].freeze
 
-  ARCH_REGEX = Regexp.new('\.' + ARCH_LIST.join('|\.'))
+  ARCH_REGEX = Regexp.new(ARCH_LIST.map { |arch| "\\.#{arch}" }.join('|'))
 
   # This is an attempt at implementing RPM's
   # lib/rpmvercmp.c rpmvercmp(a, b) in Ruby.

--- a/spec/shared_examples/rhel_package_provider.rb
+++ b/spec/shared_examples/rhel_package_provider.rb
@@ -172,6 +172,20 @@ shared_examples "RHEL package provider" do |provider_class, provider_name|
         allow(arch_provider).to receive(:query).and_return(:ensure => version)
         arch_provider.install
       end
+
+      it "does not move '-noarch' to the end of version" do
+        version = '1.2.3'
+        resource = Puppet::Type.type(:package).new(
+          :name => "#{name}-noarch",
+          :ensure => version,
+          :provider =>provider_name
+        )
+        expect(Puppet::Util::Execution).to receive(:execute).with(["/usr/bin/#{provider_name}", '-d', '0', '-e', error_level, '-y', :install, "#{name}-noarch-#{version}"])
+        provider = provider_class.new
+        provider.resource = resource
+        allow(provider).to receive(:query).and_return(:ensure => version)
+        provider.install
+      end
     end
 
     describe 'when uninstalling' do

--- a/spec/unit/util/rpm_compare_spec.rb
+++ b/spec/unit/util/rpm_compare_spec.rb
@@ -172,6 +172,11 @@ describe Puppet::Util::RpmCompare do
       expect([version[:epoch], version[:version], version[:release]]).to \
         eq([nil, '2.2', 'SNAPSHOT20121119105647'])
     end
+
+    it 'parses .noarch' do
+      version = RpmTest.rpm_parse_evr('3.0.12-1.el5.centos.noarch')
+      expect(version[:arch]).to eq('noarch')
+    end
   end
 
   describe '.compare_values' do


### PR DESCRIPTION
Commit 3a548510ee detected cases where the "architecture was in the title of a package and moves it to the end of the version string" such as ".86_64" But the noarch regex matched any occurrence "noarch", including "-noarch". That bug was fixed in commit ca36fc66ae. This commit adds some missing tests and refactors the regex.