### PR TITLE
Check for nil before closing Uniquefile

### DIFF
--- a/lib/puppet/util/execution.rb
+++ b/lib/puppet/util/execution.rb
@@ -323,7 +323,7 @@ module Puppet::Util::Execution
       unless options[:squelch]
         # if we opened a pipe, we need to clean it up.
         reader.close if reader
-        stdout.close! if Puppet::Util::Platform.windows?
+        stdout.close! if stdout && Puppet::Util::Platform.windows?
       end
     end
 

--- a/spec/unit/util/execution_spec.rb
+++ b/spec/unit/util/execution_spec.rb
@@ -834,6 +834,15 @@ describe Puppet::Util::Execution, if: !Puppet::Util::Platform.jruby? do
 
           Puppet::Util::Execution.execute('test command')
         end
+
+        it "should raise if it fails to create a Uniquefile for stdout" do
+          allow(Puppet::FileSystem::Uniquefile).to receive(:new)
+            .and_raise(Errno::ENOENT, 'C:\Users\ADMINI~1\AppData\Local\Temp\doesnotexist')
+
+          expect {
+            Puppet::Util::Execution.execute('test command')
+          }.to raise_error(Errno::ENOENT, 'No such file or directory - C:\Users\ADMINI~1\AppData\Local\Temp\doesnotexist')
+        end
       end
 
       it "should raise an error if failonfail is true and the child failed" do


### PR DESCRIPTION
On Windows, if squelch was false and Uniquefile.new raised, then we attempted to
close a nil stdout. This scenario can occur if TEMP or similar environment
variable is defined but refers to a non-existent directory.

So check for nil before closing. We don't have this issue on posix, because
it uses an IO pipe instead of Uniquefile.

Fixes https://github.com/puppetlabs/puppet/issues/9385