### PR TITLE
(PUP-11949) Set systemd as default for Raspbian 12

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -31,6 +31,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   defaultfor 'os.name' => :ubuntu
   notdefaultfor 'os.name' => :ubuntu, 'os.release.major' => ["10.04", "12.04", "14.04", "14.10"] # These are using upstart
   defaultfor 'os.name' => :cumuluslinux, 'os.release.major' => %w[3 4]
+  defaultfor 'os.name' => :raspbian, 'os.release.major' => %w[12]
 
   def self.instances
     i = []

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -171,6 +171,13 @@ describe 'Puppet::Type::Service::Provider::Systemd',
     end
   end
 
+  it "should be the default provider on raspbian12" do
+    allow(Facter).to receive(:value).with('os.family').and_return(:debian)
+    allow(Facter).to receive(:value).with('os.name').and_return(:raspbian)
+    allow(Facter).to receive(:value).with('os.release.major').and_return("12")
+    expect(provider_class).to be_default
+  end
+
   %i[enabled? daemon_reload? enable disable start stop status restart].each do |method|
     it "should have a #{method} method" do
       expect(provider).to respond_to(method)


### PR DESCRIPTION
Select systemd as the default service provider

Author: James Evans <54334+jaevans@users.noreply.github.com>
Supersedes https://github.com/puppetlabs/puppet/pull/9170