### PR TITLE
Documentation updates

### DIFF
--- a/lib/puppet/application/filebucket.rb
+++ b/lib/puppet/application/filebucket.rb
@@ -76,10 +76,10 @@ class Puppet::Application::Filebucket < Puppet::Application
       use your local file bucket by specifying '--local', or by specifying
       '--bucket' with a local path.
 
-      **Note**: Enabling and using the backup option, and by extension the
-      filebucket resource, requires appropriate planning and management to ensure
-      that sufficient disk space is available for the file backups. Generally, you
-      can implement this using one of the following two options:
+      **Important**: When you enable and use the backup option, and by extension
+      the filebucket resource, you must ensure that sufficient disk space is
+      available for the file backups. Generally, you can provide the disk space
+      by using one of the following two options:
 
         - Use a `find` command and `crontab` entry to retain only the last X days
         of file backups. For example:

--- a/lib/puppet/face/catalog.rb
+++ b/lib/puppet/face/catalog.rb
@@ -29,7 +29,7 @@ Puppet::Indirector::Face.define(:catalog, '0.0.1') do
     summary _("Retrieve the catalog for the node from which the command is run.")
     arguments "<certname>, <facts>"
     option("--facts_for_catalog") do
-      summary _("Not yet implemented for the CLI; facts will be collected internally.")
+      summary _("Not implemented for the CLI; facts are collected internally.")
     end
     returns <<-'EOT'
       A serialized catalog. When used from the Ruby API, returns a


### PR DESCRIPTION
Updates based on feedback:

1. Avoid making promises about future releases ... (so) avoid the word "yet."

2. We assume that users are reading the documentation while they use the product, so we write in the present tense.

3. Avoid the "Note" label because it doesn't tell users anything about the content of the note. Users can't tell whether the note will present crucial information or be just a tip. In this case, we could use the "Important" or "Restriction" label instead.