### PR TITLE
Bump to JRuby 9.3.14.0, reenable test

### DIFF
--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -20,7 +20,7 @@ jobs:
           - {os: ubuntu-latest, ruby: '2.6'}
           - {os: ubuntu-latest, ruby: '2.7'}
           - {os: ubuntu-latest, ruby: '3.0'}
-          - {os: ubuntu-latest, ruby: 'jruby-9.3.9.0'}
+          - {os: ubuntu-latest, ruby: 'jruby-9.3.14.0'}
           - {os: windows-2019, ruby: '2.5'}
           - {os: windows-2019, ruby: '2.6'}
           - {os: windows-2019, ruby: '2.7'}

--- a/lib/puppet/node/environment.rb
+++ b/lib/puppet/node/environment.rb
@@ -591,12 +591,11 @@ class Puppet::Node::Environment
       if file == NO_MANIFEST
         empty_parse_result
       elsif File.directory?(file)
-        # JRuby does not properly perform Dir.glob operations with wildcards, (see PUP-11788 and https://github.com/jruby/jruby/issues/7836).
         # We sort the results because Dir.glob order is inconsistent in Ruby < 3 (see PUP-10115).
-        parse_results = Puppet::FileSystem::PathPattern.absolute(File.join(file, '**/*')).glob.select {|globbed_file| globbed_file.end_with?('.pp')}.sort.map do | file_to_parse |
-                          parser.file = file_to_parse
-                          parser.parse
-                        end
+        parse_results = Puppet::FileSystem::PathPattern.absolute(File.join(file, '**/*.pp')).glob.sort.map do | file_to_parse |
+          parser.file = file_to_parse
+          parser.parse
+        end
         # Use a parser type specific merger to concatenate the results
         Puppet::Parser::AST::Hostclass.new('', :code => Puppet::Parser::ParserFactory.code_merger.concatenate(parse_results))
       else

--- a/spec/unit/file_system/path_pattern_spec.rb
+++ b/spec/unit/file_system/path_pattern_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 require 'puppet_spec/files'
 require 'puppet/file_system'
-require 'puppet/util'
 
 describe Puppet::FileSystem::PathPattern do
   include PuppetSpec::Files
@@ -134,9 +133,6 @@ describe Puppet::FileSystem::PathPattern do
   end
 
   it 'globs wildcard patterns properly' do
-    # See PUP-11788 and https://github.com/jruby/jruby/issues/7836.
-    pending 'JRuby does not properly handle Dir.glob' if Puppet::Util::Platform.jruby?
-
     dir = tmpdir('globtest')
     create_file_in(dir, 'foo.pp')
     create_file_in(dir, 'foo.pp.pp')


### PR DESCRIPTION
This commit updates JRuby to 9.3.14.0 in tests. This version of JRuby addresses a bug with Dir.glob (see jruby/jruby@5b06409) that we had previously worked around in both code and tests (see 663062a). Because the Dir.glob bug has now been addressed, this commit also removes the workarounds we had added.