### PR TITLE
(PUP-12041) Handle libuser's unavailability in Fedora 40

### DIFF
--- a/spec/unit/provider/group/groupadd_spec.rb
+++ b/spec/unit/provider/group/groupadd_spec.rb
@@ -44,6 +44,10 @@ describe Puppet::Type.type(:group).provider(:groupadd) do
     end
 
     describe "on systems with libuser" do
+      before do
+        allow(Puppet.features).to receive(:libuser?).and_return(true)
+      end
+
       describe "with forcelocal=true" do
         before do
           described_class.has_feature(:manages_local_users_and_groups)
@@ -71,7 +75,7 @@ describe Puppet::Type.type(:group).provider(:groupadd) do
       describe "with a list of members" do
         before do
           members.each { |m| allow(Etc).to receive(:getpwnam).with(m).and_return(true) }
-
+          allow(provider).to receive(:flag).and_return('-M')
           described_class.has_feature(:manages_members)
           resource[:forcelocal] = false
           resource[:members] = members
@@ -92,6 +96,10 @@ describe Puppet::Type.type(:group).provider(:groupadd) do
     end
 
     describe "on systems with libuser" do
+      before do
+        allow(Puppet.features).to receive(:libuser?).and_return(true)
+      end
+
       describe "with forcelocal=false" do
         before do
           described_class.has_feature(:manages_local_users_and_groups)
@@ -156,6 +164,7 @@ describe Puppet::Type.type(:group).provider(:groupadd) do
           before { resource[:auth_membership] = false }
 
           it "should add to the existing users" do
+            allow(provider).to receive(:flag).and_return('-M')
             new_members = ['user1', 'user2', 'user3', 'user4']
             allow(provider).to receive(:members).and_return(members)
             expect(provider).not_to receive(:localmodify).with('-m', members.join(','), 'mygroup')
@@ -236,6 +245,10 @@ describe Puppet::Type.type(:group).provider(:groupadd) do
 
     describe "on systems with the libuser and forcelocal=false" do
       before do
+        allow(Puppet.features).to receive(:libuser?).and_return(true)
+      end
+
+      before do
         described_class.has_feature(:manages_local_users_and_groups)
         resource[:forcelocal] = :false
       end
@@ -247,6 +260,10 @@ describe Puppet::Type.type(:group).provider(:groupadd) do
     end
 
     describe "on systems with the libuser and forcelocal=true" do
+      before do
+        allow(Puppet.features).to receive(:libuser?).and_return(true)
+      end
+
       before do
         described_class.has_feature(:manages_local_users_and_groups)
         resource[:forcelocal] = :true


### PR DESCRIPTION
 - Starting from version 40, Fedora does not have the lgroup* commands available due to deprecation of libuser: https://fedoraproject.org/wiki/Changes/LibuserDeprecation.
 - groupadd relies on libuser to add/purge members to/from groups.
 - Add manages_members feature to Fedora 40 and above since groupmod can add members to groups now. Historically, it was unable to do so that's why puppet used lgroupmod for it.
 - Handle flags for lgroupmod (-M) and groupmod (-aU) commands properly.
 - Only use lgroup* commands if libuser is supported.
 - When libuser is not supported, members should be purged using the usermod command. Since usermod does not support comma separated list of users they should be removed one by one.

(cherry picked from commit 6a1db9e53b721c31e6771f181fb7457a92dc86d7)