### PR TITLE
Add workaround for test on Red Hat 8 POWER

### DIFF
--- a/acceptance/tests/resource/user/should_create_modify_with_password.rb
+++ b/acceptance/tests/resource/user/should_create_modify_with_password.rb
@@ -41,6 +41,13 @@ test_name 'should create a user with password and modify the password' do
     end
 
     step 'modify the user with a different password' do
+      # There is a known issue with SSSD and Red Hat 8, this is a temporary workaround until a permanent fix is
+      # implemented in our images. See ITHELP-100250
+      # https://access.redhat.com/solutions/7031304
+      if agent['platform'] = 'el-8-ppc64le'
+        on(agent, 'systemctl stop sssd; rm -f /var/lib/sss/db/*; systemctl start sssd', acceptable_exit_codes: 0)
+      end
+
       apply_manifest_on(agent, <<-MANIFEST, catch_failures: true)
 	    user { '#{name}':
 	      ensure => present,


### PR DESCRIPTION
Due to an issue with SSSD, this commit adds a workaround for the test to modify a user's password on Red Hat 8 POWER machines (ppc64le). We have submitted an ITHELP ticket (ITHELP-100250) for a more permanent fix.