### PR TITLE
Add space to URI error

### DIFF
--- a/spec/unit/provider/package/puppetserver_gem_spec.rb
+++ b/spec/unit/provider/package/puppetserver_gem_spec.rb
@@ -77,7 +77,7 @@ describe Puppet::Type.type(:package).provider(:puppetserver_gem) do
 
       it "raises if given an invalid URI" do
         resource[:source] = 'h;ttp://rubygems.com'
-        expect { provider.install }.to raise_error(Puppet::Error, /Invalid source '': bad URI\(is not URI\?\)/)
+        expect { provider.install }.to raise_error(Puppet::Error, /Invalid source '': bad URI \(is not URI\?\)/)
       end
     end
   end


### PR DESCRIPTION
The URI gem recently updated its error messages to include a space where there previously was not one: ruby/uri@9f2c7ed5f2e2c4060c05e3db8fa1dc73dd24ba0f

This commit updates our test to reflect that change.