### PR TITLE
Add Style/AccessModifierDeclarations exclusions

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -920,7 +920,10 @@ Naming/VariableNumber:
 # SupportedStyles: inline, group
 Style/AccessModifierDeclarations:
   Exclude:
+    - 'lib/puppet/util/command_line/trollop.rb'
     - 'lib/puppet/util/suidmanager.rb'
+    - 'lib/puppet/util/windows/com.rb'
+    - 'lib/puppet/util/windows/monkey_patches/process.rb'
 
 # This cop supports safe auto-correction (--auto-correct).
 # Configuration parameters: EnforcedStyle.


### PR DESCRIPTION
Rubocop recently started flagging several files for violations of the Style/AccessModifierDeclarations cop.

This only occurs in 7.x as many Rubocop fixes have landed in main/8.x. Because 7.x is so close to its end-of-life, these violations aren't really worth fixing and this commit excludes them from the cop.