### PR TITLE
(maint) Remove needless check in setting  default

### DIFF
--- a/ext/windows/service/daemon.rb
+++ b/ext/windows/service/daemon.rb
@@ -179,7 +179,7 @@ class WindowsDaemon < Puppet::Util::Windows::Daemon
 
   def parse_log_level(puppet_path, cmdline_debug)
     begin
-      loglevel = %x(#{puppet_path} config --section agent --log_level notice print log_level).chomp
+      loglevel = "notice"
       unless loglevel && respond_to?("log_#{loglevel}")
         loglevel = :notice
         log_err("Failed to determine loglevel, defaulting to #{loglevel}")


### PR DESCRIPTION
This line is not sane for the setting of the log_level default (because specifying `--log_level` on the command line always takes precedence over what's specified in puppet.conf)

    loglevel = %x{ #{puppet_path} config --section agent --log_level notice print log_level }.chomp

It sets log_level to notice, and then return the output of the log_level setting

      loglevel = "notice"

is the same thing with fewer steps

Author: Marty Ewings <martyewings@gmail.com>
Supersedes PR #8958