### PR TITLE
(PUP-12047) Add logic to skip MD5 checksum method on a FIPS system

### DIFF
--- a/lib/puppet/file_serving/http_metadata.rb
+++ b/lib/puppet/file_serving/http_metadata.rb
@@ -51,6 +51,8 @@ class Puppet::FileServing::HttpMetadata < Puppet::FileServing::Metadata
     # Prefer the checksum_type from the indirector request options
     # but fall back to the alternative otherwise
     [@checksum_type, :sha256, :sha1, :md5, :mtime].each do |type|
+      next if type == :md5 && Puppet::Util::Platform.fips_enabled?
+
       @checksum_type = type
       @checksum = @checksums[type]
       break if @checksum


### PR DESCRIPTION
This commit adds logic in `http_metadata.rb` to skip MD5 related checksums when FIPS is enabled since MD5 is not supported on FIPS enabled systems. This PR addresses https://github.com/puppetlabs/puppet/issues/9375.