### PR TITLE
Use token to check out reference action

### DIFF
--- a/.github/workflows/references.yaml
+++ b/.github/workflows/references.yaml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout current PR
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
This commit updates the GitHub Aciton used to generate reference documentation to use the token of the puppet-release-bot GitHub user to check out code. This should enable the action to push to the protected main branch, which it was unable to before.