### PR TITLE
Use bundler-cache to bundle install and cache gems

### DIFF
--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -24,6 +24,8 @@ jobs:
           - {os: windows-2019, ruby: '3.2'} # openssl 3
 
     runs-on: ${{ matrix.cfg.os }}
+    env:
+      BUNDLE_SET: "without packaging documentation"
     steps:
       - name: Checkout current PR
         uses: actions/checkout@v4
@@ -32,12 +34,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.cfg.ruby }}
-
-      - name: Update rubygems and install gems
-        run: |
-          gem update --system --silent --no-document
-          bundle config set without packaging documentation
-          bundle install --jobs 4 --retry 3
+          bundler-cache: true
 
       - name: Run tests on Windows
         if: runner.os == 'Windows'


### PR DESCRIPTION
The setup-ruby action makes it trivial to bundle install gems from a cache and update the cache when the run completes.

When using `bundler-cache`, we can't use `bundle config` commands, but we can achieve the same effect specifying BUNDLE_SET as an env variable.

See https://github.com/ruby/setup-ruby for details

On Ubuntu 22.04:

```
> bundle install
/opt/hostedtoolcache/Ruby/3.2.4/x64/bin/bundle config --local path /home/runner/work/puppet/puppet/vendor/bundle
/opt/hostedtoolcache/Ruby/3.2.4/x64/bin/bundle lock
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Writing lockfile to /home/runner/work/puppet/puppet/Gemfile.lock
Cache key: setup-ruby-bundler-cache-v6-ubuntu-22.04-x64-ruby-3.2.4-wd-/home/runner/work/puppet/puppet-with--without--only--Gemfile.lock-6185088470ded95016515539e14e1cd5f8944fabbb2851ece3a74dcc8e02f5f9
Cache Size: ~[24](https://github.com/puppetlabs/puppet/actions/runs/9574586858/job/26398059207?pr=9400#step:3:30) MB (24880861 B)
/usr/bin/tar -xf /home/runner/work/_temp/77788843-aafe-4128-b8ba-72781e8e961e/cache.tzst -P -C /home/runner/work/puppet/puppet --use-compress-program unzstd
Cache restored successfully
Found cache for key: setup-ruby-bundler-cache-v6-ubuntu-22.04-x64-ruby-3.2.4-wd-/home/runner/work/puppet/puppet-with--without--only--Gemfile.lock-6185088470ded95016515539e14e1cd5f8944fabbb[28](https://github.com/puppetlabs/puppet/actions/runs/9574586858/job/26398059207?pr=9400#step:3:34)51ece3a74dcc8e02f5f9
/opt/hostedtoolcache/Ruby/3.2.4/x64/bin/bundle install --jobs 4
Bundle complete! 34 Gemfile dependencies, 94 gems now installed.
Bundled gems are installed into `./vendor/bundle`
Took   3.36 seconds
```

Previously the ["install ruby 3.2" and "update rubygems and install gems" steps took 1+17=18 seconds](https://github.com/puppetlabs/puppet/actions/runs/9571121383/job/26387431246). Now the combined ["install ruby 3.2" step took 4 seconds](https://github.com/puppetlabs/puppet/actions/runs/9574586858/job/26398059098).
