### PR TITLE
(PUP-12040) WIP: Use group* commands instead of lgroup*

### DIFF
--- a/lib/puppet/provider/group/groupadd.rb
+++ b/lib/puppet/provider/group/groupadd.rb
@@ -17,11 +17,11 @@ Puppet::Type.type(:group).provide :groupadd, :parent => Puppet::Provider::NameSe
     value.is_a? Integer
   end
 
-  optional_commands :localadd => "lgroupadd", :localdelete => "lgroupdel", :localmodify => "lgroupmod"
+  optional_commands :localadd => "groupadd", :localdelete => "groupdel", :localmodify => "groupmod"
 
-  has_feature :manages_local_users_and_groups, :manages_members if Puppet.features.libuser?
+  has_feature :manages_local_users_and_groups, :manages_members #if Puppet.features.libuser?
 
-  options :members, :flag => '-M', :method => :mem
+  options :members, :flag => '-aU', :method => :mem
 
   def exists?
     return !!localgid if @resource.forcelocal?


### PR DESCRIPTION
 - Replace lgroup* commands with group* commands.
 - Remove libuser condition since it is now deprecated.
 - Adjust flags as per how groupmod requires them.