### PR TITLE
Handle groupadd in Ubuntu 24.04

### DIFF
--- a/lib/puppet/provider/group/groupadd.rb
+++ b/lib/puppet/provider/group/groupadd.rb
@@ -22,7 +22,9 @@ Puppet::Type.type(:group).provide :groupadd, :parent => Puppet::Provider::NameSe
   has_feature :manages_local_users_and_groups if Puppet.features.libuser?
   has_feature :manages_members if Puppet.features.libuser? ||
                                   (Puppet.runtime[:facter].value('os.name') == "Fedora" &&
-                                  Puppet.runtime[:facter].value('os.release.major').to_i >= 40)
+                                  Puppet.runtime[:facter].value('os.release.major').to_i >= 40) ||
+                                  (Puppet.runtime[:facter].value('os.name') == "Ubuntu" &&
+                                  Puppet.runtime[:facter].value('os.release.major').to_f >= 24.04)
 
   # Libuser's modify command 'lgroupmod' requires '-M' flag for member additions.
   # 'groupmod' command requires the '-aU' flags for it.


### PR DESCRIPTION
Hi team,

May I inquire about the `groupadd` enhancement in Ubuntu 24.04? Below is the content.
Closes: #9502 

- Starting from Ubuntu 24.04, the shadow package has been upgraded to 4.13: https://launchpad.net/ubuntu/+source/shadow.
- `groupadd` and `groupmod` commands can now modify members.
- Add manages_members feature to Ubuntu 24.04 and above.

```bash
root@dev:~# groupadd --help
Usage: groupadd [options] GROUP

Options:
  -f, --force                   exit successfully if the group already exists,
                                and cancel -g if the GID is already used
  -g, --gid GID                 use GID for the new group
  -h, --help                    display this help message and exit
  -K, --key KEY=VALUE           override /etc/login.defs defaults
  -o, --non-unique              allow to create groups with duplicate
                                (non-unique) GID
  -p, --password PASSWORD       use this encrypted password for the new group
  -r, --system                  create a system account
  -R, --root CHROOT_DIR         directory to chroot into
  -P, --prefix PREFIX_DI        directory prefix
  -U, --users USERS             list of user members of this group
      --extrausers              Use the extra users database

root@dev:~# groupmod --help
Usage: groupmod [options] GROUP

Options:
  -a, --append                  append the users mentioned by -U option to the group
                                without removing existing user members
  -g, --gid GID                 change the group ID to GID
  -h, --help                    display this help message and exit
  -n, --new-name NEW_GROUP      change the name to NEW_GROUP
  -o, --non-unique              allow to use a duplicate (non-unique) GID
  -p, --password PASSWORD       change the password to this (encrypted)
                                PASSWORD
  -R, --root CHROOT_DIR         directory to chroot into
  -P, --prefix PREFIX_DIR       prefix directory where are located the /etc/* files
  -U, --users USERS             list of user members of this group
```