### PR TITLE
maint<ALT>: Fix owner for the facts folder

### DIFF
--- a/lib/puppet/file_system/file_impl.rb
+++ b/lib/puppet/file_system/file_impl.rb
@@ -161,8 +161,8 @@ class Puppet::FileSystem::FileImpl
   def replace_file(path, mode = nil)
     begin
       stat = lstat(path)
-      gid = stat.gid
-      uid = stat.uid
+      gid = Puppet::Type.type(:group).new(name: Puppet[:group]).exists? ? Puppet[:group] : stat.gid
+      uid = Puppet::Type.type(:user).new(name: Puppet[:user]).exists? ? Puppet[:user] : stat.uid
       mode ||= stat.mode & 0o7777
     rescue Errno::ENOENT
       mode ||= 0o640

--- a/lib/puppet/indirector/yaml.rb
+++ b/lib/puppet/indirector/yaml.rb
@@ -26,7 +26,7 @@ class Puppet::Indirector::Yaml < Puppet::Indirector::Terminus
     basedir = File.dirname(file)
 
     # This is quite likely a bad idea, since we're not managing ownership or modes.
-    Dir.mkdir(basedir) unless Puppet::FileSystem.exist?(basedir)
+    touch_dir(basedir) unless Puppet::FileSystem.exist?(basedir)
 
     begin
       Puppet::Util::Yaml.dump(request.instance, file)
@@ -58,6 +58,15 @@ class Puppet::Indirector::Yaml < Puppet::Indirector::Terminus
   end
 
   protected
+
+  def touch_dir(dir)
+    Dir.mkdir(dir)
+
+    user = Puppet::Type.type(:user).new(name: Puppet[:user]).exists? ? Puppet[:user] : nil
+    group = Puppet::Type.type(:group).new(name: Puppet[:group]).exists? ? Puppet[:group] : nil
+    Puppet.debug("Fixing perms for #{user}:#{group} on #{dir}")
+    FileUtils.chown(user, group, dir) if user || group
+  end
 
   def load_file(file)
     Puppet::Util::Yaml.safe_load_file(file, [model, Symbol])


### PR DESCRIPTION
- [x] * When retrieving facts and string them to the facts fils as yaml, the folder is created as of root, so changing them to puppet defaults.