### PR TITLE
Call the correct ResponseError method

### DIFF
--- a/lib/puppet/ssl/state_machine.rb
+++ b/lib/puppet/ssl/state_machine.rb
@@ -358,7 +358,7 @@ class Puppet::SSL::StateMachine
         Wait.new(@machine)
       else
         to_error(_("Failed to retrieve certificate for %{certname}: %{message}") %
-                 { certname: Puppet[:certname], message: e.response.message }, e)
+                 { certname: Puppet[:certname], message: e.message }, e)
       end
     end
   end
@@ -391,7 +391,7 @@ class Puppet::SSL::StateMachine
       end
       Done.new(@machine, @ssl_context)
     rescue => e
-      Puppet.warning(_("Unable to automatically renew certificate: %{message}") % { message: e })
+      Puppet.warning(_("Unable to automatically renew certificate: %{message}") % { message: e.message })
       Done.new(@machine, @ssl_context)
     end
   end

--- a/spec/unit/ssl/state_machine_spec.rb
+++ b/spec/unit/ssl/state_machine_spec.rb
@@ -928,6 +928,14 @@ describe Puppet::SSL::StateMachine, unless: Puppet::Util::Platform.jruby? do
         expect(state.next_state).to be_an_instance_of(Puppet::SSL::StateMachine::Wait)
       end
 
+      it 'transitions to Error if the server returns 500' do
+        stub_request(:get, %r{puppet-ca/v1/certificate/#{Puppet[:certname]}}).to_return(status: 500)
+
+        st = state.next_state
+        expect(st).to be_an_instance_of(Puppet::SSL::StateMachine::Error)
+        expect(st.message).to match(/Failed to retrieve certificate/)
+      end
+
       it "verifies the server's certificate when getting the client cert" do
         stub_request(:get, %r{puppet-ca/v1/certificate/#{Puppet[:certname]}}).to_return(status: 200, body: client_cert.to_pem)
         allow(cert_provider).to receive(:save_client_cert)


### PR DESCRIPTION
If the agent failed to download it's client cert leading to an Puppet::HTTP:ReponseError exception, then it tried to call a nonexistent `message` method on the Puppet::HTTP::Response.

Instead call `message` directly on the ResponseError, which contains the HTTP reason, e.g. Internal Server Error.

Also when renewing a client cert, explicitly call e.message instead of relying on whatever ResponseError#to_s returns.