### PR TITLE
(packaging) Bump to version '7.33.0' [no-promote]

### DIFF
--- a/puppet.gemspec
+++ b/puppet.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name = "puppet"
-  spec.version = "7.32.1"
+  spec.version = "7.33.0"
   spec.license = 'Apache-2.0'
 
   spec.required_rubygems_version = Gem::Requirement.new("> 1.3.1")


### PR DESCRIPTION
This reconciles both the version.rb and gemspec to the same version number (7.33.0).