### PR TITLE
Workaround strings bug when generating function docs

### DIFF
--- a/lib/puppet/functions/hiera.rb
+++ b/lib/puppet/functions/hiera.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'hiera/puppet_function'
+
 # Performs a standard priority lookup of the hierarchy and returns the most specific value
 # for a given key. The returned value can be any type of data.
 #

--- a/lib/puppet/functions/yaml_data.rb
+++ b/lib/puppet/functions/yaml_data.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'yaml'
+
 # The `yaml_data` is a hiera 5 `data_hash` data provider function.
 # See [the configuration guide documentation](https://puppet.com/docs/puppet/latest/hiera_config_yaml_5.html#configuring-a-hierarchy-level-built-in-backends) for
 # how to use this function.


### PR DESCRIPTION
Added a newline between the require statement and start of documentation to work around https://github.com/puppetlabs/puppet-strings/issues/296

To verify, run:

    echo 'gem "puppet-strings"' >> Gemfile.local
    bundle update
    bundle exec puppet strings generate --format json --out /tmp/strings.json
    jq -r '.puppet_functions[] | select(.name == "yaml_data").docstring.text ' /tmp/strings.json | head

This should be backported to 7.x