### PR TITLE
[Backport 7.x] Mark some failing 8.3 Windows tests as pending

### DIFF
--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -58,7 +58,7 @@ jobs:
           Get-ChildItem Env: | % { Write-Output "$($_.Key): $($_.Value)"  }
           # list current OpenSSL install
           gem list openssl
-          ruby -ropenssl -e 'puts \"OpenSSL Version - #{OpenSSL::OPENSSL_VERSION}\"; puts \"OpenSSL Library Version - #{OpenSSL::OPENSSL_LIBRARY_VERSION}\"'
+          ruby -ropenssl -e 'puts "OpenSSL Version - #{OpenSSL::OPENSSL_VERSION}"; puts "OpenSSL Library Version - #{OpenSSL::OPENSSL_LIBRARY_VERSION}"'
           Get-Content Gemfile.lock
           ruby -v
           gem --version

--- a/spec/integration/directory_environments_spec.rb
+++ b/spec/integration/directory_environments_spec.rb
@@ -30,6 +30,7 @@ describe "directory environments" do
 
     it 'given an 8.3 style path on Windows, will config print an expanded path',
       :if => Puppet::Util::Platform.windows? do
+      pending("GH runners seem to have disabled 8.3 support")
 
       # ensure an 8.3 style path is set for environmentpath
       shortened = Puppet::Util::Windows::File.get_short_pathname(Puppet[:environmentpath])

--- a/spec/integration/node/environment_spec.rb
+++ b/spec/integration/node/environment_spec.rb
@@ -38,6 +38,7 @@ describe Puppet::Node::Environment do
 
   it "should expand 8.3 paths on Windows when creating an environment",
     :if => Puppet::Util::Platform.windows? do
+    pending("GH runners seem to have disabled 8.3 support")
 
     # asking for short names only works on paths that exist
     base = Puppet::Util::Windows::File.get_short_pathname(tmpdir("env_modules"))

--- a/spec/unit/file_system_spec.rb
+++ b/spec/unit/file_system_spec.rb
@@ -908,6 +908,8 @@ describe "Puppet::FileSystem" do
         end
 
         it 'should expand a shortened path completely, unlike Ruby File.expand_path' do
+          pending("GH runners seem to have disabled 8.3 support")
+
           tmp_long_dir = tmpdir('super-long-thing-that-Windows-shortens')
           short_path = Puppet::Util::Windows::File.get_short_pathname(tmp_long_dir)
 

--- a/spec/unit/util/autoload_spec.rb
+++ b/spec/unit/util/autoload_spec.rb
@@ -203,6 +203,8 @@ describe Puppet::Util::Autoload do
     end
 
     it "autoloads from a directory whose ancestor is Windows 8.3", if: Puppet::Util::Platform.windows? do
+      pending("GH runners seem to have disabled 8.3 support")
+
       # File.expand_path will expand ~ in the last directory component only(!)
       # so create an ancestor directory with a long path
       dir = File.join(tmpdir('longpath'), 'short')


### PR DESCRIPTION
Backport https://github.com/puppetlabs/puppet/pull/9368

Since this modifies the `.github/workflows` directory it must be manually backported
