### PR TITLE
(PUP-12029) Prepare for Ruby 3.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ group(:features) do
   # requires native ldap headers/libs
   # gem 'ruby-ldap', '~> 0.9', require: false, platforms: [:ruby]
   gem 'puppetserver-ca', '~> 2.0', require: false
+  gem 'syslog', '~> 0.1.1', require: false, platforms: [:ruby]
   gem 'CFPropertyList', ['>= 3.0.6', '< 4'], require: false
 end
 

--- a/puppet.gemspec
+++ b/puppet.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency(%q<concurrent-ruby>, "~> 1.0")
   spec.add_runtime_dependency(%q<deep_merge>, "~> 1.0")
   spec.add_runtime_dependency(%q<scanf>, "~> 1.0")
+  spec.add_runtime_dependency(%q<getoptlong>, "~> 0.2.0")
 
   platform = spec.platform.to_s
   if platform == 'universal-darwin'

--- a/puppet.gemspec
+++ b/puppet.gemspec
@@ -20,16 +20,16 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.summary = "Puppet, an automated configuration management tool"
   spec.specification_version = 4
-  spec.add_runtime_dependency(%q<facter>, [">= 4.3.0", "< 5"])
-  spec.add_runtime_dependency(%q<semantic_puppet>, "~> 1.0")
-  spec.add_runtime_dependency(%q<fast_gettext>, ">= 2.1", "< 4")
-  spec.add_runtime_dependency(%q<locale>, "~> 2.1")
-  spec.add_runtime_dependency(%q<multi_json>, "~> 1.13")
-  spec.add_runtime_dependency(%q<puppet-resource_api>, "~> 1.5")
-  spec.add_runtime_dependency(%q<concurrent-ruby>, "~> 1.0")
-  spec.add_runtime_dependency(%q<deep_merge>, "~> 1.0")
-  spec.add_runtime_dependency(%q<scanf>, "~> 1.0")
-  spec.add_runtime_dependency(%q<getoptlong>, "~> 0.2.0")
+  spec.add_runtime_dependency('concurrent-ruby', '~> 1.0')
+  spec.add_runtime_dependency('deep_merge', '~> 1.0')
+  spec.add_runtime_dependency('facter', ['>= 4.3.0', '< 5'])
+  spec.add_runtime_dependency('fast_gettext', '>= 2.1', '< 4')
+  spec.add_runtime_dependency('getoptlong', '~> 0.2.0')
+  spec.add_runtime_dependency('locale', '~> 2.1')
+  spec.add_runtime_dependency('multi_json', '~> 1.13')
+  spec.add_runtime_dependency('puppet-resource_api', '~> 1.5')
+  spec.add_runtime_dependency('scanf', '~> 1.0')
+  spec.add_runtime_dependency('semantic_puppet', '~> 1.0')
 
   platform = spec.platform.to_s
   if platform == 'universal-darwin'

--- a/spec/unit/interface_spec.rb
+++ b/spec/unit/interface_spec.rb
@@ -129,12 +129,22 @@ describe Puppet::Interface do
   describe 'when raising NoMethodErrors' do
     subject { described_class.new(:foo, '1.0.0') }
 
-    it 'includes the face name in the error message' do
-      expect { subject.boombaz }.to raise_error(NoMethodError, /#{subject.name}/)
-    end
+    if RUBY_VERSION.to_f >= 3.3
+      it 'includes the face name in the error message' do
+        expect { subject.boombaz }.to raise_error(NoMethodError, /for an instance of Puppet::Interface/)
+      end
 
-    it 'includes the face version in the error message' do
-      expect { subject.boombaz }.to raise_error(NoMethodError, /#{subject.version}/)
+      it 'includes the face version in the error message' do
+        expect { subject.boombaz }.to raise_error(NoMethodError, /for an instance of Puppet::Interface/)
+      end
+    else
+      it 'includes the face name in the error message' do
+        expect { subject.boombaz }.to raise_error(NoMethodError, /#{subject.name}/)
+      end
+
+      it 'includes the face version in the error message' do
+        expect { subject.boombaz }.to raise_error(NoMethodError, /#{subject.version}/)
+      end
     end
   end
 


### PR DESCRIPTION
Running puppet with Ruby 3.3.0 prints:

    $ bundle exec puppet --version
    /home/josh/work/puppet/lib/puppet/settings.rb:4: warning: getoptlong was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add getoptlong to your Gemfile or gemspec.
    /home/josh/work/puppet/lib/puppet/util/feature.rb:116: warning: syslog was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add syslog to your Gemfile or gemspec.

Since getoptlong is necessary to parse the command line and is a pure ruby gem,
it's safe to add it as a runtime dependency in puppet.gemspec.

Since syslog is a feature and requires native extensions, add it to the features
group in the Gemfile. It will also need to be added to the runtime on
non-Windows platforms.

The versions were chosen to match what is currently shipped in ruby 3.2.4, but
updates to the patch component are allowed.

Fixes #9209