### PR TITLE
Flesh out Gemspec description

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -24,7 +24,10 @@ Gem::Specification.new do |s|
   s.required_ruby_version = Gem::Requirement.new(">= 3.1.0")
   s.authors = ["Puppet Labs"]
   s.date = "2012-08-17"
-  s.description = "Puppet, an automated configuration management tool"
+  s.description = <<~EOF
+    Puppet, an automated administrative engine for your Linux, Unix, and Windows systems, performs administrative tasks
+    (such as adding users, installing packages, and updating server configurations) based on a centralized specification.
+  EOF
   s.email = "puppet@puppetlabs.com"
   s.executables = ["puppet"]
   s.files = ["bin/puppet"]


### PR DESCRIPTION
Prior to this commit, Puppet's Gemspec summary and description were identical short, single sentences.

This commit updates Puppet's Gemspec description to a longer explanation of what Puppet does, taken from Puppet's README.