### PR TITLE
[Backport 7.x] Use bundler-cache to bundle install and cache gems

### DIFF
--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -27,6 +27,8 @@ jobs:
           - {os: windows-2019, ruby: '3.0'}
 
     runs-on: ${{ matrix.cfg.os }}
+    env:
+      BUNDLE_SET: "without packaging documentation"
     steps:
       - name: Checkout current PR
         uses: actions/checkout@v4
@@ -35,12 +37,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.cfg.ruby }}
-
-      - name: Update rubygems and install gems
-        run: |
-          gem update --system 3.3.26 --silent --no-document
-          bundle config set without packaging documentation
-          bundle install --jobs 4 --retry 3
+          bundler-cache: true
 
       - name: Run tests on Windows
         if: runner.os == 'Windows'


### PR DESCRIPTION
The setup-ruby action makes it trivial to bundle install gems from a cache and update the cache when the run completes.

When using `bundler-cache`, we can't use `bundle config` commands, but we can achieve the same effect specifying BUNDLE_SET as an env variable.

See https://github.com/ruby/setup-ruby for details

(cherry picked from commit 86820eee25e428f7e667bf9529b97c32e6575d9b)