### PR TITLE
feat:report CA

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,3 +84,5 @@ if File.exist? "#{__FILE__}.local"
 end
 
 # vim:filetype=ruby
+
+gem "erb", "~> 6.0"

--- a/lib/puppet/configurer.rb
+++ b/lib/puppet/configurer.rb
@@ -304,6 +304,7 @@ class Puppet::Configurer
     # exceptions.
     options[:report] ||= Puppet::Transaction::Report.new(nil, @environment, @transaction_uuid, @job_id, options[:start_time] || Time.now)
     report = options[:report]
+    report.ca_server = "#{Puppet[:ca_server]}:#{Puppet[:ca_port]}"
     init_storage
 
     Puppet::Util::Log.newdestination(report)

--- a/lib/puppet/node/facts.rb
+++ b/lib/puppet/node/facts.rb
@@ -31,6 +31,7 @@ class Puppet::Node::Facts
     values["clientcert"] = Puppet.settings[:certname]
     values["clientversion"] = Puppet.version.to_s
     values["clientnoop"] = Puppet.settings[:noop]
+    values["ca_server"] = "#{Puppet.settings[:ca_server]}:#{Puppet.settings[:ca_port]}"
   end
 
   def initialize(name, values = {})

--- a/lib/puppet/transaction/report.rb
+++ b/lib/puppet/transaction/report.rb
@@ -70,6 +70,10 @@ class Puppet::Transaction::Report
   # @return [String] a string of the format 'servername:port'
   attr_accessor :server_used
 
+  # Contains the name and port of the configured Puppet CA server
+  # @return [String] a string of the format 'caname:caport'
+  attr_accessor :ca_server
+
   # The host name for which the report is generated
   # @return [String] the host name
   attr_accessor :host
@@ -240,6 +244,7 @@ class Puppet::Transaction::Report
     @catalog_uuid = nil
     @cached_catalog_status = nil
     @server_used = nil
+    @ca_server = nil
     @environment = environment
     @status = 'failed' # assume failed until the report is finalized
     @noop = Puppet[:noop]
@@ -267,6 +272,10 @@ class Puppet::Transaction::Report
       @server_used = data['server_used']
     elsif data['master_used']
       @server_used = data['master_used']
+    end
+
+    if data['ca_server']
+      @ca_server = data['ca_server']
     end
 
     if data['catalog_uuid']
@@ -352,6 +361,7 @@ class Puppet::Transaction::Report
 
     # The following is include only when set
     hash['server_used'] = @server_used unless @server_used.nil?
+    hash['ca_server'] = @ca_server unless @ca_server.nil?
     hash['catalog_uuid'] = @catalog_uuid unless @catalog_uuid.nil?
     hash['code_id'] = @code_id unless @code_id.nil?
     hash['job_id'] = @job_id unless @job_id.nil?

--- a/spec/unit/configurer_spec.rb
+++ b/spec/unit/configurer_spec.rb
@@ -1177,6 +1177,17 @@ describe Puppet::Configurer do
     end
   end
 
+  describe "when populating ca_server on the report" do
+    it "sets report.ca_server from configured ca_server and ca_port" do
+      Puppet[:ca_server] = "ca.example.com"
+      Puppet[:ca_port] = 8141
+
+      options = {}
+      configurer.run(options)
+      expect(options[:report].ca_server).to eq("ca.example.com:8141")
+    end
+  end
+  
   describe "when attempting failover" do
     it "should not failover if server_list is not set" do
       Puppet.settings[:server_list] = []

--- a/spec/unit/node/facts_spec.rb
+++ b/spec/unit/node/facts_spec.rb
@@ -25,6 +25,13 @@ describe Puppet::Node::Facts, "when indirecting" do
       expect(@facts.values["clientnoop"]).to eq(Puppet.settings[:noop])
     end
 
+    it "adds the configured CA server and port as 'ca_server'" do
+      Puppet[:ca_server] = "ca.example.com"
+      Puppet[:ca_port] = 8141
+      @facts.add_local_facts
+      expect(@facts.values["ca_server"]).to eq("ca.example.com:8141")
+    end
+
     it "doesn't add the current environment" do
       @facts.add_local_facts
       expect(@facts.values).not_to include("environment")

--- a/spec/unit/transaction/report_spec.rb
+++ b/spec/unit/transaction/report_spec.rb
@@ -302,6 +302,31 @@ describe Puppet::Transaction::Report do
     end
   end
 
+   describe "ca_server" do
+    it "defaults to nil" do
+      report = Puppet::Transaction::Report.new
+      expect(report.ca_server).to be_nil
+    end
+
+    it "round-trips through to_data_hash and from_data_hash when set" do
+      report = Puppet::Transaction::Report.new
+      report.ca_server = "ca.example.com:8140"
+      parsed = Puppet::Transaction::Report.from_data_hash(report.to_data_hash)
+      expect(parsed.ca_server).to eq("ca.example.com:8140")
+    end
+
+    it "is omitted from to_data_hash when nil" do
+      report = Puppet::Transaction::Report.new
+      expect(report.to_data_hash).not_to have_key('ca_server')
+    end
+
+    it "is included in to_data_hash when set" do
+      report = Puppet::Transaction::Report.new
+      report.ca_server = "ca.example.com:8140"
+      expect(report.to_data_hash['ca_server']).to eq("ca.example.com:8140")
+    end
+  end
+
   describe "before finalizing the report" do
     it "should have a status of 'failed'" do
       report = Puppet::Transaction::Report.new


### PR DESCRIPTION
Problem: https://github.com/puppetlabs/puppet/issues/9561

  Foreman provisions and manages Puppet hosts based on data the agent uploads during a run — both facts (used to create
  or update the host record) and reports (used to track ongoing state). Today, that data tells Foreman which Puppet
  master the agent contacted (via the server_used field on the report and the implicit master in fact uploads), but it
  says nothing about which Puppet CA signed the agent's certificate. In split-CA topologies — where one server compiles
  catalogs and a different server handles certificate signing and revocation — Foreman has no reliable way to know which
   CA owns a given host. That gap matters at two moments in the host lifecycle: at registration, Foreman can't
  auto-assign the correct CA to a new host, so an operator has to set it manually; at deletion, Foreman can't reliably
  revoke the host's certificate from the right CA, leaving stale certs behind. Users have asked for the agent itself to
  surface this information, since the agent already knows its configured ca_server and ca_port settings, and is the
  authoritative source for that mapping.

  Solution

  We added the agent's configured CA as a first-class field in three places, scoped to the configured CA value (not the
  "actually contacted" CA — that would have required threading state out of the HTTP/SSL stack and was deferred). First,
   Puppet::Transaction::Report gained a new optional ca_server attribute that serializes as "caname:caport", sitting
  alongside the existing server_used field with the same "include only when set" pattern, no report_format bump (it's
  purely additive, so older consumers that ignore unknown keys keep working). Second, Puppet::Configurer#run populates
  report.ca_server from Puppet[:ca_server]:Puppet[:ca_port] immediately after the report is created, so every report
  carries the value regardless of failover, cached-catalog, or apply-mode code paths. Third,
  Puppet::Node::Facts#add_local_facts adds a matching ca_server core fact, which is critical because Foreman creates
  host records from the first facts upload — before any report exists — so without the fact, the report field alone
  wouldn't solve the registration case. The two changes ship together: the fact handles host creation, the report field
  keeps the mapping current across runs (e.g. if the CA is reconfigured later). Specs cover all three: round-trip
  serialization on the report, configurer population, and the new fact value.