### PR TITLE
(maint) Update pip provider regex

### DIFF
--- a/lib/puppet/provider/package/pip.rb
+++ b/lib/puppet/provider/package/pip.rb
@@ -160,7 +160,7 @@ Puppet::Type.type(:package).provide :pip, :parent => ::Puppet::Provider::Package
     command = resource_or_provider_command
     self.class.validate_command(command)
 
-    command_and_options = [self.class.quote(command), 'install', "#{@resource[:name]}==versionplease"]
+    command_and_options = [self.class.quote(command), 'install', "#{@resource[:name]}==9!0dev0+x"]
     extra_arg = list_extra_flags(command_version)
     command_and_options << extra_arg if extra_arg
     command_and_options << install_options if @resource[:install_options]

--- a/spec/unit/provider/package/pip_spec.rb
+++ b/spec/unit/provider/package/pip_spec.rb
@@ -281,12 +281,12 @@ describe Puppet::Type.type(:package).provider(:pip) do
         it "should use legacy-resolver argument" do
           p = StringIO.new(
             <<-EOS
-            Collecting real-package==versionplease
-              Could not find a version that satisfies the requirement real-package==versionplease (from versions: 1.1.3, 1.0, 1.9b1)
-            No matching distribution found for real-package==versionplease
+            Collecting real-package==9!0dev0+x
+              Could not find a version that satisfies the requirement real-package==9!0dev0+x (from versions: 1.1.3, 1.0, 1.9b1)
+            No matching distribution found for real-package==9!0dev0+x
             EOS
           )
-          expect(Puppet::Util::Execution).to receive(:execpipe).with(["/fake/bin/pip", "install", "real_package==versionplease",
+          expect(Puppet::Util::Execution).to receive(:execpipe).with(["/fake/bin/pip", "install", "real_package==9!0dev0+x",
             "--use-deprecated=legacy-resolver"]).and_yield(p).once
           @resource[:name] = "real_package"
           @provider.latest
@@ -300,12 +300,12 @@ describe Puppet::Type.type(:package).provider(:pip) do
         it "should not use legacy-resolver argument" do
           p = StringIO.new(
             <<-EOS
-            Collecting real-package==versionplease
-              Could not find a version that satisfies the requirement real-package==versionplease (from versions: 1.1.3, 1.0, 1.9b1)
-            No matching distribution found for real-package==versionplease
+            Collecting real-package==9!0dev0+x
+              Could not find a version that satisfies the requirement real-package==9!0dev0+x (from versions: 1.1.3, 1.0, 1.9b1)
+            No matching distribution found for real-package==9!0dev0+x
             EOS
           )
-          expect(Puppet::Util::Execution).to receive(:execpipe).with(["/fake/bin/pip", "install", "real_package==versionplease"]).and_yield(p).once
+          expect(Puppet::Util::Execution).to receive(:execpipe).with(["/fake/bin/pip", "install", "real_package==9!0dev0+x"]).and_yield(p).once
           @resource[:name] = "real_package"
           @provider.latest
         end
@@ -314,12 +314,12 @@ describe Puppet::Type.type(:package).provider(:pip) do
       it "should find a version number for real_package" do
         p = StringIO.new(
           <<-EOS
-          Collecting real-package==versionplease
-            Could not find a version that satisfies the requirement real-package==versionplease (from versions: 1.1.3, 1.2, 1.9b1)
-          No matching distribution found for real-package==versionplease
+          Collecting real-package==9!0dev0+x
+            Could not find a version that satisfies the requirement real-package==9!0dev0+x (from versions: 1.1.3, 1.2, 1.9b1)
+          No matching distribution found for real-package==9!0dev0+x
           EOS
         )
-        expect(Puppet::Util::Execution).to receive(:execpipe).with(["/fake/bin/pip", "install", "real_package==versionplease"]).and_yield(p).once
+        expect(Puppet::Util::Execution).to receive(:execpipe).with(["/fake/bin/pip", "install", "real_package==9!0dev0+x"]).and_yield(p).once
         @resource[:name] = "real_package"
         latest = @provider.latest
         expect(latest).to eq('1.9b1')
@@ -328,12 +328,12 @@ describe Puppet::Type.type(:package).provider(:pip) do
       it "should not find a version number for fake_package" do
         p = StringIO.new(
           <<-EOS
-          Collecting fake-package==versionplease
-            Could not find a version that satisfies the requirement fake-package==versionplease (from versions: )
-          No matching distribution found for fake-package==versionplease
+          Collecting fake-package==9!0dev0+x
+            Could not find a version that satisfies the requirement fake-package==9!0dev0+x (from versions: )
+          No matching distribution found for fake-package==9!0dev0+x
           EOS
         )
-        expect(Puppet::Util::Execution).to receive(:execpipe).with(["/fake/bin/pip", "install", "fake_package==versionplease"]).and_yield(p).once
+        expect(Puppet::Util::Execution).to receive(:execpipe).with(["/fake/bin/pip", "install", "fake_package==9!0dev0+x"]).and_yield(p).once
         @resource[:name] = "fake_package"
         expect(@provider.latest).to eq(nil)
       end
@@ -341,12 +341,12 @@ describe Puppet::Type.type(:package).provider(:pip) do
       it "should handle out-of-order version numbers for real_package" do
         p = StringIO.new(
           <<-EOS
-          Collecting real-package==versionplease
-            Could not find a version that satisfies the requirement real-package==versionplease (from versions: 1.11, 13.0.3, 1.6, 1!1.2.rev33+123456, 1.9, 1.3.2, 14.0.1, 12.0.7, 13.0.3, 1.7.2, 1.8.4, 1.2+123abc456, 1.6.1, 0.9.2, 1.3, 1.8.3, 12.1.1, 1.1, 1.11.6, 1.2+123456, 1.4.8, 1.6.3, 1!1.0b2.post345.dev456, 1.10.1, 14.0.2, 1.11.3, 14.0.3, 1.4rc1, 1.0b2.post345.dev456, 0.8.4, 1.0, 1!1.0.post456, 12.0.5, 14.0.6, 1.11.5, 1.0rc2, 1.7.1.1, 1.11.4, 13.0.1, 13.1.2, 1.3.3, 0.8.2, 14.0.0, 12.0, 1.8, 1.3.4, 12.0, 1.2, 12.0.6, 0.9.1, 13.1.1, 2!2.3.4.alpha5.rev6.dev7+abc89, 14.0.5, 15.0.2, 15.0.0, 1.4.5, 1.4.3, 13.1.1, 1.11.2, 13.1.2, 1.2+abc123def, 1.3.1, 13.1.0, 12.0.2, 1.11.1, 12.0.1, 12.1.0, 0.9, 1.4.4, 1.2+abc123, 13.0.0, 1.4.9, 1.1.dev1, 12.1.0, 1.7.1, 1.4.2, 14.0.5, 0.8.1, 1.4.6, 0.8.3, 1.11.3, 1.5.1, 1.4.7, 13.0.2, 12.0.7, 1!13.0, 0!13.0, 1.9.1, 1.0.post456.dev34, 1.8.2, 14.0.1, 14.0.0, 1.2.rev33+123456, 14.0.4, 1.6.2, 15.0.1, 13.1.0, 0.8, 1.2+1234.abc, 1.7, 15.0.2, 12.0.5, 13.0.1, 1.8.1, 1.11.6, 15.0.1, 12.0.4, 1.2+123abc, 12.1.1, 13.0.2, 1.11.4, 1.10, 1.2.r32+123456, 14.0.4, 14.0.6, 1.4.1, 1.4, 1.5.2, 12.0.2, 12.0.1, 14.0.3, 14.0.2, 1.11.1, 1.7.1.2, 15.0.0, 12.0.4, 1.6.4, 1.11.2, 1.5, 0.1, 0.10, 0.10.1, 0.10.1.0.1, 1.0.dev456, 1.0a1, 1.0a2.dev456, 1.0a12.dev456, 1.0a12, 1.0b1.dev456, 1.0b2, 1.0b2.post345, 1.0b2-346, 1.0c1.dev456, 1.0c1, 1.0c3, 1.0, 1.0.post456, 1.2+abc, 1!1.0, 1!1.0.post456.dev34)
-          No distributions matching the version for real-package==versionplease
+          Collecting real-package==9!0dev0+x
+            Could not find a version that satisfies the requirement real-package==9!0dev0+x (from versions: 1.11, 13.0.3, 1.6, 1!1.2.rev33+123456, 1.9, 1.3.2, 14.0.1, 12.0.7, 13.0.3, 1.7.2, 1.8.4, 1.2+123abc456, 1.6.1, 0.9.2, 1.3, 1.8.3, 12.1.1, 1.1, 1.11.6, 1.2+123456, 1.4.8, 1.6.3, 1!1.0b2.post345.dev456, 1.10.1, 14.0.2, 1.11.3, 14.0.3, 1.4rc1, 1.0b2.post345.dev456, 0.8.4, 1.0, 1!1.0.post456, 12.0.5, 14.0.6, 1.11.5, 1.0rc2, 1.7.1.1, 1.11.4, 13.0.1, 13.1.2, 1.3.3, 0.8.2, 14.0.0, 12.0, 1.8, 1.3.4, 12.0, 1.2, 12.0.6, 0.9.1, 13.1.1, 2!2.3.4.alpha5.rev6.dev7+abc89, 14.0.5, 15.0.2, 15.0.0, 1.4.5, 1.4.3, 13.1.1, 1.11.2, 13.1.2, 1.2+abc123def, 1.3.1, 13.1.0, 12.0.2, 1.11.1, 12.0.1, 12.1.0, 0.9, 1.4.4, 1.2+abc123, 13.0.0, 1.4.9, 1.1.dev1, 12.1.0, 1.7.1, 1.4.2, 14.0.5, 0.8.1, 1.4.6, 0.8.3, 1.11.3, 1.5.1, 1.4.7, 13.0.2, 12.0.7, 1!13.0, 0!13.0, 1.9.1, 1.0.post456.dev34, 1.8.2, 14.0.1, 14.0.0, 1.2.rev33+123456, 14.0.4, 1.6.2, 15.0.1, 13.1.0, 0.8, 1.2+1234.abc, 1.7, 15.0.2, 12.0.5, 13.0.1, 1.8.1, 1.11.6, 15.0.1, 12.0.4, 1.2+123abc, 12.1.1, 13.0.2, 1.11.4, 1.10, 1.2.r32+123456, 14.0.4, 14.0.6, 1.4.1, 1.4, 1.5.2, 12.0.2, 12.0.1, 14.0.3, 14.0.2, 1.11.1, 1.7.1.2, 15.0.0, 12.0.4, 1.6.4, 1.11.2, 1.5, 0.1, 0.10, 0.10.1, 0.10.1.0.1, 1.0.dev456, 1.0a1, 1.0a2.dev456, 1.0a12.dev456, 1.0a12, 1.0b1.dev456, 1.0b2, 1.0b2.post345, 1.0b2-346, 1.0c1.dev456, 1.0c1, 1.0c3, 1.0, 1.0.post456, 1.2+abc, 1!1.0, 1!1.0.post456.dev34)
+          No distributions matching the version for real-package==9!0dev0+x
           EOS
         )
-        expect(Puppet::Util::Execution).to receive(:execpipe).with(["/fake/bin/pip", "install", "real_package==versionplease"]).and_yield(p).once
+        expect(Puppet::Util::Execution).to receive(:execpipe).with(["/fake/bin/pip", "install", "real_package==9!0dev0+x"]).and_yield(p).once
         @resource[:name] = "real_package"
         expect(@provider.latest).to eq('2!2.3.4.alpha5.rev6.dev7+abc89')
       end


### PR DESCRIPTION
When searching for versions of a Pip module a regex we depend on needs to be updated to work with Pip version 24. 