### PR TITLE
Remove unnecessary ETC requirement

### DIFF
--- a/lib/puppet/type/user.rb
+++ b/lib/puppet/type/user.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'etc'
 require_relative '../../puppet/parameter/boolean'
 require_relative '../../puppet/property/list'
 require_relative '../../puppet/property/ordered_list'


### PR DESCRIPTION
When the user type was originally created, it used methods from the ETC module. That code was removed in 12452ee in 2006, so we no longer need to require ETC.