### PR TITLE
(PUP-12077) Respect rich_data setting in base context

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -237,7 +237,11 @@ module Puppet
       :ssl_context => proc { Puppet.runtime[:http].default_ssl_context },
       :http_session => proc { Puppet.runtime[:http].create_session },
       :plugins => proc { Puppet::Plugins::Configuration.load_plugins },
-      :rich_data => Puppet[:rich_data]
+      :rich_data => Puppet[:rich_data],
+      # `stringify_rich` controls whether `rich_data` is stringified into a lossy format
+      # instead of a lossless format. Catalogs should not be stringified, though to_yaml
+      # and the resource application have uses for a lossy, user friendly format.
+      :stringify_rich => false
     }
   end
 

--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -237,7 +237,7 @@ module Puppet
       :ssl_context => proc { Puppet.runtime[:http].default_ssl_context },
       :http_session => proc { Puppet.runtime[:http].create_session },
       :plugins => proc { Puppet::Plugins::Configuration.load_plugins },
-      :rich_data => false
+      :rich_data => Puppet[:rich_data]
     }
   end
 

--- a/lib/puppet/application/resource.rb
+++ b/lib/puppet/application/resource.rb
@@ -155,7 +155,9 @@ class Puppet::Application::Resource < Puppet::Application
 
       if options[:to_yaml]
         data = resources.map do |resource|
-          resource.prune_parameters(:parameters_to_include => @extra_params).to_hiera_hash
+          Puppet.override(rich_data: false) do
+            resource.prune_parameters(:parameters_to_include => @extra_params).to_hiera_hash
+          end
         end.inject(:merge!)
         text = YAML.dump(type.downcase => data)
       else

--- a/lib/puppet/application/resource.rb
+++ b/lib/puppet/application/resource.rb
@@ -146,7 +146,11 @@ class Puppet::Application::Resource < Puppet::Application
     # If the specified environment does not exist locally, fall back to the default (production) environment
     env = Puppet.lookup(:environments).get(Puppet[:environment]) || create_default_environment
 
-    Puppet.override(:current_environment => env, :loaders => Puppet::Pops::Loaders.new(env)) do
+    Puppet.override(
+      current_environment: env,
+      loaders: Puppet::Pops::Loaders.new(env),
+      stringify_rich: true
+    ) do
       type, name, params = parse_args(command_line.args)
 
       raise _("Editing with Yaml output is not supported") if options[:edit] and options[:to_yaml]
@@ -155,9 +159,7 @@ class Puppet::Application::Resource < Puppet::Application
 
       if options[:to_yaml]
         data = resources.map do |resource|
-          Puppet.override(stringify_rich: true) do
-            resource.prune_parameters(:parameters_to_include => @extra_params).to_hiera_hash
-          end
+          resource.prune_parameters(:parameters_to_include => @extra_params).to_hiera_hash
         end.inject(:merge!)
         text = YAML.dump(type.downcase => data)
       else

--- a/lib/puppet/application/resource.rb
+++ b/lib/puppet/application/resource.rb
@@ -155,7 +155,7 @@ class Puppet::Application::Resource < Puppet::Application
 
       if options[:to_yaml]
         data = resources.map do |resource|
-          Puppet.override(rich_data: false) do
+          Puppet.override(stringify_rich: true) do
             resource.prune_parameters(:parameters_to_include => @extra_params).to_hiera_hash
           end
         end.inject(:merge!)

--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -112,7 +112,7 @@ class Puppet::Resource
     # To get stringified parameter values the flag :stringify_rich can be set
     # in the puppet context.
     #
-    stringify = Puppet.lookup(:stringify_rich) { false }
+    stringify = Puppet.lookup(:stringify_rich)
     converter = stringify ? Puppet::Pops::Serialization::ToStringifiedConverter.new : nil
 
     params = {}

--- a/spec/integration/application/apply_spec.rb
+++ b/spec/integration/application/apply_spec.rb
@@ -447,6 +447,12 @@ class amod::bad_type {
         Puppet[:strict] = :warning
       end
 
+      around :each do |test|
+        Puppet.override(rich_data: false) do
+          test.run
+        end
+      end
+
       it 'will notify a string that is the result of Regexp#inspect (from Runtime3xConverter)' do
         catalog = compile_to_catalog(execute, node)
         apply.command_line.args = ['--catalog', file_containing('manifest', catalog.to_json)]

--- a/spec/unit/application/resource_spec.rb
+++ b/spec/unit/application/resource_spec.rb
@@ -170,15 +170,6 @@ describe Puppet::Application::Resource do
       expect { @resource_app.main }.not_to raise_error
     end
 
-    it "should raise an error when printing yaml if rich_data is off" do
-      @resource_app.options[:to_yaml] = true
-      allow(@resource_app.command_line).to receive(:args).and_return(['stringify', 'hello', 'ensure=present', 'string=asd'])
-      Puppet.override(rich_data: false) do
-        expect { @resource_app.main }.to raise_error( Puppet::PreformattedError,
-          /Stringify\[hello\]\['string'\] contains a Puppet::Util::Execution::ProcessOutput value. It will be converted to the String 'test'/)
-      end
-    end
-
     it "should ensure all values to be printed are in the external encoding" do
       resources = [
         Puppet::Type.type(:user).new(:name => "\u2603".force_encoding(Encoding::UTF_8)).to_resource,

--- a/spec/unit/application/resource_spec.rb
+++ b/spec/unit/application/resource_spec.rb
@@ -170,11 +170,13 @@ describe Puppet::Application::Resource do
       expect { @resource_app.main }.not_to raise_error
     end
 
-    it "should raise an error when printing yaml by default" do
+    it "should raise an error when printing yaml if rich_data is off" do
       @resource_app.options[:to_yaml] = true
       allow(@resource_app.command_line).to receive(:args).and_return(['stringify', 'hello', 'ensure=present', 'string=asd'])
-      expect { @resource_app.main }.to raise_error( Puppet::PreformattedError,
-        /Stringify\[hello\]\['string'\] contains a Puppet::Util::Execution::ProcessOutput value. It will be converted to the String 'test'/)
+      Puppet.override(rich_data: false) do
+        expect { @resource_app.main }.to raise_error( Puppet::PreformattedError,
+          /Stringify\[hello\]\['string'\] contains a Puppet::Util::Execution::ProcessOutput value. It will be converted to the String 'test'/)
+      end
     end
 
     it "should ensure all values to be printed are in the external encoding" do

--- a/spec/unit/resource/catalog_spec.rb
+++ b/spec/unit/resource/catalog_spec.rb
@@ -965,8 +965,13 @@ describe Puppet::Resource::Catalog, "when converting a resource catalog to json"
 
     context 'and rich_data is disabled' do
       before(:each) do
-        Puppet[:rich_data] = false 
         Puppet[:strict] = :warning # do not want to stub out behavior in tests
+      end
+
+      around(:each) do |test|
+        Puppet.override(rich_data: false) do
+          test.run
+        end
       end
 
       let(:catalog_w_regexp)  { compile_to_catalog("notify {'foo': message => /[a-z]+/ }") }

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -906,6 +906,26 @@ describe Puppet::Resource do
     # Note: to_stringified_spec.rb has tests for all other data types
   end
 
+  describe 'when serializing resources' do
+    require 'puppet_spec/compiler'
+    include PuppetSpec::Compiler
+
+    it 'should do something' do
+      resource = compile_to_catalog('notify {"foo": message => Deferred("func", ["a", "b", "c"])}')
+
+      # This should be true by default
+      if Puppet[:rich_data]
+        expect(resource.to_data_hash.class).to be(Hash)
+      end
+
+      expect {
+        Puppet.override(rich_data: false) do
+          resource.to_data_hash
+        end
+      }.to raise_error(Puppet::PreformattedError)
+    end
+  end
+
   describe "when converting from json" do
     before do
       @data = {

--- a/spec/unit/resource_spec.rb
+++ b/spec/unit/resource_spec.rb
@@ -910,14 +910,15 @@ describe Puppet::Resource do
     require 'puppet_spec/compiler'
     include PuppetSpec::Compiler
 
-    it 'should do something' do
+    it 'serializes rich data' do
       resource = compile_to_catalog('notify {"foo": message => Deferred("func", ["a", "b", "c"])}')
 
-      # This should be true by default
-      if Puppet[:rich_data]
-        expect(resource.to_data_hash.class).to be(Hash)
-      end
+      # This assume rich_data is true by default
+      expect(resource.to_data_hash.class).to be(Hash)
+    end
 
+    it 'raises when rich data is disabled' do
+      resource = compile_to_catalog('notify {"foo": message => Deferred("func", ["a", "b", "c"])}')
       expect {
         Puppet.override(rich_data: false) do
           resource.to_data_hash


### PR DESCRIPTION
Since Puppet 6.0 "datafication" has inspected the context for the value
of rich_data. However, in only some code paths does the value in the
context get overridden with a value taken from the settings. This means
in some cases the rich_data value will always be true or always be
false, regardless of how the user has configured the rich_data setting.
And, in the case the simply calling `to_data_hash` on a resource the
rich_data value will always be false.

This updates the base_context to set rich_data to the settings value,
ensuring that the default value for rich_data in the context is the
value users have set.

Additional changes are primarily where tests still assumed the default
value of rich_data was false, with one exception - YAML serialization in
the resource application will break if the internal rich_data `__pcore`
values are output. This forces rich_data to be false for that code path
in the resource application.

Fixes GH https://github.com/puppetlabs/puppet/issues/9470