### PR TITLE
Add missing return

### DIFF
--- a/lib/puppet/pops/evaluator/runtime3_resource_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_resource_support.rb
@@ -76,7 +76,8 @@ module Runtime3ResourceSupport
   end
 
   def self.resource_to_ptype(resource)
-    nil if resource.nil?
+    return nil if resource.nil?
+
     # inference returns the meta type since the 3x Resource is an alternate way to describe a type
     Puppet::Pops::Types::TypeCalculator.singleton().infer(resource).type
   end

--- a/lib/puppet/pops/evaluator/runtime3_support.rb
+++ b/lib/puppet/pops/evaluator/runtime3_support.rb
@@ -443,12 +443,6 @@ module Runtime3Support
     resource.valid_parameter?(name)
   end
 
-  def resource_to_ptype(resource)
-    nil if resource.nil?
-    # inference returns the meta type since the 3x Resource is an alternate way to describe a type
-    type_calculator.infer(resource).type
-  end
-
   # This is the same type of "truth" as used in the current Puppet DSL.
   #
   def is_true?(value, o)

--- a/lib/puppet/provider/package/pkgutil.rb
+++ b/lib/puppet/provider/package/pkgutil.rb
@@ -115,11 +115,12 @@ Puppet::Type.type(:package).provide :pkgutil, :parent => :sun, :source => :sun d
 
   # Identify common types of pkgutil noise as it downloads catalogs etc
   def self.noise?(line)
-    true if line =~ /^#/
-    true if line =~ /^Checking integrity / # use_gpg
-    true if line =~ /^gpg: /               # gpg verification
-    true if line =~ /^=+> /                # catalog fetch
-    true if line =~ /\d+:\d+:\d+ URL:/     # wget without -q
+    return true if line =~ /^#/
+    return true if line =~ /^Checking integrity / # use_gpg
+    return true if line =~ /^gpg: /               # gpg verification
+    return true if line =~ /^=+> /                # catalog fetch
+    return true if line =~ /\d+:\d+:\d+ URL:/     # wget without -q
+
     false
   end
 


### PR DESCRIPTION
rubocop 1.65.0 fixed false negatives for Lint/Void, which highlighted some bugs where the guard clauses weren't doing anything.

Commit 01db61e241 moved code from runtime3_support to runtime3_resource_support:

    * Runtime3Support is modified to use Runtime3ResourceSupport instead of
      directly containing the methods for resource search and creation.

But the `resource_to_ptype` method was copied instead of moved. So delete it from Runtime3Support.

This should not be backported to 7.x, since we're constrained to an older version: https://github.com/puppetlabs/puppet/blob/46e88b416de67c85ee32b42395a6464ee9397342/Gemfile#L55