### PR TITLE
(PUP-12047) Add logic to skip MD5 checksum method on a FIPS system

### DIFF
--- a/lib/puppet/file_serving/http_metadata.rb
+++ b/lib/puppet/file_serving/http_metadata.rb
@@ -51,7 +51,9 @@ class Puppet::FileServing::HttpMetadata < Puppet::FileServing::Metadata
   def collect
     # Prefer the checksum_type from the indirector request options
     # but fall back to the alternative otherwise
-    [ @checksum_type, :sha256, :sha1, :md5, :mtime ].each do |type|
+    [@checksum_type, :sha256, :sha1, :md5, :mtime].each do |type|
+      next if type == :md5 && Puppet::Util::Platform.fips_enabled?
+
       @checksum_type = type
       @checksum = @checksums[type]
       break if @checksum

--- a/spec/unit/file_serving/http_metadata_spec.rb
+++ b/spec/unit/file_serving/http_metadata_spec.rb
@@ -29,6 +29,14 @@ describe Puppet::FileServing::HttpMetadata do
       expect( metadata.mode ).to be_nil
     end
 
+    it "skips md5 checksum type in collect on FIPS enabled platforms" do
+      allow(Puppet::Util::Platform).to receive(:fips_enabled?).and_return(true)
+      http_response['X-Checksum-Md5'] = 'c58989e9740a748de4f5054286faf99b'
+      metadata = described_class.new(http_response)
+      metadata.collect
+      expect( metadata.checksum_type ).to eq :mtime
+    end
+
     context "with no Last-Modified or Content-MD5 header from the server" do
       it "should use :mtime as the checksum type, based on current time" do
         # Stringifying Time.now does some rounding; do so here so we don't end up with a time


### PR DESCRIPTION
This commit adds logic in http_metadata.rb to skip MD5 related checksums when FIPS is enabled since MD5 is not supported on FIPS enabled systems. Additionally, a test is added to http_metadata_spec.rb that checks that the MD5 checksum type is skipped on FIPS enabled platforms.

Cherry picked from two commits:
(cherry picked from commit 1f7c8ef64843847846b0a8b2d8a1fe9858eb0bd8) 
(cherry picked from commit fa721bea4fe479273306c93b70eca10fa661fc4e)