### PR TITLE
(PA-6427) Add rake tasks for building nightly gem 

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -29,13 +29,41 @@ end
 
 namespace :pl_ci do
   desc 'Build puppet gems'
-  task :gem_build do
-    stdout, stderr, status = Open3.capture3('gem build puppet.gemspec --platform x86-mingw32 && gem build puppet.gemspec --platform x64-mingw32 && gem build puppet.gemspec --platform universal-darwin && gem build puppet.gemspec')
+  task :gem_build, [:gemspec] do |t, args|
+    args.with_defaults(gemspec: 'puppet.gemspec')
+    stdout, stderr, status = Open3.capture3(<<~END)
+      gem build #{args.gemspec} --platform x86-mingw32 && \
+      gem build #{args.gemspec} --platform x64-mingw32 && \
+      gem build #{args.gemspec} --platform universal-darwin && \
+      gem build #{args.gemspec}
+    END
     if !status.exitstatus.zero?
-      puts "Error building facter.gemspec \n#{stdout} \n#{stderr}"
+      puts "Error building #{args.gemspec}\n#{stdout} \n#{stderr}"
       exit(1)
     else
       puts stdout
+    end
+  end
+
+  desc 'build the nightly puppet gems'
+  task :nightly_gem_build do
+    # this is taken from `rake package:nightly_gem`
+    extended_dot_version = %x{git describe --tags --dirty --abbrev=7}.chomp.tr('-', '.')
+
+    # we must create tempfile in the same directory as puppetg.gemspec, since
+    # it uses __dir__ to determine which files to include
+    require 'tempfile'
+    Tempfile.create('gemspec', __dir__) do |dst|
+      File.open('puppet.gemspec', 'r') do |src|
+        src.readlines.each do |line|
+          if line.match?(/version\s*=\s*['"][0-9.]+['"]/)
+            line = "spec.version = '#{extended_dot_version}'"
+          end
+          dst.puts line
+        end
+      end
+      dst.flush
+      Rake::Task['pl_ci:gem_build'].invoke(dst.path)
     end
   end
 end

--- a/puppet.gemspec
+++ b/puppet.gemspec
@@ -1,45 +1,43 @@
-Gem::Specification.new do |s|
-  s.name = "puppet"
-  version = "8.7.0"
-  mdata = version.match(/(\d+\.\d+\.\d+)/)
-  s.version = mdata ? mdata[1] : version
-  s.licenses = ['Apache-2.0']
+Gem::Specification.new do |spec|
+  spec.name = "puppet"
+  spec.version = "8.7.0"
+  spec.licenses = ['Apache-2.0']
 
-  s.required_rubygems_version = Gem::Requirement.new("> 1.3.1")
-  s.required_ruby_version = Gem::Requirement.new(">= 3.1.0")
-  s.authors = ["Puppet Labs"]
-  s.date = "2012-08-17"
-  s.description = <<~EOF
+  spec.required_rubygems_version = Gem::Requirement.new("> 1.3.1")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.1.0")
+  spec.authors = ["Puppet Labs"]
+  spec.date = "2012-08-17"
+  spec.description = <<~EOF
     Puppet, an automated administrative engine for your Linux, Unix, and Windows systems, performs administrative tasks
     (such as adding users, installing packages, and updating server configurations) based on a centralized specification.
   EOF
-  s.email = "info@puppetlabs.com"
-  s.executables = ["puppet"]
-  s.files = Dir['[A-Z]*'] + Dir['install.rb'] + Dir['bin/*'] + Dir['lib/**/*'] + Dir['conf/*'] + Dir['man/**/*'] + Dir['tasks/*'] + Dir['locales/**/*'] + Dir['ext/**/*'] + Dir['examples/**/*']
-  s.license = "Apache-2.0"
-  s.homepage = "https://github.com/puppetlabs/puppet"
-  s.rdoc_options = ["--title", "Puppet - Configuration Management", "--main", "README", "--line-numbers"]
-  s.require_paths = ["lib"]
-  s.summary = "Puppet, an automated configuration management tool"
-  s.specification_version = 4
-  s.add_runtime_dependency(%q<facter>, [">= 4.3.0", "< 5"])
-  s.add_runtime_dependency(%q<semantic_puppet>, "~> 1.0")
-  s.add_runtime_dependency(%q<fast_gettext>, ">= 2.1", "< 3")
-  s.add_runtime_dependency(%q<locale>, "~> 2.1")
-  s.add_runtime_dependency(%q<multi_json>, "~> 1.13")
-  s.add_runtime_dependency(%q<puppet-resource_api>, "~> 1.5")
-  s.add_runtime_dependency(%q<concurrent-ruby>, "~> 1.0")
-  s.add_runtime_dependency(%q<deep_merge>, "~> 1.0")
-  s.add_runtime_dependency(%q<scanf>, "~> 1.0")
+  spec.email = "info@puppetlabs.com"
+  spec.executables = ["puppet"]
+  spec.files = Dir['[A-Z]*'] + Dir['install.rb'] + Dir['bin/*'] + Dir['lib/**/*'] + Dir['conf/*'] + Dir['man/**/*'] + Dir['tasks/*'] + Dir['locales/**/*'] + Dir['ext/**/*'] + Dir['examples/**/*']
+  spec.license = "Apache-2.0"
+  spec.homepage = "https://github.com/puppetlabs/puppet"
+  spec.rdoc_options = ["--title", "Puppet - Configuration Management", "--main", "README", "--line-numbers"]
+  spec.require_paths = ["lib"]
+  spec.summary = "Puppet, an automated configuration management tool"
+  spec.specification_version = 4
+  spec.add_runtime_dependency(%q<facter>, [">= 4.3.0", "< 5"])
+  spec.add_runtime_dependency(%q<semantic_puppet>, "~> 1.0")
+  spec.add_runtime_dependency(%q<fast_gettext>, ">= 2.1", "< 3")
+  spec.add_runtime_dependency(%q<locale>, "~> 2.1")
+  spec.add_runtime_dependency(%q<multi_json>, "~> 1.13")
+  spec.add_runtime_dependency(%q<puppet-resource_api>, "~> 1.5")
+  spec.add_runtime_dependency(%q<concurrent-ruby>, "~> 1.0")
+  spec.add_runtime_dependency(%q<deep_merge>, "~> 1.0")
+  spec.add_runtime_dependency(%q<scanf>, "~> 1.0")
 
-  platform = s.platform.to_s
-    if platform == 'universal-darwin'
-      s.add_runtime_dependency('CFPropertyList', ['>= 3.0.6', '< 4'])
-    end
+  platform = spec.platform.to_s
+  if platform == 'universal-darwin'
+    spec.add_runtime_dependency('CFPropertyList', ['>= 3.0.6', '< 4'])
+  end
 
-    if platform == 'x64-mingw32' || platform == 'x86-mingw32'
-      # ffi 1.16.0 - 1.16.2 are broken on Windows
-      s.add_runtime_dependency('ffi', '>= 1.15.5', '< 1.17.0', '!= 1.16.0', '!= 1.16.1', '!= 1.16.2')
-      s.add_runtime_dependency('minitar', '~> 0.9')
-    end
+  if platform == 'x64-mingw32' || platform == 'x86-mingw32'
+    # ffi 1.16.0 - 1.16.2 are broken on Windows
+    spec.add_runtime_dependency('ffi', '>= 1.15.5', '< 1.17.0', '!= 1.16.0', '!= 1.16.1', '!= 1.16.2')
+    spec.add_runtime_dependency('minitar', '~> 0.9')
+  end
 end


### PR DESCRIPTION
Adds `pl_ci:nightly_gem_build` The only difference from `gem_build` is that the nightly version uses the extended dot version as the version string in the gemspec (and therefore resulting filename). Based on https://github.com/puppetlabs/facter/pull/2726