### PR TITLE
Fix typos in source comments (succesfully, enviroment)

### DIFF
--- a/lib/puppet/indirector/catalog/compiler.rb
+++ b/lib/puppet/indirector/catalog/compiler.rb
@@ -61,7 +61,7 @@ class Puppet::Resource::Catalog::Compiler < Puppet::Indirector::Code
       # If the requested environment name doesn't match the server specified environment
       # name, as determined by the node terminus, and the request wants us to check for an
       # environment mismatch, then return an empty catalog with the server-specified
-      # enviroment.
+      # environment.
       if request.remote? && request.options[:check_environment]
         # The "environment" may be same while environment objects differ. This
         # is most likely because the environment cache was flushed between the request

--- a/lib/puppet/util/windows/service.rb
+++ b/lib/puppet/util/windows/service.rb
@@ -219,7 +219,7 @@ module Puppet::Util::Windows
             FFI::MemoryPointer.new(:dword) do |resume_ptr|
               resume_ptr.write_dword(0)
               # Fetch the bytes of memory required to be allocated
-              # for QueryServiceConfigW to return succesfully. This
+              # for QueryServiceConfigW to return successfully. This
               # is done by sending NULL and 0 for the pointer and size
               # respectively, letting the command fail, then reading the
               # value of pcbBytesNeeded
@@ -414,7 +414,7 @@ module Puppet::Util::Windows
         size_required = nil
         status = nil
         # Fetch the bytes of memory required to be allocated
-        # for QueryServiceConfigW to return succesfully. This
+        # for QueryServiceConfigW to return successfully. This
         # is done by sending NULL and 0 for the pointer and size
         # respectively, letting the command fail, then reading the
         # value of pcbBytesNeeded
@@ -458,7 +458,7 @@ module Puppet::Util::Windows
         config = nil
         size_required = nil
         # Fetch the bytes of memory required to be allocated
-        # for QueryServiceConfigW to return succesfully. This
+        # for QueryServiceConfigW to return successfully. This
         # is done by sending NULL and 0 for the pointer and size
         # respectively, letting the command fail, then reading the
         # value of pcbBytesNeeded
@@ -496,7 +496,7 @@ module Puppet::Util::Windows
         config = nil
         size_required = nil
         # Fetch the bytes of memory required to be allocated
-        # for QueryServiceConfig2W to return succesfully. This
+        # for QueryServiceConfig2W to return successfully. This
         # is done by sending NULL and 0 for the pointer and size
         # respectively, letting the command fail, then reading the
         # value of pcbBytesNeeded


### PR DESCRIPTION

**Repo:** puppetlabs/puppet (⭐ 7300)
**Type:** docs
**Files changed:** 2
**Lines:** +5/-5

## What
Corrects misspellings in inline code comments: four occurrences of "succesfully" → "successfully" in `lib/puppet/util/windows/service.rb`, and one occurrence of "enviroment" → "environment" in `lib/puppet/indirector/catalog/compiler.rb`. Comments only; no runtime behavior changes.

## Why
Minor documentation hygiene. The misspellings are grep-visible and appear in comments explaining non-obvious Windows service API behavior and environment-mismatch handling in the catalog compiler — areas future maintainers are likely to read. Correcting them improves readability without risk.

## Testing
No runtime code is touched, so no test changes required. Verified with `git diff` that only comment lines are modified. A full `rspec` run is unnecessary for comment-only edits.

## Risk
Low — comment-only changes in two files.
