### PR TITLE
Update splaylimit during daemon run

### DIFF
--- a/lib/puppet/daemon.rb
+++ b/lib/puppet/daemon.rb
@@ -165,6 +165,7 @@ class Puppet::Daemon
     reparse_run = Puppet::Scheduler.create_job(Puppet[:filetimeout]) do
       Puppet.settings.reparse_config_files
       agent_run.run_interval = Puppet[:runinterval]
+      agent_run.splay_limit = Puppet[:splaylimit] if Puppet[:splay]
       if Puppet[:filetimeout] == 0
         reparse_run.disable
       else

--- a/lib/puppet/scheduler/splay_job.rb
+++ b/lib/puppet/scheduler/splay_job.rb
@@ -25,6 +25,15 @@ module Puppet::Scheduler
       end
     end
 
+    # Recalculates splay.
+    #
+    # @param splay_limit [Integer] the maximum time (in seconds) to delay before an agent's first run.
+    # @return @splay [Integer] a random integer less than or equal to the splay limit that represents the seconds to
+    # delay before next agent run.
+    def splay_limit=(splay_limit)
+      @splay = calculate_splay(splay_limit)
+    end
+
     private
 
     def calculate_splay(limit)

--- a/spec/unit/daemon_spec.rb
+++ b/spec/unit/daemon_spec.rb
@@ -79,6 +79,18 @@ describe Puppet::Daemon, :unless => Puppet::Util::Platform.windows? do
       daemon.start
       expect(scheduler.jobs[0]).not_to be_enabled
     end
+
+    it "recalculates splay if splaylimit changes" do
+      # Set file timeout so the daemon reparses
+      Puppet[:filetimeout] = 1
+      Puppet[:splay] = true
+      allow(agent).to receive(:run)
+      daemon.start
+      first_splay = scheduler.jobs[1].splay
+      allow(Kernel).to receive(:rand).and_return(1738)
+      scheduler.jobs[0].run(Time.now)
+      expect(scheduler.jobs[1].splay).to_not eq(first_splay)
+    end
   end
 
   describe "when stopping" do


### PR DESCRIPTION
Prior to this commit, updates to splay settings in the Puppet configuration file (puppet.conf) would not get picked up in a daemonized Puppet run.

This commit updates the daemon class to call a new public method in the splay job class to update the splaylimit.