### PR TITLE
Improve manpage reproducibility

### DIFF
--- a/rakelib/manpages.rake
+++ b/rakelib/manpages.rake
@@ -15,7 +15,7 @@ task :gen_manpages do
   ronn_args = '--manual="Puppet manual" --organization="Puppet, Inc." --roff'
 
   unless ENV['SOURCE_DATE_EPOCH'].nil?
-    source_date = Time.at(ENV['SOURCE_DATE_EPOCH'].to_i).strftime('%Y-%m-%d')
+    source_date = Time.at(ENV['SOURCE_DATE_EPOCH'].to_i, in: 'UTC').strftime('%Y-%m-%d')
     ronn_args += " --date=#{source_date}"
   end
 


### PR DESCRIPTION
Always treat SOURCHE_DATE_EPOCH as a UTC timestamp, to prevent variability introduced by the environment's timezone setting.