### PR TITLE
fix<ALT>: default os family for aptrpm package provider

### DIFF
--- a/lib/puppet/provider/package/aptrpm.rb
+++ b/lib/puppet/provider/package/aptrpm.rb
@@ -12,6 +12,8 @@ Puppet::Type.type(:package).provide :aptrpm, :parent => :rpm, :source => :rpm do
   commands :aptcache => "apt-cache"
   commands :rpm => "rpm"
 
+  defaultfor :osfamily => "Altlinux"
+
   # Mixing confine statements, control expressions, and exception handling
   # confuses Rubocop's Layout cops, so we disable them entirely.
   # rubocop:disable Layout

--- a/spec/integration/type/package_spec.rb
+++ b/spec/integration/type/package_spec.rb
@@ -14,6 +14,8 @@ describe Puppet::Type.type(:package), "when choosing a default package provider"
       else
         :sun
       end
+    when 'ALT'
+      :aptrpm
     when 'Ubuntu'
       :apt
     when 'Debian'


### PR DESCRIPTION
- [x] ! default os family for aptrpm package provider