### PR TITLE
Add fix for package running dnf5 on fedora (alternative)

### DIFF
--- a/lib/puppet/provider/package/dnfmodule.rb
+++ b/lib/puppet/provider/package/dnfmodule.rb
@@ -35,7 +35,7 @@ Puppet::Type.type(:package).provide :dnfmodule, :parent => :dnf do
 
   def self.instances
     packages = []
-    cmd = "#{command(:dnf)} module list -y -d 0 -e #{error_level}"
+    cmd = "#{command(:dnf)} module list -y"
     execute(cmd).each_line do |line|
       # select only lines with actual packages since DNF clutters the output
       next unless line =~ /\[[eix]\][, ]/
@@ -90,7 +90,7 @@ Puppet::Type.type(:package).provide :dnfmodule, :parent => :dnf do
       enable(args)
     else
       begin
-        execute([command(:dnf), 'module', 'install', '-d', '0', '-e', self.class.error_level, '-y', args])
+        execute([command(:dnf), 'module', 'install', '-y', args])
       rescue Puppet::ExecutionFailure => e
         # module has no default profile and no profile was requested, so just enable the stream
         # DNF versions prior to 4.2.8 do not need this workaround
@@ -117,20 +117,20 @@ Puppet::Type.type(:package).provide :dnfmodule, :parent => :dnf do
   end
 
   def enable(args = @resource[:name])
-    execute([command(:dnf), 'module', 'enable', '-d', '0', '-e', self.class.error_level, '-y', args])
+    execute([command(:dnf), 'module', 'enable', '-y', args])
   end
 
   def uninstall
-    execute([command(:dnf), 'module', 'remove', '-d', '0', '-e', self.class.error_level, '-y', @resource[:name]])
+    execute([command(:dnf), 'module', 'remove', '-y', @resource[:name]])
     reset # reset module to the default stream
   end
 
   def disable(args = @resource[:name])
-    execute([command(:dnf), 'module', 'disable', '-d', '0', '-e', self.class.error_level, '-y', args])
+    execute([command(:dnf), 'module', 'disable', '-y', args])
   end
 
   def reset
-    execute([command(:dnf), 'module', 'reset', '-d', '0', '-e', self.class.error_level, '-y', @resource[:name]])
+    execute([command(:dnf), 'module', 'reset', '-y', @resource[:name]])
   end
 
   def flavor

--- a/lib/puppet/provider/package/yum.rb
+++ b/lib/puppet/provider/package/yum.rb
@@ -247,7 +247,7 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
     update_command = self.class.update_command
     # If not allowing virtual packages, do a query to ensure a real package exists
     unless @resource.allow_virtual?
-      execute([command(:cmd), '-d', '0', '-e', error_level, '-y', install_options, :list, wanted].compact)
+      execute([command(:cmd), '-y', install_options, :list, wanted].compact)
     end
 
     should = @resource.should(:ensure)
@@ -307,10 +307,7 @@ Puppet::Type.type(:package).provide :yum, :parent => :rpm, :source => :rpm do
       end
     end
 
-    # Yum on el-4 and el-5 returns exit status 0 when trying to install a package it doesn't recognize;
-    # ensure we capture output to check for errors.
-    no_debug = Puppet.runtime[:facter].value('os.release.major').to_i > 5 ? ["-d", "0"] : []
-    command = [command(:cmd)] + no_debug + ["-e", error_level, "-y", install_options, operation, wanted].compact
+    command = [command(:cmd)] + ["-y", install_options, operation, wanted].compact
     output = execute(command)
 
     if output.to_s =~ /^No package #{wanted} available\.$/

--- a/spec/unit/provider/package/yum_spec.rb
+++ b/spec/unit/provider/package/yum_spec.rb
@@ -363,7 +363,7 @@ describe Puppet::Type.type(:package).provider(:yum) do
 
         it 'selects best_version' do
           expect(provider).to receive(:execute).with(
-            ['/usr/bin/yum', '-d', '0', '-e', '0', '-y', :install, 'myresource-18.3.2']
+            ['/usr/bin/yum', '-y', :install, 'myresource-18.3.2']
           )
           provider.install
         end
@@ -374,7 +374,7 @@ describe Puppet::Type.type(:package).provider(:yum) do
 
           it 'treats no epoch as zero' do
             expect(provider).to receive(:execute).with(
-              ['/usr/bin/yum', '-d', '0', '-e', '0', '-y', :install, 'myresource-18.3.2']
+              ['/usr/bin/yum', '-y', :install, 'myresource-18.3.2']
               )
             provider.install
           end
@@ -387,7 +387,7 @@ describe Puppet::Type.type(:package).provider(:yum) do
 
         it 'selects best_version and removes epoch' do
           expect(provider).to receive(:execute).with(
-            ['/usr/bin/yum', '-d', '0', '-e', '0', '-y', :install, 'myresource-18.3.2']
+            ['/usr/bin/yum', '-y', :install, 'myresource-18.3.2']
           )
           provider.install
         end
@@ -399,14 +399,14 @@ describe Puppet::Type.type(:package).provider(:yum) do
 
         it 'uses requested version' do
           expect(provider).to receive(:execute).with(
-            ['/usr/bin/yum', '-d', '0', '-e', '0', '-y', :install, "myresource->18.1 <19"]
+            ['/usr/bin/yum', '-y', :install, "myresource->18.1 <19"]
           )
           provider.install
         end
 
         it 'logs a debug message' do
           allow(provider).to receive(:execute).with(
-            ['/usr/bin/yum', '-d', '0', '-e', '0', '-y', :install, "myresource->18.1 <19"]
+            ['/usr/bin/yum', '-y', :install, "myresource->18.1 <19"]
           )
 
           expect(Puppet).to receive(:debug).with(
@@ -422,7 +422,7 @@ describe Puppet::Type.type(:package).provider(:yum) do
 
       it 'passes the version to yum command' do
         expect(provider).to receive(:execute).with(
-            ['/usr/bin/yum', '-d', '0', '-e', '0', '-y', :install, "myresource-1:18.12"]
+            ['/usr/bin/yum', '-y', :install, "myresource-1:18.12"]
           )
           provider.install
       end
@@ -440,7 +440,7 @@ describe Puppet::Type.type(:package).provider(:yum) do
 
       it 'adds update flag to install command' do
         expect(provider).to receive(:execute).with(
-          ['/usr/bin/yum', '-d', '0', '-e', '0', '-y', 'update', 'myresource-18.3.2']
+          ['/usr/bin/yum', '-y', 'update', 'myresource-18.3.2']
         )
         provider.install
       end
@@ -458,7 +458,7 @@ describe Puppet::Type.type(:package).provider(:yum) do
 
       it 'adds downgrade flag to install command' do
         expect(provider).to receive(:execute).with(
-          ['/usr/bin/yum', '-d', '0', '-e', '0', '-y', :downgrade, 'myresource-18.3.2']
+          ['/usr/bin/yum', '-y', :downgrade, 'myresource-18.3.2']
         )
         provider.install
       end
@@ -470,7 +470,7 @@ describe Puppet::Type.type(:package).provider(:yum) do
       context 'when execute command fails' do
         before do
           allow(provider).to receive(:execute).with(
-            ['/usr/bin/yum', '-d', '0', '-e', '0', '-y', :install, "myresource-20"]
+            ['/usr/bin/yum', '-y', :install, "myresource-20"]
           ).and_return('No package myresource-20 available.')
         end
 
@@ -484,7 +484,7 @@ describe Puppet::Type.type(:package).provider(:yum) do
         before do
           allow(provider).to receive(:query)
           allow(provider).to receive(:execute).with(
-            ['/usr/bin/yum', '-d', '0', '-e', '0', '-y', :install, "myresource-20"]
+            ['/usr/bin/yum', '-y', :install, "myresource-20"]
           )
         end
 
@@ -497,7 +497,7 @@ describe Puppet::Type.type(:package).provider(:yum) do
       context 'when package is not installed' do
         before do
           allow(provider).to receive(:execute).with(
-            ['/usr/bin/yum', '-d', '0', '-e', '0', '-y', :install, "myresource-20"]
+            ['/usr/bin/yum', '-y', :install, "myresource-20"]
           )
           allow(provider).to receive(:insync?).and_return(false)
         end


### PR DESCRIPTION
Hi,
on fedora 41 we experience the following errors due to the new dnf version, dnf5 (https://docs.fedoraproject.org/en-US/fedora/latest/release-notes/sysadmin/#dnf-5).

```
Error: Execution of '/usr/bin/dnf -d 0 -e 1 -y install XX' returned 2: Unknown argument "-d" for command "dnf5". Add "--help" for more information about the arguments.
```

The flags '-d' and '-e' have as a workaround been removed for newer versions of fedora.

This fixes https://github.com/puppetlabs/puppet/issues/9506

This is an alternative approache as suggested in https://github.com/puppetlabs/puppet/pull/9520. This will break old systems that require the usage of the flags.