### PR TITLE
(PUP-12075) Render puppet man page correctly

### DIFF
--- a/lib/puppet/reference/configuration.rb
+++ b/lib/puppet/reference/configuration.rb
@@ -43,6 +43,8 @@ config = Puppet::Util::Reference.newreference(:configuration, :depth => 1, :doc 
       val = "the Host's fully qualified domain name, as determined by Facter"
     when 'srv_domain'
       val = 'example.com'
+    when 'http_user_agent'
+      val = 'Puppet/<version> Ruby/<version> (<architecture>)'
     end
 
     # Leave out the section information; it was apparently confusing people.

--- a/man/man5/puppet.conf.5
+++ b/man/man5/puppet.conf.5
@@ -973,7 +973,7 @@ The time to wait for data to be read from an HTTP connection\. If nothing is rea
 The HTTP User\-Agent string to send when making network requests\.
 .
 .IP "\(bu" 4
-\fIDefault\fR: \fBPuppet/8\.9\.0 Ruby/3\.1\.1\-p18 (x86_64\-linux)\fR
+\fIDefault\fR: \fBPuppet/<version> Ruby/<version> (<architecture>)\fR
 .
 .IP "" 0
 .

--- a/man/man8/puppet.8
+++ b/man/man8/puppet.8
@@ -4,25 +4,138 @@
 .TH "PUPPET" "8" "August 2024" "Puppet, Inc." "Puppet manual"
 .
 .SH "NAME"
-\fBpuppet\fR
+\fBpuppet\fR \- an automated configuration management tool
 .
-.P
-Usage: puppet \fIsubcommand\fR [options] \fIaction\fR [options]
+.SH "SYNOPSIS"
+\fBpuppet\fR \fIsubcommand\fR [options] \fIaction\fR [options]
 .
-.P
-Available subcommands:
+.SH "DESCRIPTION"
+Puppet, an automated administrative engine for your Linux, Unix, and Windows systems, performs administrative tasks (such as adding users, installing packages, and updating server configurations) based on a centralized specification\.
 .
-.P
-Common:
+.SH "COMMANDS"
 .
-.br
-agent The puppet agent daemon apply Apply Puppet manifests locally config Interact with Puppet\'s settings\. help Display Puppet help\. lookup Interactive Hiera lookup module Creates, installs and searches for modules on the Puppet Forge\. resource The resource abstraction layer shell
-.
-.P
-Specialized:
+.SS "Common"
+\fBapply\fR
 .
 .br
-catalog Compile, save, view, and convert catalogs\. describe Display help about resource types device Manage remote network devices doc Generate Puppet references epp Interact directly with the EPP template parser/renderer\. facts Retrieve and store facts\. filebucket Store and retrieve files in a filebucket generate Generates Puppet code from Ruby definitions\. node View and manage node definitions\. parser Interact directly with the parser\. plugin Interact with the Puppet plugin system\. script Run a puppet manifests as a script without compiling a catalog ssl Manage SSL keys and certificates for puppet SSL clients
+\~\~\~\~Apply Puppet manifests locally
 .
 .P
-See \'puppet help \fIsubcommand\fR \fIaction\fR\' for help on a specific subcommand action\. See \'puppet help \fIsubcommand\fR\' for help on a specific subcommand\. Puppet v8\.9\.0
+\fBagent\fR
+.
+.br
+\~\~\~\~The puppet agent daemon
+.
+.P
+\fBconfig\fR
+.
+.br
+\~\~\~\~Interact with Puppet\'s settings\.
+.
+.P
+\fBhelp\fR
+.
+.br
+\~\~\~\~Display Puppet help\.
+.
+.P
+\fBlookup\fR
+.
+.br
+\~\~\~\~Interactive Hiera lookup
+.
+.P
+\fBmodule\fR
+.
+.br
+\~\~\~\~Creates, installs and searches for modules on the Puppet Forge\.
+.
+.P
+\fBresource\fR
+.
+.br
+\~\~\~\~The resource abstraction layer shell
+.
+.SS "Specialized"
+\fBcatalog\fR
+.
+.br
+\~\~\~\~Compile, save, view, and convert catalogs\.
+.
+.P
+\fBdescribe\fR
+.
+.br
+\~\~\~\~Display help about resource types
+.
+.P
+\fBdevice\fR
+.
+.br
+\~\~\~\~Manage remote network devices
+.
+.P
+\fBdoc\fR
+.
+.br
+\~\~\~\~Generate Puppet references
+.
+.P
+\fBepp\fR
+.
+.br
+\~\~\~\~Interact directly with the EPP template parser/renderer\.
+.
+.P
+\fBfacts\fR
+.
+.br
+\~\~\~\~Retrieve and store facts\.
+.
+.P
+\fBfilebucket\fR
+.
+.br
+\~\~\~\~Store and retrieve files in a filebucket
+.
+.P
+\fBgenerate\fR
+.
+.br
+\~\~\~\~Generates Puppet code from Ruby definitions\.
+.
+.P
+\fBnode\fR
+.
+.br
+\~\~\~\~View and manage node definitions\.
+.
+.P
+\fBparser\fR
+.
+.br
+\~\~\~\~Interact directly with the parser\.
+.
+.P
+\fBplugin\fR
+.
+.br
+\~\~\~\~Interact with the Puppet plugin system\.
+.
+.P
+\fBscript\fR
+.
+.br
+\~\~\~\~Run a puppet manifests as a script without compiling a catalog
+.
+.P
+\fBssl\fR
+.
+.br
+\~\~\~\~Manage SSL keys and certificates for puppet SSL clients
+.
+.SH "SEE ALSO"
+See \fBpuppet help <subcommand>\fR for help on a specific subcommand\.
+.
+.P
+See \fBpuppet help <subcommand> <action>\fR for help on a specific subcommand action\.

--- a/rakelib/man/puppet.erb
+++ b/rakelib/man/puppet.erb
@@ -1,0 +1,34 @@
+puppet(8) - an automated configuration management tool
+=========
+
+## SYNOPSIS
+
+`puppet` <subcommand> [options] <action> [options]
+
+## DESCRIPTION
+
+Puppet, an automated administrative engine for your Linux, Unix, and Windows systems, performs administrative tasks
+(such as adding users, installing packages, and updating server configurations) based on a centralized specification.
+
+## COMMANDS
+
+### Common
+
+<% common.each do |appname, summary, _| -%>
+`<%= appname.to_s %>`<br>
+&nbsp;&nbsp;&nbsp;&nbsp;<%= summary %>
+
+<% end -%>
+
+### Specialized
+
+<% specialized.each do |appname, summary, _| -%>
+`<%= appname.to_s %>`<br>
+&nbsp;&nbsp;&nbsp;&nbsp;<%= summary %>
+
+<% end -%>
+
+## SEE ALSO
+See `puppet help <subcommand>` for help on a specific subcommand.
+
+See `puppet help <subcommand> <action>` for help on a specific subcommand action.


### PR DESCRIPTION
Previously, the man/man8/puppet.8 man page wasn't formatted correctly
with each subcommand and summary on a new line. This was because
`puppet --help` doesn't output ronn format, just raw text. So generate
`puppet.8.ronn` in valid ronn format so that it can be converted to
roff. Use `man --local-file man/man8/puppet.8` to verify the results.

Also don't blindly run `<bin>/<app> --help` for every app. That's left
over from when puppet had multiple bin stubs.

Since ronn shells out to groff, abort if the latter is not installed.

Hardcode the http_user_agent value so it's not sensitive to the puppet
version or the ruby version/architecture the user is running.
