### PR TITLE
Add syslog & ostruct as runtime dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,6 @@ group(:features) do
   # requires native ldap headers/libs
   # gem 'ruby-ldap', '~> 0.9', require: false, platforms: [:ruby]
   gem 'puppetserver-ca', '~> 2.0', require: false
-  gem 'syslog', '~> 0.1.1', require: false, platforms: [:ruby]
   gem 'CFPropertyList', ['>= 3.0.6', '< 4'], require: false
 end
 

--- a/puppet.gemspec
+++ b/puppet.gemspec
@@ -37,9 +37,12 @@ Gem::Specification.new do |spec|
     spec.add_runtime_dependency('CFPropertyList', ['>= 3.0.6', '< 4'])
   end
 
-  if platform == 'x64-mingw32' || platform == 'x86-mingw32'
+  if (platform == 'x64-mingw32' || platform == 'x86-mingw32') || Gem.win_platform?
     # ffi 1.16.0 - 1.16.2 are broken on Windows
     spec.add_runtime_dependency('ffi', '>= 1.15.5', '< 1.17.0', '!= 1.16.0', '!= 1.16.1', '!= 1.16.2')
     spec.add_runtime_dependency('minitar', '~> 0.9')
+  elsif !Gem.java_platform?
+    # don't depend on syslog on jruby, it requires extensions
+    spec.add_runtime_dependency('syslog', '~> 0.1.2')
   end
 end

--- a/puppet.gemspec
+++ b/puppet.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency('puppet-resource_api', '~> 1.5')
   spec.add_runtime_dependency('scanf', '~> 1.0')
   spec.add_runtime_dependency('semantic_puppet', '~> 1.0')
+  spec.add_runtime_dependency('ostruct', '~> 0.6.0')
 
   platform = spec.platform.to_s
   if platform == 'universal-darwin'


### PR DESCRIPTION
The syslog gem moves from default gems to a normal gem in Ruby 3.4. It raises the following warning on Ruby 3.3.5:

```
lib/puppet/util/command_line.rb:14: warning: syslog was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add syslog to your Gemfile or gemspec to silence this warning.
```

The ostruct gem moves from default gems to a normal gem in Ruby 3.5. It raises the following warning on Ruby 3.3.5:

```
lib/puppet/util/command_line.rb:14: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
```