### PR TITLE
JSON and URI updates

### DIFF
--- a/lib/puppet/face/facts.rb
+++ b/lib/puppet/face/facts.rb
@@ -167,7 +167,15 @@ Puppet::Indirector::Face.define(:facts, '0.0.1') do
 
       case result
       when Array, Hash
-        Puppet::Util::Json.dump(result, :pretty => true)
+        # JSON < 2.8.0 would pretty print empty arrays and hashes with newlines
+        # Maintain that behavior for our users for now
+        if result.is_a?(Array) && result.empty?
+          "[\n\n]"
+        elsif result.is_a?(Hash) && result.empty?
+          "{\n}"
+        else
+          Puppet::Util::Json.dump(result, :pretty => true)
+        end
       else # one of VALID_TYPES above
         result
       end

--- a/spec/unit/application/facts_spec.rb
+++ b/spec/unit/application/facts_spec.rb
@@ -91,6 +91,7 @@ describe Puppet::Application::Facts do
 
     {
       "type_hash" => [{'a' => 2}, "{\n  \"a\": 2\n}"],
+      "type_empty_hash" => [{}, "{\n}"],
       "type_array" => [[], "[\n\n]"],
       "type_string" => ["str", "str"],
       "type_int" => [1, "1"],

--- a/spec/unit/provider/package/puppetserver_gem_spec.rb
+++ b/spec/unit/provider/package/puppetserver_gem_spec.rb
@@ -77,7 +77,7 @@ describe Puppet::Type.type(:package).provider(:puppetserver_gem) do
 
       it "raises if given an invalid URI" do
         resource[:source] = 'h;ttp://rubygems.com'
-        expect { provider.install }.to raise_error(Puppet::Error, /Invalid source '': bad URI\(is not URI\?\)/)
+        expect { provider.install }.to raise_error(Puppet::Error, /Invalid source '': bad URI \(is not URI\?\)/)
       end
     end
   end


### PR DESCRIPTION
A new JSON gem release (2.8.0) changed how empty arrays and hashes are pretty printed. This PR updates Puppet to maintain past behavior and adds a test for empty hashes.

Ruby also released a new URI gem (1.0.0) this month that adds a space to their error messages. This PR updates our test to reflect that.