### PR TITLE
(bug) - Honour custom insync message in noop mode

### DIFF
--- a/lib/puppet/transaction/resource_harness.rb
+++ b/lib/puppet/transaction/resource_harness.rb
@@ -235,9 +235,13 @@ class Puppet::Transaction::ResourceHarness
   end
 
   def noop(event, param, current_value, audit_message)
-    event.message = param.format(_("current_value %s, should be %s (noop)"),
-                                 param.is_to_s(current_value),
-                                 param.should_to_s(param.should)) + audit_message.to_s
+    if param.sensitive
+      event.message = param.format(_("current_value %s, should be %s (noop)"),
+                                   param.is_to_s(current_value),
+                                   param.should_to_s(param.should)) + audit_message.to_s
+    else
+      event.message = "#{param.change_to_s(current_value, param.should)} (noop)#{audit_message}"
+    end
     event.status = "noop"
   end
 

--- a/spec/unit/transaction/resource_harness_spec.rb
+++ b/spec/unit/transaction/resource_harness_spec.rb
@@ -176,6 +176,10 @@ describe Puppet::Transaction::ResourceHarness do
           def should_to_s(value)
             (@resource.behaviors[:on_should_to_s] || proc { "'#{value}'" }).call
           end
+
+          def change_to_s(value, should)
+            "some custom insync message"
+          end
         end
 
         newparam(:name) do
@@ -249,6 +253,7 @@ describe Puppet::Transaction::ResourceHarness do
       expect(status.events[0].property).to eq('ensure')
       expect(status.events[0].name.to_s).to eq('Testing_created')
       expect(status.events[0].status).to eq('success')
+      expect(status.events[0].message).to eq 'some custom insync message'
     end
 
     it "ensure is in sync means that the rest *does* happen" do
@@ -282,6 +287,14 @@ describe Puppet::Transaction::ResourceHarness do
       expect(resource_errors.length).to eq(1)
       expect(testing_errors[0].message).not_to be_nil
       expect(resource_errors[0].message).not_to eq("Puppet::Util::Log requires a message")
+    end
+
+    it "displays custom insync message in noop" do
+      resource = an_ensurable_resource_reacting_as(:present? => true)
+      resource[:noop] = true
+      status = @harness.evaluate(resource)
+      sync_event = status.events[0]
+      expect(sync_event.message).to eq 'some custom insync message (noop)'
     end
   end
 


### PR DESCRIPTION
Prior to this PR, a custom insync message was not honoured when applying a manifest in `noop` mode. This was later tracked down to the offending `noop` method found in the resource harness class, which did not call the `change_to_s` method to retrieve the custom insync message.

I've updated the method to match that of the `sync` method below, ensuring that the functionality of the custom isync provider feature is not any different whether running puppet in noop or no-noop mode.

Can see the two methods [here](https://github.com/puppetlabs/puppet/blob/ca922ca1f7c1cbd8c28b35a59c126b39b2c90778/lib/puppet/transaction/resource_harness.rb#L237C1-L254C6)

## Additional Context

Have opted out of adding a space between `(noop)` and `audit_message` to match the three other implementations of this in the `sync` and `noop` methods.
