### PR TITLE
(PUP-12050) Check for nested Sensitive arguments

### DIFF
--- a/lib/puppet/pops/evaluator/deferred_resolver.rb
+++ b/lib/puppet/pops/evaluator/deferred_resolver.rb
@@ -89,17 +89,25 @@ class DeferredResolver
       overrides = {}
       r.parameters.each_pair do |k, v|
         resolved = resolve(v)
-        # If the value is instance of Sensitive - assign the unwrapped value
-        # and mark it as sensitive if not already marked
-        #
         case resolved
         when Puppet::Pops::Types::PSensitiveType::Sensitive
+          # If the resolved value is instance of Sensitive - assign the unwrapped value
+          # and mark it as sensitive if not already marked
+          #
           resolved = resolved.unwrap
           mark_sensitive_parameters(r, k)
-        # If the value is a DeferredValue and it has an argument of type PSensitiveType, mark it as sensitive
-        # The DeferredValue.resolve method will unwrap it during catalog application
+
         when Puppet::Pops::Evaluator::DeferredValue
-          if v.arguments.any? { |arg| arg.is_a?(Puppet::Pops::Types::PSensitiveType) }
+          # If the resolved value is a DeferredValue and it has an argument of type
+          # PSensitiveType, mark it as sensitive. Since DeferredValues can nest,
+          # we must walk all arguments, e.g. the DeferredValue may call the `epp`
+          # function, where one of its arguments is a DeferredValue to call the
+          # `vault:lookup` function.
+          #
+          # The DeferredValue.resolve method will unwrap the sensitive during
+          # catalog application
+          #
+          if contains_sensitive_args?(v)
             mark_sensitive_parameters(r, k)
           end
         end
@@ -108,6 +116,33 @@ class DeferredResolver
       r.parameters.merge!(overrides) unless overrides.empty?
     end
   end
+
+  # Return true if x contains an argument that is an instance of PSensitiveType:
+  #
+  #   Deferred('new', [Sensitive, 'password'])
+  #
+  # Or an instance of PSensitiveType::Sensitive:
+  #
+  #   Deferred('join', [['a', Sensitive('b')], ':'])
+  #
+  # Since deferred values can nest, descend into Arrays and Hash keys and values,
+  # short-circuiting when the first occurrence is found.
+  #
+  def contains_sensitive_args?(x)
+    case x
+    when @deferred_class
+      contains_sensitive_args?(x.arguments)
+    when Array
+      x.any? { |v| contains_sensitive_args?(v) }
+    when Hash
+      x.any? { |k, v| contains_sensitive_args?(k) || contains_sensitive_args?(v) }
+    when Puppet::Pops::Types::PSensitiveType, Puppet::Pops::Types::PSensitiveType::Sensitive
+      true
+    else
+      false
+    end
+  end
+  private :contains_sensitive_args?
 
   def mark_sensitive_parameters(r, k)
     unless r.sensitive_parameters.include?(k.to_sym)

--- a/spec/integration/application/apply_spec.rb
+++ b/spec/integration/application/apply_spec.rb
@@ -777,5 +777,20 @@ class amod::bad_type {
       }.to exit_with(0)
         .and output(/ensure: changed \[redacted\] to \[redacted\]/).to_stdout
     end
+
+    it "applies nested deferred sensitive file content" do
+      manifest = <<~END
+      $vars = {'token' => Deferred('new', [Sensitive, "hello"])}
+      file { '#{deferred_file}':
+        ensure => file,
+        content => Deferred('inline_epp', ['<%= $token %>', $vars])
+      }
+      END
+      apply.command_line.args = ['-e', manifest]
+      expect {
+        apply.run
+      }.to exit_with(0)
+        .and output(/ensure: changed \[redacted\] to \[redacted\]/).to_stdout
+    end
   end
 end

--- a/spec/unit/pops/evaluator/deferred_resolver_spec.rb
+++ b/spec/unit/pops/evaluator/deferred_resolver_spec.rb
@@ -7,37 +7,40 @@ describe Puppet::Pops::Evaluator::DeferredResolver do
   let(:environment) { Puppet::Node::Environment.create(:testing, []) }
   let(:facts) { Puppet::Node::Facts.new('node.example.com') }
 
+  def compile_and_resolve_catalog(code, preprocess = false)
+    catalog = compile_to_catalog(code)
+    described_class.resolve_and_replace(facts, catalog, environment, preprocess)
+    catalog
+  end
+
   it 'resolves deferred values in a catalog' do
-    catalog = compile_to_catalog(<<~END)
+    catalog = compile_and_resolve_catalog(<<~END, true)
       notify { "deferred":
         message => Deferred("join", [[1,2,3], ":"])
       }
     END
-    described_class.resolve_and_replace(facts, catalog)
 
     expect(catalog.resource(:notify, 'deferred')[:message]).to eq('1:2:3')
   end
 
   it 'lazily resolves deferred values in a catalog' do
-    catalog = compile_to_catalog(<<~END)
+    catalog = compile_and_resolve_catalog(<<~END)
       notify { "deferred":
         message => Deferred("join", [[1,2,3], ":"])
       }
     END
-    described_class.resolve_and_replace(facts, catalog, environment, false)
 
     deferred = catalog.resource(:notify, 'deferred')[:message]
     expect(deferred.resolve).to eq('1:2:3')
   end
 
   it 'lazily resolves nested deferred values in a catalog' do
-    catalog = compile_to_catalog(<<~END)
+    catalog = compile_and_resolve_catalog(<<~END)
       $args = Deferred("inline_epp", ["<%= 'a,b,c' %>"])
       notify { "deferred":
         message => Deferred("split", [$args, ","])
       }
     END
-    described_class.resolve_and_replace(facts, catalog, environment, false)
 
     deferred = catalog.resource(:notify, 'deferred')[:message]
     expect(deferred.resolve).to eq(["a", "b", "c"])


### PR DESCRIPTION
Previously, a manifest containing nested Deferred values did not mark the corresponding parameter as sensitive, resulting in the following:

    $ cat manifest.pp
    $vars = {'token' => Deferred('new', [Sensitive, "password"])}
    file { '/tmp/a.sh':
      ensure  => file,
      content => Deferred('inline_epp', ['<%= $token %>', $vars])
    }
    $ truncate --size 0 /tmp/a.sh
    $ puppet apply --show_diff manifest.pp
    Notice: Compiled catalog for localhost in environment production in 0.01 seconds
    Notice: /Stage[main]/Main/File[/tmp/a.sh]/content:
    --- /tmp/a.sh	2024-07-03 17:30:37.024543314 -0700
    +++ /tmp/puppet-file20240703-1784698-2cu5s9	2024-07-03 17:30:41.880572413 -0700
    @@ -0,0 +1 @@
    +password
    \ No newline at end of file

The issue occurred because we were only checking if the outermost DeferredValue contained any Sensitive arguments, in this case the arguments passed to `inline_epp` function, but not the `password` passed to the `new` function.

This is not an issue when deferred values are preprocessed, because Deferred values are completely resolved and we can check if resolved value is Sensitive.

The problem was introduced in b92e4d35cc1bc38777b5df0c81d543cd46b73565 which added the ability to lazily call a deferred function when its respective resource is evaluated. It should be backported to 7.x

With this change we get:

    $ puppet apply --show_diff manifest.pp
    Notice: Compiled catalog for localhost in environment production in 0.01 seconds
    Notice: /Stage[main]/Main/File[/tmp/a.sh]/content: [diff redacted]
    Notice: /Stage[main]/Main/File[/tmp/a.sh]/content: changed [redacted] to [redacted]
    Notice: Applied catalog in 0.04 seconds

Fixes #9384 