### PR TITLE
Add files to include in tarball

### DIFF
--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -6,3 +6,15 @@ gem_rdoc_options:
   - --main
   - README.md
   - --line-numbers
+# Array of files to include when building source tarballs
+files:
+  - '[A-Z]*'
+  - install.rb
+  - bin
+  - lib
+  - conf
+  - man
+  - examples
+  - ext
+  - tasks
+  - locales


### PR DESCRIPTION
Previously, Puppet relied on the in-house Packaging library to build all artifacts related to Puppet. Puppet moved away from using Packaging to build gems in 867ce9c, which also removed the files key used to build tarballs.

This commit re-adds the files key (as a list instead of a string, as recommended by Packaging) to enable the packaging:tar Rake task, which builds source tarballs of Puppet.