### PR TITLE
Update JRuby in tests to 9.4.8.0

### DIFF
--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -19,7 +19,7 @@ jobs:
           - {os: ubuntu-latest, ruby: '3.1'}
           - {os: ubuntu-20.04, ruby: '3.2'} # openssl 1.1.1
           - {os: ubuntu-22.04, ruby: '3.2'} # openssl 3
-          - {os: ubuntu-latest, ruby: 'jruby-9.4.3.0'}
+          - {os: ubuntu-latest, ruby: 'jruby-9.4.8.0'}
           - {os: windows-2019, ruby: '3.1'}
           - {os: windows-2019, ruby: '3.2'} # openssl 3
 

--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -593,9 +593,7 @@ class Puppet::Node::Environment
       if file == NO_MANIFEST
         empty_parse_result
       elsif File.directory?(file)
-        # JRuby does not properly perform Dir.glob operations with wildcards, (see PUP-11788 and https://github.com/jruby/jruby/issues/7836).
-        # We sort the results because Dir.glob order is inconsistent in Ruby < 3 (see PUP-10115).
-        parse_results = Puppet::FileSystem::PathPattern.absolute(File.join(file, '**/*')).glob.select { |globbed_file| globbed_file.end_with?('.pp') }.sort.map do |file_to_parse|
+        parse_results = Puppet::FileSystem::PathPattern.absolute(File.join(file, '**/*.pp')).glob.map do |file_to_parse|
           parser.file = file_to_parse
           parser.parse
         end

--- a/spec/unit/file_system/path_pattern_spec.rb
+++ b/spec/unit/file_system/path_pattern_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 require 'puppet_spec/files'
 require 'puppet/file_system'
-require 'puppet/util'
 
 describe Puppet::FileSystem::PathPattern do
   include PuppetSpec::Files
@@ -134,9 +133,6 @@ describe Puppet::FileSystem::PathPattern do
   end
 
   it 'globs wildcard patterns properly' do
-    # See PUP-11788 and https://github.com/jruby/jruby/issues/7836.
-    pending 'JRuby does not properly handle Dir.glob' if Puppet::Util::Platform.jruby?
-
     dir = tmpdir('globtest')
     create_file_in(dir, 'foo.pp')
     create_file_in(dir, 'foo.pp.pp')

--- a/spec/unit/pops/types/string_converter_spec.rb
+++ b/spec/unit/pops/types/string_converter_spec.rb
@@ -316,7 +316,6 @@ describe 'The string converter' do
       '%.1f'    => '18.0',
     }.each do |fmt, result |
       it "the format #{fmt} produces #{result}" do
-        pending("PUP-8612 %a and %A not support on JRuby") if RUBY_PLATFORM == 'java' && fmt =~ /^%[aA]$/
         string_formats = { Puppet::Pops::Types::PIntegerType::DEFAULT => fmt}
         expect(converter.convert(18, string_formats)).to eq(result)
       end
@@ -410,7 +409,6 @@ describe 'The string converter' do
       '%#B'     => '0B10010',
     }.each do |fmt, result |
       it "the format #{fmt} produces #{result}" do
-        pending("PUP-8612 %a and %A not support on JRuby") if RUBY_PLATFORM == 'java' && fmt =~ /^%[-.014]*[aA]$/
         string_formats = { Puppet::Pops::Types::PFloatType::DEFAULT => fmt}
         expect(converter.convert(18.0, string_formats)).to eq(result)
       end
@@ -587,7 +585,6 @@ describe 'The string converter' do
       "%#Y"  => 'Y',
     }.each do |fmt, result |
       it "the format #{fmt} produces #{result}" do
-        pending("PUP-8612 %a and %A not support on JRuby") if RUBY_PLATFORM == 'java' && fmt =~ /^%[aA]$/
         string_formats = { Puppet::Pops::Types::PBooleanType::DEFAULT => fmt}
         expect(converter.convert(true, string_formats)).to eq(result)
       end
@@ -634,7 +631,6 @@ describe 'The string converter' do
       "%#Y"  => 'N',
     }.each do |fmt, result |
       it "the format #{fmt} produces #{result}" do
-        pending("PUP-8612 %a and %A not support on JRuby") if RUBY_PLATFORM == 'java' && fmt =~ /^%[aA]$/
         string_formats = { Puppet::Pops::Types::PBooleanType::DEFAULT => fmt}
         expect(converter.convert(false, string_formats)).to eq(result)
       end


### PR DESCRIPTION
This commit updates the version of JRuby used in spec tests from 9.4.3.0 to 9.4.8.0, which matches what is used in the latest version of Puppet Server 8.x. (See: https://github.com/puppetlabs/jruby-utils/commit/0e23173.)

JRuby 9.4.8.0 includes bug fixes to several issues that we have worked around in Puppet in the past:

- Dir.glob not properly supporting wildcard syntax (worked around in  Puppet in https://github.com/puppetlabs/puppet/commit/663062a4fb614eba53c97700b8aa55e32c9bcee5, resolved in JRuby in https://github.com/jruby/jruby/commit/a39cd49).
- format and sprintf not supporting %a and %A (worked around in Puppet  in https://github.com/puppetlabs/puppet/commit/334ea05e4d4885f28420615039042f47f75c9f30, resolved in JRuby in https://github.com/jruby/jruby/pull/7996).

Because of these bug fixes in JRuby, this commit also removes Puppet's workarounds.