### PR TITLE
Fix tests on Red Hat 9

### DIFF
--- a/acceptance/lib/puppet/acceptance/rpm_util.rb
+++ b/acceptance/lib/puppet/acceptance/rpm_util.rb
@@ -7,17 +7,13 @@ module Puppet
 
       def rpm_provider(agent)
         has_dnf = on(agent, 'which dnf', :acceptable_exit_codes => [0,1]).exit_code
-        if has_dnf == 0
-          'dnf'
-        else
-          'yum'
-        end
+        has_dnf == 0 ? 'dnf' : 'yum'
       end
 
       def setup(agent)
         @@setup_packages[agent] ||= {}
         cmd = rpm_provider(agent)
-        required_packages = ['createrepo', 'curl', 'rpm-build']
+        required_packages = %w[createrepo curl rpm-build]
         required_packages.each do |pkg|
           pkg_installed = (on agent, "#{cmd} list installed #{pkg}", :acceptable_exit_codes => (0..255)).exit_code == 0
           # package not present, so perform a new install

--- a/acceptance/lib/puppet/acceptance/rpm_util.rb
+++ b/acceptance/lib/puppet/acceptance/rpm_util.rb
@@ -16,6 +16,9 @@ module Puppet
         required_packages = %w[createrepo curl rpm-build]
         required_packages.each do |pkg|
           pkg_installed = (on agent, "#{cmd} list installed #{pkg}", :acceptable_exit_codes => (0..255)).exit_code == 0
+          # We need a newer OpenSSH for the newer OpenSSL that curl installs
+          # RE-16677
+          on(agent, 'dnf upgrade -y openssh') if (agent.platform.start_with?('el-9') && pkg == 'curl')
           # package not present, so perform a new install
           if !pkg_installed
             on agent, "#{cmd} install -y #{pkg}"


### PR DESCRIPTION
This PR addresses an issue with an older version of OpenSSH in our Red Hat 9 images with a temporary workaround.

This is a manual backport of https://github.com/puppetlabs/puppet/pull/9521