### PR TITLE
fix: do not treat clientcert as a legacy network fact in puppet lookup

### DIFF
--- a/lib/puppet/application/lookup.rb
+++ b/lib/puppet/application/lookup.rb
@@ -9,7 +9,7 @@ require_relative '../../puppet/parser/compiler'
 class Puppet::Application::Lookup < Puppet::Application
   RUN_HELP = _("Run 'puppet lookup --help' for more details").freeze
   DEEP_MERGE_OPTIONS = '--knock-out-prefix, --sort-merged-arrays, and --merge-hash-arrays'
-  TRUSTED_INFORMATION_FACTS = %w[hostname domain fqdn clientcert].freeze
+  TRUSTED_INFORMATION_FACTS = %w[hostname domain fqdn].freeze
 
   run_mode :server
 

--- a/spec/unit/application/lookup_spec.rb
+++ b/spec/unit/application/lookup_spec.rb
@@ -659,7 +659,7 @@ Searching for "a"
 
           expect {
             lookup.run_command
-          }.to raise_error(/When overriding any of the hostname,domain,fqdn,clientcert facts with #{file_path} given via the --facts flag, they must all be overridden./)
+          }.to raise_error(/When overriding any of the hostname,domain,fqdn facts with #{file_path} given via the --facts flag, they must all be overridden./)
         end
 
         it 'does not fail when all trusted information facts are provided via --facts file' do
@@ -668,6 +668,18 @@ Searching for "a"
             fqdn: some.fqdn.com
             hostname: some.hostname
             domain: some.domain
+          CONTENT
+          lookup.options[:fact_file] = file_path
+
+          expect {
+            lookup.run_command
+          }.to exit_with(0)
+           .and output(/This is in facts hash/).to_stdout
+        end
+
+        it 'does not fail when clientcert is provided without other trusted facts' do
+          file_path = file_containing('facts.yaml', <<~CONTENT)
+            ---
             clientcert: some.clientcert
           CONTENT
           lookup.options[:fact_file] = file_path

--- a/spec/unit/provider/package/dnf_spec.rb
+++ b/spec/unit/provider/package/dnf_spec.rb
@@ -58,5 +58,11 @@ describe Puppet::Type.type(:package).provider(:dnf) do
     it { is_expected.to be_install_only }
   end
 
+  describe '.quiet_flags' do
+    it 'returns an empty array to avoid using deprecated -d/-e flags removed in dnf5' do
+      expect(described_class.quiet_flags).to eq([])
+    end
+  end
+
   it_behaves_like 'RHEL package provider', described_class, 'dnf'
 end


### PR DESCRIPTION
### Description

Remove `clientcert` from `TRUSTED_INFORMATION_FACTS` in `puppet lookup` so that its presence in a `--facts` file does not require `hostname`, `domain`, and `fqdn` to also be present.

### Problem

In Puppet 8, legacy facts (`hostname`, `domain`, `fqdn`) are no longer calculated by default. However, `clientcert` is still present in cached facts because it's set by puppet agent (not facter).

When running `puppet lookup --facts <facts_file>`, if the facts file contains `clientcert` but not the other three facts, puppet raises:

```
When overriding any of the hostname,domain,fqdn,clientcert facts ... they must all be overridden.
```

Removing `clientcert` works around the error, but then `$trusted['certname']` is broken.

### Fix

Remove `clientcert` from `TRUSTED_INFORMATION_FACTS`. It is not a facter fact and should not be grouped with the network addressing facts (`hostname`, `domain`, `fqdn`).

### Tests

Updated existing tests and added a new test verifying that providing only `clientcert` without the other facts does not raise an error.

Fixes #9564