### PR TITLE
fix: select systemd as default service provider on Raspbian 13

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -31,7 +31,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   defaultfor 'os.name' => :ubuntu
   notdefaultfor 'os.name' => :ubuntu, 'os.release.major' => ["10.04", "12.04", "14.04", "14.10"] # These are using upstart
   defaultfor 'os.name' => :cumuluslinux, 'os.release.major' => %w[3 4]
-  defaultfor 'os.name' => :raspbian, 'os.release.major' => %w[12]
+  defaultfor 'os.name' => :raspbian, 'os.release.major' => %w[12 13]
 
   def self.instances
     i = []

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -178,6 +178,13 @@ describe 'Puppet::Type::Service::Provider::Systemd',
     expect(provider_class).to be_default
   end
 
+  it "should be the default provider on raspbian13" do
+    allow(Facter).to receive(:value).with('os.family').and_return(:debian)
+    allow(Facter).to receive(:value).with('os.name').and_return(:raspbian)
+    allow(Facter).to receive(:value).with('os.release.major').and_return("13")
+    expect(provider_class).to be_default
+  end
+
   %i[enabled? daemon_reload? enable disable start stop status restart].each do |method|
     it "should have a #{method} method" do
       expect(provider).to respond_to(method)


### PR DESCRIPTION
### Description

Add Raspbian 13 (trixie) to the list of versions that default to the systemd service provider.

### Problem

On 32-bit Raspberry Pi OS 13 (trixie), which is branded as Raspbian, puppet selects `init` instead of `systemd` as the default service provider. This causes the warning:

```
Warning: Found multiple default providers for service: init, systemd; using init
```

and service resources fail.

### Fix

Add `'13'` to the `defaultfor` array for Raspbian in the systemd service provider, matching the same pattern established for Raspbian 12 in the fix for #9169.

### Test

Added a spec test for Raspbian 13 matching the existing Raspbian 12 test.

Fixes #9565