### PR TITLE
fast_gettext: Allow 3.x

### DIFF
--- a/puppet.gemspec
+++ b/puppet.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.specification_version = 4
   spec.add_runtime_dependency(%q<facter>, [">= 4.3.0", "< 5"])
   spec.add_runtime_dependency(%q<semantic_puppet>, "~> 1.0")
-  spec.add_runtime_dependency(%q<fast_gettext>, ">= 2.1", "< 3")
+  spec.add_runtime_dependency(%q<fast_gettext>, ">= 2.1", "< 4")
   spec.add_runtime_dependency(%q<locale>, "~> 2.1")
   spec.add_runtime_dependency(%q<multi_json>, "~> 1.13")
   spec.add_runtime_dependency(%q<puppet-resource_api>, "~> 1.5")


### PR DESCRIPTION
fast_gettext 3 was released yesterday and it basically dropped support for Ruby 2.7. Pulling in version 3 is fine because puppet 8 already requires Ruby 3.1 or newer.