### PR TITLE
(PUP-1881) Correct Windows runinterval behavior

### DIFF
--- a/ext/windows/service/daemon.rb
+++ b/ext/windows/service/daemon.rb
@@ -161,10 +161,13 @@ class WindowsDaemon < Puppet::Util::Windows::Daemon
   # @return runinterval [Integer] How often to do a Puppet run, in seconds.
   def parse_runinterval(puppet_path)
     begin
-      runinterval = %x(#{puppet_path} config --section agent --log_level notice print runinterval).to_i
-      if runinterval == 0
+      runinterval = %x(#{puppet_path} config --section agent --log_level notice print runinterval).chomp
+      if runinterval == ''
         runinterval = 1800
         log_err("Failed to determine runinterval, defaulting to #{runinterval} seconds")
+      else
+        # Use Kernel#Integer because to_i will return 0 with non-numeric strings.
+        runinterval = Integer(runinterval)
       end
     rescue Exception => e
       log_exception(e)

--- a/ext/windows/service/daemon.rb
+++ b/ext/windows/service/daemon.rb
@@ -155,6 +155,10 @@ class WindowsDaemon < Puppet::Util::Windows::Daemon
     end
   end
 
+  # Parses runinterval.
+  #
+  # @param puppet_path [String] The file path for the Puppet executable.
+  # @return runinterval [Integer] How often to do a Puppet run, in seconds.
   def parse_runinterval(puppet_path)
     begin
       runinterval = %x(#{puppet_path} config --section agent --log_level notice print runinterval).to_i


### PR DESCRIPTION
Previously when Puppet parsed a runinterval of 0 on Windows, it would set the runinterval to 1800 seconds, Puppet's default runinterval value. This was incorrect behavior, as on other platforms and in the documentation, a runinterval of 0 indicates that Puppet should run continuously.

This commit updates the Windows daemon to set the runinterval to 1800 seconds when it receives an empty string and cast to integer in all other cases.