### PR TITLE
Hardcode hostname and domain

### DIFF
--- a/lib/puppet/reference/configuration.rb
+++ b/lib/puppet/reference/configuration.rb
@@ -41,6 +41,10 @@ config = Puppet::Util::Reference.newreference(:configuration, :depth => 1, :doc 
       val = '$confdir/hiera.yaml. However, for backwards compatibility, if a file exists at $codedir/hiera.yaml, Puppet uses that instead.'
     when 'certname'
       val = "the Host's fully qualified domain name, as determined by Facter"
+    when 'hostname'
+      val = "(the system's fully qualified hostname)"
+    when 'domain'
+      val = "(the system's own domain)"
     when 'srv_domain'
       val = 'example.com'
     when 'http_user_agent'

--- a/lib/puppet/settings.rb
+++ b/lib/puppet/settings.rb
@@ -81,11 +81,11 @@ class Puppet::Settings
   end
 
   def self.hostname_fact
-    ENV['PUPPET_REFERENCES_HOSTNAME'] || Puppet.runtime[:facter].value('networking.hostname')
+    Puppet.runtime[:facter].value('networking.hostname')
   end
 
   def self.domain_fact
-    ENV['PUPPET_REFERENCES_DOMAIN'] || Puppet.runtime[:facter].value('networking.domain')
+    Puppet.runtime[:facter].value('networking.domain')
   end
 
   def self.default_config_file_name

--- a/rakelib/generate_references.rake
+++ b/rakelib/generate_references.rake
@@ -41,9 +41,6 @@ end
 namespace :references do
   desc "Generate configuration reference"
   task :configuration do
-    ENV['PUPPET_REFERENCES_HOSTNAME'] = "(the system's fully qualified hostname)"
-    ENV['PUPPET_REFERENCES_DOMAIN'] = "(the system's own domain)"
-
     body = puppet_doc('configuration')
     generate_reference('configuration', CONFIGURATION_ERB, body, CONFIGURATION_MD)
   end


### PR DESCRIPTION
Rather than introducing new environment variables, just hard code the default value in the config reference like we do for others.

See also c5c7fc8412497647aa1a591e39067f1440e51a2b