### PR TITLE
Update init.rb to support Nvidia's Cumulus Linux

### DIFF
--- a/lib/puppet/provider/service/init.rb
+++ b/lib/puppet/provider/service/init.rb
@@ -21,7 +21,7 @@ Puppet::Type.type(:service).provide :init, :parent => :base do
   end
 
   # Debian and Ubuntu should use the Debian provider.
-  confine :false => %w[Debian Ubuntu].include?(Puppet.runtime[:facter].value('os.name'))
+  confine :false => %w[Debian Ubuntu Cumulus].include?(Puppet.runtime[:facter].value('os.name'))
   # RedHat systems should use the RedHat provider.
   confine :false => Puppet.runtime[:facter].value('os.family') == 'RedHat'
 


### PR DESCRIPTION
Cumulus Linux uses systemd, not system-v's init.
This fixes errors like:

Failed to call refresh: Could not find init script for 'telegraf'