### PR TITLE
(PUP-12047) Add test to ensure MD5 checksum is skipped for FIPS

### DIFF
--- a/spec/unit/file_serving/http_metadata_spec.rb
+++ b/spec/unit/file_serving/http_metadata_spec.rb
@@ -29,6 +29,14 @@ describe Puppet::FileServing::HttpMetadata do
       expect( metadata.mode ).to be_nil
     end
 
+    it "skips md5 checksum type in collect on FIPS enabled platforms" do
+      allow(Puppet::Util::Platform).to receive(:fips_enabled?).and_return(true)
+      http_response['X-Checksum-Md5'] = 'c58989e9740a748de4f5054286faf99b'
+      metadata = described_class.new(http_response)
+      metadata.collect
+      expect( metadata.checksum_type ).to eq :mtime
+    end
+
     context "with no Last-Modified or Content-MD5 header from the server" do
       it "should use :mtime as the checksum type, based on current time" do
         # Stringifying Time.now does some rounding; do so here so we don't end up with a time


### PR DESCRIPTION
This commit adds a test to http_metadata_spec.rb that checks that the MD5 checksum type is skipped in the collect method on FIPS enabled platforms.