### PR TITLE
fix<ALT>: usage of unsupported ronn gem in favor to ronn-ng

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ end
 
 group(:documentation, optional: true) do
   gem 'gettext-setup', '~> 1.0', require: false, platforms: [:ruby]
-  gem 'ronn', '~> 0.7.3', require: false, platforms: [:ruby]
+  gem 'ronn-ng', '~> 0.7', require: false, platforms: [:ruby]
   gem 'puppet-strings', require: false, platforms: [:ruby]
   gem 'pandoc-ruby', require: false, platforms: [:ruby]
 end


### PR DESCRIPTION
- [x] * changed usage of unsupported ronn gem in favor to ronn-ng