### PR TITLE
(PA-7108) Temporarily pin Windows Ruby 3.2 rspec check to Ruby 3.2.5

### DIFF
--- a/.github/workflows/rspec_tests.yaml
+++ b/.github/workflows/rspec_tests.yaml
@@ -22,7 +22,7 @@ jobs:
           - {os: ubuntu-22.04, ruby: '3.3'} # openssl 3 / latest Ruby
           - {os: ubuntu-latest, ruby: 'jruby-9.4.3.0'}
           - {os: windows-2019, ruby: '3.1'}
-          - {os: windows-2019, ruby: '3.2'} # openssl 3
+          - {os: windows-2019, ruby: '3.2.5'} # openssl 3 & temporarily pinned to ruby 3.2.5, see PA-7108
           - {os: windows-2019, ruby: '3.3'} # openssl 3 / latest Ruby
 
     runs-on: ${{ matrix.cfg.os }}

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -294,6 +294,8 @@ Performance/UnfreezeString:
 Style/AccessModifierDeclarations:
   Exclude:
     - 'lib/puppet/util/suidmanager.rb'
+    - 'lib/puppet/util/command_line/trollop.rb'
+    - 'lib/puppet/util/windows/monkey_patches/process.rb'
 
 # This cop supports safe auto-correction (--auto-correct).
 # Configuration parameters: EnforcedStyle.


### PR DESCRIPTION
Temporarily pin Windows Ruby 3.2 rspec check test to Ruby 3.2.5 to resolve the OpenSSL errors that popped up when using Ruby 3.2.6. This should be reverted once PA-7108 is resolved.