### PR TITLE
Revert "Merge pull request #9390 from AriaXLi/revert_selinux_matchpathcon"

### DIFF
--- a/lib/puppet/type/file/selcontext.rb
+++ b/lib/puppet/type/file/selcontext.rb
@@ -40,11 +40,12 @@ module Puppet
     end
 
     def retrieve_default_context(property)
+      return nil if Puppet::Util::Platform.windows?
       if @resource[:selinux_ignore_defaults] == :true
         return nil
       end
 
-      context = get_selinux_default_context(@resource[:path], @resource[:ensure])
+      context = get_selinux_default_context_with_handle(@resource[:path], provider.class.selinux_handle)
       unless context
         return nil
       end
@@ -85,7 +86,7 @@ module Puppet
   end
 
   Puppet::Type.type(:file).newparam(:selinux_ignore_defaults) do
-    desc "If this is set then Puppet will not ask SELinux (via matchpathcon) to
+    desc "If this is set then Puppet will not ask SELinux (via selabel_lookup) to
       supply defaults for the SELinux attributes (seluser, selrole,
       seltype, and selrange). In general, you should leave this set at its
       default and only set it to true when you need Puppet to not try to fix
@@ -98,7 +99,7 @@ module Puppet
   Puppet::Type.type(:file).newproperty(:seluser, :parent => Puppet::SELFileContext) do
     desc "What the SELinux user component of the context of the file should be.
       Any valid SELinux user component is accepted.  For example `user_u`.
-      If not specified it defaults to the value returned by matchpathcon for
+      If not specified it defaults to the value returned by selabel_lookup for
       the file, if any exists.  Only valid on systems with SELinux support
       enabled."
 
@@ -109,7 +110,7 @@ module Puppet
   Puppet::Type.type(:file).newproperty(:selrole, :parent => Puppet::SELFileContext) do
     desc "What the SELinux role component of the context of the file should be.
       Any valid SELinux role component is accepted.  For example `role_r`.
-      If not specified it defaults to the value returned by matchpathcon for
+      If not specified it defaults to the value returned by selabel_lookup for
       the file, if any exists.  Only valid on systems with SELinux support
       enabled."
 
@@ -120,7 +121,7 @@ module Puppet
   Puppet::Type.type(:file).newproperty(:seltype, :parent => Puppet::SELFileContext) do
     desc "What the SELinux type component of the context of the file should be.
       Any valid SELinux type component is accepted.  For example `tmp_t`.
-      If not specified it defaults to the value returned by matchpathcon for
+      If not specified it defaults to the value returned by selabel_lookup for
       the file, if any exists.  Only valid on systems with SELinux support
       enabled."
 
@@ -132,7 +133,7 @@ module Puppet
     desc "What the SELinux range component of the context of the file should be.
       Any valid SELinux range component is accepted.  For example `s0` or
       `SystemHigh`.  If not specified it defaults to the value returned by
-      matchpathcon for the file, if any exists.  Only valid on systems with
+      selabel_lookup for the file, if any exists.  Only valid on systems with
       SELinux support enabled and that have support for MCS (Multi-Category
       Security)."
 

--- a/spec/unit/transaction_spec.rb
+++ b/spec/unit/transaction_spec.rb
@@ -758,15 +758,15 @@ describe Puppet::Transaction do
       transaction.evaluate
     end
 
-    it "should call Selinux.matchpathcon_fini in case Selinux is enabled ", :if => Puppet.features.posix? do
-      selinux = double('selinux', is_selinux_enabled: true, matchpathcon_fini: nil)
+    it "should call Selinux.selabel_close in case Selinux is enabled", :if => Puppet.features.posix? do
+      handle = double('selinux_handle')
+      selinux = class_double('selinux', is_selinux_enabled: 1, selabel_close: nil, selabel_open: handle, selabel_lookup: -1)
       stub_const('Selinux', selinux)
-
+      stub_const('Selinux::SELABEL_CTX_FILE', 0)
       resource = Puppet::Type.type(:file).new(:path => make_absolute("/tmp/foo"))
       transaction = transaction_with_resource(resource)
 
-      expect(Selinux).to receive(:matchpathcon_fini)
-      expect(Puppet::Util::SELinux).to receive(:selinux_support?).and_return(true)
+      expect(Selinux).to receive(:selabel_close).with(handle)
 
       transaction.evaluate
     end

--- a/spec/unit/type/file/selinux_spec.rb
+++ b/spec/unit/type/file/selinux_spec.rb
@@ -50,13 +50,16 @@ require 'spec_helper'
     end
 
     it "should handle no default gracefully" do
-      expect(@sel).to receive(:get_selinux_default_context).with(@path, :file).and_return(nil)
+      skip if Puppet::Util::Platform.windows?
+      expect(@sel).to receive(:get_selinux_default_context_with_handle).with(@path, nil).and_return(nil)
       expect(@sel.default).to be_nil
     end
 
-    it "should be able to detect matchpathcon defaults" do
+    it "should be able to detect default context on platforms other than Windows", unless: Puppet::Util::Platform.windows? do
       allow(@sel).to receive(:debug)
-      expect(@sel).to receive(:get_selinux_default_context).with(@path, :file).and_return("user_u:role_r:type_t:s0")
+      hnd = double("SWIG::TYPE_p_selabel_handle")
+      allow(@sel.provider.class).to receive(:selinux_handle).and_return(hnd)
+      expect(@sel).to receive(:get_selinux_default_context_with_handle).with(@path, hnd).and_return("user_u:role_r:type_t:s0")
       expectedresult = case param
         when :seluser; "user_u"
         when :selrole; "role_r"
@@ -64,6 +67,11 @@ require 'spec_helper'
         when :selrange; "s0"
       end
       expect(@sel.default).to eq(expectedresult)
+    end
+
+    it "returns nil default context on Windows", if: Puppet::Util::Platform.windows? do
+      expect(@sel).to receive(:retrieve_default_context)
+      expect(@sel.default).to be_nil
     end
 
     it "should return nil for defaults if selinux_ignore_defaults is true" do

--- a/spec/unit/util/selinux_spec.rb
+++ b/spec/unit/util/selinux_spec.rb
@@ -241,6 +241,35 @@ describe Puppet::Util::SELinux do
     end
   end
 
+  describe "get_selinux_default_context_with_handle" do
+    it "should return a context if a default context exists" do
+      without_partial_double_verification do
+        expect(self).to receive(:selinux_support?).and_return(true)
+        expect(self).to receive(:find_fs).with("/foo").and_return("ext3")
+        hnd = double("SWIG::TYPE_p_selabel_handle")
+        expect(Selinux).to receive(:selabel_lookup).with(hnd, '/foo', 0).and_return([0, "user_u:role_r:type_t:s0"])
+        expect(get_selinux_default_context_with_handle("/foo", hnd)).to eq("user_u:role_r:type_t:s0")
+      end
+    end
+
+    it "should raise an ArgumentError when handle is nil" do
+      allow(self).to receive(:selinux_support?).and_return(true)
+      allow(self).to receive(:selinux_label_support?).and_return(true)
+      expect{get_selinux_default_context_with_handle("/foo", nil)}.to raise_error(ArgumentError, /Cannot get default context with nil handle/)
+    end
+
+    it "should return nil if there is no SELinux support" do
+      expect(self).to receive(:selinux_support?).and_return(false)
+      expect(get_selinux_default_context_with_handle("/foo", nil)).to be_nil
+    end
+
+    it "should return nil if selinux_label_support returns false" do
+      expect(self).to receive(:selinux_support?).and_return(true)
+      expect(self).to receive(:find_fs).with("/foo").and_return("nfs")
+      expect(get_selinux_default_context_with_handle("/foo", nil)).to be_nil
+    end
+  end
+
   describe "parse_selinux_context" do
     it "should return nil if no context is passed" do
       expect(parse_selinux_context(:seluser, nil)).to be_nil


### PR DESCRIPTION
This reverts commit 2417766ced648f6fc67972a114fa2a06b573483f, reversing changes made to 7927dcf53cad403625b1c862000296833597c9d0.

Since puppetlabs/puppet-runtime#864 resolved the `warning: undefining the allocator of T_DATA class SWIG::TYPE_p_selabel_handle` failures seen in seen in RedHat 8 x86_64, RedHat FIPS 7 x86_64, and RedHat 7 x86_64 in CI, #9349 can be safely re-reverted.