### PR TITLE
Fix include matcher behavior

### DIFF
--- a/spec/integration/parser/collection_spec.rb
+++ b/spec/integration/parser/collection_spec.rb
@@ -8,7 +8,7 @@ describe 'collectors' do
     catalog = compile_to_catalog(code, node)
     messages = catalog.resources.find_all { |resource| resource.type == 'Notify' }.
                                  collect { |notify| notify[:message] }
-    expect(messages).to include(*expected_messages)
+    expected_messages.each { |message| expect(messages).to include(message) }
   end
 
   def warnings


### PR DESCRIPTION
rspec-expectations recently released v3.13.2, which includes a change to the include matcher (see rspec/rspec-expectations@bd5d306).

This change breaks using the splat operator on an array into the include matcher.

This commit updates the matcher to iterate over the array instead of using the splat operator.