### PR TITLE
Mark some failing 8.3 Windows tests as pending

### DIFF
--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -55,7 +55,7 @@ jobs:
           Get-ChildItem Env: | % { Write-Output "$($_.Key): $($_.Value)"  }
           # list current OpenSSL install
           gem list openssl
-          ruby -ropenssl -e 'puts \"OpenSSL Version - #{OpenSSL::OPENSSL_VERSION}\"; puts \"OpenSSL Library Version - #{OpenSSL::OPENSSL_LIBRARY_VERSION}\"'
+          ruby -ropenssl -e 'puts "OpenSSL Version - #{OpenSSL::OPENSSL_VERSION}"; puts "OpenSSL Library Version - #{OpenSSL::OPENSSL_LIBRARY_VERSION}"'
           Get-Content Gemfile.lock
           ruby -v
           gem --version

--- a/spec/integration/directory_environments_spec.rb
+++ b/spec/integration/directory_environments_spec.rb
@@ -30,6 +30,7 @@ describe "directory environments" do
 
     it 'given an 8.3 style path on Windows, will config print an expanded path',
       :if => Puppet::Util::Platform.windows? do
+      pending("GH runners seem to have disabled 8.3 support")
 
       # ensure an 8.3 style path is set for environmentpath
       shortened = Puppet::Util::Windows::File.get_short_pathname(Puppet[:environmentpath])

--- a/spec/integration/node/environment_spec.rb
+++ b/spec/integration/node/environment_spec.rb
@@ -38,6 +38,7 @@ describe Puppet::Node::Environment do
 
   it "should expand 8.3 paths on Windows when creating an environment",
     :if => Puppet::Util::Platform.windows? do
+    pending("GH runners seem to have disabled 8.3 support")
 
     # asking for short names only works on paths that exist
     base = Puppet::Util::Windows::File.get_short_pathname(tmpdir("env_modules"))

--- a/spec/unit/file_system_spec.rb
+++ b/spec/unit/file_system_spec.rb
@@ -908,6 +908,8 @@ describe "Puppet::FileSystem" do
         end
 
         it 'should expand a shortened path completely, unlike Ruby File.expand_path' do
+          pending("GH runners seem to have disabled 8.3 support")
+
           tmp_long_dir = tmpdir('super-long-thing-that-Windows-shortens')
           short_path = Puppet::Util::Windows::File.get_short_pathname(tmp_long_dir)
 

--- a/spec/unit/util/autoload_spec.rb
+++ b/spec/unit/util/autoload_spec.rb
@@ -203,6 +203,8 @@ describe Puppet::Util::Autoload do
     end
 
     it "autoloads from a directory whose ancestor is Windows 8.3", if: Puppet::Util::Platform.windows? do
+      pending("GH runners seem to have disabled 8.3 support")
+
       # File.expand_path will expand ~ in the last directory component only(!)
       # so create an ancestor directory with a long path
       dir = File.join(tmpdir('longpath'), 'short')


### PR DESCRIPTION
Tests started failing with a new GH Windows Server runner 20240526.1.1. The
previous version worked 20240514.1.0. Mark as pending until we can determine the
cause.

As noted in https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file

> When you create a long file name, Windows may also create a short 8.3 form of the name, called the 8.3 alias or short name, and store it on disk also. This 8.3 aliasing can be disabled for performance reasons either system-wide or for a specified volume, depending on the particular file system.

> On many file systems, a file name will contain a tilde (~) within each component of the name that is too long to comply with 8.3 naming rules. ... Not all file systems follow the tilde substitution convention, and systems can be configured to disable 8.3 alias generation even if they normally support it. Therefore, do not make the assumption that the 8.3 alias already exists on-disk.

Also fix how the openssl version is printed on Windows

