### PR TITLE
Add file mode-awareness to selabel_lookup

### DIFF
--- a/lib/puppet/type/file/selcontext.rb
+++ b/lib/puppet/type/file/selcontext.rb
@@ -45,7 +45,7 @@ module Puppet
         return nil
       end
 
-      context = get_selinux_default_context_with_handle(@resource[:path], provider.class.selinux_handle)
+      context = get_selinux_default_context_with_handle(@resource[:path], provider.class.selinux_handle, @resource[:ensure])
       unless context
         return nil
       end

--- a/spec/unit/type/file/selinux_spec.rb
+++ b/spec/unit/type/file/selinux_spec.rb
@@ -51,7 +51,7 @@ require 'spec_helper'
 
     it "should handle no default gracefully" do
       skip if Puppet::Util::Platform.windows?
-      expect(@sel).to receive(:get_selinux_default_context_with_handle).with(@path, nil).and_return(nil)
+      expect(@sel).to receive(:get_selinux_default_context_with_handle).with(@path, nil, :file).and_return(nil)
       expect(@sel.default).to be_nil
     end
 
@@ -59,7 +59,7 @@ require 'spec_helper'
       allow(@sel).to receive(:debug)
       hnd = double("SWIG::TYPE_p_selabel_handle")
       allow(@sel.provider.class).to receive(:selinux_handle).and_return(hnd)
-      expect(@sel).to receive(:get_selinux_default_context_with_handle).with(@path, hnd).and_return("user_u:role_r:type_t:s0")
+      expect(@sel).to receive(:get_selinux_default_context_with_handle).with(@path, hnd, :file).and_return("user_u:role_r:type_t:s0")
       expectedresult = case param
         when :seluser; "user_u"
         when :selrole; "role_r"


### PR DESCRIPTION
Fixes https://github.com/puppetlabs/puppet/issues/9431
Supersedes https://github.com/puppetlabs/puppet/pull/9437

This PR reproduces much of the mode-related functionality of the now-deprecated matchpathcon codepath. This is important because without this, Puppet determines an incorrect SELinux label to apply to files -- i.e. it does not match what restorecon would do -- which is important because correct SELinux labelling is a necessity in order to ensure that policy is applied correctly.