### PR TITLE
Fix: Use case-insensitive comparison for Windows service logonaccount

### DIFF
--- a/lib/puppet/provider/service/windows.rb
+++ b/lib/puppet/provider/service/windows.rb
@@ -127,7 +127,7 @@ Puppet::Type.type(:service).provide :windows, :parent => :service do
     @normalized_logon_account ||= normalize_logonaccount
     @resource[:logonaccount] = @normalized_logon_account
 
-    insync = @resource[:logonaccount] == current
+    insync = @resource[:logonaccount].casecmp(current) == 0
     self.logonpassword = @resource[:logonpassword] if insync
     insync
   end


### PR DESCRIPTION
Resolves issue where services would restart unnecessarily when the desired and current logonaccount values differed only in case (e.g., 'DOMAIN\User'  vs 'domain\user').