### PR TITLE
(PUP-12071) Increase default value for number_of_facts_soft_limit

### DIFF
--- a/lib/puppet/defaults.rb
+++ b/lib/puppet/defaults.rb
@@ -1803,7 +1803,7 @@ EOT
       :desc       => "The soft limit for the number of top level facts.",
     },
     :number_of_facts_soft_limit => {
-      :default    => 2048,
+      :default    => 10_240,
       :type       => :integer,
       :desc       => "The soft limit for the total number of fact values. This counts the
         child elements of all facts (e.g. all items of an array or a hash), not just top


### PR DESCRIPTION
This commit increases default value of `number_of_facts_soft_limit` from 2048 to 2048 * 5 = 10240.

2048 is too small for `number_of_facts_soft_limit` because:
  - The `_package_inventory_1` fact in PE will report packages present by multiple providers which results in a package being reported up to 3 times and `_package_inventory_1` to be have many more fact values than expected
  - A default PE install reports 5019 fact values which already exceeds the previous limit, 2048.

Taking into account the issues above and the feedback from Vox Pupuli in the Puppet Community Slack about their fact count, 10240 is a more suitable limit.