### PR TITLE
(packaging) Bump to version '8.9.0' [no-promote]

### DIFF
--- a/puppet.gemspec
+++ b/puppet.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name = "puppet"
-  spec.version = "8.8.1"
+  spec.version = "8.9.0"
   spec.licenses = ['Apache-2.0']
 
   spec.required_rubygems_version = Gem::Requirement.new("> 1.3.1")


### PR DESCRIPTION
This reconciles both the version.rb and gemspec to the same version number (8.9.0).