### PR TITLE
Accept ffi >= 1.16.3, < 1.17.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,8 @@ group(:features) do
 end
 
 group(:test) do
-  gem "ffi", '1.15.5', require: false
+  # 1.16.0 - 1.16.2 are broken on Windows
+  gem 'ffi', '>= 1.15.5', '< 1.17.0', '!= 1.16.0', '!= 1.16.1', '!= 1.16.2', require: false
   gem "json-schema", "~> 2.0", require: false
   gem "rake", *location_for(ENV['RAKE_LOCATION'] || '~> 13.0')
   gem "rspec", "~> 3.1", require: false

--- a/puppet.gemspec
+++ b/puppet.gemspec
@@ -38,7 +38,8 @@ Gem::Specification.new do |s|
     end
 
     if platform == 'x64-mingw32' || platform == 'x86-mingw32'
-      s.add_runtime_dependency('ffi', '1.15.5')
+      # ffi 1.16.0 - 1.16.2 are broken on Windows
+      s.add_runtime_dependency('ffi', '>= 1.15.5', '< 1.17.0', '!= 1.16.0', '!= 1.16.1', '!= 1.16.2')
       s.add_runtime_dependency('minitar', '~> 0.9')
     end
 end


### PR DESCRIPTION
ffi 1.16.0 - 1.16.2 had a bug when defining a layout in an FFI::Struct and it was fixed in 1.16.3.

See https://github.com/puppetlabs/facter/pull/2707