### PR TITLE
Remove broken pacman command for installing packages 

### DIFF
--- a/lib/puppet/provider/package/pacman.rb
+++ b/lib/puppet/provider/package/pacman.rb
@@ -29,7 +29,7 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
 
   # Checks if a given name is a group
   def self.group?(name)
-    !pacman("-Sg", name).empty?
+    !pacman('--sync', '--groups', name).empty?
   rescue Puppet::ExecutionFailure
     # pacman returns an expected non-zero exit code when the name is not a group
     false
@@ -74,7 +74,7 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
   # returns a hash package => version of installed packages
   def self.get_installed_packages
     packages = {}
-    execpipe([command(:pacman), "-Q"]) do |pipe|
+    execpipe([command(:pacman), "--query"]) do |pipe|
       # pacman -Q output is 'packagename version-rel'
       regex = /^(\S+)\s(\S+)/
       pipe.each_line do |line|
@@ -96,7 +96,7 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
     groups = {}
     begin
       # Build a hash of group name => list of packages
-      command = [command(:pacman), "-Sgg"]
+      command = [command(:pacman), '--sync', '-gg']
       command << filter if filter
       execpipe(command) do |pipe|
         pipe.each_line do |line|
@@ -134,14 +134,14 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
     resource_name = @resource[:name]
 
     # If target is a group, construct the group version
-    return pacman("-Sp", "--print-format", "%n %v", resource_name).lines.map(&:chomp).sort.join(', ') if self.class.group?(resource_name)
+    return pacman("--sync", "--print", "--print-format", "%n %v", resource_name).lines.map(&:chomp).sort.join(', ') if self.class.group?(resource_name)
 
     # Start by querying with pacman first
     # If that fails, retry using yaourt against the AUR
     pacman_check = true
     begin
       if pacman_check
-        output = pacman "-Sp", "--print-format", "%v", resource_name
+        output = pacman "--sync", "--print", "--print-format", "%v", resource_name
         output.chomp
       else
         output = yaourt "-Qma", resource_name
@@ -210,8 +210,8 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
 
     cmd = %w[--noconfirm --noprogressbar]
     cmd += uninstall_options if @resource[:uninstall_options]
-    cmd << "-R"
-    cmd << '-s' if is_group
+    cmd << "--remove"
+    cmd << '--recursive' if is_group
     cmd << '--nosave' if purge_configs
     cmd << resource_name
 
@@ -248,7 +248,7 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
              else
                fail _("Source %{source} is not supported by pacman") % { source: source }
              end
-    pacman "--noconfirm", "--noprogressbar", "-U", source
+    pacman "--noconfirm", "--noprogressbar", "--update", source
   end
 
   def install_from_repo
@@ -259,7 +259,7 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
 
     cmd = %w[--noconfirm --needed --noprogressbar]
     cmd += install_options if @resource[:install_options]
-    cmd << "-S" << resource_name
+    cmd << "--sync" << resource_name
 
     if self.class.yaourt?
       yaourt(*cmd)

--- a/lib/puppet/provider/package/pacman.rb
+++ b/lib/puppet/provider/package/pacman.rb
@@ -248,7 +248,6 @@ Puppet::Type.type(:package).provide :pacman, :parent => Puppet::Provider::Packag
              else
                fail _("Source %{source} is not supported by pacman") % { source: source }
              end
-    pacman "--noconfirm", "--noprogressbar", "-S"
     pacman "--noconfirm", "--noprogressbar", "-U", source
   end
 

--- a/spec/unit/provider/package/pacman_spec.rb
+++ b/spec/unit/provider/package/pacman_spec.rb
@@ -98,11 +98,6 @@ describe Puppet::Type.type(:package).provider(:pacman) do
             resource[:source] = source
 
             expect(executor).to receive(:execute).
-              with(include("-S") & include("--noprogressbar"), no_extra_options).
-              ordered.
-              and_return("")
-
-            expect(executor).to receive(:execute).
               with(include("-U") & include(source), no_extra_options).
               ordered.
               and_return("")
@@ -120,12 +115,6 @@ describe Puppet::Type.type(:package).provider(:pacman) do
         end
 
         it "should install from the path segment of the URL" do
-          expect(executor).to receive(:execute).
-            with(include("-S") & include("--noprogressbar") & include("--noconfirm"),
-                 no_extra_options).
-            ordered.
-            and_return("")
-
           expect(executor).to receive(:execute).
             with(include("-U") & include(actual_file_path), no_extra_options).
             ordered.

--- a/spec/unit/provider/package/pacman_spec.rb
+++ b/spec/unit/provider/package/pacman_spec.rb
@@ -26,7 +26,7 @@ describe Puppet::Type.type(:package).provider(:pacman) do
     end
 
     it "should call pacman to install the right package quietly when yaourt is not installed" do
-      args = ['--noconfirm', '--needed', '--noprogressbar', '-S', resource[:name]]
+      args = ['--noconfirm', '--needed', '--noprogressbar', '--sync', resource[:name]]
       expect(provider).to receive(:pacman).at_least(:once).with(*args).and_return('')
       provider.install
     end
@@ -34,7 +34,7 @@ describe Puppet::Type.type(:package).provider(:pacman) do
     it "should call yaourt to install the right package quietly when yaourt is installed" do
       without_partial_double_verification do
         allow(described_class).to receive(:yaourt?).and_return(true)
-        args = ['--noconfirm', '--needed', '--noprogressbar', '-S', resource[:name]]
+        args = ['--noconfirm', '--needed', '--noprogressbar', '--sync', resource[:name]]
         expect(provider).to receive(:yaourt).at_least(:once).with(*args).and_return('')
         provider.install
       end
@@ -70,7 +70,7 @@ describe Puppet::Type.type(:package).provider(:pacman) do
       end
 
       it "should call pacman to install the right package quietly when yaourt is not installed" do
-        args = ['--noconfirm', '--needed', '--noprogressbar', '-x', '--arg=value', '-S', resource[:name]]
+        args = ['--noconfirm', '--needed', '--noprogressbar', '-x', '--arg=value', '--sync', resource[:name]]
         expect(provider).to receive(:pacman).at_least(:once).with(*args).and_return('')
         provider.install
       end
@@ -78,7 +78,7 @@ describe Puppet::Type.type(:package).provider(:pacman) do
       it "should call yaourt to install the right package quietly when yaourt is installed" do
         without_partial_double_verification do
           expect(described_class).to receive(:yaourt?).and_return(true)
-          args = ['--noconfirm', '--needed', '--noprogressbar', '-x', '--arg=value', '-S', resource[:name]]
+          args = ['--noconfirm', '--needed', '--noprogressbar', '-x', '--arg=value', '--sync', resource[:name]]
           expect(provider).to receive(:yaourt).at_least(:once).with(*args).and_return('')
           provider.install
         end
@@ -98,7 +98,7 @@ describe Puppet::Type.type(:package).provider(:pacman) do
             resource[:source] = source
 
             expect(executor).to receive(:execute).
-              with(include("-U") & include(source), no_extra_options).
+              with(include("--update") & include(source), no_extra_options).
               ordered.
               and_return("")
 
@@ -116,7 +116,7 @@ describe Puppet::Type.type(:package).provider(:pacman) do
 
         it "should install from the path segment of the URL" do
           expect(executor).to receive(:execute).
-            with(include("-U") & include(actual_file_path), no_extra_options).
+            with(include("--update") & include(actual_file_path), no_extra_options).
             ordered.
             and_return("")
 
@@ -159,7 +159,7 @@ describe Puppet::Type.type(:package).provider(:pacman) do
 
   describe "when purging" do
     it "should call pacman to remove the right package and configs quietly" do
-      args = ["/usr/bin/pacman", "--noconfirm", "--noprogressbar", "-R", "--nosave", resource[:name]]
+      args = ["/usr/bin/pacman", "--noconfirm", "--noprogressbar", "--remove", "--nosave", resource[:name]]
       expect(executor).to receive(:execute).with(args, no_extra_options).and_return("")
       provider.purge
     end
@@ -167,7 +167,7 @@ describe Puppet::Type.type(:package).provider(:pacman) do
 
   describe "when uninstalling" do
     it "should call pacman to remove the right package quietly" do
-      args = ["/usr/bin/pacman", "--noconfirm", "--noprogressbar", "-R", resource[:name]]
+      args = ["/usr/bin/pacman", "--noconfirm", "--noprogressbar", "--remove", resource[:name]]
       expect(executor).to receive(:execute).with(args, no_extra_options).and_return("")
       provider.uninstall
     end
@@ -175,7 +175,7 @@ describe Puppet::Type.type(:package).provider(:pacman) do
     it "should call yaourt to remove the right package quietly" do
       without_partial_double_verification do
         allow(described_class).to receive(:yaourt?).and_return(true)
-        args = ["--noconfirm", "--noprogressbar", "-R", resource[:name]]
+        args = ["--noconfirm", "--noprogressbar", "--remove", resource[:name]]
         expect(provider).to receive(:yaourt).with(*args)
         provider.uninstall
       end
@@ -183,14 +183,14 @@ describe Puppet::Type.type(:package).provider(:pacman) do
 
     it "adds any uninstall_options" do
       resource[:uninstall_options] = ['-x', {'--arg' => 'value'}]
-      args = ["/usr/bin/pacman", "--noconfirm", "--noprogressbar", "-x", "--arg=value", "-R", resource[:name]]
+      args = ["/usr/bin/pacman", "--noconfirm", "--noprogressbar", "-x", "--arg=value", "--remove", resource[:name]]
       expect(executor).to receive(:execute).with(args, no_extra_options).and_return("")
       provider.uninstall
     end
 
     it "should recursively remove packages when given a package group" do
       allow(described_class).to receive(:group?).and_return(true)
-      args = ["/usr/bin/pacman", "--noconfirm", "--noprogressbar", "-R", "-s", resource[:name]]
+      args = ["/usr/bin/pacman", "--noconfirm", "--noprogressbar", "--remove", "--recursive", resource[:name]]
       expect(executor).to receive(:execute).with(args, no_extra_options).and_return("")
       provider.uninstall
     end
@@ -198,19 +198,19 @@ describe Puppet::Type.type(:package).provider(:pacman) do
 
   describe "when querying" do
     it "should query pacman" do
-      expect(executor).to receive(:execpipe).with(["/usr/bin/pacman", '-Q'])
-      expect(executor).to receive(:execpipe).with(["/usr/bin/pacman", '-Sgg', 'package'])
+      expect(executor).to receive(:execpipe).with(["/usr/bin/pacman", '--query'])
+      expect(executor).to receive(:execpipe).with(["/usr/bin/pacman", '--sync', '-gg', 'package'])
       provider.query
     end
 
     it "should return the version" do
       expect(executor).to receive(:execpipe).
-          with(["/usr/bin/pacman", "-Q"]).and_yield(<<EOF)
+          with(["/usr/bin/pacman", "--query"]).and_yield(<<EOF)
 otherpackage 1.2.3.4
 package 1.01.3-2
 yetanotherpackage 1.2.3.4
 EOF
-      expect(executor).to receive(:execpipe).with(['/usr/bin/pacman', '-Sgg', 'package']).and_yield('')
+      expect(executor).to receive(:execpipe).with(['/usr/bin/pacman', '--sync', '-gg', 'package']).and_yield('')
 
       expect(provider.query).to eq({ :name => 'package', :ensure => '1.01.3-2', :provider => :pacman,  })
     end
@@ -228,8 +228,8 @@ EOF
 
     describe 'when querying a group' do
       before :each do
-        expect(executor).to receive(:execpipe).with(['/usr/bin/pacman', '-Q']).and_yield('foo 1.2.3')
-        expect(executor).to receive(:execpipe).with(['/usr/bin/pacman', '-Sgg', 'package']).and_yield('package foo')
+        expect(executor).to receive(:execpipe).with(['/usr/bin/pacman', '--query']).and_yield('foo 1.2.3')
+        expect(executor).to receive(:execpipe).with(['/usr/bin/pacman', '--sync', '-gg', 'package']).and_yield('package foo')
       end
 
       it 'should warn when allow_virtual is false' do
@@ -248,14 +248,14 @@ EOF
 
   describe "when determining instances" do
     it "should retrieve installed packages and groups" do
-      expect(described_class).to receive(:execpipe).with(["/usr/bin/pacman", '-Q'])
-      expect(described_class).to receive(:execpipe).with(["/usr/bin/pacman", '-Sgg'])
+      expect(described_class).to receive(:execpipe).with(["/usr/bin/pacman", '--query'])
+      expect(described_class).to receive(:execpipe).with(["/usr/bin/pacman", '--sync', '-gg'])
       described_class.instances
     end
 
     it "should return installed packages" do
-      expect(described_class).to receive(:execpipe).with(["/usr/bin/pacman", '-Q']).and_yield(StringIO.new("package1 1.23-4\npackage2 2.00\n"))
-      expect(described_class).to receive(:execpipe).with(["/usr/bin/pacman", '-Sgg']).and_yield("")
+      expect(described_class).to receive(:execpipe).with(["/usr/bin/pacman", '--query']).and_yield(StringIO.new("package1 1.23-4\npackage2 2.00\n"))
+      expect(described_class).to receive(:execpipe).with(["/usr/bin/pacman", '--sync', '-gg']).and_yield("")
       instances = described_class.instances
 
       expect(instances.length).to eq(2)
@@ -274,11 +274,11 @@ EOF
     end
 
     it "should return completely installed groups with a virtual version together with packages" do
-      expect(described_class).to receive(:execpipe).with(["/usr/bin/pacman", '-Q']).and_yield(<<EOF)
+      expect(described_class).to receive(:execpipe).with(["/usr/bin/pacman", '--query']).and_yield(<<EOF)
 package1 1.00
 package2 1.00
 EOF
-      expect(described_class).to receive(:execpipe).with(["/usr/bin/pacman", '-Sgg']).and_yield(<<EOF)
+      expect(described_class).to receive(:execpipe).with(["/usr/bin/pacman", '--sync', '-gg']).and_yield(<<EOF)
 group1 package1
 group1 package2
 EOF
@@ -304,10 +304,10 @@ EOF
     end
 
     it "should not return partially installed packages" do
-      expect(described_class).to receive(:execpipe).with(["/usr/bin/pacman", '-Q']).and_yield(<<EOF)
+      expect(described_class).to receive(:execpipe).with(["/usr/bin/pacman", '--query']).and_yield(<<EOF)
 package1 1.00
 EOF
-      expect(described_class).to receive(:execpipe).with(["/usr/bin/pacman", '-Sgg']).and_yield(<<EOF)
+      expect(described_class).to receive(:execpipe).with(["/usr/bin/pacman", '--sync', '-gg']).and_yield(<<EOF)
 group1 package1
 group1 package2
 EOF
@@ -323,7 +323,7 @@ EOF
     end
 
     it 'should sort package names for installed groups' do
-      expect(described_class).to receive(:execpipe).with(['/usr/bin/pacman', '-Sgg', 'group1']).and_yield(<<EOF)
+      expect(described_class).to receive(:execpipe).with(['/usr/bin/pacman', '--sync', '-gg', 'group1']).and_yield(<<EOF)
 group1 aa
 group1 b
 group1 a
@@ -354,7 +354,7 @@ EOF
     it "should get query pacman for the latest version" do
       expect(executor).to receive(:execute).
         ordered.
-        with(['/usr/bin/pacman', '-Sp', '--print-format', '%v', resource[:name]], no_extra_options).
+        with(['/usr/bin/pacman', '--sync', '--print', '--print-format', '%v', resource[:name]], no_extra_options).
         and_return("")
 
       provider.latest
@@ -368,7 +368,7 @@ EOF
 
     it "should return a virtual group version when resource is a package group" do
       allow(described_class).to receive(:group?).and_return(true)
-      expect(executor).to receive(:execute).with(['/usr/bin/pacman', '-Sp', '--print-format', '%n %v', resource[:name]], no_extra_options).ordered.
+      expect(executor).to receive(:execute).with(['/usr/bin/pacman', '--sync', '--print', '--print-format', '%n %v', resource[:name]], no_extra_options).ordered.
         and_return(<<EOF)
 package2 1.0.1
 package1 1.0.0
@@ -383,17 +383,17 @@ EOF
     end
 
     it 'should return false on non-zero pacman exit' do
-      allow(executor).to receive(:execute).with(['/usr/bin/pacman', '-Sg', 'git'], {:failonfail => true, :combine => true, :custom_environment => {}}).and_raise(Puppet::ExecutionFailure, 'error')
+      allow(executor).to receive(:execute).with(['/usr/bin/pacman', '--sync', '--groups', 'git'], {:failonfail => true, :combine => true, :custom_environment => {}}).and_raise(Puppet::ExecutionFailure, 'error')
       expect(described_class.group?('git')).to eq(false)
     end
 
     it 'should return false on empty pacman output' do
-      allow(executor).to receive(:execute).with(['/usr/bin/pacman', '-Sg', 'git'], {:failonfail => true, :combine => true, :custom_environment => {}}).and_return('')
+      allow(executor).to receive(:execute).with(['/usr/bin/pacman', '--sync', '--groups', 'git'], {:failonfail => true, :combine => true, :custom_environment => {}}).and_return('')
       expect(described_class.group?('git')).to eq(false)
     end
 
     it 'should return true on non-empty pacman output' do
-      allow(executor).to receive(:execute).with(['/usr/bin/pacman', '-Sg', 'vim-plugins'], {:failonfail => true, :combine => true, :custom_environment => {}}).and_return('vim-plugins vim-a')
+      allow(executor).to receive(:execute).with(['/usr/bin/pacman', '--sync', '--groups', 'vim-plugins'], {:failonfail => true, :combine => true, :custom_environment => {}}).and_return('vim-plugins vim-a')
       expect(described_class.group?('vim-plugins')).to eq(true)
     end
   end
@@ -403,13 +403,13 @@ EOF
     let(:groups) { [['foo package1'], ['foo package2'], ['bar package3'], ['bar package4'], ['baz package5']] }
 
     it 'should raise an error on non-zero pacman exit without a filter' do
-      expect(executor).to receive(:open).with('| /usr/bin/pacman -Sgg 2>&1').and_return('error!')
+      expect(executor).to receive(:open).with('| /usr/bin/pacman --sync -gg 2>&1').and_return('error!')
       expect(Puppet::Util::Execution).to receive(:exitstatus).and_return(1)
       expect { described_class.get_installed_groups(installed_packages) }.to raise_error(Puppet::ExecutionFailure, 'error!')
     end
 
     it 'should return empty groups on non-zero pacman exit with a filter' do
-      expect(executor).to receive(:open).with('| /usr/bin/pacman -Sgg git 2>&1').and_return('')
+      expect(executor).to receive(:open).with('| /usr/bin/pacman --sync -gg git 2>&1').and_return('')
       expect(Puppet::Util::Execution).to receive(:exitstatus).and_return(1)
       expect(described_class.get_installed_groups(installed_packages, 'git')).to eq({})
     end
@@ -417,7 +417,7 @@ EOF
     it 'should return empty groups on empty pacman output' do
       pipe = double()
       expect(pipe).to receive(:each_line)
-      expect(executor).to receive(:open).with('| /usr/bin/pacman -Sgg 2>&1').and_yield(pipe).and_return('')
+      expect(executor).to receive(:open).with('| /usr/bin/pacman --sync -gg 2>&1').and_yield(pipe).and_return('')
       expect(Puppet::Util::Execution).to receive(:exitstatus).and_return(0)
       expect(described_class.get_installed_groups(installed_packages)).to eq({})
     end
@@ -427,7 +427,7 @@ EOF
       pipe_expectation = receive(:each_line)
       groups.each { |group| pipe_expectation = pipe_expectation.and_yield(*group) }
       expect(pipe).to pipe_expectation
-      expect(executor).to receive(:open).with('| /usr/bin/pacman -Sgg 2>&1').and_yield(pipe).and_return('')
+      expect(executor).to receive(:open).with('| /usr/bin/pacman --sync -gg 2>&1').and_yield(pipe).and_return('')
       expect(Puppet::Util::Execution).to receive(:exitstatus).and_return(0)
       expect(described_class.get_installed_groups(installed_packages)).to eq({'foo' => 'package1 1.0, package2 2.0'})
     end


### PR DESCRIPTION
This is a regression from https://github.com/puppetlabs/puppet/commit/d23d6dbfd2e578016441ab292d934b4d74ab436f

During some cleanup, the command

```
pacman pacman --noconfirm --noprogressbar -Sy
```

got modified to:

```
pacman pacman --noconfirm --noprogressbar -S
```

But this isn't a valid command anymore:

```
root@bastelfreak-nb ~ # pacman --noconfirm --noprogressbar -S
error: no targets specified (use -h for help)
root@bastelfreak-nb ~ #
```

The idea was to prevent partial system upgrades while installing new packages. To do this, the `sync` option was removed from the installation routine. The correct fix is to remove the command completely.